### PR TITLE
feat(phase7): Jarvis-parity hooks — tool/reasoning visibility in Telegram

### DIFF
--- a/plugin/scripts/install-hooks.sh
+++ b/plugin/scripts/install-hooks.sh
@@ -50,6 +50,16 @@ if [ -z "$SETTINGS" ] || [ -z "$CHAT_ID" ] || [ -z "$WEBHOOK_URL" ]; then
   exit 2
 fi
 
+# Reject non-http(s) URLs — a typo'd `file:///etc/passwd` or `javascript:`
+# would otherwise be written into settings.json and become a hook command
+# (review L3). The post-hook.ts helper uses fetch() which refuses file://
+# anyway, but stop the bad value at install time so settings.json never
+# carries it.
+if [[ ! "$WEBHOOK_URL" =~ ^https?:// ]]; then
+  echo "install-hooks.sh: --webhook-url must start with http:// or https:// (got '$WEBHOOK_URL')" >&2
+  exit 2
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PATCH_TS="$SCRIPT_DIR/patch-claude-settings.ts"
 

--- a/plugin/scripts/install-hooks.sh
+++ b/plugin/scripts/install-hooks.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Install Claude Code hooks that route stdin to the dashi-channel plugin's
+# webhook. Operator passes the per-agent settings.json explicitly — no
+# auto-discovery of ~/.claude/settings.json.
+#
+# Usage:
+#   scripts/install-hooks.sh \
+#     --settings /path/to/agent/settings.json \
+#     --chat-id 164795011 \
+#     --webhook-url http://127.0.0.1:8089/hooks/agent \
+#     [--agent-id dashi-channel]
+#
+# Hard rules:
+#   * The bearer token (TELEGRAM_WEBHOOK_TOKEN) is NEVER written to
+#     settings.json — operator exports it in the agent's runtime env.
+#   * Idempotent: re-running the same command replaces the previous entry
+#     rather than duplicating it (stable marker = "dashi-channel-hook").
+
+set -euo pipefail
+
+SETTINGS=""
+CHAT_ID=""
+WEBHOOK_URL=""
+AGENT_ID=""
+HELPER=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --settings)
+      SETTINGS="$2"; shift 2;;
+    --chat-id)
+      CHAT_ID="$2"; shift 2;;
+    --webhook-url)
+      WEBHOOK_URL="$2"; shift 2;;
+    --agent-id)
+      AGENT_ID="$2"; shift 2;;
+    --helper)
+      HELPER="$2"; shift 2;;
+    -h|--help)
+      sed -n 's/^# \{0,1\}//p' "$0" | head -n 18
+      exit 0;;
+    *)
+      echo "install-hooks.sh: unknown arg '$1'" >&2
+      exit 2;;
+  esac
+done
+
+if [ -z "$SETTINGS" ] || [ -z "$CHAT_ID" ] || [ -z "$WEBHOOK_URL" ]; then
+  echo "install-hooks.sh: --settings, --chat-id, --webhook-url are required" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PATCH_TS="$SCRIPT_DIR/patch-claude-settings.ts"
+
+if [ ! -f "$PATCH_TS" ]; then
+  echo "install-hooks.sh: missing helper '$PATCH_TS'" >&2
+  exit 3
+fi
+
+if [ -z "$HELPER" ]; then
+  HELPER="$SCRIPT_DIR/post-hook.ts"
+fi
+
+# Build arg array so paths with spaces survive intact.
+ARGS=(
+  "$PATCH_TS"
+  --settings "$SETTINGS"
+  --chat-id "$CHAT_ID"
+  --webhook-url "$WEBHOOK_URL"
+  --helper "$HELPER"
+)
+if [ -n "$AGENT_ID" ]; then
+  ARGS+=(--agent-id "$AGENT_ID")
+fi
+
+# Ensure the parent dir exists so `bun` can write the file atomically.
+mkdir -p "$(dirname "$SETTINGS")"
+
+bun "${ARGS[@]}"
+
+echo "install-hooks.sh: patched $SETTINGS" >&2

--- a/plugin/scripts/patch-claude-settings.ts
+++ b/plugin/scripts/patch-claude-settings.ts
@@ -1,0 +1,182 @@
+#!/usr/bin/env bun
+// Idempotently patch a Claude Code per-agent settings.json with the five
+// hook entries that route to plugin/scripts/post-hook.ts.
+//
+// Hard invariants:
+//   * Never write the bearer token. The hook command pulls
+//     TELEGRAM_WEBHOOK_TOKEN from the agent's process env at runtime.
+//   * Preserve unrelated keys and existing hook entries.
+//   * Stable marker — `hooks[event][].marker = "dashi-channel-hook"` — lets
+//     re-runs replace the previous entry instead of duplicating.
+//   * Atomic write through a temp file in the same dir so a partial write
+//     cannot corrupt settings.json.
+//
+// CLI:
+//   bun scripts/patch-claude-settings.ts \
+//     --settings /path/to/settings.json \
+//     --chat-id 164795011 \
+//     --webhook-url http://127.0.0.1:8089/hooks/agent \
+//     [--agent-id dashi-channel] \
+//     [--helper /abs/path/to/post-hook.ts]
+
+import { readFileSync, writeFileSync, mkdtempSync, renameSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { dirname, join, resolve as pathResolve } from 'path'
+
+const MARKER = 'dashi-channel-hook'
+const HOOK_EVENTS = [
+  'SessionStart',
+  'UserPromptSubmit',
+  'PreToolUse',
+  'PostToolUse',
+  'Stop',
+] as const
+
+type HookEvent = (typeof HOOK_EVENTS)[number]
+
+const MATCHER_BY_EVENT: Partial<Record<HookEvent, string>> = {
+  PreToolUse: '.*',
+  PostToolUse: '.*',
+}
+
+export interface PatchOptions {
+  readonly settingsPath: string
+  readonly chatId: string
+  readonly webhookUrl: string
+  readonly agentId?: string
+  readonly helperPath: string
+}
+
+interface HookEntry {
+  marker?: string
+  matcher?: string
+  hooks: Array<{ type: 'command'; command: string }>
+  [k: string]: unknown
+}
+
+interface SettingsShape {
+  hooks?: Partial<Record<HookEvent, HookEntry[] | undefined>>
+  [k: string]: unknown
+}
+
+function buildCommand(opts: PatchOptions): string {
+  // Single-quote env exports — the host shell (zsh/bash) keeps them literal
+  // so a token-shaped chat id can't trigger expansion.
+  const envParts: string[] = [
+    `TELEGRAM_HOOK_CHAT_ID='${opts.chatId.replace(/'/g, "'\\''")}'`,
+  ]
+  if (opts.agentId) {
+    envParts.push(
+      `TELEGRAM_HOOK_AGENT_ID='${opts.agentId.replace(/'/g, "'\\''")}'`,
+    )
+  }
+  envParts.push(
+    `TELEGRAM_WEBHOOK_URL='${opts.webhookUrl.replace(/'/g, "'\\''")}'`,
+  )
+  return `${envParts.join(' ')} bun '${opts.helperPath.replace(/'/g, "'\\''")}'`
+}
+
+function buildEntryFor(event: HookEvent, opts: PatchOptions): HookEntry {
+  const entry: HookEntry = {
+    marker: MARKER,
+    hooks: [{ type: 'command', command: buildCommand(opts) }],
+  }
+  const matcher = MATCHER_BY_EVENT[event]
+  if (matcher !== undefined) entry.matcher = matcher
+  return entry
+}
+
+/** Pure patcher — exposed for unit tests. */
+export function applyPatch(settings: SettingsShape, opts: PatchOptions): SettingsShape {
+  const hooks: NonNullable<SettingsShape['hooks']> = { ...(settings.hooks ?? {}) }
+  for (const event of HOOK_EVENTS) {
+    const next = buildEntryFor(event, opts)
+    const existing = hooks[event] ?? []
+    // Replace any entry that carries our marker. Append if none exists.
+    const withoutMarker = existing.filter(
+      (e) => !e || e.marker !== MARKER,
+    )
+    hooks[event] = [...withoutMarker, next]
+  }
+  return { ...settings, hooks }
+}
+
+function parseArgs(argv: ReadonlyArray<string>): PatchOptions {
+  let settingsPath = ''
+  let chatId = ''
+  let webhookUrl = ''
+  let agentId: string | undefined
+  let helperPath = ''
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    const next = argv[i + 1]
+    if (a === '--settings' && next) { settingsPath = next; i++; continue }
+    if (a === '--chat-id' && next) { chatId = next; i++; continue }
+    if (a === '--webhook-url' && next) { webhookUrl = next; i++; continue }
+    if (a === '--agent-id' && next) { agentId = next; i++; continue }
+    if (a === '--helper' && next) { helperPath = next; i++; continue }
+  }
+  if (!settingsPath || !chatId || !webhookUrl) {
+    process.stderr.write(
+      'Usage: patch-claude-settings.ts --settings PATH --chat-id ID --webhook-url URL [--agent-id ID] [--helper PATH]\n',
+    )
+    process.exit(2)
+  }
+  if (!helperPath) {
+    // Default to sibling post-hook.ts.
+    helperPath = pathResolve(import.meta.dir, 'post-hook.ts')
+  }
+  const opts: PatchOptions = agentId
+    ? { settingsPath, chatId, webhookUrl, agentId, helperPath }
+    : { settingsPath, chatId, webhookUrl, helperPath }
+  return opts
+}
+
+function readSettings(path: string): SettingsShape {
+  if (!existsSync(path)) return {}
+  const raw = readFileSync(path, 'utf8')
+  if (raw.trim().length === 0) return {}
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      throw new Error('settings.json must be a JSON object')
+    }
+    return parsed as SettingsShape
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`failed to parse ${path}: ${msg}`)
+  }
+}
+
+function writeAtomic(path: string, contents: string): void {
+  const dir = dirname(path)
+  const stage = mkdtempSync(join(tmpdir(), 'dashi-settings-'))
+  const tmp = join(stage, 'settings.json')
+  writeFileSync(tmp, contents, { mode: 0o600 })
+  // Ensure target dir exists.
+  // (We don't mkdir here — settings.json's parent is created by claude.)
+  void dir
+  renameSync(tmp, path)
+}
+
+export function patchSettingsFile(opts: PatchOptions): void {
+  const settings = readSettings(opts.settingsPath)
+  const patched = applyPatch(settings, opts)
+  const out = `${JSON.stringify(patched, null, 2)}\n`
+  if (out.includes('TELEGRAM_WEBHOOK_TOKEN=')) {
+    // Defence: nothing in our patch path writes the bearer token; if a
+    // future change attempts to, fail loud.
+    throw new Error('refusing to write TELEGRAM_WEBHOOK_TOKEN to settings.json')
+  }
+  writeAtomic(opts.settingsPath, out)
+}
+
+const isMainModule = (() => {
+  const arg = process.argv[1] ?? ''
+  return arg.endsWith('patch-claude-settings.ts') || arg.endsWith('patch-claude-settings.js')
+})()
+
+if (isMainModule) {
+  const opts = parseArgs(process.argv.slice(2))
+  patchSettingsFile(opts)
+}

--- a/plugin/scripts/patch-claude-settings.ts
+++ b/plugin/scripts/patch-claude-settings.ts
@@ -19,9 +19,8 @@
 //     [--agent-id dashi-channel] \
 //     [--helper /abs/path/to/post-hook.ts]
 
-import { readFileSync, writeFileSync, mkdtempSync, renameSync, existsSync } from 'fs'
-import { tmpdir } from 'os'
-import { dirname, join, resolve as pathResolve } from 'path'
+import { readFileSync, writeFileSync, renameSync, existsSync, unlinkSync } from 'fs'
+import { dirname, resolve as pathResolve } from 'path'
 
 const MARKER = 'dashi-channel-hook'
 const HOOK_EVENTS = [
@@ -149,14 +148,22 @@ function readSettings(path: string): SettingsShape {
 }
 
 function writeAtomic(path: string, contents: string): void {
+  // Stage the temp file in the SAME directory as the target so the final
+  // rename is guaranteed same-filesystem and therefore atomic. Using
+  // os.tmpdir() failed on Linux setups where /tmp is a separate fs
+  // (tmpfs / different mount) — renameSync surfaced as EXDEV (review §5).
   const dir = dirname(path)
-  const stage = mkdtempSync(join(tmpdir(), 'dashi-settings-'))
-  const tmp = join(stage, 'settings.json')
-  writeFileSync(tmp, contents, { mode: 0o600 })
-  // Ensure target dir exists.
-  // (We don't mkdir here — settings.json's parent is created by claude.)
+  const tmp = `${path}.tmp.${process.pid}.${Date.now()}`
   void dir
-  renameSync(tmp, path)
+  writeFileSync(tmp, contents, { mode: 0o600 })
+  try {
+    renameSync(tmp, path)
+  } catch (err) {
+    // Best-effort cleanup of the staged file so a failed rename doesn't
+    // leave a `*.tmp.<pid>.<ts>` orphan next to settings.json.
+    try { unlinkSync(tmp) } catch { /* ignore */ }
+    throw err
+  }
 }
 
 export function patchSettingsFile(opts: PatchOptions): void {

--- a/plugin/scripts/patch-claude-settings.ts
+++ b/plugin/scripts/patch-claude-settings.ts
@@ -21,6 +21,7 @@
 
 import { readFileSync, writeFileSync, renameSync, existsSync, unlinkSync } from 'fs'
 import { dirname, resolve as pathResolve } from 'path'
+import { fileURLToPath } from 'url'
 
 const MARKER = 'dashi-channel-hook'
 // Substring of the dashi helper script path used to identify *markerless*
@@ -144,8 +145,11 @@ function parseArgs(argv: ReadonlyArray<string>): PatchOptions {
     process.exit(2)
   }
   if (!helperPath) {
-    // Default to sibling post-hook.ts.
-    helperPath = pathResolve(import.meta.dir, 'post-hook.ts')
+    // Default to sibling post-hook.ts. `import.meta.dir` is a Bun extension;
+    // resolve via `fileURLToPath(import.meta.url)` so the script also works
+    // when invoked under plain Node (review M5).
+    const scriptDir = dirname(fileURLToPath(import.meta.url))
+    helperPath = pathResolve(scriptDir, 'post-hook.ts')
   }
   const opts: PatchOptions = agentId
     ? { settingsPath, chatId, webhookUrl, agentId, helperPath }

--- a/plugin/scripts/patch-claude-settings.ts
+++ b/plugin/scripts/patch-claude-settings.ts
@@ -23,6 +23,12 @@ import { readFileSync, writeFileSync, renameSync, existsSync, unlinkSync } from 
 import { dirname, resolve as pathResolve } from 'path'
 
 const MARKER = 'dashi-channel-hook'
+// Substring of the dashi helper script path used to identify *markerless*
+// legacy entries — re-running install over a settings file that was
+// hand-edited (no marker but pointing at our post-hook.ts) used to leave
+// the legacy entry in place + append the marked one, firing the hook
+// twice (review §6).
+const HELPER_PATH_FINGERPRINT = 'post-hook.ts'
 const HOOK_EVENTS = [
   'SessionStart',
   'UserPromptSubmit',
@@ -85,17 +91,33 @@ function buildEntryFor(event: HookEvent, opts: PatchOptions): HookEntry {
   return entry
 }
 
+// True if an entry's command string points at our helper script, even if
+// the marker was hand-stripped or never present. Survives different
+// absolute prefixes (e.g. user moved the plugin between dirs) by matching
+// the trailing `post-hook.ts` filename inside the command string.
+function isLegacyDashiEntry(entry: HookEntry | undefined): boolean {
+  if (!entry || !Array.isArray(entry.hooks)) return false
+  for (const h of entry.hooks) {
+    if (h && typeof h.command === 'string' && h.command.includes(HELPER_PATH_FINGERPRINT)) {
+      return true
+    }
+  }
+  return false
+}
+
 /** Pure patcher — exposed for unit tests. */
 export function applyPatch(settings: SettingsShape, opts: PatchOptions): SettingsShape {
   const hooks: NonNullable<SettingsShape['hooks']> = { ...(settings.hooks ?? {}) }
   for (const event of HOOK_EVENTS) {
     const next = buildEntryFor(event, opts)
     const existing = hooks[event] ?? []
-    // Replace any entry that carries our marker. Append if none exists.
-    const withoutMarker = existing.filter(
-      (e) => !e || e.marker !== MARKER,
+    // Drop anything that's clearly ours: either marker match OR a markerless
+    // entry whose command path resolves to our helper. Unrelated entries
+    // (someone-else marker, unrelated command) survive untouched.
+    const filtered = existing.filter(
+      (e) => !e || (e.marker !== MARKER && !isLegacyDashiEntry(e)),
     )
-    hooks[event] = [...withoutMarker, next]
+    hooks[event] = [...filtered, next]
   }
   return { ...settings, hooks }
 }

--- a/plugin/scripts/post-hook.ts
+++ b/plugin/scripts/post-hook.ts
@@ -1,0 +1,189 @@
+#!/usr/bin/env bun
+// post-hook.ts — Claude Code hook → dashi-channel webhook proxy.
+//
+// Reads a Claude hook JSON envelope from stdin and POSTs it (with the chat
+// id and bearer token from env) to the plugin's `/hooks/agent` endpoint.
+//
+// Hard invariants:
+//   * Exit code 0 in ALL paths. Claude blocks the model if a hook exits non-
+//     zero; visibility is best-effort, must never gate the agent.
+//   * Stdout stays empty. Hooks that emit stdout get treated as additional
+//     model context, so a `UserPromptSubmit` hook printing anything would
+//     leak it back into the conversation.
+//   * Stderr lines are redacted: never the bearer token, never the prompt
+//     body, never the full tool input. One short message on failure paths
+//     is the maximum.
+//
+// The helper does not write or read any files; configuration lives in env:
+//   TELEGRAM_WEBHOOK_URL     e.g. http://127.0.0.1:8089/hooks/agent
+//   TELEGRAM_WEBHOOK_TOKEN   bearer token configured on the plugin
+//   TELEGRAM_HOOK_CHAT_ID    target Telegram chat id (string or numeric)
+//   TELEGRAM_HOOK_AGENT_ID   optional agent id (defaults to no agentId)
+
+export interface HookRequest {
+  readonly url: string
+  readonly headers: Readonly<Record<string, string>>
+  readonly body: string
+}
+
+export interface BuildHookRequestInput {
+  readonly env: Readonly<Record<string, string | undefined>>
+  readonly hook: Record<string, unknown>
+}
+
+export interface BuildHookRequestError {
+  readonly kind: 'error'
+  readonly reason: string
+}
+
+export type BuildHookRequestResult = HookRequest | BuildHookRequestError
+
+/**
+ * Pure builder so unit tests can verify the wire shape without a network.
+ * Returns either a request blueprint or a structured `error` shape — never
+ * throws. Callers are expected to log the redacted `reason` and exit 0.
+ */
+export function buildHookRequest(input: BuildHookRequestInput): BuildHookRequestResult {
+  const url = input.env.TELEGRAM_WEBHOOK_URL
+  const token = input.env.TELEGRAM_WEBHOOK_TOKEN
+  const chatId = input.env.TELEGRAM_HOOK_CHAT_ID
+  const agentId = input.env.TELEGRAM_HOOK_AGENT_ID
+
+  if (!url) return { kind: 'error', reason: 'missing TELEGRAM_WEBHOOK_URL' }
+  if (!token) return { kind: 'error', reason: 'missing TELEGRAM_WEBHOOK_TOKEN' }
+  if (!chatId) return { kind: 'error', reason: 'missing TELEGRAM_HOOK_CHAT_ID' }
+
+  // Validate the hook payload looks like a Claude hook envelope by checking
+  // for at least `hook_event_name` and `session_id`. We don't re-validate
+  // the full schema here — the server is the boundary.
+  if (typeof input.hook.hook_event_name !== 'string') {
+    return { kind: 'error', reason: 'hook payload missing hook_event_name' }
+  }
+
+  const merged: Record<string, unknown> = {
+    chatId,
+    ...(agentId ? { agentId } : {}),
+    ...input.hook,
+  }
+
+  return {
+    url,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(merged),
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Stdin reader. Bun supports `Bun.stdin.text()`, but we also accept the
+// no-content case (some Claude hooks fire without stdin in dev).
+// ─────────────────────────────────────────────────────────────────────
+
+async function readStdin(): Promise<string> {
+  try {
+    // Bun.stdin is a `Bun.ReadableStream`-like object with `.text()`.
+    const stdin: unknown = (globalThis as Record<string, unknown>).Bun
+    if (stdin && typeof stdin === 'object') {
+      const bunObj = stdin as { stdin?: { text?: () => Promise<string> } }
+      const fn = bunObj.stdin?.text
+      if (typeof fn === 'function') return await fn.call(bunObj.stdin)
+    }
+  } catch {
+    /* fall through to Node-style fallback */
+  }
+  // Fallback for non-Bun runtimes (used in tests).
+  return await new Promise<string>((resolve) => {
+    const chunks: Buffer[] = []
+    process.stdin.on('data', (chunk: Buffer) => chunks.push(chunk))
+    process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+    process.stdin.on('error', () => resolve(''))
+  })
+}
+
+// Short, secret-free warning line. Anything we emit MUST be redacted —
+// never include bearer tokens, prompt body, tool_input keys, etc.
+function warn(reason: string): void {
+  // 80 char cap so a verbose error string can't tail-leak through a long
+  // line. Stderr only — stdout is intentionally untouched.
+  const safe = reason.length > 80 ? `${reason.slice(0, 77)}...` : reason
+  process.stderr.write(`telegram-hook: ${safe}\n`)
+}
+
+async function main(): Promise<void> {
+  let raw = ''
+  try {
+    raw = await readStdin()
+  } catch {
+    warn('stdin read failed')
+    return
+  }
+  if (raw.trim().length === 0) {
+    // No payload — nothing to forward, exit cleanly.
+    return
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    warn('stdin not valid JSON')
+    return
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    warn('stdin payload not an object')
+    return
+  }
+
+  const req = buildHookRequest({
+    env: process.env,
+    hook: parsed as Record<string, unknown>,
+  })
+  if ('kind' in req && req.kind === 'error') {
+    warn(req.reason)
+    return
+  }
+
+  // Narrow to HookRequest after the discriminator check.
+  const request = req as HookRequest
+  try {
+    const response = await fetch(request.url, {
+      method: 'POST',
+      headers: { ...request.headers },
+      body: request.body,
+    })
+    if (!response.ok) {
+      // Don't log response body — could contain server-emitted Zod issues
+      // that quote payload fields back.
+      warn(`webhook responded ${response.status}`)
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    // grep out anything that looks like a token before logging.
+    const redacted = msg.replace(/Bearer\s+\S+/gi, 'Bearer ***')
+    warn(`webhook fetch failed: ${redacted}`)
+  }
+}
+
+// Bun executes top-level await; we wrap so the script can also be imported
+// by tests without running main(). Only run when executed directly.
+const isMainModule = (() => {
+  try {
+    // Bun + Node both expose `import.meta.url` and (in CJS-compat layer)
+    // `require.main === module`. We use a robust check: argv[1] basename
+    // matches this file.
+    const arg = process.argv[1] ?? ''
+    return arg.endsWith('post-hook.ts') || arg.endsWith('post-hook.js')
+  } catch {
+    return false
+  }
+})()
+
+if (isMainModule) {
+  // Top-level await is supported in Bun; we explicitly catch so any unawaited
+  // rejection still exits 0.
+  await main().catch((err) => {
+    warn(err instanceof Error ? err.message : 'unknown error')
+  })
+}

--- a/plugin/scripts/post-hook.ts
+++ b/plugin/scripts/post-hook.ts
@@ -81,15 +81,18 @@ export function buildHookRequest(input: BuildHookRequestInput): BuildHookRequest
 // no-content case (some Claude hooks fire without stdin in dev).
 // ─────────────────────────────────────────────────────────────────────
 
+interface BunGlobal {
+  readonly stdin?: { readonly text?: () => Promise<string> }
+}
+
 async function readStdin(): Promise<string> {
   try {
-    // Bun.stdin is a `Bun.ReadableStream`-like object with `.text()`.
-    const stdin: unknown = (globalThis as Record<string, unknown>).Bun
-    if (stdin && typeof stdin === 'object') {
-      const bunObj = stdin as { stdin?: { text?: () => Promise<string> } }
-      const fn = bunObj.stdin?.text
-      if (typeof fn === 'function') return await fn.call(bunObj.stdin)
-    }
+    // Bun exposes `Bun.stdin.text()`; the global type is opaque under Node
+    // so we narrow through a local interface instead of an `unknown` cast
+    // chain (review L1).
+    const bun = (globalThis as { Bun?: BunGlobal }).Bun
+    const fn = bun?.stdin?.text
+    if (typeof fn === 'function') return await fn.call(bun?.stdin)
   } catch {
     /* fall through to Node-style fallback */
   }

--- a/plugin/src/hooks/claude-events.ts
+++ b/plugin/src/hooks/claude-events.ts
@@ -1,0 +1,90 @@
+// Mapping from validated Claude hook payloads to the ActivityStatusEvent
+// shape consumed by StatusManager. Keeping this module pure (no I/O) lets
+// the webhook server stay thin: parse → guard → map → forward.
+//
+// We never reach into `tool_result`, `prompt`, or freeform Claude metadata
+// from here — those are intentionally dropped before any string reaches
+// Telegram or our logs.
+
+import type { ClaudeHookPayload } from '../schemas.js'
+
+// Tool-call lifecycle pair used by the rolling activity window. PreToolUse
+// emits `tool_start`; PostToolUse emits `tool_end`. The renderer collapses
+// matching pairs into a single rendered line and uses `tool_use_id` to
+// resolve Agent done-summary updates.
+export interface ToolStartEvent {
+  readonly kind: 'tool_start'
+  readonly toolName: string
+  readonly toolInput: Record<string, unknown>
+  readonly toolUseId: string
+}
+
+export interface ToolEndEvent {
+  readonly kind: 'tool_end'
+  readonly toolName: string
+  readonly toolInput: Record<string, unknown>
+  readonly toolUseId: string
+  // Optional masked done-summary; renderer truncates to 30 chars (see
+  // gateway.py:1855: dispatch "summary" cap) before display. We carry the
+  // raw value so the renderer is the single mask point.
+  readonly toolResult?: unknown
+}
+
+// Phase events flip the status to `reasoning…` without recording a tool
+// call. SessionStart also opens a status if none is active; Stop closes it.
+export interface ReasoningEvent {
+  readonly kind: 'reasoning'
+}
+
+export interface SessionStartEvent {
+  readonly kind: 'session_start'
+}
+
+export interface SessionStopEvent {
+  readonly kind: 'session_stop'
+}
+
+export type ActivityStatusEvent =
+  | ToolStartEvent
+  | ToolEndEvent
+  | ReasoningEvent
+  | SessionStartEvent
+  | SessionStopEvent
+
+/**
+ * Convert a validated Claude hook payload to an ActivityStatusEvent.
+ *
+ * `UserPromptSubmit` carries the user prompt text — we deliberately drop it
+ * here so the prompt never reaches StatusManager (and through it Telegram).
+ * The phase change to `reasoning` is the only signal that survives.
+ */
+export function toActivityEvent(payload: ClaudeHookPayload): ActivityStatusEvent {
+  switch (payload.hook_event_name) {
+    case 'PreToolUse':
+      return {
+        kind: 'tool_start',
+        toolName: payload.tool_name,
+        toolInput: payload.tool_input,
+        toolUseId: payload.tool_use_id,
+      }
+    case 'PostToolUse': {
+      const event: ToolEndEvent = {
+        kind: 'tool_end',
+        toolName: payload.tool_name,
+        toolInput: payload.tool_input,
+        toolUseId: payload.tool_use_id,
+      }
+      // exactOptionalPropertyTypes: only attach `toolResult` if defined,
+      // otherwise the property must be absent — `undefined` is not allowed.
+      return payload.tool_result !== undefined
+        ? { ...event, toolResult: payload.tool_result }
+        : event
+    }
+    case 'Stop':
+      return { kind: 'session_stop' }
+    case 'UserPromptSubmit':
+      return { kind: 'reasoning' }
+    case 'SessionStart':
+      return { kind: 'session_start' }
+  }
+}

--- a/plugin/src/schemas.ts
+++ b/plugin/src/schemas.ts
@@ -62,12 +62,106 @@ export const StatusArgsSchema = z.object({
 })
 export type StatusArgs = z.infer<typeof StatusArgsSchema>
 
-// Webhook payload for /hooks/agent
-export const WebhookPayloadSchema = z.object({
+// Webhook payload for /hooks/agent — message variant.
+// Today's `/hooks/agent` callers post `{ message, chatId, agentId? }` and the
+// server forwards content as a channel notification (gateway.py:3531-3589 path).
+export const WebhookMessagePayloadSchema = z.object({
   message: z.string().min(1).max(64 * 1024),
   chatId: z.union([z.number(), z.string()]).transform((v) => String(v)),
   agentId: z.string().optional(),
 })
+export type WebhookMessagePayload = z.infer<typeof WebhookMessagePayloadSchema>
+
+// Common fields every Claude Code hook payload carries. Claude doesn't know
+// which Telegram chat to update, so the plugin requires `chatId` as part of
+// the same envelope — same gate as the message variant.
+const ClaudeHookCommonShape = {
+  chatId: z.union([z.number(), z.string()]).transform((v) => String(v)),
+  agentId: z.string().optional(),
+  session_id: z.string().min(1),
+  transcript_path: z.string().min(1),
+  cwd: z.string().min(1),
+  permission_mode: z.string().optional(),
+  agent_id: z.string().optional(),
+  agent_type: z.string().optional(),
+} as const
+
+// Tool input is an opaque record per Claude hook spec; renderer reads explicit
+// keys only and never embeds the raw object. `passthrough` keeps unknown
+// fields from Claude (Bash `description`, `run_in_background`, etc.) usable
+// downstream without forcing schema churn on every Claude version bump.
+const ToolInputSchema = z.record(z.unknown())
+
+export const ClaudePreToolUseSchema = z
+  .object({
+    ...ClaudeHookCommonShape,
+    hook_event_name: z.literal('PreToolUse'),
+    tool_name: z.string().min(1),
+    tool_use_id: z.string().min(1),
+    tool_input: ToolInputSchema,
+  })
+  .passthrough()
+
+export const ClaudePostToolUseSchema = z
+  .object({
+    ...ClaudeHookCommonShape,
+    hook_event_name: z.literal('PostToolUse'),
+    tool_name: z.string().min(1),
+    tool_use_id: z.string().min(1),
+    tool_input: ToolInputSchema,
+    tool_result: z.unknown().optional(),
+  })
+  .passthrough()
+
+export const ClaudeStopSchema = z
+  .object({
+    ...ClaudeHookCommonShape,
+    hook_event_name: z.literal('Stop'),
+    effort: z.unknown().optional(),
+  })
+  .passthrough()
+
+export const ClaudeUserPromptSubmitSchema = z
+  .object({
+    ...ClaudeHookCommonShape,
+    hook_event_name: z.literal('UserPromptSubmit'),
+    // We require prompt to validate Claude's contract but the renderer must
+    // never display it (private to the user → leaking into Telegram would
+    // double-broadcast the question that triggered the agent).
+    prompt: z.string(),
+  })
+  .passthrough()
+
+export const ClaudeSessionStartSchema = z
+  .object({
+    ...ClaudeHookCommonShape,
+    hook_event_name: z.literal('SessionStart'),
+    source: z.enum(['startup', 'resume', 'clear', 'compact']).optional(),
+    model: z.string().optional(),
+  })
+  .passthrough()
+
+export const ClaudeHookPayloadSchema = z.discriminatedUnion('hook_event_name', [
+  ClaudePreToolUseSchema,
+  ClaudePostToolUseSchema,
+  ClaudeStopSchema,
+  ClaudeUserPromptSubmitSchema,
+  ClaudeSessionStartSchema,
+])
+export type ClaudeHookPayload = z.infer<typeof ClaudeHookPayloadSchema>
+
+// Unified webhook payload. Transform tags the variant so `server.ts` can
+// branch without re-sniffing fields. The discriminator is presence of
+// `hook_event_name` — message payloads never carry it.
+export const WebhookPayloadSchema = z
+  .union([
+    WebhookMessagePayloadSchema.transform(
+      (p) => ({ kind: 'message' as const, ...p }),
+    ),
+    ClaudeHookPayloadSchema.transform(
+      (p) => ({ kind: 'claude_hook' as const, ...p }),
+    ),
+  ])
 export type WebhookPayload = z.infer<typeof WebhookPayloadSchema>
 
 // Telegram Update — minimal runtime guard before dispatch.

--- a/plugin/src/schemas.ts
+++ b/plugin/src/schemas.ts
@@ -151,17 +151,44 @@ export const ClaudeHookPayloadSchema = z.discriminatedUnion('hook_event_name', [
 export type ClaudeHookPayload = z.infer<typeof ClaudeHookPayloadSchema>
 
 // Unified webhook payload. Transform tags the variant so `server.ts` can
-// branch without re-sniffing fields. The discriminator is presence of
-// `hook_event_name` — message payloads never carry it.
-export const WebhookPayloadSchema = z
-  .union([
-    WebhookMessagePayloadSchema.transform(
-      (p) => ({ kind: 'message' as const, ...p }),
-    ),
-    ClaudeHookPayloadSchema.transform(
-      (p) => ({ kind: 'claude_hook' as const, ...p }),
-    ),
-  ])
+// branch without re-sniffing fields.
+//
+// Discriminator: presence of `hook_event_name` selects the Claude hook
+// schema; everything else falls through to message. We pre-check at the
+// schema boundary instead of relying on `z.union` evaluation order — the
+// message schema has very permissive optional fields, so a payload like
+// `{ message, chatId, hook_event_name }` would otherwise match message
+// first and silently drop the hook fields (review §3).
+export const WebhookPayloadSchema = z.preprocess(
+  (raw) => raw,
+  z.unknown(),
+).transform((value, ctx) => {
+  // Empty / non-object payloads fall through to message validation so the
+  // existing "missing required" 400 path still fires with a helpful summary.
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    const parsed = WebhookMessagePayloadSchema.safeParse(value)
+    if (!parsed.success) {
+      for (const issue of parsed.error.issues) ctx.addIssue(issue)
+      return z.NEVER
+    }
+    return { kind: 'message' as const, ...parsed.data }
+  }
+  const obj = value as Record<string, unknown>
+  if (typeof obj.hook_event_name === 'string') {
+    const parsed = ClaudeHookPayloadSchema.safeParse(obj)
+    if (!parsed.success) {
+      for (const issue of parsed.error.issues) ctx.addIssue(issue)
+      return z.NEVER
+    }
+    return { kind: 'claude_hook' as const, ...parsed.data }
+  }
+  const parsed = WebhookMessagePayloadSchema.safeParse(obj)
+  if (!parsed.success) {
+    for (const issue of parsed.error.issues) ctx.addIssue(issue)
+    return z.NEVER
+  }
+  return { kind: 'message' as const, ...parsed.data }
+})
 export type WebhookPayload = z.infer<typeof WebhookPayloadSchema>
 
 // Telegram Update — minimal runtime guard before dispatch.

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -476,6 +476,7 @@ try {
     config,
     statePaths,
     log,
+    statusManager,
   })
 } catch (err) {
   log.error('webhook server failed to start', {

--- a/plugin/src/status/activity-renderer.ts
+++ b/plugin/src/status/activity-renderer.ts
@@ -61,11 +61,19 @@ function basename(rawPath: string): string {
  */
 export function maskSecrets(input: string): string {
   let s = input
-  // IPv4 — keep first/last octet so debugging stays possible.
+  // IPv4 — keep first/last octet so debugging stays possible. Loopback
+  // (`127.*`) and `0.*` placeholders are pure debug noise, never secrets;
+  // masking them just hurts operator readability (review M3).
   s = s.replace(
     /\b(\d{1,3})\.\d{1,3}\.\d{1,3}\.(\d{1,3})\b/g,
-    '$1.***.***.$2',
+    (full, first: string, last: string) => {
+      if (first === '127' || first === '0') return full
+      return `${first}.***.***.${last}`
+    },
   )
+  // `localhost` / `::1` literals are also debug-friendly; leave untouched.
+  // (Regex above already skips them — IPv6 ::1 and the literal string
+  // `localhost` don't match the IPv4 pattern.)
   // Secret paths under ~/.foo/secrets/...  (legacy tilde-anchored form)
   s = s.replace(/(~\/?\.\w+\/)secrets\/\S+/g, '$1secrets/***')
   // Anchored `secrets/<file>` — catches summarized last-two-segments output
@@ -258,6 +266,14 @@ export function humanizeTool(toolName: string, toolInput: ToolInput): string | n
 export interface ActivityCall {
   readonly toolName: string
   readonly detail: string
+  // Pre-rendered humanized HTML for the line (e.g. `reading <code>foo.ts</code>`)
+  // or `null`/absent when the tool doesn't have a richer label (TodoWrite,
+  // unknown). The HTML is already secret-masked + escape-safe — its internal
+  // `<code>` and `<b>` tags are emitted verbatim inside the `<pre>` body,
+  // while non-tag content was passed through `escapeHtml` at construction.
+  // Optional so legacy callers (test fixtures) without humanized can build
+  // ActivityCall literals; renderer treats `undefined` the same as `null`.
+  readonly humanized?: string | null
 }
 
 export interface ActivitySnapshot {
@@ -268,22 +284,31 @@ export interface ActivitySnapshot {
 
 const ACTIVITY_WINDOW = 5
 
+// Telegram editMessageText rejects messages > 4096 chars. Cap the inner
+// `<pre>` body well below that limit (room for the wrapping tags + safety
+// margin in case maskSecrets or escape expands a line).
+const PRE_BODY_MAX_CHARS = 3900
+
 /**
  * Render the full `<pre>working -- Ns\n\n[reasoning…]\n\n▸ …</pre>` block.
- * Ports `_render`/`_render_activity` from gateway.py:1740-1784. The whole
- * body is HTML-escaped once (inside <pre>) so callers can hand the result
- * straight to Telegram with `parse_mode=HTML`.
+ * Ports `_render`/`_render_activity` from gateway.py:1740-1784.
+ *
+ * Lines are escaped individually so a humanized line (which carries safe
+ * inline HTML like `<code>foo.ts</code>`) lands verbatim while plain-detail
+ * lines and the timer header get standard escaping. Body is capped at
+ * `PRE_BODY_MAX_CHARS` so a runaway summary can never blow past Telegram's
+ * 4096-char editMessageText limit (review M2).
  */
 export function renderActivityBlock(
   snapshot: ActivitySnapshot,
   nowMs: number,
 ): string {
   const elapsedSec = Math.max(0, Math.floor((nowMs - snapshot.startedAtMs) / 1000))
-  const lines: string[] = [`working -- ${elapsedSec}s`]
+  const lines: string[] = [escapeHtml(`working -- ${elapsedSec}s`)]
 
   if (snapshot.phase === 'reasoning') {
     lines.push('')
-    lines.push('reasoning...')
+    lines.push(escapeHtml('reasoning...'))
   }
 
   if (snapshot.calls.length > 0) {
@@ -292,17 +317,45 @@ export function renderActivityBlock(
     const window = Math.min(ACTIVITY_WINDOW, total)
     const recent = snapshot.calls.slice(total - window)
     if (total > recent.length) {
-      lines.push(`▸ ... +${total - recent.length} earlier`)
+      lines.push(escapeHtml(`▸ ... +${total - recent.length} earlier`))
     }
     for (const call of recent) {
-      // detail may already be the humanized string; mask again to be safe.
-      // The Python pipeline also re-masks at render time (gateway.py:1782).
-      lines.push(`▸ ${maskSecrets(call.detail)}`)
+      if (call.humanized) {
+        // Humanized string is already HTML-safe: inner identifiers were
+        // escaped at construction (see humanizeTool), inline tags are
+        // intentional. Re-mask defensively against any post-store mutation.
+        lines.push(`▸ ${maskSecretsPreserveTags(call.humanized)}`)
+      } else {
+        // Plain detail — single escape at render boundary so a Grep pattern
+        // like `"recordActivity"` lands as `&quot;recordActivity&quot;` once,
+        // not twice (review §1).
+        lines.push(escapeHtml(`▸ ${maskSecrets(call.detail)}`))
+      }
     }
   }
 
-  const body = lines.join('\n').trim()
-  return `<pre>${escapeHtml(body)}</pre>`
+  let body = lines.join('\n').trim()
+  if (body.length > PRE_BODY_MAX_CHARS) {
+    // Truncate at a line boundary so we don't split an HTML entity.
+    const truncated = body.slice(0, PRE_BODY_MAX_CHARS)
+    const lastNl = truncated.lastIndexOf('\n')
+    const head = lastNl > 0 ? truncated.slice(0, lastNl) : truncated
+    body = `${head}\n…+truncated`
+  }
+  return `<pre>${body}</pre>`
+}
+
+/**
+ * Re-mask a humanized HTML line without disturbing the inline tags. The
+ * masking rules only touch IPs, secret paths, long tokens, Telegram bot
+ * tokens, and Supabase hosts — none of those overlap with the `<code>`/`<b>`
+ * tag bodies emitted by humanizeTool (we already mask path/cmd content
+ * before wrapping). So a plain pass is safe; this is kept as a separate
+ * function for clarity and to localize future changes if a mask rule ever
+ * threatens an HTML tag.
+ */
+function maskSecretsPreserveTags(html: string): string {
+  return maskSecrets(html)
 }
 
 /**
@@ -318,4 +371,20 @@ export function buildActivityDetail(toolName: string, toolInput: ToolInput): str
   const lower = toolName.toLowerCase()
   const detail = summary ? `${lower} ${summary}` : lower
   return maskSecrets(detail)
+}
+
+/**
+ * Build the pre-rendered humanized HTML line for `ActivityCall.humanized`.
+ * Returns null for TodoWrite/unknown so the renderer falls back to the
+ * plain `detail` path. The string already contains escaped content + safe
+ * inline tags (e.g. `<code>`, `<b>`) — masking is applied at the end so
+ * the buffer never holds a raw token.
+ */
+export function buildHumanizedActivityLine(
+  toolName: string,
+  toolInput: ToolInput,
+): string | null {
+  const raw = humanizeTool(toolName, toolInput)
+  if (raw === null) return null
+  return maskSecrets(raw)
 }

--- a/plugin/src/status/activity-renderer.ts
+++ b/plugin/src/status/activity-renderer.ts
@@ -1,0 +1,310 @@
+// Activity renderer — ports gateway.py:1506-1612 (humanize/summarize/mask)
+// and gateway.py:1761-1784 (rolling activity window).
+//
+// All output destined for Telegram (or any log) flows through `maskSecrets`
+// at the last possible moment. Callers may pass tool input verbatim — the
+// only public exits are pre-masked strings.
+
+import { escapeHtml } from '../format/html.js'
+
+// gateway.py:1476-1487 — mirrors SUBAGENT_LABELS.
+const SUBAGENT_LABELS: Record<string, string> = {
+  researcher: 'searching and verifying sources',
+  'content-writer': 'writing draft',
+  'content-orchestrator': 'preparing content',
+  'firebase-auditor': 'auditing data',
+  'code-reviewer': 'code review',
+  'general-purpose': 'running research',
+  Explore: 'exploring structure',
+  Plan: 'building plan',
+  'statusline-setup': 'setting up status',
+  'claude-code-guide': 'checking docs',
+}
+
+// Tool input is always an opaque record from Claude; helpers read explicit
+// keys only. We never embed the entire object.
+type ToolInput = Record<string, unknown>
+
+function strField(input: ToolInput, key: string): string {
+  const v = input[key]
+  return typeof v === 'string' ? v : ''
+}
+
+function lastTwoSegments(rawPath: string): string {
+  if (!rawPath) return ''
+  const normalized = rawPath.replace(/\\/g, '/')
+  const parts = normalized.split('/').filter((p) => p.length > 0)
+  if (parts.length >= 2) {
+    return parts.slice(-2).join('/')
+  }
+  // Match gateway.py:1512 fall-through: when rsplit yields < 2 parts, use
+  // the raw normalized path.
+  return normalized
+}
+
+function basename(rawPath: string): string {
+  if (!rawPath) return ''
+  const normalized = rawPath.replace(/\\/g, '/')
+  const parts = normalized.split('/')
+  return parts[parts.length - 1] ?? ''
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Secret masking
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Mask IPs, secret paths, long tokens, Telegram bot tokens, Supabase hosts.
+ * Port of `_mask_secrets` from gateway.py:1539-1563. Order matters — the
+ * generic long-token rule would chew through IPs and Supabase hosts if it
+ * ran first.
+ */
+export function maskSecrets(input: string): string {
+  let s = input
+  // IPv4 — keep first/last octet so debugging stays possible.
+  s = s.replace(
+    /\b(\d{1,3})\.\d{1,3}\.\d{1,3}\.(\d{1,3})\b/g,
+    '$1.***.***.$2',
+  )
+  // Secret paths under ~/.foo/secrets/...
+  s = s.replace(/(~\/?\.\w+\/)secrets\/\S+/g, '$1secrets/***')
+  // Generic long tokens (≥24 chars of [A-Za-z0-9_-]).
+  s = s.replace(
+    /\b([A-Za-z0-9_-]{4})[A-Za-z0-9_-]{16,}([A-Za-z0-9_-]{4})\b/g,
+    '$1***$2',
+  )
+  // Telegram bot tokens: NNN…:AAxx… → NNN***:AA***
+  s = s.replace(
+    /\b(\d{3})\d{7,}:(AA\w{2})\w+/g,
+    '$1***:$2***',
+  )
+  // Supabase host: <projectid>.supabase.co — mask the project id segment.
+  s = s.replace(/[a-z0-9]{10,}\.supabase\.co/g, (host) => {
+    const parts = host.split('.')
+    if (parts.length === 0) return host
+    const first = parts[0] ?? ''
+    if (first.length > 8) {
+      parts[0] = `${first.slice(0, 4)}*****${first.slice(-4)}`
+    }
+    if (parts.length > 1) {
+      const idx = parts.length - 2
+      const seg = parts[idx] ?? ''
+      if (seg.length > 5) {
+        parts[idx] = `${seg.slice(0, 4)}***`
+      }
+    }
+    return parts.join('.')
+  })
+  return s
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Summarize tool input — produces the short text used in activity lines.
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Compact description of a tool invocation for the rolling activity window.
+ * Output is HTML-escaped and capped at 40 chars (gateway.py:1506-1536).
+ * Renderer applies `maskSecrets` again to the whole detail string before
+ * display — masking here is a belt-and-braces pass for non-`unknown` paths.
+ */
+export function summarizeToolInput(toolName: string, toolInput: ToolInput): string {
+  let s: string
+
+  switch (toolName) {
+    case 'Read':
+    case 'Write':
+    case 'Edit':
+    case 'MultiEdit': {
+      const fp = strField(toolInput, 'file_path') || strField(toolInput, 'path')
+      s = lastTwoSegments(fp)
+      break
+    }
+    case 'Bash': {
+      s = strField(toolInput, 'command').slice(0, 40)
+      break
+    }
+    case 'Grep':
+    case 'Glob': {
+      const pattern = strField(toolInput, 'pattern')
+      s = pattern ? `"${pattern}"` : ''
+      break
+    }
+    case 'Agent': {
+      s =
+        strField(toolInput, 'subagent_type') ||
+        strField(toolInput, 'description')
+      break
+    }
+    case 'WebFetch': {
+      const url = strField(toolInput, 'url')
+      try {
+        s = new URL(url).host || url.slice(0, 40)
+      } catch {
+        s = url.slice(0, 40)
+      }
+      break
+    }
+    case 'WebSearch': {
+      s = strField(toolInput, 'query').slice(0, 40)
+      break
+    }
+    default: {
+      // Unknown tools — produce a safe, bounded summary. Never embed the raw
+      // object via JSON.stringify because nested objects can be huge.
+      s = ''
+      const keys = Object.keys(toolInput)
+      if (keys.length > 0) {
+        // Use Python `str(dict)`-style summary length cap (gateway.py:1535
+        // does `str(tinput)[:30]`). We emit a stable shape that doesn't leak
+        // raw values for objects.
+        const parts: string[] = []
+        for (const k of keys.slice(0, 4)) {
+          const v = toolInput[k]
+          let valueStr: string
+          if (typeof v === 'string') valueStr = v
+          else if (typeof v === 'number' || typeof v === 'boolean') valueStr = String(v)
+          else valueStr = typeof v
+          parts.push(`${k}=${valueStr}`)
+        }
+        s = parts.join(', ').slice(0, 30)
+      }
+      break
+    }
+  }
+
+  return escapeHtml(s.slice(0, 40))
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Humanize tool — compact HTML status line (gateway.py:1571-1612).
+// Returns `null` for TodoWrite and unknown tools so callers can skip.
+// ─────────────────────────────────────────────────────────────────────
+
+function codeBlock(s: string): string {
+  return `<code>${escapeHtml(s)}</code>`
+}
+
+export function humanizeTool(toolName: string, toolInput: ToolInput): string | null {
+  switch (toolName) {
+    case 'Agent': {
+      const sub = strField(toolInput, 'subagent_type') || '?'
+      const label = SUBAGENT_LABELS[sub] ?? `running ${sub}`
+      return `<b>${escapeHtml(label)}</b>`
+    }
+    case 'Bash': {
+      const cmd = strField(toolInput, 'command').trim()
+      if (cmd.startsWith('curl')) return 'calling API'
+      if (cmd.startsWith('git')) return 'git command'
+      if (
+        cmd.startsWith('cat ') ||
+        cmd.startsWith('tail ') ||
+        cmd.startsWith('head ') ||
+        cmd.startsWith('ls ') ||
+        cmd.startsWith('grep ')
+      ) {
+        return 'reading files'
+      }
+      // gateway.py:1585 — mask cmd[:60] BEFORE wrapping in <code>.
+      return `running: ${codeBlock(maskSecrets(cmd.slice(0, 60)))}`
+    }
+    case 'Read': {
+      const name = basename(strField(toolInput, 'file_path'))
+      return name ? `reading ${codeBlock(name)}` : 'reading file'
+    }
+    case 'Write': {
+      const name = basename(strField(toolInput, 'file_path'))
+      return name ? `creating ${codeBlock(name)}` : 'creating file'
+    }
+    case 'Edit':
+    case 'MultiEdit': {
+      const name = basename(strField(toolInput, 'file_path'))
+      return name ? `editing ${codeBlock(name)}` : 'editing file'
+    }
+    case 'Glob': {
+      const p = strField(toolInput, 'pattern')
+      return p ? `searching files: ${codeBlock(p.slice(0, 40))}` : 'searching files'
+    }
+    case 'Grep': {
+      const p = strField(toolInput, 'pattern')
+      return p ? `searching code: ${codeBlock(p.slice(0, 40))}` : 'searching code'
+    }
+    case 'WebFetch': {
+      const url = strField(toolInput, 'url')
+      return `fetching web: ${codeBlock(url.slice(0, 60))}`
+    }
+    case 'WebSearch': {
+      const q = strField(toolInput, 'query')
+      return `web search: <i>${escapeHtml(q.slice(0, 60))}</i>`
+    }
+    case 'TodoWrite':
+      return null
+    default:
+      return null
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Rolling activity window — ActivitySnapshot + render
+// ─────────────────────────────────────────────────────────────────────
+
+export interface ActivityCall {
+  readonly toolName: string
+  readonly detail: string
+}
+
+export interface ActivitySnapshot {
+  readonly startedAtMs: number
+  readonly calls: ReadonlyArray<ActivityCall>
+  readonly phase: 'reasoning' | 'tool'
+}
+
+const ACTIVITY_WINDOW = 5
+
+/**
+ * Render the full `<pre>working -- Ns\n\n[reasoning…]\n\n▸ …</pre>` block.
+ * Ports `_render`/`_render_activity` from gateway.py:1740-1784. The whole
+ * body is HTML-escaped once (inside <pre>) so callers can hand the result
+ * straight to Telegram with `parse_mode=HTML`.
+ */
+export function renderActivityBlock(
+  snapshot: ActivitySnapshot,
+  nowMs: number,
+): string {
+  const elapsedSec = Math.max(0, Math.floor((nowMs - snapshot.startedAtMs) / 1000))
+  const lines: string[] = [`working -- ${elapsedSec}s`]
+
+  if (snapshot.phase === 'reasoning') {
+    lines.push('')
+    lines.push('reasoning...')
+  }
+
+  if (snapshot.calls.length > 0) {
+    lines.push('')
+    const total = snapshot.calls.length
+    const window = Math.min(ACTIVITY_WINDOW, total)
+    const recent = snapshot.calls.slice(total - window)
+    if (total > recent.length) {
+      lines.push(`▸ ... +${total - recent.length} earlier`)
+    }
+    for (const call of recent) {
+      // detail may already be the humanized string; mask again to be safe.
+      // The Python pipeline also re-masks at render time (gateway.py:1782).
+      lines.push(`▸ ${maskSecrets(call.detail)}`)
+    }
+  }
+
+  const body = lines.join('\n').trim()
+  return `<pre>${escapeHtml(body)}</pre>`
+}
+
+/**
+ * Combine summarizeToolInput with the lowercase tool name to produce the
+ * detail string stored on `ActivityCall.detail`. Renderer applies maskSecrets
+ * again on the final string.
+ */
+export function buildActivityDetail(toolName: string, toolInput: ToolInput): string {
+  const summary = summarizeToolInput(toolName, toolInput)
+  const lower = toolName.toLowerCase()
+  return summary ? `${lower} ${summary}` : lower
+}

--- a/plugin/src/status/activity-renderer.ts
+++ b/plugin/src/status/activity-renderer.ts
@@ -104,9 +104,10 @@ export function maskSecrets(input: string): string {
 
 /**
  * Compact description of a tool invocation for the rolling activity window.
- * Output is HTML-escaped and capped at 40 chars (gateway.py:1506-1536).
- * Renderer applies `maskSecrets` again to the whole detail string before
- * display — masking here is a belt-and-braces pass for non-`unknown` paths.
+ * Returns the RAW (unescaped) logical content, capped at 40 chars
+ * (gateway.py:1506-1536). HTML escape happens exactly once at render time
+ * in `renderActivityBlock` — applying it here too would double-escape Grep
+ * patterns ("recordActivity" → `&amp;quot;...&amp;quot;`).
  */
 export function summarizeToolInput(toolName: string, toolInput: ToolInput): string {
   let s: string
@@ -173,7 +174,7 @@ export function summarizeToolInput(toolName: string, toolInput: ToolInput): stri
     }
   }
 
-  return escapeHtml(s.slice(0, 40))
+  return s.slice(0, 40)
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/plugin/src/status/activity-renderer.ts
+++ b/plugin/src/status/activity-renderer.ts
@@ -66,8 +66,14 @@ export function maskSecrets(input: string): string {
     /\b(\d{1,3})\.\d{1,3}\.\d{1,3}\.(\d{1,3})\b/g,
     '$1.***.***.$2',
   )
-  // Secret paths under ~/.foo/secrets/...
+  // Secret paths under ~/.foo/secrets/...  (legacy tilde-anchored form)
   s = s.replace(/(~\/?\.\w+\/)secrets\/\S+/g, '$1secrets/***')
+  // Anchored `secrets/<file>` — catches summarized last-two-segments output
+  // (e.g. `/Users/x/.claude-lab/silvana/secrets/openviking.key` collapses to
+  // `secrets/openviking.key`). Without this the secret filename slips
+  // through summarize → render. Pattern matches at string start or after a
+  // path separator so unrelated occurrences (`my-secrets/x`) are unaffected.
+  s = s.replace(/(^|[\s/])secrets\/\S+/g, '$1secrets/***')
   // Generic long tokens (≥24 chars of [A-Za-z0-9_-]).
   s = s.replace(
     /\b([A-Za-z0-9_-]{4})[A-Za-z0-9_-]{16,}([A-Za-z0-9_-]{4})\b/g,
@@ -301,11 +307,15 @@ export function renderActivityBlock(
 
 /**
  * Combine summarizeToolInput with the lowercase tool name to produce the
- * detail string stored on `ActivityCall.detail`. Renderer applies maskSecrets
- * again on the final string.
+ * detail string stored on `ActivityCall.detail`. Masking happens here —
+ * AFTER path summarization (which can collapse `/abs/.../secrets/foo.key`
+ * to `secrets/foo.key`) and BEFORE the value lands in the activity buffer.
+ * Renderer re-masks defensively but the buffer should never hold raw
+ * secret-shaped strings (review §4).
  */
 export function buildActivityDetail(toolName: string, toolInput: ToolInput): string {
   const summary = summarizeToolInput(toolName, toolInput)
   const lower = toolName.toLowerCase()
-  return summary ? `${lower} ${summary}` : lower
+  const detail = summary ? `${lower} ${summary}` : lower
+  return maskSecrets(detail)
 }

--- a/plugin/src/status/status-manager.ts
+++ b/plugin/src/status/status-manager.ts
@@ -23,6 +23,7 @@ import { escapeHtml } from '../format/html.js'
 import type { ActivityStatusEvent } from '../hooks/claude-events.js'
 import {
   buildActivityDetail,
+  buildHumanizedActivityLine,
   maskSecrets,
   renderActivityBlock,
   type ActivityCall,
@@ -348,7 +349,8 @@ export class StatusManager {
       case 'tool_start': {
         // Record every call up to the buffer cap so PostToolUse can pair.
         const detail = buildActivityDetail(event.toolName, event.toolInput)
-        const call: ActivityCall = { toolName: event.toolName, detail }
+        const humanized = buildHumanizedActivityLine(event.toolName, event.toolInput)
+        const call: ActivityCall = { toolName: event.toolName, detail, humanized }
         entry.activityCalls.push(call)
         if (entry.activityCalls.length > ACTIVITY_MAX_BUFFER) {
           entry.activityCalls.shift()
@@ -396,6 +398,10 @@ export class StatusManager {
                 entry.activityCalls[idx] = {
                   toolName: prev.toolName,
                   detail: `${prev.detail} — ${summary}`,
+                  humanized:
+                    prev.humanized !== null
+                      ? `${prev.humanized} — ${escapeHtml(summary)}`
+                      : null,
                 }
               }
             }

--- a/plugin/src/status/status-manager.ts
+++ b/plugin/src/status/status-manager.ts
@@ -20,6 +20,13 @@ import type { AppConfig } from '../config.js'
 import type { Logger } from '../log.js'
 import type { ChatAction, TelegramApi } from '../channel/tools.js'
 import { escapeHtml } from '../format/html.js'
+import type { ActivityStatusEvent } from '../hooks/claude-events.js'
+import {
+  buildActivityDetail,
+  renderActivityBlock,
+  type ActivityCall,
+  type ActivitySnapshot,
+} from './activity-renderer.js'
 
 // Telegram's `sendChatAction` indicator expires after 5 s; re-pulse on a 4 s
 // timer to keep the header animation continuous without spamming the API.
@@ -34,6 +41,7 @@ function chatActionFor(state: StatusState): ChatAction | null {
     case 'typing':
     case 'thinking':
     case 'tool':
+    case 'activity':
       return 'typing'
     case 'stopped':
     case 'error':
@@ -45,8 +53,20 @@ export type StatusState =
   | { kind: 'typing' }
   | { kind: 'thinking' }
   | { kind: 'tool'; toolName: string }
+  | { kind: 'activity'; snapshot: ActivitySnapshot }
   | { kind: 'stopped'; reason?: string }
   | { kind: 'error'; reason?: string }
+
+// Cap on the in-memory tool-call buffer per active chat. Gateway uses 10
+// (gateway.py:1876-1879); render window is 5 (`activity-renderer.ts`
+// `ACTIVITY_WINDOW`). Keeping more than we render lets the "+N earlier"
+// summary stay accurate after collapses without an unbounded buffer.
+const ACTIVITY_MAX_BUFFER = 10
+
+// Throttle non-Agent tool edits to once per this many ms. Agent dispatches
+// always edit immediately. Mirrors gateway.py:1738 `_last_tool_render` + 5 s
+// throttle in `_TaskBoundaryTracker`.
+const ACTIVITY_EDIT_THROTTLE_MS = 5000
 
 export interface StatusHandle {
   readonly chatId: string
@@ -86,6 +106,16 @@ interface InternalEntry {
   ttlHandle: NodeJS.Timeout | null
   // Separate cadence from the message edit ticker — see CHAT_ACTION_PULSE_MS.
   chatActionHandle: NodeJS.Timeout | null
+  // Rolling activity state — kept on the entry even while state.kind!=
+  // 'activity' so a Stop after a non-tool reasoning phase still has the
+  // recorded history. Last-tool-render timestamp throttles non-Agent edits.
+  activityCalls: ActivityCall[]
+  activityPhase: 'reasoning' | 'tool'
+  activityStartedAt: number
+  lastToolRenderAt: number
+  // Map tool_use_id → call buffer index, so PostToolUse Agent can update
+  // the recorded line with a short done summary.
+  toolUseIndex: Map<string, number>
 }
 
 // Reuse Telegram's "message is not modified" detection. We can't import a
@@ -96,7 +126,7 @@ function isMessageNotModifiedError(err: unknown): boolean {
   return /message is not modified/i.test(msg)
 }
 
-function renderState(state: StatusState, tick: number): string {
+function renderState(state: StatusState, tick: number, nowMs: number): string {
   // Ellipsis animation for typing/thinking: 1→2→3 dots.
   const dotCount = (tick % 3) + 1
   const dots = '.'.repeat(dotCount)
@@ -107,6 +137,8 @@ function renderState(state: StatusState, tick: number): string {
       return `<i>Думает${dots}</i>`
     case 'tool':
       return `<i>🔧 ${escapeHtml(state.toolName)}</i>`
+    case 'activity':
+      return renderActivityBlock(state.snapshot, nowMs)
     case 'stopped': {
       const tail = state.reason ? `: ${escapeHtml(state.reason)}` : ''
       return `<i>Остановлено${tail}</i>`
@@ -162,7 +194,7 @@ export class StatusManager {
       await this.cancel(chatId, 'superseded')
     }
 
-    const text = renderState(initialState, 0)
+    const text = renderState(initialState, 0, this.now())
     const sendOpts: { parse_mode: 'HTML'; reply_to_message_id?: number } = {
       parse_mode: 'HTML',
     }
@@ -195,6 +227,13 @@ export class StatusManager {
       intervalHandle: null,
       ttlHandle: null,
       chatActionHandle: null,
+      activityCalls: [],
+      activityPhase: 'reasoning',
+      activityStartedAt: this.now(),
+      // Sentinel — first non-Agent tool call always renders. Throttle only
+      // applies AFTER a render has actually occurred.
+      lastToolRenderAt: Number.NEGATIVE_INFINITY,
+      toolUseIndex: new Map(),
     }
     this.entries.set(chatId, entry)
 
@@ -213,7 +252,7 @@ export class StatusManager {
       const live = this.entries.get(chatId)
       if (!live || live.handle.messageId !== handle.messageId) return
       live.tick += 1
-      const next = renderState(live.state, live.tick)
+      const next = renderState(live.state, live.tick, this.now())
       void this.editSafely(live, next)
       // Re-arm next tick.
       live.intervalHandle = this.setTimer(tick, this.config.status.interval_ms)
@@ -241,7 +280,7 @@ export class StatusManager {
     entry.state = state
     // Reset tick on state change so the ellipsis animation restarts at 1.
     entry.tick = 0
-    const text = renderState(state, 0)
+    const text = renderState(state, 0, this.now())
     await this.editSafely(entry, text)
   }
 
@@ -252,6 +291,145 @@ export class StatusManager {
     const entry = this.entries.get(chatId)
     if (!entry) return
     await this.update(entry.handle, state)
+  }
+
+  /**
+   * Apply a Claude Code hook event to the chat's status. Opens a new status
+   * with no `reply_to_message_id` if none is active (SessionStart /
+   * UserPromptSubmit / PreToolUse all act as openers — gateway parity).
+   * Stop completes via `complete()` so existing delete_on_complete behaviour
+   * holds.
+   *
+   * Non-Agent PreToolUse calls are recorded immediately but the on-Telegram
+   * edit is throttled to once per 5 s; the next reasoning/Agent/Stop event
+   * flushes the buffer (mirrors gateway.py:1738 `_last_tool_render`).
+   */
+  async recordActivityByChatId(chatId: string, event: ActivityStatusEvent): Promise<void> {
+    // Stop closes the session. Use existing complete() so delete_on_complete
+    // semantics + timer cleanup stay in one place.
+    if (event.kind === 'session_stop') {
+      await this.complete(chatId)
+      return
+    }
+
+    // Lazy-open: hook events can arrive before any inbound Telegram message.
+    // In that case we open a status with no reply target so the rendering
+    // surface exists. Initial state is `activity` so the first edit shows
+    // the working block, not "Печатает…".
+    let entry = this.entries.get(chatId)
+    if (!entry) {
+      const initial: StatusState = {
+        kind: 'activity',
+        snapshot: this.buildSnapshot([], 'reasoning', this.now()),
+      }
+      try {
+        await this.start(chatId, undefined, initial)
+      } catch {
+        // Telegram send failed — already logged inside start(). Visibility
+        // failure must not back-pressure Claude hooks; bail silently.
+        return
+      }
+      entry = this.entries.get(chatId)
+      if (!entry) return
+    }
+
+    const now = this.now()
+    let shouldRender = false
+    let isAgentEvent = false
+
+    switch (event.kind) {
+      case 'session_start':
+      case 'reasoning': {
+        entry.activityPhase = 'reasoning'
+        shouldRender = true
+        break
+      }
+      case 'tool_start': {
+        // Record every call up to the buffer cap so PostToolUse can pair.
+        const detail = buildActivityDetail(event.toolName, event.toolInput)
+        const call: ActivityCall = { toolName: event.toolName, detail }
+        entry.activityCalls.push(call)
+        if (entry.activityCalls.length > ACTIVITY_MAX_BUFFER) {
+          entry.activityCalls.shift()
+          // After shifting, indexes in toolUseIndex are stale; rebuild
+          // lazily — only PostToolUse readers touch them.
+          const rebuilt = new Map<string, number>()
+          for (const [k, v] of entry.toolUseIndex.entries()) {
+            if (v > 0) rebuilt.set(k, v - 1)
+          }
+          entry.toolUseIndex = rebuilt
+        }
+        entry.toolUseIndex.set(event.toolUseId, entry.activityCalls.length - 1)
+        entry.activityPhase = 'tool'
+
+        isAgentEvent = event.toolName === 'Agent'
+        if (isAgentEvent) {
+          shouldRender = true
+        } else if (now - entry.lastToolRenderAt >= ACTIVITY_EDIT_THROTTLE_MS) {
+          shouldRender = true
+        } else {
+          // Throttled — buffer remains; next render flush will surface it.
+          shouldRender = false
+        }
+        break
+      }
+      case 'tool_end': {
+        entry.activityPhase = 'reasoning'
+        // For Agent PostToolUse, attach a short done summary to the matching
+        // line — capped at 30 chars + masked. PLAN §3 T3 / §6 final bullet.
+        if (event.toolName === 'Agent' && event.toolResult !== undefined) {
+          const idx = entry.toolUseIndex.get(event.toolUseId)
+          if (idx !== undefined && idx >= 0 && idx < entry.activityCalls.length) {
+            const summary =
+              typeof event.toolResult === 'string'
+                ? event.toolResult.slice(0, 30)
+                : ''
+            if (summary) {
+              const prev = entry.activityCalls[idx]
+              if (prev) {
+                entry.activityCalls[idx] = {
+                  toolName: prev.toolName,
+                  detail: `${prev.detail} — ${summary}`,
+                }
+              }
+            }
+          }
+        }
+        shouldRender = true
+        break
+      }
+    }
+
+    if (!shouldRender) return
+
+    if (event.kind === 'tool_start' && !isAgentEvent) {
+      entry.lastToolRenderAt = now
+    } else if (event.kind === 'tool_start' && isAgentEvent) {
+      entry.lastToolRenderAt = now
+    }
+
+    const snapshot = this.buildSnapshot(
+      entry.activityCalls,
+      entry.activityPhase,
+      entry.activityStartedAt,
+    )
+    entry.state = { kind: 'activity', snapshot }
+    entry.tick = 0
+    const text = renderState(entry.state, 0, now)
+    await this.editSafely(entry, text)
+  }
+
+  private buildSnapshot(
+    calls: ReadonlyArray<ActivityCall>,
+    phase: 'reasoning' | 'tool',
+    startedAtMs: number,
+  ): ActivitySnapshot {
+    return {
+      startedAtMs,
+      // Defensive copy so consumers don't see future mutations.
+      calls: calls.slice(),
+      phase,
+    }
   }
 
   async complete(chatId: string): Promise<void> {
@@ -278,7 +456,7 @@ export class StatusManager {
     if (!entry) return
     this.stopTimers(entry)
     this.entries.delete(chatId)
-    const text = renderState({ kind: 'stopped', reason }, 0)
+    const text = renderState({ kind: 'stopped', reason }, 0, this.now())
     try {
       await this.telegramApi.editMessageText(
         chatId,

--- a/plugin/src/status/status-manager.ts
+++ b/plugin/src/status/status-manager.ts
@@ -23,6 +23,7 @@ import { escapeHtml } from '../format/html.js'
 import type { ActivityStatusEvent } from '../hooks/claude-events.js'
 import {
   buildActivityDetail,
+  maskSecrets,
   renderActivityBlock,
   type ActivityCall,
   type ActivitySnapshot,
@@ -376,14 +377,19 @@ export class StatusManager {
       case 'tool_end': {
         entry.activityPhase = 'reasoning'
         // For Agent PostToolUse, attach a short done summary to the matching
-        // line — capped at 30 chars + masked. PLAN §3 T3 / §6 final bullet.
+        // line — capped at 30 chars + masked AT STORE TIME (review §7).
+        // Pre-fix the raw tool_result lived in the buffer until render; an
+        // in-memory leak (debug dump, future log sink, serializer) would
+        // surface raw tokens. Masking here means the buffer never holds an
+        // unmasked secret-shaped string.
         if (event.toolName === 'Agent' && event.toolResult !== undefined) {
           const idx = entry.toolUseIndex.get(event.toolUseId)
           if (idx !== undefined && idx >= 0 && idx < entry.activityCalls.length) {
-            const summary =
+            const rawSummary =
               typeof event.toolResult === 'string'
                 ? event.toolResult.slice(0, 30)
                 : ''
+            const summary = rawSummary ? maskSecrets(rawSummary) : ''
             if (summary) {
               const prev = entry.activityCalls[idx]
               if (prev) {

--- a/plugin/src/webhook/server.ts
+++ b/plugin/src/webhook/server.ts
@@ -92,18 +92,20 @@ function reply(res: ServerResponse, status: number, body: Record<string, unknown
 }
 
 function bearerEquals(received: string, expected: string): boolean {
-  // Encode to fixed-length buffers so timingSafeEqual never throws on
-  // length mismatch; length difference is independently checked.
+  // Pad both sides to a single fixed length BEFORE the comparison so we run
+  // the exact same timingSafeEqual call regardless of input lengths — no
+  // length-conditional code path that could leak a length bit (review M4).
+  // Final result combines the constant-time byte-compare with an explicit
+  // length-equality bit, so mismatched lengths still return false.
   const a = Buffer.from(received)
   const b = Buffer.from(expected)
-  if (a.length !== b.length) {
-    // Still run a constant-time compare on equal-length padded buffers so
-    // the failure path runs the same code; the length check is its own bit.
-    const pad = Buffer.alloc(b.length)
-    timingSafeEqual(pad, b)
-    return false
-  }
-  return timingSafeEqual(a, b)
+  const max = Math.max(a.length, b.length, 32)
+  const padA = Buffer.alloc(max)
+  const padB = Buffer.alloc(max)
+  a.copy(padA)
+  b.copy(padB)
+  const bytesEqual = timingSafeEqual(padA, padB)
+  return bytesEqual && a.length === b.length
 }
 
 // Drain request body up to BODY_LIMIT_BYTES + 1. We return early as soon

--- a/plugin/src/webhook/server.ts
+++ b/plugin/src/webhook/server.ts
@@ -260,7 +260,11 @@ async function handleRequest(
   // Branch on payload variant. Discriminator was set by the Zod transform
   // so we don't have to re-sniff fields here.
   if (payload.kind === 'claude_hook') {
-    if (statusManager) {
+    // PLAN.md:173 — when config.status.enabled=false the hook path must
+    // be a no-op. We accept the request (200) so Claude hooks don't
+    // back-pressure on a disabled visibility surface, but skip dispatch
+    // entirely (no statusManager call, no lazy status open).
+    if (config.status.enabled === true && statusManager) {
       try {
         await statusManager.recordActivityByChatId(
           payload.chatId,
@@ -274,12 +278,24 @@ async function handleRequest(
           error: err instanceof Error ? err.message : String(err),
         })
       }
-    } else {
-      log.debug('hook event accepted without status manager', {
+      reply(res, 200, { status: 'accepted' })
+      return
+    }
+
+    if (config.status.enabled !== true) {
+      log.debug('hook event accepted but status disabled', {
         chat_id: payload.chatId,
         hook: payload.hook_event_name,
       })
+      reply(res, 200, { status: 'accepted', note: 'status_disabled' })
+      return
     }
+
+    // statusManager not wired — visibility outage tolerated.
+    log.debug('hook event accepted without status manager', {
+      chat_id: payload.chatId,
+      hook: payload.hook_event_name,
+    })
     reply(res, 200, { status: 'accepted' })
     return
   }

--- a/plugin/src/webhook/server.ts
+++ b/plugin/src/webhook/server.ts
@@ -23,15 +23,30 @@ import type { Logger } from '../log.js'
 import { writeDeadLetter } from '../state/store.js'
 import { WebhookPayloadSchema, type WebhookPayload } from '../schemas.js'
 import { sendChannelNotification, normalizeMeta } from '../channel/notify.js'
+import { toActivityEvent } from '../hooks/claude-events.js'
 
 const BODY_LIMIT_BYTES = 256 * 1024
 const DEFAULT_AGENT_ID = 'dashi-channel'
+
+// Structural surface for the hook branch. Avoids importing the full
+// StatusManager type so test stubs can pass a minimal object. The webhook
+// server only needs to push events into the manager — no read APIs.
+export interface StatusManagerForWebhook {
+  recordActivityByChatId(
+    chatId: string,
+    event: ReturnType<typeof toActivityEvent>,
+  ): Promise<void>
+}
 
 export interface WebhookDeps {
   mcpServer: McpServer
   config: AppConfig
   statePaths: StatePaths
   log: Logger
+  // Optional — if absent, hook-event payloads are accepted but no Telegram
+  // status update happens. The 200 path stays open so Claude hooks never
+  // back-pressure on visibility outages.
+  statusManager?: StatusManagerForWebhook
 }
 
 export interface WebhookServerHandle {
@@ -147,7 +162,7 @@ async function handleRequest(
   deps: WebhookDeps,
   webhookToken: string | undefined,
 ): Promise<void> {
-  const { config, statePaths, log, mcpServer } = deps
+  const { config, statePaths, log, mcpServer, statusManager } = deps
   const method = req.method ?? 'GET'
   const url = req.url ?? '/'
 
@@ -242,7 +257,34 @@ async function handleRequest(
     return
   }
 
-  // Forward to MCP channel.
+  // Branch on payload variant. Discriminator was set by the Zod transform
+  // so we don't have to re-sniff fields here.
+  if (payload.kind === 'claude_hook') {
+    if (statusManager) {
+      try {
+        await statusManager.recordActivityByChatId(
+          payload.chatId,
+          toActivityEvent(payload),
+        )
+      } catch (err) {
+        // Visibility failure must not block Claude. Log + 200.
+        log.warn('hook event status update failed (ignored)', {
+          chat_id: payload.chatId,
+          hook: payload.hook_event_name,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    } else {
+      log.debug('hook event accepted without status manager', {
+        chat_id: payload.chatId,
+        hook: payload.hook_event_name,
+      })
+    }
+    reply(res, 200, { status: 'accepted' })
+    return
+  }
+
+  // Forward message payload to MCP channel (existing behaviour).
   const metaRaw: Record<string, unknown> = {
     source: 'webhook',
     chat_id: payload.chatId,

--- a/plugin/src/webhook/server.ts
+++ b/plugin/src/webhook/server.ts
@@ -65,9 +65,14 @@ export function validateWebhookPayload(value: unknown): WebhookPayload {
     return WebhookPayloadSchema.parse(value)
   } catch (err) {
     if (err instanceof z.ZodError) {
+      // Cap the issue summary so a deeply-nested or discriminated-union
+      // failure can't return a kilobyte-long error to the caller / dead
+      // letter (review L2). 512 chars is plenty to identify which field
+      // failed without amplifying payload-shaped attacks.
       const summary = err.issues
         .map((i) => `${i.path.join('.') || '<root>'}: ${i.message}`)
         .join('; ')
+        .slice(0, 512)
       throw new Error(redactToken(`invalid webhook payload: ${summary}`))
     }
     throw new Error(redactToken(`invalid webhook payload: ${err instanceof Error ? err.message : String(err)}`))

--- a/plugin/tests/hooks/claude-events.test.ts
+++ b/plugin/tests/hooks/claude-events.test.ts
@@ -1,0 +1,243 @@
+// Phase 7 / T1 — schema + ActivityStatusEvent mapping tests.
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  WebhookPayloadSchema,
+  ClaudeHookPayloadSchema,
+  WebhookMessagePayloadSchema,
+  type WebhookPayload,
+} from '../../src/schemas.js'
+import { toActivityEvent } from '../../src/hooks/claude-events.js'
+
+function parse(value: unknown): WebhookPayload {
+  return WebhookPayloadSchema.parse(value)
+}
+
+describe('WebhookPayloadSchema — message variant unchanged', () => {
+  test('accepts {message, chatId}', () => {
+    const p = parse({ message: 'hi', chatId: 164795011 })
+    expect(p.kind).toBe('message')
+    if (p.kind !== 'message') throw new Error('unreachable')
+    expect(p.message).toBe('hi')
+    expect(p.chatId).toBe('164795011')
+    expect(p.agentId).toBeUndefined()
+  })
+
+  test('rejects empty message', () => {
+    expect(() => parse({ message: '', chatId: 1 })).toThrow()
+  })
+
+  test('rejects payload missing both message and hook_event_name', () => {
+    expect(() => parse({ chatId: 1 })).toThrow()
+  })
+
+  test('legacy direct schema still works', () => {
+    const p = WebhookMessagePayloadSchema.parse({ message: 'x', chatId: 1 })
+    expect(p.message).toBe('x')
+    expect(p.chatId).toBe('1')
+  })
+})
+
+describe('WebhookPayloadSchema — Claude hook variant', () => {
+  const baseCommon = {
+    chatId: 164795011,
+    session_id: 'abc123',
+    transcript_path: '/Users/.../session.jsonl',
+    cwd: '/Users/project',
+    permission_mode: 'default',
+  } as const
+
+  test('PreToolUse round-trips and tags kind=claude_hook', () => {
+    const p = parse({
+      ...baseCommon,
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_use_id: 'toolu_01',
+      tool_input: { command: 'bun test', description: 'Run tests' },
+    })
+    expect(p.kind).toBe('claude_hook')
+    if (p.kind !== 'claude_hook') throw new Error('unreachable')
+    expect(p.hook_event_name).toBe('PreToolUse')
+    expect(p.chatId).toBe('164795011')
+    if (p.hook_event_name !== 'PreToolUse') throw new Error('unreachable')
+    expect(p.tool_name).toBe('Bash')
+    expect(p.tool_use_id).toBe('toolu_01')
+    expect(p.tool_input.command).toBe('bun test')
+  })
+
+  test('PostToolUse with tool_result accepted', () => {
+    const p = parse({
+      ...baseCommon,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_use_id: 'toolu_01',
+      tool_input: { command: 'bun test' },
+      tool_result: '245 pass',
+    })
+    expect(p.kind).toBe('claude_hook')
+    if (p.kind !== 'claude_hook' || p.hook_event_name !== 'PostToolUse') {
+      throw new Error('unreachable')
+    }
+    expect(p.tool_result).toBe('245 pass')
+  })
+
+  test('Stop accepts effort and ignores unknown fields via passthrough', () => {
+    const p = parse({
+      ...baseCommon,
+      hook_event_name: 'Stop',
+      effort: { level: 'medium' },
+      stop_hook_active: false,
+    })
+    expect(p.kind).toBe('claude_hook')
+    if (p.kind !== 'claude_hook' || p.hook_event_name !== 'Stop') {
+      throw new Error('unreachable')
+    }
+    expect(p.effort).toEqual({ level: 'medium' })
+  })
+
+  test('UserPromptSubmit requires prompt but renderer must drop it', () => {
+    const p = parse({
+      ...baseCommon,
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'Write a function',
+    })
+    expect(p.kind).toBe('claude_hook')
+    // Verify the activity-event mapping does not leak prompt text.
+    if (p.kind !== 'claude_hook') throw new Error('unreachable')
+    const event = toActivityEvent(p)
+    expect(event.kind).toBe('reasoning')
+    expect(JSON.stringify(event)).not.toContain('Write a function')
+  })
+
+  test('SessionStart accepts source/model and permission_mode optional', () => {
+    const p = parse({
+      chatId: 164795011,
+      session_id: 'abc',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/tmp',
+      hook_event_name: 'SessionStart',
+      source: 'startup',
+      model: 'claude-sonnet-4-6',
+    })
+    expect(p.kind).toBe('claude_hook')
+    if (p.kind !== 'claude_hook' || p.hook_event_name !== 'SessionStart') {
+      throw new Error('unreachable')
+    }
+    expect(p.source).toBe('startup')
+    expect(p.model).toBe('claude-sonnet-4-6')
+  })
+
+  test('rejects missing chatId on hook payload', () => {
+    expect(() =>
+      parse({
+        hook_event_name: 'PreToolUse',
+        session_id: 's',
+        transcript_path: '/t',
+        cwd: '/',
+        tool_name: 'Bash',
+        tool_use_id: 'u',
+        tool_input: {},
+      }),
+    ).toThrow()
+  })
+
+  test('rejects unknown hook_event_name', () => {
+    expect(() =>
+      parse({
+        ...baseCommon,
+        hook_event_name: 'PreCompact',
+        session_id: 's',
+      }),
+    ).toThrow()
+  })
+
+  test('rejects non-object tool_input', () => {
+    expect(() =>
+      parse({
+        ...baseCommon,
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_use_id: 'u1',
+        tool_input: 'not-an-object',
+      }),
+    ).toThrow()
+  })
+
+  test('accepts numeric or string chatId, both transform to string', () => {
+    const p1 = ClaudeHookPayloadSchema.parse({
+      chatId: '12345',
+      session_id: 's',
+      transcript_path: '/t',
+      cwd: '/',
+      hook_event_name: 'Stop',
+    })
+    expect(p1.chatId).toBe('12345')
+    const p2 = ClaudeHookPayloadSchema.parse({
+      chatId: 12345,
+      session_id: 's',
+      transcript_path: '/t',
+      cwd: '/',
+      hook_event_name: 'Stop',
+    })
+    expect(p2.chatId).toBe('12345')
+  })
+})
+
+describe('toActivityEvent mapping', () => {
+  test('PreToolUse → tool_start carries name/id/input only', () => {
+    const event = toActivityEvent({
+      chatId: '1',
+      session_id: 's',
+      transcript_path: '/t',
+      cwd: '/',
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Read',
+      tool_use_id: 'u1',
+      tool_input: { file_path: '/repo/a.ts' },
+    })
+    expect(event.kind).toBe('tool_start')
+    if (event.kind !== 'tool_start') throw new Error('unreachable')
+    expect(event.toolName).toBe('Read')
+    expect(event.toolUseId).toBe('u1')
+    expect(event.toolInput.file_path).toBe('/repo/a.ts')
+  })
+
+  test('PostToolUse without tool_result omits the field entirely', () => {
+    const event = toActivityEvent({
+      chatId: '1',
+      session_id: 's',
+      transcript_path: '/t',
+      cwd: '/',
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      tool_use_id: 'u1',
+      tool_input: { command: 'ls' },
+    })
+    expect(event.kind).toBe('tool_end')
+    if (event.kind !== 'tool_end') throw new Error('unreachable')
+    expect('toolResult' in event).toBe(false)
+  })
+
+  test('Stop → session_stop', () => {
+    const event = toActivityEvent({
+      chatId: '1',
+      session_id: 's',
+      transcript_path: '/t',
+      cwd: '/',
+      hook_event_name: 'Stop',
+    })
+    expect(event.kind).toBe('session_stop')
+  })
+
+  test('SessionStart → session_start', () => {
+    const event = toActivityEvent({
+      chatId: '1',
+      session_id: 's',
+      transcript_path: '/t',
+      cwd: '/',
+      hook_event_name: 'SessionStart',
+    })
+    expect(event.kind).toBe('session_start')
+  })
+})

--- a/plugin/tests/hooks/install-hooks.test.ts
+++ b/plugin/tests/hooks/install-hooks.test.ts
@@ -1,0 +1,163 @@
+// Phase 7 / T6 — install-hooks.sh + patch-claude-settings.ts.
+// Drives the real shell script against a temp settings.json so the end-to-end
+// flow is exercised.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { spawnSync } from 'child_process'
+
+import { applyPatch } from '../../scripts/patch-claude-settings.js'
+
+const PLUGIN_DIR = join(import.meta.dir, '..', '..')
+const INSTALL_SH = join(PLUGIN_DIR, 'scripts', 'install-hooks.sh')
+const POST_HOOK = join(PLUGIN_DIR, 'scripts', 'post-hook.ts')
+
+let tmp: string
+let settings: string
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'dashi-install-hooks-'))
+  settings = join(tmp, 'settings.json')
+})
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+function readJson(): Record<string, unknown> {
+  return JSON.parse(readFileSync(settings, 'utf8')) as Record<string, unknown>
+}
+
+function runInstall(extraArgs: string[] = []): { code: number; stderr: string } {
+  const r = spawnSync(
+    'bash',
+    [
+      INSTALL_SH,
+      '--settings', settings,
+      '--chat-id', '164795011',
+      '--webhook-url', 'http://127.0.0.1:8089/hooks/agent',
+      '--agent-id', 'dashi-channel',
+      ...extraArgs,
+    ],
+    { encoding: 'utf8' },
+  )
+  return { code: r.status ?? -1, stderr: r.stderr }
+}
+
+describe('install-hooks.sh — fresh settings file', () => {
+  test('creates hooks for all five events', () => {
+    const r = runInstall()
+    expect(r.code).toBe(0)
+    const parsed = readJson()
+    const flat = JSON.stringify(parsed)
+    for (const ev of ['SessionStart', 'UserPromptSubmit', 'PreToolUse', 'PostToolUse', 'Stop']) {
+      expect(flat).toContain(ev)
+    }
+    expect(flat).toContain(POST_HOOK)
+    expect(flat).toContain("TELEGRAM_HOOK_CHAT_ID='164795011'")
+    expect(flat).toContain("TELEGRAM_HOOK_AGENT_ID='dashi-channel'")
+  })
+
+  test('never writes TELEGRAM_WEBHOOK_TOKEN', () => {
+    runInstall()
+    const raw = readFileSync(settings, 'utf8')
+    expect(raw).not.toContain('TELEGRAM_WEBHOOK_TOKEN')
+  })
+
+  test('matchers present on PreToolUse and PostToolUse only', () => {
+    runInstall()
+    const parsed = readJson() as {
+      hooks?: Record<string, Array<{ matcher?: string }>>
+    }
+    expect(parsed.hooks?.PreToolUse?.[0]?.matcher).toBe('.*')
+    expect(parsed.hooks?.PostToolUse?.[0]?.matcher).toBe('.*')
+    expect(parsed.hooks?.SessionStart?.[0]?.matcher).toBeUndefined()
+    expect(parsed.hooks?.Stop?.[0]?.matcher).toBeUndefined()
+  })
+})
+
+describe('install-hooks.sh — idempotency', () => {
+  test('second run does not duplicate hook entries', () => {
+    runInstall()
+    const firstCount = countPluginEntries(readJson())
+    runInstall()
+    const secondCount = countPluginEntries(readJson())
+    expect(secondCount).toBe(firstCount)
+  })
+
+  test('preserves unrelated keys', () => {
+    writeFileSync(
+      settings,
+      JSON.stringify({
+        otherKey: { keep: 'me' },
+        hooks: {
+          PreToolUse: [
+            { marker: 'someone-else', hooks: [{ type: 'command', command: 'echo unrelated' }] },
+          ],
+        },
+      }),
+    )
+    runInstall()
+    const parsed = readJson() as Record<string, unknown> & {
+      hooks?: { PreToolUse?: Array<{ marker?: string; hooks?: Array<{ command?: string }> }> }
+    }
+    expect(parsed.otherKey).toEqual({ keep: 'me' })
+    // Other plugin's entry must survive.
+    const preToolUse = parsed.hooks?.PreToolUse ?? []
+    const others = preToolUse.filter((e) => e.marker === 'someone-else')
+    const ours = preToolUse.filter((e) => e.marker === 'dashi-channel-hook')
+    expect(others.length).toBe(1)
+    expect(ours.length).toBe(1)
+    expect(others[0]!.hooks?.[0]?.command).toBe('echo unrelated')
+  })
+})
+
+describe('applyPatch (pure)', () => {
+  test('handles missing hooks section', () => {
+    const out = applyPatch(
+      {},
+      {
+        settingsPath: '/tmp/x',
+        chatId: '1',
+        webhookUrl: 'http://x',
+        helperPath: '/tmp/post-hook.ts',
+      },
+    )
+    expect((out as Record<string, unknown>).hooks).toBeDefined()
+  })
+
+  test('replaces previous dashi-channel-hook entry rather than appending', () => {
+    let s: Record<string, unknown> = {}
+    s = applyPatch(s, {
+      settingsPath: '/tmp/x',
+      chatId: '1',
+      webhookUrl: 'http://old',
+      helperPath: '/tmp/post-hook.ts',
+    })
+    s = applyPatch(s, {
+      settingsPath: '/tmp/x',
+      chatId: '1',
+      webhookUrl: 'http://new',
+      helperPath: '/tmp/post-hook.ts',
+    })
+    const hooks = (s as { hooks?: Record<string, Array<{ marker?: string; hooks?: Array<{ command?: string }> }>> }).hooks
+    const stop = hooks?.Stop ?? []
+    const ours = stop.filter((e) => e.marker === 'dashi-channel-hook')
+    expect(ours.length).toBe(1)
+    expect(ours[0]!.hooks?.[0]?.command).toContain('http://new')
+    expect(ours[0]!.hooks?.[0]?.command).not.toContain('http://old')
+  })
+})
+
+function countPluginEntries(parsed: Record<string, unknown>): number {
+  const hooks = parsed.hooks as Record<string, Array<{ marker?: string }>> | undefined
+  if (!hooks) return 0
+  let total = 0
+  for (const arr of Object.values(hooks)) {
+    if (!Array.isArray(arr)) continue
+    total += arr.filter((e) => e?.marker === 'dashi-channel-hook').length
+  }
+  return total
+}

--- a/plugin/tests/hooks/install-hooks.test.ts
+++ b/plugin/tests/hooks/install-hooks.test.ts
@@ -84,6 +84,47 @@ describe('install-hooks.sh — fresh settings file', () => {
   })
 })
 
+describe('install-hooks.sh — URL validation (L3)', () => {
+  function runWithUrl(badUrl: string): { code: number; stderr: string } {
+    const bunBin =
+      process.env.BUN_INSTALL_BIN ?? join(process.env.HOME ?? '', '.bun', 'bin')
+    const pathPrefix = `${bunBin}:${process.env.PATH ?? ''}`
+    const r = spawnSync(
+      'bash',
+      [
+        INSTALL_SH,
+        '--settings', settings,
+        '--chat-id', '164795011',
+        '--webhook-url', badUrl,
+        '--agent-id', 'dashi-channel',
+      ],
+      { encoding: 'utf8', env: { ...process.env, PATH: pathPrefix } },
+    )
+    return { code: r.status ?? -1, stderr: r.stderr }
+  }
+
+  test('rejects file:// scheme without writing settings', async () => {
+    const r = runWithUrl('file:///etc/passwd')
+    expect(r.code).not.toBe(0)
+    expect(r.stderr).toContain('http://')
+    const { existsSync } = await import('fs')
+    expect(existsSync(settings)).toBe(false)
+  })
+
+  test('rejects javascript: scheme', () => {
+    const r = runWithUrl('javascript:alert(1)')
+    expect(r.code).not.toBe(0)
+  })
+
+  test('accepts http:// and https:// schemes', () => {
+    expect(runWithUrl('http://127.0.0.1:8089/hooks/agent').code).toBe(0)
+    // Reset settings between runs (idempotent install is fine, but a fresh
+    // file is clearer).
+    rmSync(settings, { force: true })
+    expect(runWithUrl('https://example.com/hooks/agent').code).toBe(0)
+  })
+})
+
 describe('install-hooks.sh — idempotency', () => {
   test('second run does not duplicate hook entries', () => {
     runInstall()

--- a/plugin/tests/hooks/install-hooks.test.ts
+++ b/plugin/tests/hooks/install-hooks.test.ts
@@ -114,6 +114,27 @@ describe('install-hooks.sh — idempotency', () => {
   })
 })
 
+describe('patchSettingsFile — writeAtomic same-dir staging (regression)', () => {
+  test('writes settings.json without leaving *.tmp.* orphans in dir', async () => {
+    const { patchSettingsFile } = await import('../../scripts/patch-claude-settings.js')
+    const target = join(tmp, 'settings.json')
+    patchSettingsFile({
+      settingsPath: target,
+      chatId: '164795011',
+      webhookUrl: 'http://127.0.0.1:8089/hooks/agent',
+      helperPath: '/abs/post-hook.ts',
+    })
+    const entries = readFileSync(target, 'utf8')
+    expect(entries).toContain('dashi-channel-hook')
+    // No leftover *.tmp.* staging file (would imply rename failed silently
+    // or temp lived in a different dir).
+    const { readdirSync } = await import('fs')
+    const dirEntries = readdirSync(tmp)
+    const orphans = dirEntries.filter((n) => n.includes('.tmp.'))
+    expect(orphans).toEqual([])
+  })
+})
+
 describe('applyPatch (pure)', () => {
   test('handles missing hooks section', () => {
     const out = applyPatch(

--- a/plugin/tests/hooks/install-hooks.test.ts
+++ b/plugin/tests/hooks/install-hooks.test.ts
@@ -31,6 +31,12 @@ function readJson(): Record<string, unknown> {
 }
 
 function runInstall(extraArgs: string[] = []): { code: number; stderr: string } {
+  // The install script invokes `bun` to run patch-claude-settings.ts. In some
+  // test runners `~/.bun/bin` is not on PATH, so prepend it explicitly. We
+  // also accept BUN_INSTALL_BIN override for CI.
+  const bunBin =
+    process.env.BUN_INSTALL_BIN ?? join(process.env.HOME ?? '', '.bun', 'bin')
+  const pathPrefix = `${bunBin}:${process.env.PATH ?? ''}`
   const r = spawnSync(
     'bash',
     [
@@ -41,7 +47,7 @@ function runInstall(extraArgs: string[] = []): { code: number; stderr: string } 
       '--agent-id', 'dashi-channel',
       ...extraArgs,
     ],
-    { encoding: 'utf8' },
+    { encoding: 'utf8', env: { ...process.env, PATH: pathPrefix } },
   )
   return { code: r.status ?? -1, stderr: r.stderr }
 }

--- a/plugin/tests/hooks/install-hooks.test.ts
+++ b/plugin/tests/hooks/install-hooks.test.ts
@@ -139,7 +139,45 @@ describe('patchSettingsFile — writeAtomic same-dir staging (regression)', () =
     const orphans = dirEntries.filter((n) => n.includes('.tmp.'))
     expect(orphans).toEqual([])
   })
+
+  test('writeAtomic stages tmp file in same dir as target (cross-volume regression)', async () => {
+    // Asserts the implementation invariant: even on platforms where the
+    // process tmpdir lives on a different fs, the staged tmp file is
+    // never created outside the target's parent directory. We can't fake
+    // a cross-volume mount in a unit test, so we instead inspect the
+    // module source to confirm the staging strategy. The post-fix
+    // patcher derives its temp path from `dirname(settingsPath)`.
+    const src = readFileSync(
+      join(PLUGIN_DIR, 'scripts', 'patch-claude-settings.ts'),
+      'utf8',
+    )
+    expect(src).toContain('dirname(path)')
+    expect(src).toContain('${path}.tmp.')
+    // And the obsolete tmpdir-based staging must be gone.
+    expect(src).not.toContain("mkdtempSync(join(tmpdir()")
+    expect(src).not.toContain("mkdtempSync(tmpdir())")
+  })
 })
+
+describe('default helper path resolution (M5)', () => {
+  test('module exports patchSettingsFile importable under Bun (and resolved post-hook.ts exists)', async () => {
+    const mod = await import('../../scripts/patch-claude-settings.js')
+    expect(typeof mod.patchSettingsFile).toBe('function')
+    // The default helper resolution kicks in only when --helper is omitted
+    // (CLI path). For the unit test we just verify the sibling
+    // post-hook.ts file is present at the path the resolver would land on.
+    expect(existsSyncWrapper(POST_HOOK)).toBe(true)
+  })
+})
+
+function existsSyncWrapper(p: string): boolean {
+  try {
+    readFileSync(p)
+    return true
+  } catch {
+    return false
+  }
+}
 
 describe('applyPatch (pure)', () => {
   test('handles missing hooks section', () => {

--- a/plugin/tests/hooks/install-hooks.test.ts
+++ b/plugin/tests/hooks/install-hooks.test.ts
@@ -149,6 +149,37 @@ describe('applyPatch (pure)', () => {
     expect((out as Record<string, unknown>).hooks).toBeDefined()
   })
 
+  test('removes markerless legacy entries that point at post-hook.ts (regression)', () => {
+    // settings.json hand-edited: marker stripped but the command still
+    // points at our post-hook.ts helper. install must NOT leave both the
+    // legacy entry and the new marked one (double-fire).
+    const legacyCmd = `TELEGRAM_HOOK_CHAT_ID='1' bun '/old/plugin/scripts/post-hook.ts'`
+    const seed: Record<string, unknown> = {
+      hooks: {
+        PreToolUse: [
+          { hooks: [{ type: 'command', command: legacyCmd }] },
+        ],
+        Stop: [
+          { hooks: [{ type: 'command', command: legacyCmd }] },
+        ],
+      },
+    }
+    const out = applyPatch(seed, {
+      settingsPath: '/tmp/x',
+      chatId: '1',
+      webhookUrl: 'http://x',
+      helperPath: '/new/plugin/scripts/post-hook.ts',
+    }) as { hooks: Record<string, Array<{ marker?: string; hooks?: Array<{ command?: string }> }>> }
+    for (const ev of ['PreToolUse', 'Stop']) {
+      const arr = out.hooks[ev] ?? []
+      expect(arr.length).toBe(1)
+      expect(arr[0]!.marker).toBe('dashi-channel-hook')
+      expect(arr[0]!.hooks?.[0]?.command).toContain('/new/plugin/scripts/post-hook.ts')
+      // Old legacy command must be gone.
+      expect(arr.find((e) => e.hooks?.[0]?.command === legacyCmd)).toBeUndefined()
+    }
+  })
+
   test('replaces previous dashi-channel-hook entry rather than appending', () => {
     let s: Record<string, unknown> = {}
     s = applyPatch(s, {

--- a/plugin/tests/hooks/post-hook.test.ts
+++ b/plugin/tests/hooks/post-hook.test.ts
@@ -1,0 +1,143 @@
+// Phase 7 / T5 — unit tests around the post-hook request builder.
+// No real network: we exercise `buildHookRequest` directly.
+
+import { describe, expect, test } from 'bun:test'
+
+import { buildHookRequest } from '../../scripts/post-hook.js'
+
+const TOKEN = 'unit-test-token'
+
+function baseHook(): Record<string, unknown> {
+  return {
+    hook_event_name: 'Stop',
+    session_id: 's1',
+    transcript_path: '/tmp/t.jsonl',
+    cwd: '/tmp',
+  }
+}
+
+describe('buildHookRequest', () => {
+  test('builds POST with bearer + JSON body containing chatId', () => {
+    const result = buildHookRequest({
+      env: {
+        TELEGRAM_HOOK_CHAT_ID: '164795011',
+        TELEGRAM_WEBHOOK_URL: 'http://127.0.0.1:8089/hooks/agent',
+        TELEGRAM_WEBHOOK_TOKEN: TOKEN,
+      },
+      hook: baseHook(),
+    })
+    expect('kind' in result).toBe(false)
+    if ('kind' in result) throw new Error('unreachable')
+    expect(result.url).toBe('http://127.0.0.1:8089/hooks/agent')
+    expect(result.headers.Authorization).toBe(`Bearer ${TOKEN}`)
+    expect(result.headers['Content-Type']).toBe('application/json')
+    expect(result.body).toContain('"chatId":"164795011"')
+    expect(result.body).toContain('"hook_event_name":"Stop"')
+  })
+
+  test('attaches optional agentId when provided', () => {
+    const result = buildHookRequest({
+      env: {
+        TELEGRAM_HOOK_CHAT_ID: '1',
+        TELEGRAM_HOOK_AGENT_ID: 'dashi-channel',
+        TELEGRAM_WEBHOOK_URL: 'http://x',
+        TELEGRAM_WEBHOOK_TOKEN: TOKEN,
+      },
+      hook: baseHook(),
+    })
+    if ('kind' in result) throw new Error('unreachable')
+    expect(result.body).toContain('"agentId":"dashi-channel"')
+  })
+
+  test('omits agentId when env unset', () => {
+    const result = buildHookRequest({
+      env: {
+        TELEGRAM_HOOK_CHAT_ID: '1',
+        TELEGRAM_WEBHOOK_URL: 'http://x',
+        TELEGRAM_WEBHOOK_TOKEN: TOKEN,
+      },
+      hook: baseHook(),
+    })
+    if ('kind' in result) throw new Error('unreachable')
+    expect(result.body).not.toContain('"agentId"')
+  })
+
+  test('missing TELEGRAM_WEBHOOK_URL → structured error', () => {
+    const result = buildHookRequest({
+      env: { TELEGRAM_HOOK_CHAT_ID: '1', TELEGRAM_WEBHOOK_TOKEN: TOKEN },
+      hook: baseHook(),
+    })
+    expect('kind' in result).toBe(true)
+    if (!('kind' in result)) throw new Error('unreachable')
+    expect(result.reason).toContain('TELEGRAM_WEBHOOK_URL')
+  })
+
+  test('missing TELEGRAM_WEBHOOK_TOKEN → structured error', () => {
+    const result = buildHookRequest({
+      env: { TELEGRAM_HOOK_CHAT_ID: '1', TELEGRAM_WEBHOOK_URL: 'http://x' },
+      hook: baseHook(),
+    })
+    if (!('kind' in result)) throw new Error('unreachable')
+    expect(result.reason).toContain('TELEGRAM_WEBHOOK_TOKEN')
+  })
+
+  test('missing TELEGRAM_HOOK_CHAT_ID → structured error', () => {
+    const result = buildHookRequest({
+      env: { TELEGRAM_WEBHOOK_URL: 'http://x', TELEGRAM_WEBHOOK_TOKEN: TOKEN },
+      hook: baseHook(),
+    })
+    if (!('kind' in result)) throw new Error('unreachable')
+    expect(result.reason).toContain('TELEGRAM_HOOK_CHAT_ID')
+  })
+
+  test('hook payload without hook_event_name → error, never reaches network', () => {
+    const result = buildHookRequest({
+      env: {
+        TELEGRAM_HOOK_CHAT_ID: '1',
+        TELEGRAM_WEBHOOK_URL: 'http://x',
+        TELEGRAM_WEBHOOK_TOKEN: TOKEN,
+      },
+      hook: { foo: 'bar' },
+    })
+    if (!('kind' in result)) throw new Error('unreachable')
+    expect(result.reason).toContain('hook_event_name')
+  })
+
+  test('PreToolUse with prompt-shaped fields keeps tool_input intact', () => {
+    const result = buildHookRequest({
+      env: {
+        TELEGRAM_HOOK_CHAT_ID: '1',
+        TELEGRAM_WEBHOOK_URL: 'http://x',
+        TELEGRAM_WEBHOOK_TOKEN: TOKEN,
+      },
+      hook: {
+        hook_event_name: 'PreToolUse',
+        session_id: 's1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+        tool_name: 'Bash',
+        tool_use_id: 'u1',
+        tool_input: { command: 'bun test' },
+      },
+    })
+    if ('kind' in result) throw new Error('unreachable')
+    // tool_input is forwarded verbatim — the server is the masking boundary,
+    // not the helper. Keeps the helper trivial enough to audit by eye.
+    expect(result.body).toContain('"command":"bun test"')
+  })
+
+  test('bearer token not echoed into body', () => {
+    const result = buildHookRequest({
+      env: {
+        TELEGRAM_HOOK_CHAT_ID: '1',
+        TELEGRAM_WEBHOOK_URL: 'http://x',
+        TELEGRAM_WEBHOOK_TOKEN: 'super-secret-token',
+      },
+      hook: baseHook(),
+    })
+    if ('kind' in result) throw new Error('unreachable')
+    expect(result.body).not.toContain('super-secret-token')
+    // …and lives only inside the header.
+    expect(result.headers.Authorization).toBe('Bearer super-secret-token')
+  })
+})

--- a/plugin/tests/status/activity-renderer.test.ts
+++ b/plugin/tests/status/activity-renderer.test.ts
@@ -1,0 +1,245 @@
+// Phase 7 / T2 — humanization + rolling activity render.
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  buildActivityDetail,
+  humanizeTool,
+  maskSecrets,
+  renderActivityBlock,
+  summarizeToolInput,
+  type ActivitySnapshot,
+} from '../../src/status/activity-renderer.js'
+
+describe('maskSecrets', () => {
+  test('masks IPv4 keeping first and last octet', () => {
+    expect(maskSecrets('connect 10.2.3.44 done')).toBe('connect 10.***.***.44 done')
+  })
+
+  test('masks secret paths (direct ~/.foo/secrets/...)', () => {
+    // Python regex `(~/?\.\w+/)secrets/\S+` matches a single dot-prefixed
+    // segment immediately before `secrets/`. Deep paths (e.g.
+    // `~/.claude-lab/silvana/secrets/...`) intentionally fall through to
+    // the generic-long-token rule instead.
+    expect(maskSecrets('~/.config/secrets/openviking.key')).toContain('secrets/***')
+    expect(maskSecrets('~/.config/secrets/openviking.key')).not.toContain('openviking.key')
+  })
+
+  test('masks generic long tokens (≥24 chars)', () => {
+    const tok = `abcd${'x'.repeat(20)}wxyz`
+    const masked = maskSecrets(`bearer ${tok} ok`)
+    expect(masked).not.toContain(tok)
+    expect(masked).toContain('abcd***wxyz')
+  })
+
+  test('does not mangle short identifiers', () => {
+    expect(maskSecrets('short_id=foo')).toBe('short_id=foo')
+  })
+
+  test('masks Telegram bot token (generic-long covers the secret half)', () => {
+    // Python order: IPv4 → secret-paths → generic-long → bot-token. The
+    // generic-long rule consumes the alphanumeric run after the colon
+    // before bot-token can match. Both behaviours mask the secret payload
+    // (`AAH-fake_test_token...`) — verify the secret is gone, regardless
+    // of which rule fired.
+    const tok = '1234567890:AAH-fake_test_token_with_at_least_thirty_chars'
+    const masked = maskSecrets(`Authorization: ${tok}`)
+    expect(masked).not.toContain('AAH-fake_test_token')
+    expect(masked).not.toContain('thirty_chars')
+  })
+
+  test('masks Supabase host project id', () => {
+    const masked = maskSecrets('https://abcdefghij1234567890.supabase.co/rest/v1')
+    expect(masked).not.toContain('abcdefghij1234567890.supabase.co')
+    expect(masked).toContain('*****')
+  })
+})
+
+describe('summarizeToolInput', () => {
+  test('Read returns last two path segments', () => {
+    expect(summarizeToolInput('Read', { file_path: '/a/b/c/server.ts' })).toBe('c/server.ts')
+  })
+
+  test('Read accepts `path` fallback and normalizes backslashes', () => {
+    expect(summarizeToolInput('Read', { path: 'src\\\\foo\\\\bar.ts' })).toBe('foo/bar.ts')
+  })
+
+  test('Bash truncates to 40', () => {
+    const long = 'a'.repeat(80)
+    expect(summarizeToolInput('Bash', { command: long }).length).toBeLessThanOrEqual(40)
+  })
+
+  test('Grep wraps pattern in quotes', () => {
+    expect(summarizeToolInput('Grep', { pattern: 'TODO' })).toBe('&quot;TODO&quot;')
+  })
+
+  test('Agent uses subagent_type', () => {
+    expect(summarizeToolInput('Agent', { subagent_type: 'researcher' })).toBe('researcher')
+  })
+
+  test('WebFetch returns host', () => {
+    expect(summarizeToolInput('WebFetch', { url: 'https://example.com/path?x=1' })).toBe('example.com')
+  })
+
+  test('Unknown tool produces bounded safe summary', () => {
+    const out = summarizeToolInput('Hypothetical', { a: 'one', b: 2, c: false, d: 'longvalue' })
+    expect(out.length).toBeLessThanOrEqual(40)
+    expect(out).toContain('a=one')
+  })
+
+  test('Unknown tool with empty input returns empty string', () => {
+    expect(summarizeToolInput('Hypothetical', {})).toBe('')
+  })
+
+  test('escapes HTML special chars', () => {
+    expect(summarizeToolInput('Bash', { command: '<script>' })).toBe('&lt;script&gt;')
+  })
+})
+
+describe('humanizeTool', () => {
+  test('Bash curl → calling API', () => {
+    expect(humanizeTool('Bash', { command: 'curl https://x' })).toBe('calling API')
+  })
+
+  test('Bash git → git command', () => {
+    expect(humanizeTool('Bash', { command: 'git status --short' })).toBe('git command')
+  })
+
+  test('Bash read-like → reading files', () => {
+    expect(humanizeTool('Bash', { command: 'cat /etc/hosts' })).toBe('reading files')
+  })
+
+  test('Bash other → masked running:', () => {
+    const out = humanizeTool('Bash', { command: 'echo helloworld' })
+    expect(out).toContain('running:')
+    expect(out).toContain('<code>')
+  })
+
+  test('Bash running: truncates to 60 and masks long token', () => {
+    const tok = `abcd${'x'.repeat(20)}wxyz`
+    const out = humanizeTool('Bash', { command: `echo ${tok}` }) ?? ''
+    expect(out).not.toContain(tok)
+  })
+
+  test('Read returns basename only', () => {
+    expect(humanizeTool('Read', { file_path: '/repo/a/b/server.ts' })).toBe('reading <code>server.ts</code>')
+  })
+
+  test('Read without file_path falls back', () => {
+    expect(humanizeTool('Read', {})).toBe('reading file')
+  })
+
+  test('Write, Edit, MultiEdit return creating/editing labels', () => {
+    expect(humanizeTool('Write', { file_path: '/x/y.txt' })).toBe('creating <code>y.txt</code>')
+    expect(humanizeTool('Edit', { file_path: '/x/y.txt' })).toBe('editing <code>y.txt</code>')
+    expect(humanizeTool('MultiEdit', { file_path: '/x/y.txt' })).toBe('editing <code>y.txt</code>')
+  })
+
+  test('Agent uses SUBAGENT_LABELS map', () => {
+    expect(humanizeTool('Agent', { subagent_type: 'researcher' })).toBe(
+      '<b>searching and verifying sources</b>',
+    )
+  })
+
+  test('Agent unknown subagent_type falls back to "running X"', () => {
+    expect(humanizeTool('Agent', { subagent_type: 'mystery' })).toBe('<b>running mystery</b>')
+  })
+
+  test('TodoWrite and unknown tools return null', () => {
+    expect(humanizeTool('TodoWrite', { todos: [] })).toBeNull()
+    expect(humanizeTool('Hypothetical', {})).toBeNull()
+  })
+
+  test('WebSearch wraps query in <i>', () => {
+    expect(humanizeTool('WebSearch', { query: 'latest news' })).toBe(
+      'web search: <i>latest news</i>',
+    )
+  })
+})
+
+describe('renderActivityBlock', () => {
+  const baseStart = 1_000_000_000_000
+
+  test('no calls, reasoning phase, 0s', () => {
+    const snap: ActivitySnapshot = {
+      startedAtMs: baseStart,
+      calls: [],
+      phase: 'reasoning',
+    }
+    const out = renderActivityBlock(snap, baseStart)
+    expect(out).toContain('working -- 0s')
+    expect(out).toContain('reasoning...')
+    expect(out.startsWith('<pre>')).toBe(true)
+    expect(out.endsWith('</pre>')).toBe(true)
+  })
+
+  test('renders last 5 calls with arrow prefix', () => {
+    const snap: ActivitySnapshot = {
+      startedAtMs: baseStart,
+      calls: [
+        { toolName: 'Read', detail: 'read a.ts' },
+        { toolName: 'Read', detail: 'read b.ts' },
+        { toolName: 'Bash', detail: 'bash bun test' },
+      ],
+      phase: 'tool',
+    }
+    const out = renderActivityBlock(snap, baseStart + 12_000)
+    expect(out).toContain('working -- 12s')
+    expect(out).toContain('▸ read a.ts')
+    expect(out).toContain('▸ bash bun test')
+  })
+
+  test('rolling overflow shows +N earlier', () => {
+    const snap: ActivitySnapshot = {
+      startedAtMs: baseStart,
+      calls: [
+        { toolName: 'Bash', detail: 'bash one' },
+        { toolName: 'Bash', detail: 'bash two' },
+        { toolName: 'Bash', detail: 'bash three' },
+        { toolName: 'Grep', detail: 'grep four' },
+        { toolName: 'Read', detail: 'read five' },
+        { toolName: 'Edit', detail: 'edit six' },
+        { toolName: 'Bash', detail: 'bash seven' },
+        { toolName: 'Bash', detail: 'bash eight' },
+      ],
+      phase: 'tool',
+    }
+    const out = renderActivityBlock(snap, baseStart + 25_000)
+    expect(out).toContain('working -- 25s')
+    expect(out).toContain('+3 earlier')
+    expect(out).toContain('▸ bash eight')
+    expect(out).not.toContain('bash one')
+  })
+
+  test('masks secrets in detail before render', () => {
+    const tok = `abcd${'x'.repeat(20)}wxyz`
+    const snap: ActivitySnapshot = {
+      startedAtMs: baseStart,
+      calls: [{ toolName: 'Bash', detail: `bash echo ${tok}` }],
+      phase: 'tool',
+    }
+    const out = renderActivityBlock(snap, baseStart + 1_000)
+    expect(out).not.toContain(tok)
+  })
+
+  test('escapes HTML in <pre> body', () => {
+    const snap: ActivitySnapshot = {
+      startedAtMs: baseStart,
+      calls: [{ toolName: 'Bash', detail: 'bash <script>' }],
+      phase: 'tool',
+    }
+    const out = renderActivityBlock(snap, baseStart)
+    expect(out).toContain('&lt;script&gt;')
+    expect(out).not.toContain('<script>')
+  })
+})
+
+describe('buildActivityDetail', () => {
+  test('lowercases tool name + summary', () => {
+    expect(buildActivityDetail('Bash', { command: 'bun test' })).toBe('bash bun test')
+  })
+
+  test('omits summary if empty', () => {
+    expect(buildActivityDetail('Read', {})).toBe('read')
+  })
+})

--- a/plugin/tests/status/activity-renderer.test.ts
+++ b/plugin/tests/status/activity-renderer.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'bun:test'
 
 import {
   buildActivityDetail,
+  buildHumanizedActivityLine,
   humanizeTool,
   maskSecrets,
   renderActivityBlock,
@@ -273,6 +274,151 @@ describe('secret-path leak after summarization (regression)', () => {
     const out = renderActivityBlock(snap, 0)
     expect(out).not.toContain('openviking.key')
     expect(out).toContain('secrets/***')
+  })
+})
+
+describe('humanized lines wired into render (M1)', () => {
+  // Wiring test — renderer must surface humanizeTool output on lines that
+  // carry a `humanized` HTML string, and fall back to the plain detail
+  // path for tools that don't have a richer label (TodoWrite, unknown).
+
+  test('Bash humanized line emits `running: <code>cmd</code>` inside <pre>', () => {
+    const humanized = buildHumanizedActivityLine('Bash', { command: 'bun test' })
+    expect(humanized).toBe('running: <code>bun test</code>')
+    const snap: ActivitySnapshot = {
+      startedAtMs: 0,
+      calls: [{ toolName: 'Bash', detail: 'bash bun test', humanized }],
+      phase: 'tool',
+    }
+    const out = renderActivityBlock(snap, 0)
+    expect(out).toContain('▸ running: <code>bun test</code>')
+    // Plain detail string is no longer the primary surface.
+    expect(out).not.toContain('▸ bash bun test')
+  })
+
+  test('Agent humanized line uses SUBAGENT_LABELS map', () => {
+    const humanized = buildHumanizedActivityLine('Agent', { subagent_type: 'researcher' })
+    expect(humanized).toBe('<b>searching and verifying sources</b>')
+    const snap: ActivitySnapshot = {
+      startedAtMs: 0,
+      calls: [{ toolName: 'Agent', detail: 'agent researcher', humanized }],
+      phase: 'tool',
+    }
+    const out = renderActivityBlock(snap, 0)
+    expect(out).toContain('▸ <b>searching and verifying sources</b>')
+  })
+
+  test('TodoWrite returns null → falls back to plain detail with single escape', () => {
+    const humanized = buildHumanizedActivityLine('TodoWrite', { todos: [] })
+    expect(humanized).toBeNull()
+    const snap: ActivitySnapshot = {
+      startedAtMs: 0,
+      calls: [{ toolName: 'TodoWrite', detail: 'todowrite', humanized }],
+      phase: 'tool',
+    }
+    const out = renderActivityBlock(snap, 0)
+    expect(out).toContain('▸ todowrite')
+  })
+
+  test('Unknown tool returns null → falls back to plain detail', () => {
+    const humanized = buildHumanizedActivityLine('Hypothetical', { a: 1 })
+    expect(humanized).toBeNull()
+    const snap: ActivitySnapshot = {
+      startedAtMs: 0,
+      calls: [{ toolName: 'Hypothetical', detail: 'hypothetical a=1', humanized }],
+      phase: 'tool',
+    }
+    const out = renderActivityBlock(snap, 0)
+    expect(out).toContain('▸ hypothetical a=1')
+  })
+
+  test('humanized line still masks long tokens after the fact', () => {
+    // buildHumanizedActivityLine applies mask at construction. Render
+    // re-masks defensively — verify a token added to humanized later still
+    // gets eaten by the render pass.
+    const tok = `abcd${'x'.repeat(20)}wxyz`
+    const snap: ActivitySnapshot = {
+      startedAtMs: 0,
+      calls: [{ toolName: 'Bash', detail: '', humanized: `running: <code>${tok}</code>` }],
+      phase: 'tool',
+    }
+    const out = renderActivityBlock(snap, 0)
+    expect(out).not.toContain(tok)
+    expect(out).toContain('abcd***wxyz')
+  })
+})
+
+describe('renderActivityBlock 4096-char cap (M2)', () => {
+  // Defensive — Telegram editMessageText rejects > 4096 chars. We cap the
+  // inner body at 3900 to leave room for the wrapping `<pre>` tags + safety.
+
+  test('50 long Bash calls truncate at line boundary with …+truncated marker', () => {
+    const big = 'x'.repeat(60)
+    const snap: ActivitySnapshot = {
+      startedAtMs: 0,
+      calls: Array.from({ length: 50 }, (_, i) => ({
+        toolName: 'Bash',
+        detail: `bash ${i.toString().padStart(3, '0')} ${big}`,
+      })),
+      phase: 'tool',
+    }
+    const out = renderActivityBlock(snap, 0)
+    expect(out.length).toBeLessThanOrEqual(4096)
+    // Truncation marker absent for short outputs — only present when we cut.
+    // 50 × 60+ = 3000+; with rolling window of 5 we only render 5 → no
+    // truncation in practice. Force a real overflow with humanized payload.
+    // Use punctuation-broken filler so the generic long-token mask (which
+    // chews ≥24-char `[A-Za-z0-9_-]` runs) doesn't collapse it.
+    const filler = ('AB. '.repeat(400)).slice(0, 1500)
+    const snap2: ActivitySnapshot = {
+      startedAtMs: 0,
+      calls: Array.from({ length: 5 }, (_, i) => ({
+        toolName: 'Bash',
+        detail: 'b',
+        humanized: `running: <code>${filler}-${i}</code>`,
+      })),
+      phase: 'tool',
+    }
+    const out2 = renderActivityBlock(snap2, 0)
+    expect(out2.length).toBeLessThanOrEqual(4096)
+    expect(out2).toContain('…+truncated')
+  })
+
+  test('normal-length output gets no truncation marker', () => {
+    const snap: ActivitySnapshot = {
+      startedAtMs: 0,
+      calls: [
+        { toolName: 'Bash', detail: 'bash one' },
+        { toolName: 'Bash', detail: 'bash two' },
+      ],
+      phase: 'tool',
+    }
+    const out = renderActivityBlock(snap, 0)
+    expect(out).not.toContain('…+truncated')
+  })
+})
+
+describe('IPv4 mask exemptions (M3)', () => {
+  test('127.x.x.x loopback is NOT masked', () => {
+    expect(maskSecrets('curl 127.0.0.1:8080')).toBe('curl 127.0.0.1:8080')
+    expect(maskSecrets('hit 127.0.0.1/health')).toBe('hit 127.0.0.1/health')
+  })
+
+  test('0.x.x.x placeholder is NOT masked', () => {
+    expect(maskSecrets('bind 0.0.0.0:80')).toBe('bind 0.0.0.0:80')
+  })
+
+  test('public IPv4 ranges still masked', () => {
+    expect(maskSecrets('curl 8.8.8.8')).toBe('curl 8.***.***.8')
+    expect(maskSecrets('connect 10.2.3.44 done')).toBe('connect 10.***.***.44 done')
+  })
+
+  test('::1 IPv6 loopback literal untouched (regex never matched it)', () => {
+    expect(maskSecrets('hit [::1]:443')).toBe('hit [::1]:443')
+  })
+
+  test('localhost literal untouched', () => {
+    expect(maskSecrets('http://localhost:8089')).toBe('http://localhost:8089')
   })
 })
 

--- a/plugin/tests/status/activity-renderer.test.ts
+++ b/plugin/tests/status/activity-renderer.test.ts
@@ -25,6 +25,17 @@ describe('maskSecrets', () => {
     expect(maskSecrets('~/.config/secrets/openviking.key')).not.toContain('openviking.key')
   })
 
+  test('masks anchored secrets/<file> after path summarization (regression)', () => {
+    // After lastTwoSegments collapse, an absolute path like
+    // /Users/x/.claude-lab/silvana/secrets/openviking.key becomes
+    // `secrets/openviking.key` — the legacy `~/.foo/secrets/...` rule no
+    // longer matches. Broadened rule must mask the filename.
+    expect(maskSecrets('read secrets/openviking.key')).toContain('secrets/***')
+    expect(maskSecrets('read secrets/openviking.key')).not.toContain('openviking.key')
+    // Bare leading form (no preceding space) — first char of string anchors too.
+    expect(maskSecrets('secrets/foo.key')).toBe('secrets/***')
+  })
+
   test('masks generic long tokens (≥24 chars)', () => {
     const tok = `abcd${'x'.repeat(20)}wxyz`
     const masked = maskSecrets(`bearer ${tok} ok`)
@@ -244,6 +255,24 @@ describe('buildActivityDetail', () => {
 
   test('omits summary if empty', () => {
     expect(buildActivityDetail('Read', {})).toBe('read')
+  })
+})
+
+describe('secret-path leak after summarization (regression)', () => {
+  test('Read of /Users/.../secrets/foo.key never reaches render unmasked', () => {
+    const absPath = '/Users/jasonqwwen/.claude-lab/silvana/secrets/openviking.key'
+    const detail = buildActivityDetail('Read', { file_path: absPath })
+    // Buffer-level: filename must be masked at store time.
+    expect(detail).not.toContain('openviking.key')
+    expect(detail).toContain('secrets/***')
+    const snap: ActivitySnapshot = {
+      startedAtMs: 0,
+      calls: [{ toolName: 'Read', detail }],
+      phase: 'tool',
+    }
+    const out = renderActivityBlock(snap, 0)
+    expect(out).not.toContain('openviking.key')
+    expect(out).toContain('secrets/***')
   })
 })
 

--- a/plugin/tests/status/activity-renderer.test.ts
+++ b/plugin/tests/status/activity-renderer.test.ts
@@ -69,8 +69,10 @@ describe('summarizeToolInput', () => {
     expect(summarizeToolInput('Bash', { command: long }).length).toBeLessThanOrEqual(40)
   })
 
-  test('Grep wraps pattern in quotes', () => {
-    expect(summarizeToolInput('Grep', { pattern: 'TODO' })).toBe('&quot;TODO&quot;')
+  test('Grep wraps pattern in quotes (raw, render escapes)', () => {
+    // summarizeToolInput returns the RAW logical content (no HTML escape).
+    // Escaping happens exactly once in renderActivityBlock.
+    expect(summarizeToolInput('Grep', { pattern: 'TODO' })).toBe('"TODO"')
   })
 
   test('Agent uses subagent_type', () => {
@@ -91,8 +93,9 @@ describe('summarizeToolInput', () => {
     expect(summarizeToolInput('Hypothetical', {})).toBe('')
   })
 
-  test('escapes HTML special chars', () => {
-    expect(summarizeToolInput('Bash', { command: '<script>' })).toBe('&lt;script&gt;')
+  test('returns raw text (renderer escapes once)', () => {
+    // No HTML escape here — render boundary is the only escape site.
+    expect(summarizeToolInput('Bash', { command: '<script>' })).toBe('<script>')
   })
 })
 
@@ -241,5 +244,39 @@ describe('buildActivityDetail', () => {
 
   test('omits summary if empty', () => {
     expect(buildActivityDetail('Read', {})).toBe('read')
+  })
+})
+
+describe('full pipeline escape round-trip (regression)', () => {
+  // Round-trip: mapper builds detail → renderer assembles <pre> body.
+  // Critical bug pre-fix: summarize escaped once, render escaped again,
+  // producing `&amp;quot;recordActivity&amp;quot;` instead of
+  // `&quot;recordActivity&quot;`. This test feeds a Grep pattern containing
+  // a quote through both stages and asserts single escape.
+  test('Grep pattern "recordActivity" survives mapper→renderer as single escape', () => {
+    const detail = buildActivityDetail('Grep', { pattern: 'recordActivity' })
+    const snap: ActivitySnapshot = {
+      startedAtMs: 0,
+      calls: [{ toolName: 'Grep', detail }],
+      phase: 'tool',
+    }
+    const out = renderActivityBlock(snap, 0)
+    // Single escape produces &quot; — double escape produces &amp;quot;
+    expect(out).toContain('&quot;recordActivity&quot;')
+    expect(out).not.toContain('&amp;quot;')
+    expect(out).not.toContain('&amp;amp;')
+  })
+
+  test('Bash <script> survives single-escape through full pipeline', () => {
+    const detail = buildActivityDetail('Bash', { command: '<script>alert(1)</script>' })
+    const snap: ActivitySnapshot = {
+      startedAtMs: 0,
+      calls: [{ toolName: 'Bash', detail }],
+      phase: 'tool',
+    }
+    const out = renderActivityBlock(snap, 0)
+    expect(out).toContain('&lt;script&gt;')
+    expect(out).not.toContain('&amp;lt;')
+    expect(out).not.toContain('<script>')
   })
 })

--- a/plugin/tests/status/status-manager.test.ts
+++ b/plugin/tests/status/status-manager.test.ts
@@ -594,4 +594,40 @@ describe('StatusManager.recordActivityByChatId', () => {
     expect(mgr.isActive('164795011')).toBe(false)
     api.api.sendMessage = origSend
   })
+
+  test('Agent tool_result is masked at store time (regression §7)', async () => {
+    // The activity buffer must never hold an unmasked secret-shaped string.
+    // Pre-fix: raw tool_result lived in `activityCalls[idx].detail` until
+    // render. Verify by triggering tool_end with a long token in toolResult
+    // and inspecting the subsequent edit text — the masked summary must
+    // appear in the very next render (proving the buffer already held it).
+    const { mgr, clock, api } = makeManager()
+    await mgr.start('164795011', undefined)
+
+    // Pair: PreToolUse with toolUseId → PostToolUse with same id.
+    await mgr.recordActivityByChatId('164795011', {
+      kind: 'tool_start',
+      toolName: 'Agent',
+      toolInput: { subagent_type: 'researcher' },
+      toolUseId: 'agent-1',
+    })
+
+    const longToken = `abcd${'x'.repeat(20)}wxyz` // matches generic-long rule
+    clock.advance(100)
+    const editsBefore = api.calls.filter((c) => c.kind === 'edit').length
+    await mgr.recordActivityByChatId('164795011', {
+      kind: 'tool_end',
+      toolName: 'Agent',
+      toolInput: { subagent_type: 'researcher' },
+      toolUseId: 'agent-1',
+      toolResult: longToken,
+    })
+    const editsAfter = api.calls.filter((c) => c.kind === 'edit')
+    expect(editsAfter.length).toBeGreaterThan(editsBefore)
+    const lastEdit = editsAfter[editsAfter.length - 1]!
+    // Token must not appear anywhere in the rendered text; the masked
+    // form (abcd***wxyz) confirms maskSecrets ran before store.
+    expect(lastEdit.text).not.toContain(longToken)
+    expect(lastEdit.text).toContain('abcd***wxyz')
+  })
 })

--- a/plugin/tests/status/status-manager.test.ts
+++ b/plugin/tests/status/status-manager.test.ts
@@ -427,3 +427,171 @@ describe('StatusManager.activeChatIds', () => {
     expect(ids).toEqual(['164795011', '200'])
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────
+// Phase 7 / T3: recordActivityByChatId — Claude hook integration.
+// ─────────────────────────────────────────────────────────────────────
+
+describe('StatusManager.recordActivityByChatId', () => {
+  test('PreToolUse on existing status renders activity block edit', async () => {
+    const { mgr, api } = makeManager()
+    await mgr.start('164795011', undefined)
+    await mgr.recordActivityByChatId('164795011', {
+      kind: 'tool_start',
+      toolName: 'Bash',
+      toolInput: { command: 'bun test' },
+      toolUseId: 'u1',
+    })
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    const last = edits[edits.length - 1]!
+    expect(last.text).toContain('<pre>')
+    expect(last.text).toContain('working --')
+    expect(last.text).toContain('bash bun test')
+  })
+
+  test('SessionStart with no active status opens one without reply_to', async () => {
+    const { mgr, api } = makeManager()
+    await mgr.recordActivityByChatId('164795011', { kind: 'session_start' })
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(1)
+    expect(sends[0]!.chatId).toBe('164795011')
+    const opts = sends[0]!.opts as { reply_to_message_id?: number }
+    expect(opts.reply_to_message_id).toBeUndefined()
+    expect(mgr.isActive('164795011')).toBe(true)
+  })
+
+  test('Stop calls complete() and stops timers', async () => {
+    const { mgr, api } = makeManager()
+    await mgr.start('164795011', undefined)
+    await mgr.recordActivityByChatId('164795011', { kind: 'session_stop' })
+    expect(mgr.isActive('164795011')).toBe(false)
+    // delete_on_complete=true by default → expect one delete call.
+    const deletes = api.calls.filter((c) => c.kind === 'delete')
+    expect(deletes.length).toBe(1)
+  })
+
+  test('Agent PreToolUse renders immediately even within throttle window', async () => {
+    const { mgr, api, clock } = makeManager()
+    await mgr.start('164795011', undefined)
+    // First non-Agent record sets lastToolRenderAt.
+    await mgr.recordActivityByChatId('164795011', {
+      kind: 'tool_start',
+      toolName: 'Bash',
+      toolInput: { command: 'echo hi' },
+      toolUseId: 'u1',
+    })
+    const beforeAgent = api.calls.filter((c) => c.kind === 'edit').length
+    // Within 5 s — non-Agent would NOT trigger an edit. Agent must.
+    clock.advance(100)
+    await mgr.recordActivityByChatId('164795011', {
+      kind: 'tool_start',
+      toolName: 'Agent',
+      toolInput: { subagent_type: 'researcher' },
+      toolUseId: 'u2',
+    })
+    const afterAgent = api.calls.filter((c) => c.kind === 'edit').length
+    expect(afterAgent).toBeGreaterThan(beforeAgent)
+    const last = api.calls.filter((c) => c.kind === 'edit').pop()!
+    expect(last.text).toContain('agent researcher')
+  })
+
+  test('Non-Agent PreToolUse within 5s is recorded but not re-rendered', async () => {
+    // Use a very long interval_ms so the dot-animation ticker doesn't add
+    // noise edits between our two record calls.
+    const config = makeConfig({ interval_ms: 100_000_000 })
+    const { mgr, api, clock } = makeManager({ config })
+    await mgr.start('164795011', undefined)
+    // First non-Agent renders immediately (sentinel → past threshold).
+    await mgr.recordActivityByChatId('164795011', {
+      kind: 'tool_start',
+      toolName: 'Bash',
+      toolInput: { command: 'one' },
+      toolUseId: 'u1',
+    })
+    const editsAfterFirst = api.calls.filter((c) => c.kind === 'edit').length
+    // Second one within 5 s — throttled, no new edit.
+    clock.advance(2000)
+    await mgr.recordActivityByChatId('164795011', {
+      kind: 'tool_start',
+      toolName: 'Bash',
+      toolInput: { command: 'two' },
+      toolUseId: 'u2',
+    })
+    expect(api.calls.filter((c) => c.kind === 'edit').length).toBe(editsAfterFirst)
+    // PostToolUse (reasoning flip) flushes the buffer — must include `two`.
+    await mgr.recordActivityByChatId('164795011', {
+      kind: 'tool_end',
+      toolName: 'Bash',
+      toolInput: { command: 'two' },
+      toolUseId: 'u2',
+    })
+    const lastEdit = api.calls.filter((c) => c.kind === 'edit').pop()!
+    expect(lastEdit.text).toContain('bash two')
+    expect(lastEdit.text).toContain('reasoning...')
+  })
+
+  test('UserPromptSubmit flips phase to reasoning and renders', async () => {
+    const { mgr, api } = makeManager()
+    await mgr.start('164795011', undefined)
+    await mgr.recordActivityByChatId('164795011', {
+      kind: 'tool_start',
+      toolName: 'Bash',
+      toolInput: { command: 'ls /' },
+      toolUseId: 'u1',
+    })
+    await mgr.recordActivityByChatId('164795011', { kind: 'reasoning' })
+    const last = api.calls.filter((c) => c.kind === 'edit').pop()!
+    expect(last.text).toContain('reasoning...')
+  })
+
+  test('mid-render does not leak raw prompt text through ActivityEvent', async () => {
+    const { mgr, api } = makeManager()
+    // session_start with no prior status → opens. Then a reasoning event
+    // shouldn't carry any user prompt body because the mapping drops it.
+    await mgr.recordActivityByChatId('164795011', { kind: 'session_start' })
+    await mgr.recordActivityByChatId('164795011', { kind: 'reasoning' })
+    const everything = api.calls.map((c) => c.text ?? '').join('\n')
+    expect(everything).not.toContain('prompt')
+    expect(everything).toContain('working --')
+  })
+
+  test('Buffer enforces ACTIVITY_MAX_BUFFER (10) — older shifted out', async () => {
+    const { mgr, api, clock } = makeManager()
+    await mgr.start('164795011', undefined)
+    // Push 12 Agent calls — Agent always renders, so we exercise the path
+    // where the buffer caps and the renderer still shows +N earlier.
+    for (let i = 0; i < 12; i++) {
+      await mgr.recordActivityByChatId('164795011', {
+        kind: 'tool_start',
+        toolName: 'Agent',
+        toolInput: { subagent_type: `subagent-${i}` },
+        toolUseId: `u${i}`,
+      })
+      clock.advance(1)
+    }
+    const last = api.calls.filter((c) => c.kind === 'edit').pop()!
+    // 12 pushed, buffer capped at 10 → 0 and 1 evicted, 2..11 retained.
+    // Use unique trailing suffix to avoid substring overlap with -10/-11.
+    expect(last.text).not.toMatch(/subagent-0[^0-9]/)
+    expect(last.text).not.toMatch(/subagent-1[^0-9]/)
+    expect(last.text).toContain('subagent-11')
+    expect(last.text).toContain('subagent-10')
+    // Renderer window is 5 → "+N earlier" line appears (10 retained, 5 shown).
+    expect(last.text).toContain('earlier')
+  })
+
+  test('Visibility failure during lazy-open is swallowed', async () => {
+    const { mgr, api } = makeManager()
+    api.failEditWith = new Error('sendMessage simulated fail')
+    // Force sendMessage to throw by overriding the api's send method.
+    const origSend = api.api.sendMessage
+    api.api.sendMessage = async () => {
+      throw new Error('telegram down')
+    }
+    // Must not throw.
+    await mgr.recordActivityByChatId('164795011', { kind: 'session_start' })
+    // No active status created → no further calls succeed silently.
+    expect(mgr.isActive('164795011')).toBe(false)
+    api.api.sendMessage = origSend
+  })
+})

--- a/plugin/tests/status/status-manager.test.ts
+++ b/plugin/tests/status/status-manager.test.ts
@@ -446,7 +446,8 @@ describe('StatusManager.recordActivityByChatId', () => {
     const last = edits[edits.length - 1]!
     expect(last.text).toContain('<pre>')
     expect(last.text).toContain('working --')
-    expect(last.text).toContain('bash bun test')
+    // Humanized line: Bash non-curl/git/read → `running: <code>cmd</code>`
+    expect(last.text).toContain('running: <code>bun test</code>')
   })
 
   test('SessionStart with no active status opens one without reply_to', async () => {
@@ -492,7 +493,8 @@ describe('StatusManager.recordActivityByChatId', () => {
     const afterAgent = api.calls.filter((c) => c.kind === 'edit').length
     expect(afterAgent).toBeGreaterThan(beforeAgent)
     const last = api.calls.filter((c) => c.kind === 'edit').pop()!
-    expect(last.text).toContain('agent researcher')
+    // Humanized Agent line uses SUBAGENT_LABELS map for `researcher`.
+    expect(last.text).toContain('<b>searching and verifying sources</b>')
   })
 
   test('Non-Agent PreToolUse within 5s is recorded but not re-rendered', async () => {
@@ -526,7 +528,8 @@ describe('StatusManager.recordActivityByChatId', () => {
       toolUseId: 'u2',
     })
     const lastEdit = api.calls.filter((c) => c.kind === 'edit').pop()!
-    expect(lastEdit.text).toContain('bash two')
+    // Humanized: Bash non-curl/git/read → `running: <code>two</code>`
+    expect(lastEdit.text).toContain('running: <code>two</code>')
     expect(lastEdit.text).toContain('reasoning...')
   })
 

--- a/plugin/tests/status/status-manager.test.ts
+++ b/plugin/tests/status/status-manager.test.ts
@@ -633,4 +633,45 @@ describe('StatusManager.recordActivityByChatId', () => {
     expect(lastEdit.text).not.toContain(longToken)
     expect(lastEdit.text).toContain('abcd***wxyz')
   })
+
+  test('Non-Agent throttle + buffer overflow interaction (coverage gap §3)', async () => {
+    // Fire 12 Bash calls in quick succession. First non-Agent always renders
+    // (sentinel `Number.NEGATIVE_INFINITY`); subsequent calls within the
+    // 5 s throttle are buffered without an extra edit. Buffer cap is 10 →
+    // calls 0 and 1 evict; render window is 5 → on the eventual flush the
+    // edit shows the most recent 5 + a `+5 earlier` summary (10 buffered − 5
+    // shown). Flush via a `reasoning` event since it always renders.
+    const config = makeConfig({ interval_ms: 100_000_000 })
+    const { mgr, api, clock } = makeManager({ config })
+    await mgr.start('164795011', undefined)
+
+    const editsAtStart = api.calls.filter((c) => c.kind === 'edit').length
+    for (let i = 0; i < 12; i++) {
+      await mgr.recordActivityByChatId('164795011', {
+        kind: 'tool_start',
+        toolName: 'Bash',
+        toolInput: { command: `cmd-${i.toString().padStart(2, '0')}` },
+        toolUseId: `u${i}`,
+      })
+      // Stay well within the 5 s throttle window so only the first renders.
+      clock.advance(100)
+    }
+    // Only the first Bash should have triggered an edit (sentinel render);
+    // remaining 11 were throttled.
+    const editsAfterTools = api.calls.filter((c) => c.kind === 'edit').length
+    expect(editsAfterTools - editsAtStart).toBe(1)
+
+    // Flush via reasoning event → always renders.
+    await mgr.recordActivityByChatId('164795011', { kind: 'reasoning' })
+    const last = api.calls.filter((c) => c.kind === 'edit').pop()!
+    // Buffer kept the last 10 (cmd-02..cmd-11). Renderer window is 5 →
+    // show cmd-07..cmd-11 + a `+5 earlier` line (10 buffered − 5 shown).
+    expect(last.text).toContain('+5 earlier')
+    expect(last.text).toContain('cmd-11')
+    expect(last.text).toContain('cmd-07')
+    // cmd-00 and cmd-01 evicted; cmd-02..cmd-06 in the +5 collapse.
+    expect(last.text).not.toContain('cmd-00')
+    expect(last.text).not.toContain('cmd-01')
+    expect(last.text).not.toContain('cmd-06')
+  })
 })

--- a/plugin/tests/webhook/server.test.ts
+++ b/plugin/tests/webhook/server.test.ts
@@ -631,6 +631,39 @@ describe('POST /hooks/agent — Claude hook payload branch', () => {
     expect(resp.status).toBe(200)
   })
 
+  test('config.status.enabled=false → hook payload accepted but no dispatch', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    // Override status.enabled to false on top of webhook-enabled config.
+    const cfg: AppConfig = {
+      ...enabledConfig(),
+      status: { ...baseConfig.status, enabled: false },
+    }
+    const { handle: h, status, mcp } = await startEnabledWithStatus(cfg)
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        hook_event_name: 'PreToolUse',
+        session_id: 's1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+        tool_name: 'Read',
+        tool_use_id: 'u1',
+        tool_input: { file_path: '/x/y.ts' },
+      }),
+    })
+    expect(resp.status).toBe(200)
+    const body = (await resp.json()) as Record<string, unknown>
+    expect(body.status).toBe('accepted')
+    expect(body.note).toBe('status_disabled')
+    expect(status.calls.length).toBe(0)
+    expect(mcp.calls.length).toBe(0)
+  })
+
   test('message payload path is unchanged when statusManager is wired', async () => {
     process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
     const { handle: h, mcp, status } = await startEnabledWithStatus(enabledConfig())

--- a/plugin/tests/webhook/server.test.ts
+++ b/plugin/tests/webhook/server.test.ts
@@ -228,6 +228,26 @@ describe('POST /hooks/agent', () => {
     expect(resp.status).toBe(401)
   })
 
+  test('bearer of different length returns 401 (no length-leak path) (M4)', async () => {
+    // After the M4 fix bearerEquals pads both sides to the same fixed
+    // length and combines the byte-compare with an explicit length-equality
+    // bit. Differing-length tokens — both shorter and longer than the
+    // configured one — must still produce 401 cleanly.
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { handle: h } = await startEnabled(enabledConfig())
+    for (const token of ['short', `${WEBHOOK_TOKEN}_with_extra_tail`, '']) {
+      const resp = await fetch(url(h, '/hooks/agent'), {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ message: 'x', chatId: 164795011 }),
+      })
+      expect(resp.status).toBe(401)
+    }
+  })
+
   test('without configured token returns 503', async () => {
     // No env token set => any auth fails with 503 (gateway.py:3535-3537 parity).
     const { handle: h } = await startEnabled(enabledConfig())

--- a/plugin/tests/webhook/server.test.ts
+++ b/plugin/tests/webhook/server.test.ts
@@ -100,6 +100,8 @@ function url(h: WebhookServerHandle, path: string): string {
 describe('validateWebhookPayload', () => {
   test('accepts {message, chatId} numeric', () => {
     const p = validateWebhookPayload({ message: 'hi', chatId: 164795011 })
+    expect(p.kind).toBe('message')
+    if (p.kind !== 'message') throw new Error('unreachable')
     expect(p.message).toBe('hi')
     expect(p.chatId).toBe('164795011')
     expect(p.agentId).toBeUndefined()
@@ -374,5 +376,274 @@ describe('POST /hooks/agent', () => {
     // small enough to succeed (200). Either reject path is acceptable: this
     // test mainly proves we don't crash. Assert non-5xx.
     expect(resp.status).toBeLessThan(500)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// Phase 7 / T4: Claude hook branch — chatId allowlist, agentId guard,
+// status-manager dispatch, MCP channel must NOT fire.
+// ─────────────────────────────────────────────────────────────────────
+
+interface StatusStubCall {
+  chatId: string
+  event: { kind: string } & Record<string, unknown>
+}
+
+function makeStatusStub(): {
+  manager: { recordActivityByChatId: (chatId: string, event: unknown) => Promise<void> }
+  calls: StatusStubCall[]
+} {
+  const calls: StatusStubCall[] = []
+  return {
+    manager: {
+      recordActivityByChatId: async (chatId: string, event: unknown) => {
+        calls.push({ chatId, event: event as StatusStubCall['event'] })
+      },
+    },
+    calls,
+  }
+}
+
+async function startEnabledWithStatus(config: AppConfig): Promise<{
+  handle: WebhookServerHandle
+  mcp: ReturnType<typeof makeMcpStub>
+  status: ReturnType<typeof makeStatusStub>
+}> {
+  const mcp = makeMcpStub()
+  const status = makeStatusStub()
+  const h = await startWebhookServer(config, {
+    mcpServer: mcp.server,
+    config,
+    statePaths: paths,
+    log: createLogger('test'),
+    statusManager: status.manager,
+  })
+  if (!h) throw new Error('expected handle')
+  handle = h
+  return { handle: h, mcp, status }
+}
+
+describe('POST /hooks/agent — Claude hook payload branch', () => {
+  test('valid PreToolUse dispatches to statusManager, no MCP channel call', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { handle: h, mcp, status } = await startEnabledWithStatus(enabledConfig())
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        agentId: 'dashi-channel',
+        hook_event_name: 'PreToolUse',
+        session_id: 's1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+        permission_mode: 'default',
+        tool_name: 'Read',
+        tool_use_id: 'u1',
+        tool_input: { file_path: '/repo/plugin/src/server.ts' },
+      }),
+    })
+    expect(resp.status).toBe(200)
+    const body = (await resp.json()) as Record<string, unknown>
+    expect(body.status).toBe('accepted')
+    expect(mcp.calls).toEqual([])
+    expect(status.calls.length).toBe(1)
+    expect(status.calls[0]!.chatId).toBe('164795011')
+    expect(status.calls[0]!.event.kind).toBe('tool_start')
+  })
+
+  test('Stop payload maps to session_stop', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { handle: h, status } = await startEnabledWithStatus(enabledConfig())
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        hook_event_name: 'Stop',
+        session_id: 's1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+      }),
+    })
+    expect(resp.status).toBe(200)
+    expect(status.calls[0]!.event.kind).toBe('session_stop')
+  })
+
+  test('UserPromptSubmit does NOT leak prompt into status event', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { handle: h, status } = await startEnabledWithStatus(enabledConfig())
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        hook_event_name: 'UserPromptSubmit',
+        session_id: 's1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+        prompt: 'Top secret user question',
+      }),
+    })
+    expect(resp.status).toBe(200)
+    expect(status.calls[0]!.event.kind).toBe('reasoning')
+    expect(JSON.stringify(status.calls)).not.toContain('Top secret user question')
+  })
+
+  test('hook payload with non-allowlisted chatId returns 403, no status dispatch', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { handle: h, status } = await startEnabledWithStatus(enabledConfig())
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 999999999,
+        hook_event_name: 'Stop',
+        session_id: 's1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+      }),
+    })
+    expect(resp.status).toBe(403)
+    expect(status.calls.length).toBe(0)
+  })
+
+  test('hook payload with unknown agentId returns 404', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { handle: h, status } = await startEnabledWithStatus(enabledConfig())
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        agentId: 'someone-else',
+        hook_event_name: 'Stop',
+        session_id: 's1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+      }),
+    })
+    expect(resp.status).toBe(404)
+    expect(status.calls.length).toBe(0)
+  })
+
+  test('invalid hook payload (missing required field) dead-letters + 400', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { handle: h, status } = await startEnabledWithStatus(enabledConfig())
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        hook_event_name: 'PreToolUse',
+        session_id: 's1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+        // Missing tool_name, tool_use_id, tool_input.
+      }),
+    })
+    expect(resp.status).toBe(400)
+    expect(status.calls.length).toBe(0)
+    const dlFiles = readdirSync(paths.deadLetterWebhook)
+    expect(dlFiles.length).toBeGreaterThanOrEqual(1)
+  })
+
+  test('hook payload with no statusManager returns 200 (visibility outage tolerated)', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const mcp = makeMcpStub()
+    const cfg = enabledConfig()
+    const h = await startWebhookServer(cfg, {
+      mcpServer: mcp.server,
+      config: cfg,
+      statePaths: paths,
+      log: createLogger('test'),
+      // No statusManager intentionally.
+    })
+    if (!h) throw new Error('expected handle')
+    handle = h
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        hook_event_name: 'Stop',
+        session_id: 's1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+      }),
+    })
+    expect(resp.status).toBe(200)
+    expect(mcp.calls.length).toBe(0)
+  })
+
+  test('hook payload — statusManager throw still returns 200', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const cfg = enabledConfig()
+    const mcp = makeMcpStub()
+    const h = await startWebhookServer(cfg, {
+      mcpServer: mcp.server,
+      config: cfg,
+      statePaths: paths,
+      log: createLogger('test'),
+      statusManager: {
+        recordActivityByChatId: async () => {
+          throw new Error('Telegram down')
+        },
+      },
+    })
+    if (!h) throw new Error('expected handle')
+    handle = h
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        hook_event_name: 'Stop',
+        session_id: 's1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+      }),
+    })
+    expect(resp.status).toBe(200)
+  })
+
+  test('message payload path is unchanged when statusManager is wired', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { handle: h, mcp, status } = await startEnabledWithStatus(enabledConfig())
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ message: 'legacy hello', chatId: 164795011 }),
+    })
+    expect(resp.status).toBe(200)
+    expect(mcp.calls.length).toBe(1)
+    expect(status.calls.length).toBe(0)
   })
 })

--- a/plugin/tests/webhook/server.test.ts
+++ b/plugin/tests/webhook/server.test.ts
@@ -114,6 +114,28 @@ describe('validateWebhookPayload', () => {
   test('rejects missing chatId', () => {
     expect(() => validateWebhookPayload({ message: 'x' })).toThrow(/invalid webhook payload/)
   })
+
+  test('discriminator: hook_event_name presence routes to claude_hook (not message)', () => {
+    // Pre-fix: union evaluated message-first; this payload matched message
+    // and the hook fields were silently dropped. Post-fix: hook_event_name
+    // routes to the hook schema even when `message` is present.
+    const p = validateWebhookPayload({
+      message: 'this should NOT win',
+      chatId: 164795011,
+      hook_event_name: 'PreToolUse',
+      session_id: 's1',
+      transcript_path: '/tmp/t.jsonl',
+      cwd: '/tmp',
+      tool_name: 'Read',
+      tool_use_id: 'u1',
+      tool_input: { file_path: '/x/y.ts' },
+    })
+    expect(p.kind).toBe('claude_hook')
+    if (p.kind !== 'claude_hook') throw new Error('unreachable')
+    expect(p.hook_event_name).toBe('PreToolUse')
+    if (p.hook_event_name !== 'PreToolUse') throw new Error('unreachable')
+    expect(p.tool_name).toBe('Read')
+  })
 })
 
 // ─────────────────────────────────────────────────────────────────────

--- a/plugin/tests/webhook/server.test.ts
+++ b/plugin/tests/webhook/server.test.ts
@@ -115,6 +115,27 @@ describe('validateWebhookPayload', () => {
     expect(() => validateWebhookPayload({ message: 'x' })).toThrow(/invalid webhook payload/)
   })
 
+  test('Zod issue summary is capped at 512 chars (L2)', () => {
+    // Pre-fix: a deeply-nested or discriminated-union failure could amplify
+    // a single bad request into a kilobyte-long error string that landed in
+    // both the 400 response body and the dead-letter file. Cap is 512 chars
+    // on the appended `summary` slice. Total Error message includes the
+    // `invalid webhook payload: ` prefix (~25 chars), so message ≤ ~540.
+    let caught: unknown
+    try {
+      // Use a payload that's the wrong shape entirely — Zod produces several
+      // issues for the union failure.
+      validateWebhookPayload({ junk: 'x'.repeat(2000), more_junk: 'y'.repeat(2000) })
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(Error)
+    const msg = (caught as Error).message
+    expect(msg.startsWith('invalid webhook payload: ')).toBe(true)
+    // Prefix + capped summary should be well below 600 chars.
+    expect(msg.length).toBeLessThanOrEqual(600)
+  })
+
   test('discriminator: hook_event_name presence routes to claude_hook (not message)', () => {
     // Pre-fix: union evaluated message-first; this payload matched message
     // and the hook fields were silently dropped. Post-fix: hook_event_name

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -19,6 +19,6 @@
     "verbatimModuleSyntax": false,
     "types": ["bun-types"]
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "include": ["src/**/*.ts", "tests/**/*.ts", "scripts/**/*.ts"],
   "exclude": ["node_modules", "refs", "state"]
 }


### PR DESCRIPTION
## Summary

Adds Claude Code agent hook integration so Telegram users see live tool calls (Bash/Read/Edit/Grep/etc.) and reasoning phases — Jarvis (Python gateway.py) parity.

Pipeline: agent hooks → `post-hook.ts` (stdin → bearer auth POST) → plugin `/hooks/agent` → `StatusManager.recordActivityByChatId` → rolling 5-call `<pre>` block in Telegram status message.

## What's in

- **T1** — 5 Claude hook schemas (PreToolUse/PostToolUse/Stop/UserPromptSubmit/SessionStart) with Zod validation
- **T2** — Tool humanization (Bash special cases: curl→«calling API», git→«git command», cat/grep/etc.→«reading files») + rolling activity renderer with 5-call window, +N earlier line, secret masking
- **T3** — `StatusManager` activity state + `recordActivityByChatId` (4-second throttle, fake-clock injectable)
- **T4** — Webhook `/hooks/agent` branches on `payload.kind`, gated on `config.status.enabled`
- **T5** — `scripts/post-hook.ts` — stdin → POST with bearer, exits 0 on transport failure (never blocks agent)
- **T6** — `scripts/install-hooks.sh` + `patch-claude-settings.ts` — idempotent JSON patch, marker-based replacement, same-dir atomic write
- **T7** — End-to-end install test exercising the real shell script

## Review-loop fixes

**Iter 1** (1 critical + 6 high closed):
- Double HTML escape in activity render (`&amp;quot;` instead of `&quot;`)
- `config.status.enabled=false` ignored for hook payloads
- Payload discriminator routes by `hook_event_name` BEFORE union match
- Secret paths leak after `secrets/<file>` summarization
- `writeAtomic` EXDEV — stage tmp in same dir as target
- Markerless legacy entries accumulating on re-install
- Agent `tool_result` masked at store time (not just render)

**Iter 2** (7 medium/low + coverage gap):
- M1 `humanizeTool` wired into render
- M2 4096-char defensive `<pre>` cap
- M3 IPv4 mask exempts loopback (127.*, 0.*, ::1)
- M4 `bearerEquals` pads both sides to fixed length (timing-safe)
- M5 `fileURLToPath(import.meta.url)` — Node-portable default helper resolver
- L1 idiomatic `Bun.stdin` typing
- L2 Zod summary capped at 512 chars
- L3 install-hooks.sh rejects non-http(s) URLs (file://, javascript:)
- Coverage — non-Agent throttle + buffer overflow interaction test

## Tests

- 359 pass / 0 fail / 967 expect() — bun test
- bun run typecheck — clean (strict mode, exactOptionalPropertyTypes, noUncheckedIndexedAccess)
- 20 new tests (+ install-hooks E2E with URL validation, writeAtomic regression, applyPatch markerless-legacy)

## Loop-coding run

`.claude-lab/silvana/.claude/loop-coding-runs/2026-05-15-jarvis-parity-hooks/` — RESEARCH.md, PLAN.md (Codex GPT-5.5), REVIEW.md (merged Codex + Opus), implementation/iter-1/iter-2 logs.

## Test plan

- [ ] CI: bun test green on Ubuntu + macOS
- [ ] CI: tsc --noEmit clean
- [ ] Smoke: `bash plugin/scripts/install-hooks.sh --settings ~/.claude/settings.json --chat-id <id> --webhook-url http://127.0.0.1:8089/hooks/agent --agent-id dashi-channel` patches settings.json
- [ ] Smoke: launch agent → run Bash tool → Telegram status shows `<pre>` with tool call
- [ ] Smoke: PreToolUse + PostToolUse + Stop all visible in rolling window
- [ ] Idempotency: second install run does not duplicate hook entries
- [ ] Production cutover deferred to separate run (per-agent plists, prince approval required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)