### PR TITLE
feat(phase8): memory hooks parity — recent.md + verbose.jsonl writers

### DIFF
--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -48,6 +48,37 @@ export const AppConfigSchema = z.object({
     reset: z.boolean().default(true),
     new: z.boolean().default(true),
   }).default({}),
+  // Phase 8: Memory hooks parity with gateway.py:1938-2035. When a Claude
+  // hook (UserPromptSubmit / Stop) fires, the plugin writes a turn entry to
+  // <workspace_path>/core/hot/recent.md and a lossless record to
+  // <workspace_parent>/logs/verbose-YYYY-MM-DD.jsonl.
+  //
+  // Deviation from PLAN.md T1: `enabled` defaults to false (plan said true).
+  // With default-true, parsing the bare default ({}) trips the superRefine
+  // below because workspace_path is required when enabled — that would
+  // break every existing test fixture that calls loadConfig() without a
+  // memory block. enabled=false off-by-default matches the runtime gate
+  // in T7 ("instantiate when enabled=true AND workspace_path set"). The
+  // refine still triggers when enabled is explicitly turned on without a
+  // workspace, which is the only assertion T1's acceptance demands.
+  memory: z.object({
+    enabled: z.boolean().default(false),
+    workspace_path: z.string().optional(),
+    logs_path: z.string().optional(),
+    source_tag: z.string().default('tg'),
+    agent_label: z.string().optional(),
+    max_hot_bytes: z.number().int().positive().default(20480),
+    trim_keep_lines: z.number().int().positive().default(600),
+    buffer_ttl_ms: z.number().int().positive().default(5 * 60 * 1000),
+    buffer_max_entries: z.number().int().positive().default(100),
+  }).default({}).superRefine((m, ctx) => {
+    if (m.enabled && (m.workspace_path === undefined || m.workspace_path === '')) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'memory.workspace_path required when memory.enabled=true',
+      })
+    }
+  }),
 })
 export type AppConfig = z.infer<typeof AppConfigSchema>
 
@@ -68,6 +99,17 @@ export const RuntimeEnvSchema = z.object({
   TELEGRAM_WEBHOOK_HOST: z.string().optional(),
   TELEGRAM_WEBHOOK_PORT: z.coerce.number().int().min(0).optional(),
   TELEGRAM_WEBHOOK_TOKEN: z.string().optional(),
+  // Phase 8 memory env overrides. ENABLED accepts the usual truthy strings
+  // (1/true/yes, case-insensitive); anything else parses as false so a
+  // typo doesn't silently turn the feature on.
+  TELEGRAM_MEMORY_ENABLED: z
+    .string()
+    .transform((v) => /^(1|true|yes|on)$/i.test(v))
+    .optional(),
+  TELEGRAM_MEMORY_WORKSPACE: z.string().optional(),
+  TELEGRAM_MEMORY_LOGS_PATH: z.string().optional(),
+  TELEGRAM_MEMORY_SOURCE_TAG: z.string().optional(),
+  TELEGRAM_MEMORY_AGENT_LABEL: z.string().optional(),
   // PLAN.md Scope A only ships static allowlist mode; `pairing` is reserved
   // for Scope B. We accept both values at the schema level so we can emit
   // a clear, scope-aware error message (the bare `z.enum(['static'])` form
@@ -204,6 +246,15 @@ export function loadConfig(env: NodeJS.ProcessEnv): AppConfig {
   if (parsedEnv.TELEGRAM_WEBHOOK_HOST !== undefined) webhook.host = parsedEnv.TELEGRAM_WEBHOOK_HOST
   if (parsedEnv.TELEGRAM_WEBHOOK_PORT !== undefined) webhook.port = parsedEnv.TELEGRAM_WEBHOOK_PORT
   if (Object.keys(webhook).length > 0) merged.webhook = webhook
+
+  // Phase 8 memory env overrides.
+  const memory = (merged.memory && typeof merged.memory === 'object' ? merged.memory : {}) as Record<string, unknown>
+  if (parsedEnv.TELEGRAM_MEMORY_ENABLED !== undefined) memory.enabled = parsedEnv.TELEGRAM_MEMORY_ENABLED
+  if (parsedEnv.TELEGRAM_MEMORY_WORKSPACE !== undefined) memory.workspace_path = parsedEnv.TELEGRAM_MEMORY_WORKSPACE
+  if (parsedEnv.TELEGRAM_MEMORY_LOGS_PATH !== undefined) memory.logs_path = parsedEnv.TELEGRAM_MEMORY_LOGS_PATH
+  if (parsedEnv.TELEGRAM_MEMORY_SOURCE_TAG !== undefined) memory.source_tag = parsedEnv.TELEGRAM_MEMORY_SOURCE_TAG
+  if (parsedEnv.TELEGRAM_MEMORY_AGENT_LABEL !== undefined) memory.agent_label = parsedEnv.TELEGRAM_MEMORY_AGENT_LABEL
+  if (Object.keys(memory).length > 0) merged.memory = memory
 
   try {
     return AppConfigSchema.parse(merged)

--- a/plugin/src/memory/_mutex.ts
+++ b/plugin/src/memory/_mutex.ts
@@ -1,0 +1,46 @@
+// Phase 8 — shared intra-process async mutex.
+//
+// Extracted from hot-writer.ts so verbose-writer can share the exact same
+// primitive without duplicating the class. Underscore prefix marks this
+// module as internal to the memory/ barrel; callers outside memory/ should
+// not import it directly.
+
+/**
+ * Async mutex. Each instance serialises async callers — `run()` awaits
+ * the previous holder before invoking `fn` and only releases when `fn`
+ * settles (success or throw).
+ */
+export class Mutex {
+  private p: Promise<void> = Promise.resolve()
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    const prev = this.p
+    let release!: () => void
+    this.p = new Promise<void>((r) => {
+      release = r
+    })
+    await prev
+    try {
+      return await fn()
+    } finally {
+      release()
+    }
+  }
+}
+
+/**
+ * In-process async mutex registry keyed by absolute file path.
+ * Single-writer-per-process invariant: the map grows only when callers
+ * pass distinct paths (in production, exactly one per plugin process).
+ * Tests using mkdtemp may grow the map within a single run — acceptable
+ * because test processes are short-lived.
+ */
+const locks = new Map<string, Mutex>()
+
+export function lockFor(path: string): Mutex {
+  let m = locks.get(path)
+  if (!m) {
+    m = new Mutex()
+    locks.set(path, m)
+  }
+  return m
+}

--- a/plugin/src/memory/hot-writer.ts
+++ b/plugin/src/memory/hot-writer.ts
@@ -119,10 +119,15 @@ export async function appendHotEntry(
 }
 
 /**
- * Collapse newlines to spaces and slice to `max` chars. Used for both
- * user and agent snippets so a multi-line prompt doesn't break the
+ * Collapse newlines to spaces and slice to `max` code points. Used for
+ * both user and agent snippets so a multi-line prompt doesn't break the
  * `### header` / `**User:**` / `**Agent:**` four-line shape.
+ *
+ * Slicing uses `Array.from` so we count Unicode code points (matches
+ * Python `s[:200]`) rather than UTF-16 code units. Emoji-heavy prompts
+ * (Telegram!) would otherwise under-truncate or split a surrogate pair
+ * mid-codepoint, producing an invalid UTF-8 sequence in recent.md.
  */
 export function snippet(s: string, max = 200): string {
-  return (s || '').replace(/\n/g, ' ').slice(0, max)
+  return Array.from((s || '').replace(/\n/g, ' ')).slice(0, max).join('')
 }

--- a/plugin/src/memory/hot-writer.ts
+++ b/plugin/src/memory/hot-writer.ts
@@ -12,7 +12,7 @@
 // rename()'d into place — same-dir guarantees an atomic move on the
 // agent's workspace filesystem (no EXDEV across /tmp boundaries).
 
-import { appendFile, mkdir, readFile, rename, stat, writeFile } from 'node:fs/promises'
+import { appendFile, mkdir, readFile, rename, stat, unlink, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
 import { lockFor } from './_mutex.js'
@@ -42,14 +42,30 @@ export interface AppendHotInput {
   trimKeepLines: number
 }
 
+// Dependency-injection seam for the trim-path fs operations. Production
+// uses node:fs/promises; tests can pass a partial override to force
+// failure modes (e.g. rename throws EBUSY) and assert orphan cleanup.
+export interface TrimFsDeps {
+  writeFile: typeof writeFile
+  rename: typeof rename
+  unlink: typeof unlink
+}
+const defaultTrimDeps: TrimFsDeps = { writeFile, rename, unlink }
+
 /**
  * Append a turn entry. Auto-mkdir's the parent directory on first write
  * so the file can land in a fresh workspace without manual setup. After
  * append, if the file exceeds `maxBytes`, emergency-trim to last
  * `trimKeepLines` lines (advanced to first `### ` header) via a
  * same-dir tmp + rename for atomicity.
+ *
+ * @param _trimDeps internal — test-only injection of fs ops for the
+ *   trim path. Production callers must omit this.
  */
-export async function appendHotEntry(input: AppendHotInput): Promise<void> {
+export async function appendHotEntry(
+  input: AppendHotInput,
+  _trimDeps: TrimFsDeps = defaultTrimDeps,
+): Promise<void> {
   const entry =
     `\n### ${input.ts} [${input.sourceTag}]\n` +
     `**User:** ${input.userSnippet}\n` +
@@ -84,8 +100,21 @@ export async function appendHotEntry(input: AppendHotInput): Promise<void> {
       dirname(input.path),
       `.recent.md.tmp.${process.pid}.${Date.now()}`,
     )
-    await writeFile(tmp, header + kept.join('\n'), 'utf8')
-    await rename(tmp, input.path)
+    // Cleanup orphan tmp on rename failure (review MEDIUM). Pre-fix: if
+    // writeFile succeeded but rename failed (EBUSY, EIO, kill between
+    // awaits) the tmp would stay forever. After enough faulted trims the
+    // agent's core/hot/ would accumulate stale .recent.md.tmp.* files.
+    // unlink swallows ENOENT so a writeFile-side failure (no tmp on
+    // disk) is a no-op.
+    try {
+      await _trimDeps.writeFile(tmp, header + kept.join('\n'), 'utf8')
+      await _trimDeps.rename(tmp, input.path)
+    } catch (err) {
+      await _trimDeps.unlink(tmp).catch(() => {
+        // tmp may not exist if writeFile threw first — fine.
+      })
+      throw err
+    }
   })
 }
 

--- a/plugin/src/memory/hot-writer.ts
+++ b/plugin/src/memory/hot-writer.ts
@@ -15,39 +15,11 @@
 import { appendFile, mkdir, readFile, rename, stat, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 
-// ─────────────────────────────────────────────────────────────────────
-// Intra-process mutex. Each instance serialises async callers; the
-// `locks` map gives one Mutex per absolute path so different files
-// don't block each other.
-// ─────────────────────────────────────────────────────────────────────
+import { lockFor } from './_mutex.js'
 
-class Mutex {
-  private p: Promise<void> = Promise.resolve()
-  async run<T>(fn: () => Promise<T>): Promise<T> {
-    const prev = this.p
-    let release!: () => void
-    this.p = new Promise<void>((r) => {
-      release = r
-    })
-    await prev
-    try {
-      return await fn()
-    } finally {
-      release()
-    }
-  }
-}
-
-const locks = new Map<string, Mutex>()
-
-function lockFor(path: string): Mutex {
-  let m = locks.get(path)
-  if (!m) {
-    m = new Mutex()
-    locks.set(path, m)
-  }
-  return m
-}
+// Intra-process mutex serialisation lives in `_mutex.ts` (shared with
+// verbose-writer). One Mutex per absolute path so different files don't
+// block each other.
 
 // ─────────────────────────────────────────────────────────────────────
 // Public surface
@@ -103,7 +75,7 @@ export async function appendHotEntry(input: AppendHotInput): Promise<void> {
         break
       }
     }
-    const header = '# Hot memory — last 24h rolling journal\n\n'
+    const header = '# Hot memory -- last 24h rolling journal\n\n'
     // Same-dir tmp so rename() is a metadata-only move (no EXDEV when
     // workspace lives on a different filesystem than /tmp). PID + ms
     // disambiguate parallel trims in the unlikely case the mutex is

--- a/plugin/src/memory/hot-writer.ts
+++ b/plugin/src/memory/hot-writer.ts
@@ -1,0 +1,127 @@
+// Phase 8 / T2 — append to <workspace>/core/hot/recent.md.
+//
+// Ports gateway.py:1938-1987 (append_to_hot_memory) to TS. Python uses
+// fcntl.LOCK_EX for cross-process safety; we run one plugin process per
+// agent so an intra-process Mutex keyed on the absolute file path is
+// enough. The same key serialises concurrent UserPromptSubmit/Stop
+// bursts from 50+ chats without losing or interleaving entries.
+//
+// Emergency trim mirrors gateway.py exactly: keep last `trimKeepLines`
+// lines, then advance to the first `### ` header so a partial entry
+// isn't left at the top. Output is written to a sibling tmp file and
+// rename()'d into place — same-dir guarantees an atomic move on the
+// agent's workspace filesystem (no EXDEV across /tmp boundaries).
+
+import { appendFile, mkdir, readFile, rename, stat, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+
+// ─────────────────────────────────────────────────────────────────────
+// Intra-process mutex. Each instance serialises async callers; the
+// `locks` map gives one Mutex per absolute path so different files
+// don't block each other.
+// ─────────────────────────────────────────────────────────────────────
+
+class Mutex {
+  private p: Promise<void> = Promise.resolve()
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    const prev = this.p
+    let release!: () => void
+    this.p = new Promise<void>((r) => {
+      release = r
+    })
+    await prev
+    try {
+      return await fn()
+    } finally {
+      release()
+    }
+  }
+}
+
+const locks = new Map<string, Mutex>()
+
+function lockFor(path: string): Mutex {
+  let m = locks.get(path)
+  if (!m) {
+    m = new Mutex()
+    locks.set(path, m)
+  }
+  return m
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Public surface
+// ─────────────────────────────────────────────────────────────────────
+
+export interface AppendHotInput {
+  path: string
+  // Local-tz timestamp formatted as 'YYYY-MM-DD HH:MM'. Caller owns
+  // formatting so a fake clock in tests stays deterministic.
+  ts: string
+  // Human-friendly capitalised agent name, e.g. 'Silvana'. Rendered as
+  // `**${agentLabel}:** ...`.
+  agentLabel: string
+  sourceTag: string
+  // ≤ maxBytes / 2 sanity; in practice ≤200 chars by caller. snippet()
+  // below collapses newlines to spaces and slices to 200 chars.
+  userSnippet: string
+  agentSnippet: string
+  maxBytes: number
+  trimKeepLines: number
+}
+
+/**
+ * Append a turn entry. Auto-mkdir's the parent directory on first write
+ * so the file can land in a fresh workspace without manual setup. After
+ * append, if the file exceeds `maxBytes`, emergency-trim to last
+ * `trimKeepLines` lines (advanced to first `### ` header) via a
+ * same-dir tmp + rename for atomicity.
+ */
+export async function appendHotEntry(input: AppendHotInput): Promise<void> {
+  const entry =
+    `\n### ${input.ts} [${input.sourceTag}]\n` +
+    `**User:** ${input.userSnippet}\n` +
+    `**${input.agentLabel}:** ${input.agentSnippet}\n`
+
+  await lockFor(input.path).run(async () => {
+    // mkdir-on-first-write so the writer doesn't crash on a workspace
+    // that exists but has no core/hot/ subtree yet. recursive=true is
+    // idempotent; EEXIST is swallowed by Node.
+    await mkdir(dirname(input.path), { recursive: true })
+
+    await appendFile(input.path, entry, 'utf8')
+    const s = await stat(input.path)
+    if (s.size <= input.maxBytes) return
+
+    // Emergency trim — gateway.py:1971-1985 parity.
+    const buf = await readFile(input.path, 'utf8')
+    const all = buf.split('\n')
+    let kept = all.slice(-input.trimKeepLines)
+    for (let i = 0; i < kept.length; i++) {
+      if (kept[i]!.startsWith('### ')) {
+        kept = kept.slice(i)
+        break
+      }
+    }
+    const header = '# Hot memory — last 24h rolling journal\n\n'
+    // Same-dir tmp so rename() is a metadata-only move (no EXDEV when
+    // workspace lives on a different filesystem than /tmp). PID + ms
+    // disambiguate parallel trims in the unlikely case the mutex is
+    // bypassed by an outside caller.
+    const tmp = join(
+      dirname(input.path),
+      `.recent.md.tmp.${process.pid}.${Date.now()}`,
+    )
+    await writeFile(tmp, header + kept.join('\n'), 'utf8')
+    await rename(tmp, input.path)
+  })
+}
+
+/**
+ * Collapse newlines to spaces and slice to `max` chars. Used for both
+ * user and agent snippets so a multi-line prompt doesn't break the
+ * `### header` / `**User:**` / `**Agent:**` four-line shape.
+ */
+export function snippet(s: string, max = 200): string {
+  return (s || '').replace(/\n/g, ' ').slice(0, max)
+}

--- a/plugin/src/memory/index.ts
+++ b/plugin/src/memory/index.ts
@@ -1,0 +1,9 @@
+// Phase 8 — barrel for memory writers.
+//
+// Re-exports the surface the webhook server + server bootstrap need.
+// Internal modules (prompt-buffer, transcript-reader) are not re-
+// exported because callers should only ever talk to MemoryWriter.
+
+export { MemoryWriter, type MemoryConfig } from './writer.js'
+export { appendHotEntry, snippet, type AppendHotInput } from './hot-writer.js'
+export { appendVerbose, type AppendVerboseInput, type VerboseRecord } from './verbose-writer.js'

--- a/plugin/src/memory/prompt-buffer.ts
+++ b/plugin/src/memory/prompt-buffer.ts
@@ -1,0 +1,83 @@
+// Phase 8 / T4 — per-chatId TTL+LRU buffer of the last UserPromptSubmit.
+//
+// Claude's UserPromptSubmit hook fires when the user submits a prompt;
+// Stop fires when the turn ends. We need the prompt text at Stop time
+// to write a turn entry (user line in recent.md, user field in
+// verbose.jsonl), but the Stop payload itself doesn't carry the prompt.
+// This buffer holds the most recent UserPromptSubmit per chatId until
+// the matching Stop arrives.
+//
+// Eviction strategy:
+//   - TTL: entries older than ttlMs are dropped at insert and at take.
+//   - LRU cap: at most maxEntries simultaneous chats; on overflow we
+//     drop the oldest (Map iteration is insertion order in V8/Bun).
+// A fake `now()` injection makes time-based tests deterministic.
+
+export interface BufferedPrompt {
+  prompt: string
+  ts: number // ms timestamp at buffering (now()).
+  sessionId: string | null
+}
+
+export class PromptBuffer {
+  private map = new Map<string, BufferedPrompt>()
+
+  constructor(
+    private readonly ttlMs: number,
+    private readonly maxEntries: number,
+    private readonly now: () => number = () => Date.now(),
+  ) {}
+
+  /**
+   * Buffer a prompt for `chatId`. Overwrites any prior entry. Evicts
+   * expired entries first (lazy O(k) where k = expired count), then
+   * drops the oldest entry if we'd exceed maxEntries.
+   */
+  set(chatId: string, prompt: string, sessionId: string | null): void {
+    this.evict()
+    // Delete-then-set bumps insertion order so the new entry is "newest"
+    // even when we're overwriting an existing chatId — keeps LRU
+    // semantics correct on repeated submits from the same chat.
+    this.map.delete(chatId)
+    if (this.map.size >= this.maxEntries) {
+      const oldest = this.map.keys().next().value
+      if (oldest !== undefined) this.map.delete(oldest)
+    }
+    this.map.set(chatId, { prompt, ts: this.now(), sessionId })
+  }
+
+  /**
+   * Atomically read-and-remove the buffered prompt for `chatId`.
+   * Returns undefined if no entry exists or if the entry has expired.
+   * Removing on read prevents stale prompts from leaking into a later
+   * Stop that belongs to a different turn (or a different agent run).
+   */
+  take(chatId: string): BufferedPrompt | undefined {
+    const v = this.map.get(chatId)
+    if (!v) return undefined
+    if (this.now() - v.ts > this.ttlMs) {
+      this.map.delete(chatId)
+      return undefined
+    }
+    this.map.delete(chatId)
+    return v
+  }
+
+  /** Test-only: how many entries are currently buffered. */
+  size(): number {
+    return this.map.size
+  }
+
+  private evict(): void {
+    const cutoff = this.now() - this.ttlMs
+    for (const [k, v] of this.map) {
+      if (v.ts < cutoff) {
+        this.map.delete(k)
+      } else {
+        // Map iteration is insertion order — once we hit an entry that
+        // hasn't expired, every later entry is even fresher.
+        break
+      }
+    }
+  }
+}

--- a/plugin/src/memory/transcript-reader.ts
+++ b/plugin/src/memory/transcript-reader.ts
@@ -22,13 +22,6 @@ import { open, type FileHandle } from 'node:fs/promises'
 
 const TAIL_BYTES = 256 * 1024
 
-interface TranscriptLine {
-  message?: {
-    role?: string
-    content?: Array<{ type?: string; text?: string } | unknown>
-  }
-}
-
 export async function readLastAssistantText(
   transcriptPath: string,
 ): Promise<string | null> {
@@ -50,19 +43,29 @@ export async function readLastAssistantText(
     const lines = (start > 0 ? split.slice(1) : split).filter((l) => l.length > 0)
 
     for (let i = lines.length - 1; i >= 0; i--) {
-      let obj: TranscriptLine
+      // Permissive parse: valid JSON with the wrong shape (null, a bare
+      // array, a string, …) used to bypass the per-line try/catch and
+      // throw at the next `obj.message?.role` access, escaping to the
+      // OUTER catch and short-circuiting earlier valid assistant text.
+      // Each line is now its own boundary — shape mismatch = skip, not
+      // abort.
+      let obj: unknown
       try {
-        obj = JSON.parse(lines[i]!) as TranscriptLine
+        obj = JSON.parse(lines[i]!)
       } catch {
         continue
       }
-      if (obj.message?.role !== 'assistant') continue
-      const content = obj.message?.content
+      if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) continue
+      const msg = (obj as { message?: unknown }).message
+      if (typeof msg !== 'object' || msg === null) continue
+      const role = (msg as { role?: unknown }).role
+      if (role !== 'assistant') continue
+      const content = (msg as { content?: unknown }).content
       if (!Array.isArray(content)) continue
       const parts: string[] = []
       for (const c of content) {
         if (typeof c !== 'object' || c === null) continue
-        const block = c as { type?: string; text?: string }
+        const block = c as { type?: unknown; text?: unknown }
         if (block.type === 'text' && typeof block.text === 'string') {
           parts.push(block.text)
         }

--- a/plugin/src/memory/transcript-reader.ts
+++ b/plugin/src/memory/transcript-reader.ts
@@ -1,0 +1,84 @@
+// Phase 8 / T5 — tail-read the last assistant text from a Claude
+// transcript JSONL file.
+//
+// Claude Code persists each session as `~/.claude/projects/<slug>/<sid>.jsonl`
+// with one JSON object per line. We're interested in the last line whose
+// `message.role === 'assistant'` and whose `message.content` array has
+// at least one `{type: 'text', text: ...}` block — that's the text the
+// user would have seen at the end of the turn. Tool-use only assistant
+// messages are skipped (they have content[].type === 'tool_use').
+//
+// Strategy: open the file, read at most the trailing TAIL_BYTES bytes
+// to keep memory bounded on multi-megabyte transcripts, drop the first
+// (possibly-truncated) line when we didn't start at byte 0, then walk
+// the lines backward and return the first parseable assistant text.
+//
+// All errors are swallowed and surface as `null` — the caller treats
+// "no agent text" as "(inline)". Missing files, permission denied,
+// malformed JSON, schema drift — none of them should block the hot/
+// verbose writes for the user side.
+
+import { open, type FileHandle } from 'node:fs/promises'
+
+const TAIL_BYTES = 256 * 1024
+
+interface TranscriptLine {
+  message?: {
+    role?: string
+    content?: Array<{ type?: string; text?: string } | unknown>
+  }
+}
+
+export async function readLastAssistantText(
+  transcriptPath: string,
+): Promise<string | null> {
+  let handle: FileHandle | undefined
+  try {
+    handle = await open(transcriptPath, 'r')
+    const st = await handle.stat()
+    if (st.size === 0) return null
+    const len = Math.min(st.size, TAIL_BYTES)
+    const start = st.size - len
+    const buf = Buffer.alloc(len)
+    await handle.read(buf, 0, len, start)
+    const text = buf.toString('utf8')
+
+    // Drop possibly-truncated first chunk if we didn't start at byte 0;
+    // also filter empty lines so a trailing newline doesn't produce an
+    // empty parse attempt.
+    const split = text.split('\n')
+    const lines = (start > 0 ? split.slice(1) : split).filter((l) => l.length > 0)
+
+    for (let i = lines.length - 1; i >= 0; i--) {
+      let obj: TranscriptLine
+      try {
+        obj = JSON.parse(lines[i]!) as TranscriptLine
+      } catch {
+        continue
+      }
+      if (obj.message?.role !== 'assistant') continue
+      const content = obj.message?.content
+      if (!Array.isArray(content)) continue
+      const parts: string[] = []
+      for (const c of content) {
+        if (typeof c !== 'object' || c === null) continue
+        const block = c as { type?: string; text?: string }
+        if (block.type === 'text' && typeof block.text === 'string') {
+          parts.push(block.text)
+        }
+      }
+      if (parts.length > 0) return parts.join('\n')
+    }
+    return null
+  } catch {
+    return null
+  } finally {
+    if (handle) {
+      try {
+        await handle.close()
+      } catch {
+        // close() race on an already-closed handle is harmless
+      }
+    }
+  }
+}

--- a/plugin/src/memory/verbose-writer.ts
+++ b/plugin/src/memory/verbose-writer.ts
@@ -1,0 +1,72 @@
+// Phase 8 / T3 — append a lossless turn record to
+// <workspace_parent>/logs/verbose-YYYY-MM-DD.jsonl.
+//
+// Ports gateway.py:1990-2035 (append_to_verbose_jsonl). Records are
+// JSON.stringify'd one-per-line for downstream Cognee cron ingest.
+// Keys are constructed in the exact order Python writes them — TS V8
+// preserves insertion order in JSON.stringify, so cognee parsers that
+// rely on key order (some do, even though they shouldn't) see the same
+// shape as the Python gateway.
+//
+// No mutex: each plugin process is the sole writer of its agent's
+// verbose-*.jsonl. `appendFile` issues a single write(2) which is
+// atomic for buffers ≤ PIPE_BUF (4096 B on macOS, 4096 B on Linux);
+// records >4 KB MAY interleave under burst load, which is acceptable
+// — Cognee cron skips malformed lines and we never use this file as
+// a UI artifact. Hot-writer is the place that needs strong ordering.
+
+import { appendFile, mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export interface VerboseRecord {
+  // UTC ISO 8601 timestamp; the YYYY-MM-DD prefix is also used to
+  // derive the day-roll filename (slice(0,10)).
+  ts: string
+  // Claude session_id; null when the hook payload didn't carry one.
+  sid: string | null
+  // Source-tag (channel discriminator), e.g. 'tg'.
+  ch: string
+  // Full user text — no truncation (recent.md is the truncated mirror).
+  user: string
+  // Full agent text. Empty string when transcript could not be read.
+  agent: string
+  // Wall-clock duration of the turn in ms (from UserPromptSubmit buffer
+  // to Stop hook). 0 when no prior UserPromptSubmit was buffered.
+  dur_ms: number
+  // 'completed' on a clean Stop hook; 'error' reserved for future use.
+  status: 'completed' | 'error'
+}
+
+export interface AppendVerboseInput {
+  // Absolute path to <workspace_parent>/logs/ (resolved by caller in T6).
+  logsDir: string
+  record: VerboseRecord
+}
+
+export async function appendVerbose(input: AppendVerboseInput): Promise<void> {
+  // mkdir -p so the writer doesn't crash on a fresh workspace where
+  // logs/ hasn't been created yet. Idempotent on existing dir.
+  await mkdir(input.logsDir, { recursive: true })
+
+  // Day-roll filename derived from the record's own UTC ts. Using
+  // Date.now() formatted separately would race if the call straddled
+  // UTC midnight (record ts = 23:59:59.999, fmtDay = 00:00:00.000 +1d).
+  const day = input.record.ts.slice(0, 10) // 'YYYY-MM-DD'
+  const path = join(input.logsDir, `verbose-${day}.jsonl`)
+
+  // Construct the object literal in the order gateway.py writes the
+  // dict: ts, sid, ch, user, agent, dur_ms, status. V8 preserves
+  // insertion order in JSON.stringify so downstream cognee sees the
+  // same column shape as the Python feed.
+  const r = input.record
+  const ordered = {
+    ts: r.ts,
+    sid: r.sid,
+    ch: r.ch,
+    user: r.user,
+    agent: r.agent,
+    dur_ms: r.dur_ms,
+    status: r.status,
+  }
+  await appendFile(path, JSON.stringify(ordered) + '\n', 'utf8')
+}

--- a/plugin/src/memory/verbose-writer.ts
+++ b/plugin/src/memory/verbose-writer.ts
@@ -8,15 +8,16 @@
 // rely on key order (some do, even though they shouldn't) see the same
 // shape as the Python gateway.
 //
-// No mutex: each plugin process is the sole writer of its agent's
-// verbose-*.jsonl. `appendFile` issues a single write(2) which is
-// atomic for buffers ≤ PIPE_BUF (4096 B on macOS, 4096 B on Linux);
-// records >4 KB MAY interleave under burst load, which is acceptable
-// — Cognee cron skips malformed lines and we never use this file as
-// a UI artifact. Hot-writer is the place that needs strong ordering.
+// Mutex-serialised: `appendFile` is NOT atomic for buffers > PIPE_BUF
+// (4 KB) on Darwin — concurrent multi-KB writes can interleave and
+// corrupt JSONL. gateway.py uses `fcntl.LOCK_EX`; we reuse the same
+// `lockFor(path)` primitive as hot-writer so a single per-file mutex
+// serialises every append on the plugin process.
 
 import { appendFile, mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
+
+import { lockFor } from './_mutex.js'
 
 export interface VerboseRecord {
   // UTC ISO 8601 timestamp; the YYYY-MM-DD prefix is also used to
@@ -68,5 +69,8 @@ export async function appendVerbose(input: AppendVerboseInput): Promise<void> {
     dur_ms: r.dur_ms,
     status: r.status,
   }
-  await appendFile(path, JSON.stringify(ordered) + '\n', 'utf8')
+  const line = JSON.stringify(ordered) + '\n'
+  await lockFor(path).run(async () => {
+    await appendFile(path, line, 'utf8')
+  })
 }

--- a/plugin/src/memory/writer.ts
+++ b/plugin/src/memory/writer.ts
@@ -1,0 +1,126 @@
+// Phase 8 / T6 — MemoryWriter facade.
+//
+// One instance per plugin process (one agent = one workspace).
+// onHook(payload) is the single entry point called from the
+// /hooks/agent webhook branch. UserPromptSubmit buffers the prompt
+// by chatId; Stop reads the buffer + tail-reads the transcript for
+// the assistant text + appends one entry each to recent.md and
+// verbose-YYYY-MM-DD.jsonl.
+//
+// All errors are swallowed — the webhook still returns 200 so Claude
+// hooks don't back-pressure on a memory outage. The webhook branch
+// wraps onHook() in its own try/catch + log.warn so even an unhandled
+// throw here cannot block the HTTP response.
+
+import { join } from 'node:path'
+
+import type { Logger } from '../log.js'
+import type { ClaudeHookPayload } from '../schemas.js'
+import { appendHotEntry, snippet } from './hot-writer.js'
+import { appendVerbose, type VerboseRecord } from './verbose-writer.js'
+import { PromptBuffer } from './prompt-buffer.js'
+import { readLastAssistantText } from './transcript-reader.js'
+
+export interface MemoryConfig {
+  // <agent-workspace> root. recent.md lands at workspace/core/hot/recent.md.
+  workspacePath: string
+  // Pre-resolved logs dir (T7 derives <workspace_parent>/logs as the
+  // default when config.memory.logs_path is unset).
+  logsPath: string
+  sourceTag: string
+  // Human-friendly capitalised name (e.g. 'Silvana', 'Kaelthas').
+  agentLabel: string
+  maxHotBytes: number
+  trimKeepLines: number
+  bufferTtlMs: number
+  bufferMaxEntries: number
+}
+
+export class MemoryWriter {
+  private readonly buffer: PromptBuffer
+
+  constructor(
+    private readonly cfg: MemoryConfig,
+    private readonly log: Logger,
+    private readonly now: () => number = () => Date.now(),
+  ) {
+    this.buffer = new PromptBuffer(cfg.bufferTtlMs, cfg.bufferMaxEntries, now)
+  }
+
+  /** Dispatch on hook_event_name. Other hook kinds are no-ops. */
+  async onHook(payload: ClaudeHookPayload): Promise<void> {
+    if (payload.hook_event_name === 'UserPromptSubmit') {
+      this.buffer.set(
+        String(payload.chatId),
+        typeof payload.prompt === 'string' ? payload.prompt : '',
+        payload.session_id ?? null,
+      )
+      return
+    }
+    if (payload.hook_event_name === 'Stop') {
+      await this.onStop(payload)
+    }
+  }
+
+  private async onStop(
+    payload: ClaudeHookPayload & { hook_event_name: 'Stop' },
+  ): Promise<void> {
+    const chatId = String(payload.chatId)
+    const buffered = this.buffer.take(chatId)
+    const userText = buffered?.prompt ?? '(no prompt)'
+    if (!buffered) {
+      // Stop without a prior UserPromptSubmit can happen on resume/clear
+      // hooks, restart races, or when the buffer expired. We never drop
+      // the entry — '(no prompt)' is the gateway.py parity behaviour.
+      this.log.warn('[memory] Stop without buffered prompt', {
+        chatId,
+        session_id: payload.session_id,
+      })
+    }
+
+    let agentText = ''
+    if (typeof payload.transcript_path === 'string' && payload.transcript_path) {
+      const t = await readLastAssistantText(payload.transcript_path)
+      if (t) agentText = t
+    }
+
+    const ts = formatLocalTs(new Date(this.now()))
+    const hotPath = join(this.cfg.workspacePath, 'core', 'hot', 'recent.md')
+    await appendHotEntry({
+      path: hotPath,
+      ts,
+      agentLabel: this.cfg.agentLabel,
+      sourceTag: this.cfg.sourceTag,
+      userSnippet: snippet(userText),
+      // gateway.py:1950 uses '(inline)' as the agent fallback when no
+      // response text was captured. We mirror that to keep recent.md
+      // diff-able between the two implementations.
+      agentSnippet: snippet(agentText || '(inline)'),
+      maxBytes: this.cfg.maxHotBytes,
+      trimKeepLines: this.cfg.trimKeepLines,
+    })
+
+    const record: VerboseRecord = {
+      ts: new Date(this.now()).toISOString(),
+      sid: payload.session_id ?? null,
+      ch: this.cfg.sourceTag,
+      user: userText,
+      agent: agentText,
+      dur_ms: buffered ? this.now() - buffered.ts : 0,
+      status: 'completed',
+    }
+    await appendVerbose({ logsDir: this.cfg.logsPath, record })
+  }
+}
+
+/**
+ * Format a Date as 'YYYY-MM-DD HH:MM' in local time. Matches Python's
+ * `time.strftime("%Y-%m-%d %H:%M")` in gateway.py:1948.
+ */
+function formatLocalTs(d: Date): string {
+  const p = (n: number): string => n.toString().padStart(2, '0')
+  return (
+    `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ` +
+    `${p(d.getHours())}:${p(d.getMinutes())}`
+  )
+}

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -36,6 +36,8 @@ import {
   type ToolDeps,
 } from './channel/tools.js'
 import { StatusManager } from './status/status-manager.js'
+import { MemoryWriter, type MemoryConfig } from './memory/writer.js'
+import { dirname as pathDirname } from 'path'
 import {
   createPendingMap,
   createPermissionRelayHooks,
@@ -239,6 +241,38 @@ const mcp = new Server(
 // message we edit while Claude is composing a reply. The handler opens it
 // on inbound delivery; the reply tool closes it on successful send.
 const statusManager = new StatusManager({ telegramApi, config, log })
+
+// Phase 8 / T7: MemoryWriter persists turns to <workspace>/core/hot/recent.md
+// and <workspace_parent>/logs/verbose-YYYY-MM-DD.jsonl. Only instantiated
+// when config.memory.enabled === true AND workspace_path is set — schema
+// refine already guarantees the second condition when enabled is true, but
+// the explicit check keeps the runtime gate symmetric with the webhook
+// branch in webhook/server.ts.
+let memoryWriter: MemoryWriter | undefined
+if (config.memory.enabled === true && config.memory.workspace_path !== undefined) {
+  const memCfg: MemoryConfig = {
+    workspacePath: config.memory.workspace_path,
+    // Default logs dir is sibling of workspace ('<parent>/logs/'), mirroring
+    // gateway.py:2010 (`Path(workspace).parent / "logs"`).
+    logsPath: config.memory.logs_path ?? join(pathDirname(config.memory.workspace_path), 'logs'),
+    sourceTag: config.memory.source_tag,
+    // Agent label preference: explicit memory.agent_label > 'Agent' fallback.
+    // Telegram bot username is not used here because it's typically the
+    // assistant's tool-handle (e.g. 'fridayhumanbot') rather than the
+    // human-readable agent name ('Silvana') that goes into recent.md.
+    agentLabel: config.memory.agent_label ?? 'Agent',
+    maxHotBytes: config.memory.max_hot_bytes,
+    trimKeepLines: config.memory.trim_keep_lines,
+    bufferTtlMs: config.memory.buffer_ttl_ms,
+    bufferMaxEntries: config.memory.buffer_max_entries,
+  }
+  memoryWriter = new MemoryWriter(memCfg, log)
+  log.info('memory writer enabled', {
+    workspace: memCfg.workspacePath,
+    logs: memCfg.logsPath,
+    agent: memCfg.agentLabel,
+  })
+}
 
 const toolDeps: ToolDeps = {
   config,
@@ -482,6 +516,7 @@ try {
     statePaths,
     log,
     statusManager,
+    ...(memoryWriter !== undefined ? { memoryWriter } : {}),
   })
 } catch (err) {
   log.error('webhook server failed to start', {

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -154,6 +154,11 @@ const env = RuntimeEnvSchema.parse({
   ...(process.env.TELEGRAM_WEBHOOK_PORT !== undefined ? { TELEGRAM_WEBHOOK_PORT: process.env.TELEGRAM_WEBHOOK_PORT } : {}),
   ...(process.env.TELEGRAM_WEBHOOK_TOKEN !== undefined ? { TELEGRAM_WEBHOOK_TOKEN: process.env.TELEGRAM_WEBHOOK_TOKEN } : {}),
   ...(process.env.TELEGRAM_ACCESS_MODE !== undefined ? { TELEGRAM_ACCESS_MODE: process.env.TELEGRAM_ACCESS_MODE } : {}),
+  ...(process.env.TELEGRAM_MEMORY_ENABLED !== undefined ? { TELEGRAM_MEMORY_ENABLED: process.env.TELEGRAM_MEMORY_ENABLED } : {}),
+  ...(process.env.TELEGRAM_MEMORY_WORKSPACE !== undefined ? { TELEGRAM_MEMORY_WORKSPACE: process.env.TELEGRAM_MEMORY_WORKSPACE } : {}),
+  ...(process.env.TELEGRAM_MEMORY_LOGS_PATH !== undefined ? { TELEGRAM_MEMORY_LOGS_PATH: process.env.TELEGRAM_MEMORY_LOGS_PATH } : {}),
+  ...(process.env.TELEGRAM_MEMORY_SOURCE_TAG !== undefined ? { TELEGRAM_MEMORY_SOURCE_TAG: process.env.TELEGRAM_MEMORY_SOURCE_TAG } : {}),
+  ...(process.env.TELEGRAM_MEMORY_AGENT_LABEL !== undefined ? { TELEGRAM_MEMORY_AGENT_LABEL: process.env.TELEGRAM_MEMORY_AGENT_LABEL } : {}),
 })
 
 const config: AppConfig = loadConfig(process.env)

--- a/plugin/src/webhook/server.ts
+++ b/plugin/src/webhook/server.ts
@@ -24,6 +24,7 @@ import { writeDeadLetter } from '../state/store.js'
 import { WebhookPayloadSchema, type WebhookPayload } from '../schemas.js'
 import { sendChannelNotification, normalizeMeta } from '../channel/notify.js'
 import { toActivityEvent } from '../hooks/claude-events.js'
+import type { MemoryWriter } from '../memory/writer.js'
 
 const BODY_LIMIT_BYTES = 256 * 1024
 const DEFAULT_AGENT_ID = 'dashi-channel'
@@ -47,6 +48,10 @@ export interface WebhookDeps {
   // status update happens. The 200 path stays open so Claude hooks never
   // back-pressure on visibility outages.
   statusManager?: StatusManagerForWebhook
+  // Phase 8: optional memory writer. Receives a sibling dispatch of every
+  // hook payload (UserPromptSubmit buffers, Stop writes recent.md +
+  // verbose.jsonl). Throws are caught and logged — never block the 200.
+  memoryWriter?: MemoryWriter
 }
 
 export interface WebhookServerHandle {
@@ -169,7 +174,7 @@ async function handleRequest(
   deps: WebhookDeps,
   webhookToken: string | undefined,
 ): Promise<void> {
-  const { config, statePaths, log, mcpServer, statusManager } = deps
+  const { config, statePaths, log, mcpServer, statusManager, memoryWriter } = deps
   const method = req.method ?? 'GET'
   const url = req.url ?? '/'
 
@@ -267,6 +272,20 @@ async function handleRequest(
   // Branch on payload variant. Discriminator was set by the Zod transform
   // so we don't have to re-sniff fields here.
   if (payload.kind === 'claude_hook') {
+    // Phase 8: dispatch to memory writer first, BEFORE the status branch,
+    // so memory persistence runs regardless of status.enabled. Errors are
+    // logged and swallowed — memory must never back-pressure the 200.
+    if (config.memory.enabled && memoryWriter) {
+      try {
+        await memoryWriter.onHook(payload)
+      } catch (err) {
+        log.warn('[memory] writer error (ignored)', {
+          hook: payload.hook_event_name,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+
     // PLAN.md:173 — when config.status.enabled=false the hook path must
     // be a no-op. We accept the request (200) so Claude hooks don't
     // back-pressure on a disabled visibility surface, but skip dispatch

--- a/plugin/tests/channel/permissions.test.ts
+++ b/plugin/tests/channel/permissions.test.ts
@@ -61,6 +61,14 @@ function mkConfig(allowedIds: number[] = [164795011]): AppConfig {
     webhook: { enabled: false, host: '127.0.0.1', port: 0 },
     permission_relay: { enabled: true, allowed_user_ids: allowedIds, bash_only_proof: true },
     commands: { help: true, status: true, stop: true, reset: true, new: true },
+    memory: {
+      enabled: false,
+      source_tag: 'tg',
+      max_hot_bytes: 20480,
+      trim_keep_lines: 600,
+      buffer_ttl_ms: 5 * 60 * 1000,
+      buffer_max_entries: 100,
+    },
   }
 }
 

--- a/plugin/tests/channel/tools.test.ts
+++ b/plugin/tests/channel/tools.test.ts
@@ -57,6 +57,14 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webhook: { enabled: false, host: '127.0.0.1', port: 0 },
     permission_relay: { enabled: true, allowed_user_ids: [164795011], bash_only_proof: true },
     commands: { help: true, status: true, stop: true, reset: true, new: true },
+    memory: {
+      enabled: false,
+      source_tag: 'tg',
+      max_hot_bytes: 20480,
+      trim_keep_lines: 600,
+      buffer_ttl_ms: 5 * 60 * 1000,
+      buffer_max_entries: 100,
+    },
     ...overrides,
   }
 }

--- a/plugin/tests/commands/oob.test.ts
+++ b/plugin/tests/commands/oob.test.ts
@@ -25,6 +25,14 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       bash_only_proof: true,
     },
     commands: { help: true, status: true, stop: true, reset: true, new: true },
+    memory: {
+      enabled: false,
+      source_tag: 'tg',
+      max_hot_bytes: 20480,
+      trim_keep_lines: 600,
+      buffer_ttl_ms: 5 * 60 * 1000,
+      buffer_max_entries: 100,
+    },
     ...overrides,
   }
 }

--- a/plugin/tests/config.test.ts
+++ b/plugin/tests/config.test.ts
@@ -165,4 +165,70 @@ describe('loadConfig', () => {
     expect(cfg.allowed_user_ids).toEqual([42, 43])
     expect(cfg.workspace_root).toBe('/tmp/ws')
   })
+
+  // ─── Phase 8 / T1: memory group ──────────────────────────────────────
+
+  test('memory: defaults are off-by-default with sane field values', () => {
+    const cfg = loadConfig(env())
+    expect(cfg.memory.enabled).toBe(false)
+    expect(cfg.memory.workspace_path).toBeUndefined()
+    expect(cfg.memory.logs_path).toBeUndefined()
+    expect(cfg.memory.source_tag).toBe('tg')
+    expect(cfg.memory.max_hot_bytes).toBe(20480)
+    expect(cfg.memory.trim_keep_lines).toBe(600)
+    expect(cfg.memory.buffer_ttl_ms).toBe(5 * 60 * 1000)
+    expect(cfg.memory.buffer_max_entries).toBe(100)
+  })
+
+  test('memory: enabled=true without workspace_path fails refine with explicit message', () => {
+    writeFileSync(join(stateDir, 'config.json'), JSON.stringify({
+      memory: { enabled: true },
+    }))
+    let caught: unknown
+    try { loadConfig(env()) } catch (e) { caught = e }
+    expect(caught).toBeInstanceOf(Error)
+    const msg = (caught as Error).message
+    expect(msg).toMatch(/memory\.workspace_path required when memory\.enabled=true/)
+  })
+
+  test('memory: enabled=true with workspace_path validates', () => {
+    writeFileSync(join(stateDir, 'config.json'), JSON.stringify({
+      memory: { enabled: true, workspace_path: '/tmp/agent-ws' },
+    }))
+    const cfg = loadConfig(env())
+    expect(cfg.memory.enabled).toBe(true)
+    expect(cfg.memory.workspace_path).toBe('/tmp/agent-ws')
+  })
+
+  test('memory: env TELEGRAM_MEMORY_* overrides file config', () => {
+    writeFileSync(join(stateDir, 'config.json'), JSON.stringify({
+      memory: { enabled: false, workspace_path: '/tmp/from-file', source_tag: 'old' },
+    }))
+    const cfg = loadConfig(env({
+      TELEGRAM_MEMORY_ENABLED: 'true',
+      TELEGRAM_MEMORY_WORKSPACE: '/tmp/from-env',
+      TELEGRAM_MEMORY_LOGS_PATH: '/tmp/from-env-logs',
+      TELEGRAM_MEMORY_SOURCE_TAG: 'tg',
+      TELEGRAM_MEMORY_AGENT_LABEL: 'Silvana',
+    }))
+    expect(cfg.memory.enabled).toBe(true)
+    expect(cfg.memory.workspace_path).toBe('/tmp/from-env')
+    expect(cfg.memory.logs_path).toBe('/tmp/from-env-logs')
+    expect(cfg.memory.source_tag).toBe('tg')
+    expect(cfg.memory.agent_label).toBe('Silvana')
+  })
+
+  test('memory: TELEGRAM_MEMORY_ENABLED accepts 1/true/yes/on (case-insensitive); other values → false', () => {
+    for (const truthy of ['1', 'true', 'TRUE', 'yes', 'On']) {
+      const cfg = loadConfig(env({
+        TELEGRAM_MEMORY_ENABLED: truthy,
+        TELEGRAM_MEMORY_WORKSPACE: '/tmp/ws',
+      }))
+      expect(cfg.memory.enabled).toBe(true)
+    }
+    for (const falsy of ['0', 'false', 'no', 'off', '']) {
+      const cfg = loadConfig(env({ TELEGRAM_MEMORY_ENABLED: falsy }))
+      expect(cfg.memory.enabled).toBe(false)
+    }
+  })
 })

--- a/plugin/tests/memory/e2e-webhook.test.ts
+++ b/plugin/tests/memory/e2e-webhook.test.ts
@@ -1,0 +1,322 @@
+// Phase 8 / T8 — End-to-end: real webhook + real MemoryWriter + real
+// tmp workspace. POST UserPromptSubmit + Stop and assert recent.md and
+// verbose-YYYY-MM-DD.jsonl appear with the expected contents.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { getStatePaths, loadConfig, type AppConfig, type StatePaths } from '../../src/config.js'
+import { createLogger } from '../../src/log.js'
+import { ensureStateDirs } from '../../src/state/store.js'
+import { MemoryWriter, type MemoryConfig } from '../../src/memory/writer.js'
+import { startWebhookServer, type WebhookServerHandle } from '../../src/webhook/server.js'
+
+const FAKE_TOKEN = '123456789:AAH-fake_test_token_with_at_least_thirty_chars'
+const WEBHOOK_TOKEN = 'wh_test_token_32_chars__________'
+
+let stateDir: string
+let paths: StatePaths
+let baseConfig: AppConfig
+let handle: WebhookServerHandle | null
+let workspaceDir: string
+let logsDir: string
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), 'dashi-memory-e2e-state-'))
+  workspaceDir = mkdtempSync(join(tmpdir(), 'dashi-memory-e2e-ws-'))
+  logsDir = join(workspaceDir, '..', 'logs-' + Math.random().toString(36).slice(2, 8))
+  delete process.env.TELEGRAM_WEBHOOK_TOKEN
+  const env = {
+    TELEGRAM_BOT_TOKEN: FAKE_TOKEN,
+    TELEGRAM_STATE_DIR: stateDir,
+  }
+  baseConfig = loadConfig(env)
+  paths = getStatePaths(baseConfig, {
+    TELEGRAM_BOT_TOKEN: FAKE_TOKEN,
+    TELEGRAM_STATE_DIR: stateDir,
+  })
+  ensureStateDirs(paths)
+  handle = null
+})
+
+afterEach(async () => {
+  if (handle) {
+    await handle.close()
+    handle = null
+  }
+  delete process.env.TELEGRAM_WEBHOOK_TOKEN
+  rmSync(stateDir, { recursive: true, force: true })
+  rmSync(workspaceDir, { recursive: true, force: true })
+  rmSync(logsDir, { recursive: true, force: true })
+})
+
+function makeMcpStub(): { server: any; calls: { method: string; params: unknown }[] } {
+  const calls: { method: string; params: unknown }[] = []
+  const server = {
+    notification: async (msg: { method: string; params: unknown }) => {
+      calls.push({ method: msg.method, params: msg.params })
+    },
+  }
+  return { server, calls }
+}
+
+function memCfg(overrides: Partial<MemoryConfig> = {}): MemoryConfig {
+  return {
+    workspacePath: workspaceDir,
+    logsPath: logsDir,
+    sourceTag: 'tg',
+    agentLabel: 'Silvana',
+    maxHotBytes: 20480,
+    trimKeepLines: 600,
+    bufferTtlMs: 5 * 60 * 1000,
+    bufferMaxEntries: 100,
+    ...overrides,
+  }
+}
+
+function enabledConfig(): AppConfig {
+  return {
+    ...baseConfig,
+    webhook: { enabled: true, host: '127.0.0.1', port: 0 },
+    memory: {
+      enabled: true,
+      workspace_path: workspaceDir,
+      logs_path: logsDir,
+      source_tag: 'tg',
+      agent_label: 'Silvana',
+      max_hot_bytes: 20480,
+      trim_keep_lines: 600,
+      buffer_ttl_ms: 5 * 60 * 1000,
+      buffer_max_entries: 100,
+    },
+  }
+}
+
+async function startWithMemory(): Promise<{
+  h: WebhookServerHandle
+  mcp: ReturnType<typeof makeMcpStub>
+  writer: MemoryWriter
+}> {
+  const mcp = makeMcpStub()
+  const writer = new MemoryWriter(memCfg(), createLogger('test', {
+    stream: { write: () => true } as unknown as NodeJS.WritableStream,
+  }))
+  const cfg = enabledConfig()
+  const h = await startWebhookServer(cfg, {
+    mcpServer: mcp.server,
+    config: cfg,
+    statePaths: paths,
+    log: createLogger('test', { stream: { write: () => true } as unknown as NodeJS.WritableStream }),
+    memoryWriter: writer,
+  })
+  if (!h) throw new Error('expected handle')
+  handle = h
+  return { h, mcp, writer }
+}
+
+function url(h: WebhookServerHandle, p: string): string {
+  return `http://${h.host}:${h.port}${p}`
+}
+
+describe('end-to-end: webhook → MemoryWriter → recent.md + verbose.jsonl', () => {
+  test('UserPromptSubmit + Stop produces both files with expected contents', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+
+    // Seed a Claude transcript file the Stop hook will reference.
+    const transcriptPath = join(workspaceDir, 'session.jsonl')
+    writeFileSync(transcriptPath, JSON.stringify({
+      message: { role: 'assistant', content: [{ type: 'text', text: 'agent answered the question' }] },
+    }) + '\n', 'utf8')
+
+    const { h } = await startWithMemory()
+
+    const submit = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        hook_event_name: 'UserPromptSubmit',
+        session_id: 'e2e-sid',
+        transcript_path: transcriptPath,
+        cwd: workspaceDir,
+        prompt: 'end-to-end user prompt',
+      }),
+    })
+    expect(submit.status).toBe(200)
+
+    // verbose.jsonl shouldn't exist yet (UserPromptSubmit only buffers).
+    let logsExist = true
+    try { readdirSync(logsDir) } catch { logsExist = false }
+    expect(logsExist).toBe(false)
+
+    const stop = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        hook_event_name: 'Stop',
+        session_id: 'e2e-sid',
+        transcript_path: transcriptPath,
+        cwd: workspaceDir,
+      }),
+    })
+    expect(stop.status).toBe(200)
+
+    // recent.md
+    const hotPath = join(workspaceDir, 'core', 'hot', 'recent.md')
+    const hot = readFileSync(hotPath, 'utf8')
+    expect(hot).toMatch(/### \d{4}-\d{2}-\d{2} \d{2}:\d{2} \[tg\]/)
+    expect(hot).toContain('**User:** end-to-end user prompt\n')
+    expect(hot).toContain('**Silvana:** agent answered the question\n')
+
+    // verbose-YYYY-MM-DD.jsonl
+    const files = readdirSync(logsDir).filter(f => f.startsWith('verbose-'))
+    expect(files.length).toBe(1)
+    const v = JSON.parse(readFileSync(join(logsDir, files[0]!), 'utf8').trim())
+    expect(v.sid).toBe('e2e-sid')
+    expect(v.ch).toBe('tg')
+    expect(v.user).toBe('end-to-end user prompt')
+    expect(v.agent).toBe('agent answered the question')
+    expect(typeof v.dur_ms).toBe('number')
+    expect(v.dur_ms).toBeGreaterThanOrEqual(0)
+    expect(v.status).toBe('completed')
+  })
+
+  test('50 concurrent UserPromptSubmit+Stop turns from different chats: all entries present', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+
+    // Allow many chat ids by writing config.json before loadConfig is called
+    // for this test. Simpler: override allowed_chat_ids at runtime.
+    const cfg = enabledConfig()
+    cfg.allowed_chat_ids = Array.from({ length: 50 }, (_, i) => 100000 + i)
+    const mcp = makeMcpStub()
+    const writer = new MemoryWriter(memCfg(), createLogger('test', {
+      stream: { write: () => true } as unknown as NodeJS.WritableStream,
+    }))
+    const h = await startWebhookServer(cfg, {
+      mcpServer: mcp.server,
+      config: cfg,
+      statePaths: paths,
+      log: createLogger('test', { stream: { write: () => true } as unknown as NodeJS.WritableStream }),
+      memoryWriter: writer,
+    })
+    if (!h) throw new Error('expected handle')
+    handle = h
+
+    const transcriptPath = join(workspaceDir, 'multi.jsonl')
+    writeFileSync(transcriptPath, JSON.stringify({
+      message: { role: 'assistant', content: [{ type: 'text', text: 'shared agent answer' }] },
+    }) + '\n', 'utf8')
+
+    const N = 50
+    const submits = Array.from({ length: N }, (_, i) =>
+      fetch(url(h, '/hooks/agent'), {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${WEBHOOK_TOKEN}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          chatId: 100000 + i,
+          hook_event_name: 'UserPromptSubmit',
+          session_id: `sid-${i}`,
+          transcript_path: transcriptPath,
+          cwd: workspaceDir,
+          prompt: `user-prompt-${i.toString().padStart(3, '0')}`,
+        }),
+      }),
+    )
+    const submitResults = await Promise.all(submits)
+    for (const r of submitResults) expect(r.status).toBe(200)
+
+    const stops = Array.from({ length: N }, (_, i) =>
+      fetch(url(h, '/hooks/agent'), {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${WEBHOOK_TOKEN}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          chatId: 100000 + i,
+          hook_event_name: 'Stop',
+          session_id: `sid-${i}`,
+          transcript_path: transcriptPath,
+          cwd: workspaceDir,
+        }),
+      }),
+    )
+    const stopResults = await Promise.all(stops)
+    for (const r of stopResults) expect(r.status).toBe(200)
+
+    // Every user-prompt-NNN must appear in recent.md.
+    const hot = readFileSync(join(workspaceDir, 'core', 'hot', 'recent.md'), 'utf8')
+    for (let i = 0; i < N; i++) {
+      const id = i.toString().padStart(3, '0')
+      expect(hot).toContain(`**User:** user-prompt-${id}\n`)
+    }
+    // And all 50 records must be in the day's verbose file.
+    const vFiles = readdirSync(logsDir).filter(f => f.startsWith('verbose-'))
+    expect(vFiles.length).toBe(1)
+    const lines = readFileSync(join(logsDir, vFiles[0]!), 'utf8').trim().split('\n')
+    expect(lines.length).toBe(N)
+    const seenSids = new Set<string>()
+    for (const ln of lines) {
+      const r = JSON.parse(ln)
+      seenSids.add(r.sid)
+    }
+    expect(seenSids.size).toBe(N)
+  })
+
+  test('memory.enabled=false on config: writes nothing even with writer wired', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const cfg: AppConfig = {
+      ...enabledConfig(),
+      memory: {
+        enabled: false,
+        workspace_path: workspaceDir,
+        logs_path: logsDir,
+        source_tag: 'tg',
+        max_hot_bytes: 20480,
+        trim_keep_lines: 600,
+        buffer_ttl_ms: 5 * 60 * 1000,
+        buffer_max_entries: 100,
+      },
+    }
+    const mcp = makeMcpStub()
+    const writer = new MemoryWriter(memCfg(), createLogger('test', {
+      stream: { write: () => true } as unknown as NodeJS.WritableStream,
+    }))
+    const h = await startWebhookServer(cfg, {
+      mcpServer: mcp.server,
+      config: cfg,
+      statePaths: paths,
+      log: createLogger('test', { stream: { write: () => true } as unknown as NodeJS.WritableStream }),
+      memoryWriter: writer,
+    })
+    if (!h) throw new Error('expected handle')
+    handle = h
+
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${WEBHOOK_TOKEN}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chatId: 164795011,
+        hook_event_name: 'Stop',
+        session_id: 'sid-x',
+        transcript_path: '/tmp/missing.jsonl',
+        cwd: workspaceDir,
+      }),
+    })
+    expect(resp.status).toBe(200)
+
+    let hotExists = true
+    try { readFileSync(join(workspaceDir, 'core', 'hot', 'recent.md'), 'utf8') } catch { hotExists = false }
+    expect(hotExists).toBe(false)
+    let logsExist = true
+    try { readdirSync(logsDir) } catch { logsExist = false }
+    expect(logsExist).toBe(false)
+  })
+})
+

--- a/plugin/tests/memory/hot-writer.test.ts
+++ b/plugin/tests/memory/hot-writer.test.ts
@@ -52,6 +52,30 @@ describe('snippet', () => {
     // typecheck-safe: function tolerates undefined-ish via the `|| ''` guard
     expect(snippet(undefined as unknown as string)).toBe('')
   })
+
+  test('slices by code points, not UTF-16 code units (review LOW — astral Unicode parity)', () => {
+    // Each '👋' is a single Unicode code point but two UTF-16 code units
+    // (a surrogate pair). 150 emojis = 300 UTF-16 units = 150 code points.
+    // Pre-fix `.slice(0, 200)` cut after 100 emojis (200 UTF-16 units),
+    // matching Python `s[:200]` semantics only by accident — and could
+    // split a surrogate pair on a non-multiple-of-2 max, producing an
+    // invalid UTF-8 sequence in recent.md.
+    const out = snippet('👋'.repeat(150))
+    expect(Array.from(out).length).toBe(150)
+    // No broken surrogate pair: every code point must be a full emoji.
+    for (const c of out) {
+      expect(c).toBe('👋')
+    }
+  })
+
+  test('snippet honours code-point max even on mixed BMP + astral input', () => {
+    // 'a' (1 code point, 1 UTF-16 unit) interleaved with '😀' (1 code point,
+    // 2 UTF-16 units). 100 each = 200 code points = 300 UTF-16 units.
+    let mixed = ''
+    for (let i = 0; i < 100; i++) mixed += 'a😀'
+    const out = snippet(mixed, 200)
+    expect(Array.from(out).length).toBe(200)
+  })
 })
 
 describe('appendHotEntry', () => {

--- a/plugin/tests/memory/hot-writer.test.ts
+++ b/plugin/tests/memory/hot-writer.test.ts
@@ -166,6 +166,59 @@ describe('appendHotEntry', () => {
     }
   })
 
+  test('trim cleans up tmp orphan when rename throws (review MEDIUM)', async () => {
+    // Pre-fix: writeFile + rename had no try/catch. If rename failed
+    // (EBUSY, EIO, kill-between-awaits) the tmp file stayed forever; PID
+    // + ms suffixes meant successive faulted trims would accumulate
+    // distinct .recent.md.tmp.* orphans. After the fix, any throw
+    // between writeFile and rename triggers an unlink on tmp.
+    const fs = await import('node:fs/promises')
+    await fs.mkdir(dirname(hotPath), { recursive: true })
+    const pre = '\n### 2026-05-15 11:00 [tg]\n' +
+      '**User:** ' + 'a'.repeat(180) + '\n' +
+      '**Silvana:** ' + 'b'.repeat(180) + '\n'
+    let seed = ''
+    while (seed.length < 30 * 1024) seed += pre
+    writeFileSync(hotPath, seed, 'utf8')
+
+    // Inject deps: writeFile real, rename throws EBUSY once, unlink real.
+    let renameCalls = 0
+    let unlinkCalls = 0
+    const deps = {
+      writeFile: fs.writeFile,
+      rename: async (..._args: unknown[]) => {
+        renameCalls++
+        const e = new Error('EBUSY: device or resource busy') as Error & { code?: string }
+        e.code = 'EBUSY'
+        throw e
+      },
+      unlink: async (p: string) => {
+        unlinkCalls++
+        return fs.unlink(p)
+      },
+    } as unknown as Parameters<typeof appendHotEntry>[1]
+
+    let caught: unknown
+    try {
+      await appendHotEntry(
+        defaultInput({ maxBytes: 20480, trimKeepLines: 50 }),
+        deps,
+      )
+    } catch (err) {
+      caught = err
+    }
+    // (a) trim threw — the appendHotEntry call propagated the rename error.
+    expect(caught).toBeInstanceOf(Error)
+    expect((caught as Error & { code?: string }).code).toBe('EBUSY')
+    expect(renameCalls).toBe(1)
+    expect(unlinkCalls).toBe(1)
+    // (b) no orphan .recent.md.tmp.* file remains in the directory.
+    const siblings = readdirSync(dirname(hotPath))
+    for (const name of siblings) {
+      expect(name.startsWith('.recent.md.tmp.')).toBe(false)
+    }
+  })
+
   test('newlines in snippets are caller responsibility (writer does not collapse — uses snippet() upstream)', async () => {
     // The hot-writer takes already-flattened snippets; embedding a raw
     // newline produces multi-line entries by design. snippet() is the

--- a/plugin/tests/memory/hot-writer.test.ts
+++ b/plugin/tests/memory/hot-writer.test.ts
@@ -1,0 +1,173 @@
+// Phase 8 / T2 — hot-writer tests.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { appendHotEntry, snippet } from '../../src/memory/hot-writer.js'
+
+let dir: string
+let hotPath: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'dashi-hot-writer-'))
+  hotPath = join(dir, 'core', 'hot', 'recent.md')
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function defaultInput(overrides: Partial<Parameters<typeof appendHotEntry>[0]> = {}): Parameters<typeof appendHotEntry>[0] {
+  return {
+    path: hotPath,
+    ts: '2026-05-15 12:00',
+    agentLabel: 'Silvana',
+    sourceTag: 'tg',
+    userSnippet: 'hello',
+    agentSnippet: 'hi there',
+    maxBytes: 20480,
+    trimKeepLines: 600,
+    ...overrides,
+  }
+}
+
+describe('snippet', () => {
+  test('collapses newlines to spaces', () => {
+    expect(snippet('a\nb\nc')).toBe('a b c')
+  })
+
+  test('slices to max chars (default 200)', () => {
+    const s = 'x'.repeat(300)
+    expect(snippet(s).length).toBe(200)
+  })
+
+  test('honours explicit max', () => {
+    expect(snippet('abcdef', 3)).toBe('abc')
+  })
+
+  test('returns empty string for empty/falsy input', () => {
+    expect(snippet('')).toBe('')
+    // typecheck-safe: function tolerates undefined-ish via the `|| ''` guard
+    expect(snippet(undefined as unknown as string)).toBe('')
+  })
+})
+
+describe('appendHotEntry', () => {
+  test('writes 4-line entry with gateway.py-format header (newline + ### + tag, **User:**, **Agent:**)', async () => {
+    await appendHotEntry(defaultInput())
+    const text = readFileSync(hotPath, 'utf8')
+    // First char is a leading newline (per gateway.py format spec).
+    expect(text.startsWith('\n### 2026-05-15 12:00 [tg]\n')).toBe(true)
+    expect(text).toContain('**User:** hello\n')
+    expect(text).toContain('**Silvana:** hi there\n')
+  })
+
+  test('mkdir -p creates core/hot/ on first write', async () => {
+    // sanity — parent doesn't exist yet
+    let parentExisted = true
+    try {
+      readdirSync(dirname(hotPath))
+    } catch {
+      parentExisted = false
+    }
+    expect(parentExisted).toBe(false)
+    await appendHotEntry(defaultInput())
+    // file now exists
+    expect(readFileSync(hotPath, 'utf8').length).toBeGreaterThan(0)
+  })
+
+  test('appends across multiple calls (no overwrite)', async () => {
+    await appendHotEntry(defaultInput({ userSnippet: 'first' }))
+    await appendHotEntry(defaultInput({ userSnippet: 'second' }))
+    const text = readFileSync(hotPath, 'utf8')
+    expect(text).toContain('**User:** first\n')
+    expect(text).toContain('**User:** second\n')
+  })
+
+  test('concurrent 200 appends: every line present, no interleave', async () => {
+    const N = 200
+    const tasks: Promise<void>[] = []
+    for (let i = 0; i < N; i++) {
+      tasks.push(
+        appendHotEntry(
+          defaultInput({
+            userSnippet: `u${i.toString().padStart(4, '0')}`,
+            agentSnippet: `a${i.toString().padStart(4, '0')}`,
+          }),
+        ),
+      )
+    }
+    await Promise.all(tasks)
+    const text = readFileSync(hotPath, 'utf8')
+    for (let i = 0; i < N; i++) {
+      const id = i.toString().padStart(4, '0')
+      expect(text).toContain(`**User:** u${id}\n`)
+      expect(text).toContain(`**Silvana:** a${id}\n`)
+    }
+    // Cheap interleave check: every '**User:** uNNNN' must be followed
+    // by the matching '**Silvana:** aNNNN' on the next non-empty line.
+    const lines = text.split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      const m = /^\*\*User:\*\* u(\d{4})$/.exec(lines[i]!)
+      if (!m) continue
+      const next = lines[i + 1] ?? ''
+      expect(next).toBe(`**Silvana:** a${m[1]}`)
+    }
+  })
+
+  test('triggers emergency trim when file exceeds maxBytes', async () => {
+    // Pre-seed ~30 KB so the first append triggers the >20 KB branch.
+    const pre = '\n### 2026-05-15 11:00 [tg]\n' +
+      '**User:** ' + 'a'.repeat(180) + '\n' +
+      '**Silvana:** ' + 'b'.repeat(180) + '\n'
+    // mkdir-p so we can pre-seed before the writer ever runs.
+    const fs = await import('node:fs/promises')
+    await fs.mkdir(dirname(hotPath), { recursive: true })
+    let seed = ''
+    while (seed.length < 30 * 1024) seed += pre
+    writeFileSync(hotPath, seed, 'utf8')
+
+    await appendHotEntry(defaultInput({ maxBytes: 20480, trimKeepLines: 50 }))
+
+    const text = readFileSync(hotPath, 'utf8')
+    expect(text.length).toBeLessThanOrEqual(20480 + 256) // small slack for header
+    // First non-empty line after the header section must start with `### `
+    const lines = text.split('\n')
+    let firstEntryIdx = -1
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i]!.startsWith('### ')) { firstEntryIdx = i; break }
+    }
+    expect(firstEntryIdx).toBeGreaterThanOrEqual(0)
+    // Header is preserved at the top.
+    expect(text.startsWith('# Hot memory')).toBe(true)
+  })
+
+  test('trim leaves no orphan .recent.md.tmp.* file in target dir', async () => {
+    const fs = await import('node:fs/promises')
+    await fs.mkdir(dirname(hotPath), { recursive: true })
+    const pre = '\n### 2026-05-15 11:00 [tg]\n' +
+      '**User:** ' + 'a'.repeat(180) + '\n' +
+      '**Silvana:** ' + 'b'.repeat(180) + '\n'
+    let seed = ''
+    while (seed.length < 30 * 1024) seed += pre
+    writeFileSync(hotPath, seed, 'utf8')
+
+    await appendHotEntry(defaultInput({ maxBytes: 20480, trimKeepLines: 50 }))
+
+    const siblings = readdirSync(dirname(hotPath))
+    for (const name of siblings) {
+      expect(name.startsWith('.recent.md.tmp.')).toBe(false)
+    }
+  })
+
+  test('newlines in snippets are caller responsibility (writer does not collapse — uses snippet() upstream)', async () => {
+    // The hot-writer takes already-flattened snippets; embedding a raw
+    // newline produces multi-line entries by design. snippet() is the
+    // helper callers must use. This locks the contract.
+    await appendHotEntry(defaultInput({ userSnippet: 'line1\nline2' }))
+    const text = readFileSync(hotPath, 'utf8')
+    expect(text).toContain('**User:** line1\nline2\n')
+  })
+})

--- a/plugin/tests/memory/hot-writer.test.ts
+++ b/plugin/tests/memory/hot-writer.test.ts
@@ -140,8 +140,12 @@ describe('appendHotEntry', () => {
       if (lines[i]!.startsWith('### ')) { firstEntryIdx = i; break }
     }
     expect(firstEntryIdx).toBeGreaterThanOrEqual(0)
-    // Header is preserved at the top.
-    expect(text.startsWith('# Hot memory')).toBe(true)
+    // Header is preserved at the top — ASCII `--`, byte-parity with
+    // gateway.py:1973 + scripts/trim-hot.sh. NOT em-dash (review HIGH).
+    expect(text.startsWith('# Hot memory -- last 24h rolling journal\n\n')).toBe(true)
+    // Exact-byte check on the first 42 bytes (length of the header).
+    const headerLiteral = '# Hot memory -- last 24h rolling journal\n\n'
+    expect(text.slice(0, headerLiteral.length)).toBe(headerLiteral)
   })
 
   test('trim leaves no orphan .recent.md.tmp.* file in target dir', async () => {

--- a/plugin/tests/memory/prompt-buffer.test.ts
+++ b/plugin/tests/memory/prompt-buffer.test.ts
@@ -1,0 +1,113 @@
+// Phase 8 / T4 — prompt-buffer tests.
+//
+// All time-sensitive assertions use a fake clock so tests don't rely on
+// setTimeout latency.
+
+import { describe, expect, test } from 'bun:test'
+import { PromptBuffer } from '../../src/memory/prompt-buffer.js'
+
+function fakeClock(start = 1_000_000): { now: () => number; advance: (ms: number) => void } {
+  let t = start
+  return {
+    now: () => t,
+    advance: (ms) => { t += ms },
+  }
+}
+
+describe('PromptBuffer', () => {
+  test('set + take returns the buffered prompt and removes it', () => {
+    const c = fakeClock()
+    const buf = new PromptBuffer(60_000, 100, c.now)
+    buf.set('chat1', 'hello', 'sid-1')
+    const v = buf.take('chat1')
+    expect(v?.prompt).toBe('hello')
+    expect(v?.sessionId).toBe('sid-1')
+    expect(v?.ts).toBe(1_000_000)
+    // Second take is a miss — entries are one-shot.
+    expect(buf.take('chat1')).toBeUndefined()
+  })
+
+  test('take on unknown chatId returns undefined', () => {
+    const buf = new PromptBuffer(60_000, 100)
+    expect(buf.take('never-set')).toBeUndefined()
+  })
+
+  test('TTL expiry: take returns undefined and removes the stale entry', () => {
+    const c = fakeClock()
+    const buf = new PromptBuffer(60_000, 100, c.now)
+    buf.set('chat1', 'hi', null)
+    c.advance(60_001) // just past the TTL
+    expect(buf.take('chat1')).toBeUndefined()
+    // And the underlying map no longer holds the entry.
+    expect(buf.size()).toBe(0)
+  })
+
+  test('TTL boundary: exactly ttlMs old is still valid (>, not >=)', () => {
+    const c = fakeClock()
+    const buf = new PromptBuffer(60_000, 100, c.now)
+    buf.set('chat1', 'hi', null)
+    c.advance(60_000)
+    const v = buf.take('chat1')
+    expect(v?.prompt).toBe('hi')
+  })
+
+  test('LRU cap: oldest chat is evicted when maxEntries exceeded', () => {
+    const c = fakeClock()
+    const buf = new PromptBuffer(60_000, 2, c.now)
+    buf.set('chat1', 'p1', null)
+    c.advance(10)
+    buf.set('chat2', 'p2', null)
+    c.advance(10)
+    buf.set('chat3', 'p3', null) // chat1 evicted
+
+    expect(buf.size()).toBe(2)
+    expect(buf.take('chat1')).toBeUndefined()
+    expect(buf.take('chat2')?.prompt).toBe('p2')
+    expect(buf.take('chat3')?.prompt).toBe('p3')
+  })
+
+  test('overwriting same chatId bumps it to MRU', () => {
+    const c = fakeClock()
+    const buf = new PromptBuffer(60_000, 2, c.now)
+    buf.set('chat1', 'old', null)
+    c.advance(10)
+    buf.set('chat2', 'mid', null)
+    c.advance(10)
+    buf.set('chat1', 'new', null) // chat1 is now MRU
+    c.advance(10)
+    buf.set('chat3', 'fresh', null) // should evict chat2, not chat1
+    expect(buf.take('chat2')).toBeUndefined()
+    expect(buf.take('chat1')?.prompt).toBe('new')
+    expect(buf.take('chat3')?.prompt).toBe('fresh')
+  })
+
+  test('lazy evict on insert drops expired entries before LRU check', () => {
+    const c = fakeClock()
+    const buf = new PromptBuffer(1_000, 3, c.now)
+    buf.set('a', 'pa', null)
+    buf.set('b', 'pb', null)
+    buf.set('c', 'pc', null)
+    c.advance(2_000) // all three expire
+    buf.set('d', 'pd', null) // evict-pass should clear a/b/c
+    expect(buf.size()).toBe(1)
+    expect(buf.take('d')?.prompt).toBe('pd')
+  })
+
+  test('sessionId null preserved through the round-trip', () => {
+    const buf = new PromptBuffer(60_000, 10)
+    buf.set('chat1', 'p', null)
+    const v = buf.take('chat1')
+    expect(v?.sessionId).toBeNull()
+  })
+
+  test('default clock is Date.now (smoke — no fake injection)', () => {
+    const buf = new PromptBuffer(60_000, 10)
+    buf.set('chat1', 'p', null)
+    const before = Date.now()
+    const v = buf.take('chat1')
+    const after = Date.now()
+    expect(v).toBeDefined()
+    expect(v!.ts).toBeGreaterThanOrEqual(before)
+    expect(v!.ts).toBeLessThanOrEqual(after)
+  })
+})

--- a/plugin/tests/memory/transcript-reader.test.ts
+++ b/plugin/tests/memory/transcript-reader.test.ts
@@ -114,4 +114,46 @@ describe('readLastAssistantText', () => {
     )
     expect(await readLastAssistantText(path)).toBe('final')
   })
+
+  // ───────────────────────────────────────────────────────────────
+  // Permissive shape guard (review MEDIUM):
+  // before the fix, a valid JSON line with the wrong shape (e.g. `null`,
+  // a bare array, a string) bypassed the per-line try/catch and threw at
+  // the next `obj.message?.role` access, escaping to the OUTER catch and
+  // short-circuiting ALL earlier assistant text. After the fix every
+  // shape mismatch is a `continue`, not an abort.
+  // ───────────────────────────────────────────────────────────────
+
+  test('skips JSON `null` line between two valid assistant messages', async () => {
+    const path = write('t.jsonl',
+      line({ message: { role: 'assistant', content: [{ type: 'text', text: 'older' }] } }) +
+      'null\n' +
+      line({ message: { role: 'assistant', content: [{ type: 'text', text: 'newer' }] } }),
+    )
+    expect(await readLastAssistantText(path)).toBe('newer')
+  })
+
+  test('skips JSON array line (valid JSON, wrong shape)', async () => {
+    const path = write('t.jsonl',
+      line({ message: { role: 'assistant', content: [{ type: 'text', text: 'keep me' }] } }) +
+      '[1,2,3]\n',
+    )
+    expect(await readLastAssistantText(path)).toBe('keep me')
+  })
+
+  test('skips JSON string line (valid JSON, wrong shape)', async () => {
+    const path = write('t.jsonl',
+      line({ message: { role: 'assistant', content: [{ type: 'text', text: 'survives' }] } }) +
+      '"just a string"\n',
+    )
+    expect(await readLastAssistantText(path)).toBe('survives')
+  })
+
+  test('skips line whose `message` is itself null', async () => {
+    const path = write('t.jsonl',
+      line({ message: { role: 'assistant', content: [{ type: 'text', text: 'good' }] } }) +
+      line({ message: null }),
+    )
+    expect(await readLastAssistantText(path)).toBe('good')
+  })
 })

--- a/plugin/tests/memory/transcript-reader.test.ts
+++ b/plugin/tests/memory/transcript-reader.test.ts
@@ -1,0 +1,117 @@
+// Phase 8 / T5 — transcript-reader tests.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { readLastAssistantText } from '../../src/memory/transcript-reader.js'
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'dashi-transcript-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function write(name: string, content: string): string {
+  const p = join(dir, name)
+  writeFileSync(p, content, 'utf8')
+  return p
+}
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj) + '\n'
+}
+
+describe('readLastAssistantText', () => {
+  test('returns text from last assistant message with single text block', async () => {
+    const path = write('t.jsonl',
+      line({ message: { role: 'user', content: [{ type: 'text', text: 'hi' }] } }) +
+      line({ message: { role: 'assistant', content: [{ type: 'text', text: 'hello back' }] } }),
+    )
+    expect(await readLastAssistantText(path)).toBe('hello back')
+  })
+
+  test('joins multiple text blocks with \\n', async () => {
+    const path = write('t.jsonl',
+      line({
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'part1' },
+            { type: 'tool_use', id: 'tu', name: 'X', input: {} },
+            { type: 'text', text: 'part2' },
+          ],
+        },
+      }),
+    )
+    expect(await readLastAssistantText(path)).toBe('part1\npart2')
+  })
+
+  test('returns the LAST assistant message, not the first', async () => {
+    const path = write('t.jsonl',
+      line({ message: { role: 'assistant', content: [{ type: 'text', text: 'first' }] } }) +
+      line({ message: { role: 'user', content: [{ type: 'text', text: 'next' }] } }) +
+      line({ message: { role: 'assistant', content: [{ type: 'text', text: 'second' }] } }),
+    )
+    expect(await readLastAssistantText(path)).toBe('second')
+  })
+
+  test('skips assistant messages that have only tool_use blocks', async () => {
+    const path = write('t.jsonl',
+      line({ message: { role: 'assistant', content: [{ type: 'text', text: 'real reply' }] } }) +
+      line({ message: { role: 'assistant', content: [{ type: 'tool_use', id: 'tu', name: 'X', input: {} }] } }),
+    )
+    expect(await readLastAssistantText(path)).toBe('real reply')
+  })
+
+  test('returns null when no assistant message exists', async () => {
+    const path = write('t.jsonl',
+      line({ message: { role: 'user', content: [{ type: 'text', text: 'only user' }] } }),
+    )
+    expect(await readLastAssistantText(path)).toBeNull()
+  })
+
+  test('returns null for empty file', async () => {
+    const path = write('t.jsonl', '')
+    expect(await readLastAssistantText(path)).toBeNull()
+  })
+
+  test('returns null when path does not exist (no throw)', async () => {
+    expect(await readLastAssistantText(join(dir, 'missing.jsonl'))).toBeNull()
+  })
+
+  test('handles malformed JSON line gracefully by skipping it', async () => {
+    const path = write('t.jsonl',
+      line({ message: { role: 'assistant', content: [{ type: 'text', text: 'good' }] } }) +
+      'this is not json\n',
+    )
+    expect(await readLastAssistantText(path)).toBe('good')
+  })
+
+  test('drops possibly-truncated first line when file > TAIL_BYTES', async () => {
+    // Construct: a giant first line we DO NOT want to read, then a
+    // smaller assistant text we expect to find. Total > 256 KB.
+    const huge = JSON.stringify({
+      message: { role: 'assistant', content: [{ type: 'text', text: 'X'.repeat(300_000) }] },
+    }) + '\n'
+    const wanted = JSON.stringify({
+      message: { role: 'assistant', content: [{ type: 'text', text: 'KEEP-ME' }] },
+    }) + '\n'
+    const path = write('t.jsonl', huge + wanted)
+    const out = await readLastAssistantText(path)
+    expect(out).toBe('KEEP-ME')
+  })
+
+  test('ignores entries where message.content is not an array', async () => {
+    const path = write('t.jsonl',
+      line({ message: { role: 'assistant', content: 'string-not-array' } }) +
+      line({ message: { role: 'assistant', content: [{ type: 'text', text: 'final' }] } }),
+    )
+    expect(await readLastAssistantText(path)).toBe('final')
+  })
+})

--- a/plugin/tests/memory/verbose-writer.test.ts
+++ b/plugin/tests/memory/verbose-writer.test.ts
@@ -1,0 +1,102 @@
+// Phase 8 / T3 — verbose-writer tests.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { appendVerbose, type VerboseRecord } from '../../src/memory/verbose-writer.js'
+
+let dir: string
+let logsDir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'dashi-verbose-writer-'))
+  logsDir = join(dir, 'logs')
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function record(overrides: Partial<VerboseRecord> = {}): VerboseRecord {
+  return {
+    ts: '2026-05-15T10:30:00.000Z',
+    sid: 'session-1',
+    ch: 'tg',
+    user: 'hello',
+    agent: 'world',
+    dur_ms: 1234,
+    status: 'completed',
+    ...overrides,
+  }
+}
+
+describe('appendVerbose', () => {
+  test('creates logsDir if missing and writes verbose-YYYY-MM-DD.jsonl', async () => {
+    await appendVerbose({ logsDir, record: record() })
+    const files = readdirSync(logsDir)
+    expect(files).toEqual(['verbose-2026-05-15.jsonl'])
+  })
+
+  test('record is one JSON object per line, terminated by \\n', async () => {
+    await appendVerbose({ logsDir, record: record() })
+    const text = readFileSync(join(logsDir, 'verbose-2026-05-15.jsonl'), 'utf8')
+    expect(text.endsWith('\n')).toBe(true)
+    const parsed = JSON.parse(text.trim()) as VerboseRecord
+    expect(parsed.ts).toBe('2026-05-15T10:30:00.000Z')
+    expect(parsed.sid).toBe('session-1')
+    expect(parsed.ch).toBe('tg')
+    expect(parsed.user).toBe('hello')
+    expect(parsed.agent).toBe('world')
+    expect(parsed.dur_ms).toBe(1234)
+    expect(parsed.status).toBe('completed')
+  })
+
+  test('key order matches gateway.py: ts, sid, ch, user, agent, dur_ms, status', async () => {
+    await appendVerbose({ logsDir, record: record() })
+    const text = readFileSync(join(logsDir, 'verbose-2026-05-15.jsonl'), 'utf8').trim()
+    // Cheap order check: the substring positions of each key in the
+    // raw JSON line must be strictly increasing.
+    const expected = ['"ts":', '"sid":', '"ch":', '"user":', '"agent":', '"dur_ms":', '"status":']
+    let last = -1
+    for (const k of expected) {
+      const idx = text.indexOf(k)
+      expect(idx).toBeGreaterThan(last)
+      last = idx
+    }
+  })
+
+  test('multiple records on same day append into one file', async () => {
+    await appendVerbose({ logsDir, record: record({ user: 'first' }) })
+    await appendVerbose({ logsDir, record: record({ user: 'second' }) })
+    const text = readFileSync(join(logsDir, 'verbose-2026-05-15.jsonl'), 'utf8')
+    const lines = text.trim().split('\n')
+    expect(lines.length).toBe(2)
+    expect(JSON.parse(lines[0]!).user).toBe('first')
+    expect(JSON.parse(lines[1]!).user).toBe('second')
+  })
+
+  test('records on different UTC days land in different files', async () => {
+    await appendVerbose({ logsDir, record: record({ ts: '2026-05-15T23:59:59.999Z' }) })
+    await appendVerbose({ logsDir, record: record({ ts: '2026-05-16T00:00:00.000Z' }) })
+    const files = readdirSync(logsDir).sort()
+    expect(files).toEqual(['verbose-2026-05-15.jsonl', 'verbose-2026-05-16.jsonl'])
+  })
+
+  test('sid null is preserved (not undefined-stripped)', async () => {
+    await appendVerbose({ logsDir, record: record({ sid: null }) })
+    const text = readFileSync(join(logsDir, 'verbose-2026-05-15.jsonl'), 'utf8').trim()
+    const parsed = JSON.parse(text) as VerboseRecord
+    expect(parsed.sid).toBeNull()
+    // Raw text must contain `"sid":null`, not omit the key.
+    expect(text).toContain('"sid":null')
+  })
+
+  test('day derived from record.ts, not Date.now() (locks the doc-comment guarantee)', async () => {
+    // Even though the clock might be 2026-05-15, a record from 2025-01-01
+    // must go into the 2025 file.
+    await appendVerbose({ logsDir, record: record({ ts: '2025-01-01T12:00:00.000Z' }) })
+    expect(readdirSync(logsDir)).toEqual(['verbose-2025-01-01.jsonl'])
+  })
+})

--- a/plugin/tests/memory/verbose-writer.test.ts
+++ b/plugin/tests/memory/verbose-writer.test.ts
@@ -99,4 +99,42 @@ describe('appendVerbose', () => {
     await appendVerbose({ logsDir, record: record({ ts: '2025-01-01T12:00:00.000Z' }) })
     expect(readdirSync(logsDir)).toEqual(['verbose-2025-01-01.jsonl'])
   })
+
+  test('50 concurrent appends with multi-KB records: every line parseable JSON, no interleave (review HIGH)', async () => {
+    // Pre-fix `appendFile` was NOT atomic for buffers > PIPE_BUF on macOS;
+    // multi-KB records under burst load could interleave and produce
+    // corrupt JSONL — exact failure mode the Cognee cron would silently
+    // drop. After the mutex fix every record must round-trip JSON.parse
+    // AND retain its full 10KB user/agent text.
+    const N = 50
+    const tasks: Promise<void>[] = []
+    for (let i = 0; i < N; i++) {
+      tasks.push(
+        appendVerbose({
+          logsDir,
+          record: record({
+            sid: `sess-${i.toString().padStart(4, '0')}`,
+            user: 'U'.repeat(10_000),
+            agent: 'A'.repeat(10_000),
+          }),
+        }),
+      )
+    }
+    await Promise.all(tasks)
+
+    const text = readFileSync(join(logsDir, 'verbose-2026-05-15.jsonl'), 'utf8')
+    const lines = text.split('\n').filter((l) => l.length > 0)
+    expect(lines.length).toBe(N)
+
+    const seen = new Set<string>()
+    for (const l of lines) {
+      // No throw on JSON.parse — every line is well-formed.
+      const parsed = JSON.parse(l) as VerboseRecord
+      expect(parsed.user.length).toBeGreaterThanOrEqual(10_000)
+      expect(parsed.agent.length).toBeGreaterThanOrEqual(10_000)
+      // Every sid is preserved intact, proving no header/body mix-up.
+      if (parsed.sid) seen.add(parsed.sid)
+    }
+    expect(seen.size).toBe(N)
+  })
 })

--- a/plugin/tests/memory/writer.test.ts
+++ b/plugin/tests/memory/writer.test.ts
@@ -1,0 +1,213 @@
+// Phase 8 / T6 — MemoryWriter facade tests (unit-level).
+//
+// T8 layers an end-to-end webhook test on top of these; here we drive
+// the facade directly to assert UserPromptSubmit/Stop semantics,
+// `(no prompt)` fallback, transcript-missing graceful path, and fake-
+// clock determinism for ts + dur_ms.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { MemoryWriter, type MemoryConfig } from '../../src/memory/writer.js'
+import type { Logger } from '../../src/log.js'
+import type { ClaudeHookPayload } from '../../src/schemas.js'
+
+interface LogCall { level: 'debug' | 'info' | 'warn' | 'error'; msg: string; ctx?: Record<string, unknown> }
+function makeLog(): { log: Logger; calls: LogCall[] } {
+  const calls: LogCall[] = []
+  const log: Logger = {
+    debug: (msg, ctx) => calls.push({ level: 'debug', msg, ...(ctx !== undefined ? { ctx } : {}) }),
+    info: (msg, ctx) => calls.push({ level: 'info', msg, ...(ctx !== undefined ? { ctx } : {}) }),
+    warn: (msg, ctx) => calls.push({ level: 'warn', msg, ...(ctx !== undefined ? { ctx } : {}) }),
+    error: (msg, ctx) => calls.push({ level: 'error', msg, ...(ctx !== undefined ? { ctx } : {}) }),
+  }
+  return { log, calls }
+}
+
+let baseDir: string
+let workspacePath: string
+let logsPath: string
+
+beforeEach(() => {
+  baseDir = mkdtempSync(join(tmpdir(), 'dashi-memory-writer-'))
+  workspacePath = join(baseDir, 'workspace')
+  logsPath = join(baseDir, 'logs')
+  // workspace itself exists; core/hot/ is auto-mkdir'd by hot-writer.
+  mkdirSync(workspacePath, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(baseDir, { recursive: true, force: true })
+})
+
+function cfg(overrides: Partial<MemoryConfig> = {}): MemoryConfig {
+  return {
+    workspacePath,
+    logsPath,
+    sourceTag: 'tg',
+    agentLabel: 'Silvana',
+    maxHotBytes: 20480,
+    trimKeepLines: 600,
+    bufferTtlMs: 5 * 60 * 1000,
+    bufferMaxEntries: 100,
+    ...overrides,
+  }
+}
+
+function fakeClock(start = Date.UTC(2026, 4, 15, 10, 0, 0)): { now: () => number; advance: (ms: number) => void } {
+  let t = start
+  return { now: () => t, advance: (ms) => { t += ms } }
+}
+
+function payload<E extends ClaudeHookPayload['hook_event_name']>(
+  ev: E,
+  extra: Record<string, unknown> = {},
+): ClaudeHookPayload {
+  const base = {
+    chatId: '164795011',
+    session_id: 'sid-1',
+    transcript_path: '/tmp/none.jsonl',
+    cwd: '/tmp',
+    hook_event_name: ev,
+    ...extra,
+  }
+  return base as unknown as ClaudeHookPayload
+}
+
+function writeTranscript(dir: string, content: string): string {
+  mkdirSync(dir, { recursive: true })
+  const p = join(dir, 'session.jsonl')
+  writeFileSync(p, content, 'utf8')
+  return p
+}
+
+// ─────────────────────────────────────────────────────────────────────
+
+describe('MemoryWriter.onHook', () => {
+  test('UserPromptSubmit alone writes nothing — just buffers', async () => {
+    const c = fakeClock()
+    const { log } = makeLog()
+    const w = new MemoryWriter(cfg(), log, c.now)
+
+    await w.onHook(payload('UserPromptSubmit', { prompt: 'hi from user' }))
+
+    // No files written yet.
+    let hotExists = true
+    try { readFileSync(join(workspacePath, 'core', 'hot', 'recent.md'), 'utf8') } catch { hotExists = false }
+    expect(hotExists).toBe(false)
+    let logsExist = true
+    try { readdirSync(logsPath) } catch { logsExist = false }
+    expect(logsExist).toBe(false)
+  })
+
+  test('UserPromptSubmit + Stop writes recent.md and verbose-*.jsonl with buffered prompt and transcript text', async () => {
+    const c = fakeClock()
+    const { log } = makeLog()
+    const w = new MemoryWriter(cfg(), log, c.now)
+
+    const transcript = writeTranscript(baseDir, JSON.stringify({
+      message: { role: 'assistant', content: [{ type: 'text', text: 'agent reply here' }] },
+    }) + '\n')
+
+    await w.onHook(payload('UserPromptSubmit', { prompt: 'user question?' }))
+    c.advance(2500) // 2.5s "compute time"
+    await w.onHook(payload('Stop', { transcript_path: transcript }))
+
+    const hot = readFileSync(join(workspacePath, 'core', 'hot', 'recent.md'), 'utf8')
+    expect(hot).toContain('**User:** user question?\n')
+    expect(hot).toContain('**Silvana:** agent reply here\n')
+    // Local-tz ts format: 'YYYY-MM-DD HH:MM' — just assert shape.
+    expect(hot).toMatch(/### \d{4}-\d{2}-\d{2} \d{2}:\d{2} \[tg\]/)
+
+    // verbose: derive day from record.ts (UTC ISO). fakeClock starts
+    // at 2026-05-15 10:00 UTC + 2.5s, so day = 2026-05-15.
+    const files = readdirSync(logsPath).sort()
+    expect(files).toEqual(['verbose-2026-05-15.jsonl'])
+    const v = JSON.parse(readFileSync(join(logsPath, 'verbose-2026-05-15.jsonl'), 'utf8').trim())
+    expect(v.user).toBe('user question?')
+    expect(v.agent).toBe('agent reply here')
+    expect(v.sid).toBe('sid-1')
+    expect(v.ch).toBe('tg')
+    expect(v.dur_ms).toBe(2500)
+    expect(v.status).toBe('completed')
+    expect(v.ts).toBe(new Date(Date.UTC(2026, 4, 15, 10, 0, 2, 500)).toISOString())
+  })
+
+  test('Stop without prior UserPromptSubmit writes (no prompt) + warn + dur_ms=0', async () => {
+    const c = fakeClock()
+    const { log, calls } = makeLog()
+    const w = new MemoryWriter(cfg(), log, c.now)
+
+    await w.onHook(payload('Stop'))
+
+    const hot = readFileSync(join(workspacePath, 'core', 'hot', 'recent.md'), 'utf8')
+    expect(hot).toContain('**User:** (no prompt)\n')
+    expect(hot).toContain('**Silvana:** (inline)\n')
+
+    const v = JSON.parse(readFileSync(join(logsPath, 'verbose-2026-05-15.jsonl'), 'utf8').trim())
+    expect(v.user).toBe('(no prompt)')
+    expect(v.agent).toBe('')
+    expect(v.dur_ms).toBe(0)
+
+    const warns = calls.filter(c => c.level === 'warn')
+    expect(warns.length).toBe(1)
+    expect(warns[0]!.msg).toContain('Stop without buffered prompt')
+  })
+
+  test('Stop with unreadable transcript path uses empty agent text + (inline) snippet (no throw)', async () => {
+    const c = fakeClock()
+    const { log } = makeLog()
+    const w = new MemoryWriter(cfg(), log, c.now)
+
+    await w.onHook(payload('UserPromptSubmit', { prompt: 'q' }))
+    await w.onHook(payload('Stop', { transcript_path: '/path/that/does/not/exist.jsonl' }))
+
+    const hot = readFileSync(join(workspacePath, 'core', 'hot', 'recent.md'), 'utf8')
+    expect(hot).toContain('**Silvana:** (inline)\n')
+    const v = JSON.parse(readFileSync(join(logsPath, 'verbose-2026-05-15.jsonl'), 'utf8').trim())
+    expect(v.agent).toBe('')
+  })
+
+  test('PreToolUse / PostToolUse / SessionStart hooks are no-ops', async () => {
+    const c = fakeClock()
+    const { log } = makeLog()
+    const w = new MemoryWriter(cfg(), log, c.now)
+
+    await w.onHook(payload('PreToolUse', { tool_name: 'Read', tool_use_id: 'u1', tool_input: {} }))
+    await w.onHook(payload('PostToolUse', { tool_name: 'Read', tool_use_id: 'u1', tool_input: {} }))
+    await w.onHook(payload('SessionStart'))
+
+    let hotExists = true
+    try { readFileSync(join(workspacePath, 'core', 'hot', 'recent.md'), 'utf8') } catch { hotExists = false }
+    expect(hotExists).toBe(false)
+    let logsExist = true
+    try { readdirSync(logsPath) } catch { logsExist = false }
+    expect(logsExist).toBe(false)
+  })
+
+  test('long prompt is truncated in recent.md but full-length in verbose.jsonl', async () => {
+    const c = fakeClock()
+    const { log } = makeLog()
+    const w = new MemoryWriter(cfg(), log, c.now)
+
+    const longPrompt = 'P'.repeat(500)
+    const transcript = writeTranscript(baseDir, JSON.stringify({
+      message: { role: 'assistant', content: [{ type: 'text', text: 'A'.repeat(500) }] },
+    }) + '\n')
+
+    await w.onHook(payload('UserPromptSubmit', { prompt: longPrompt }))
+    await w.onHook(payload('Stop', { transcript_path: transcript }))
+
+    const hot = readFileSync(join(workspacePath, 'core', 'hot', 'recent.md'), 'utf8')
+    // snippet() slices to 200 chars
+    expect(hot).toContain('**User:** ' + 'P'.repeat(200) + '\n')
+    expect(hot).toContain('**Silvana:** ' + 'A'.repeat(200) + '\n')
+
+    const v = JSON.parse(readFileSync(join(logsPath, 'verbose-2026-05-15.jsonl'), 'utf8').trim())
+    expect(v.user.length).toBe(500)
+    expect(v.agent.length).toBe(500)
+  })
+})

--- a/plugin/tests/prompt/media-prompt.test.ts
+++ b/plugin/tests/prompt/media-prompt.test.ts
@@ -33,6 +33,14 @@ const voiceConfig: AppConfig = {
   webhook: { enabled: false, host: '127.0.0.1', port: 0 },
   permission_relay: { enabled: true, allowed_user_ids: [1], bash_only_proof: true },
   commands: { help: true, status: true, stop: true, reset: true, new: true },
+  memory: {
+    enabled: false,
+    source_tag: 'tg',
+    max_hot_bytes: 20480,
+    trim_keep_lines: 600,
+    buffer_ttl_ms: 5 * 60 * 1000,
+    buffer_max_entries: 100,
+  },
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/plugin/tests/security/paths.test.ts
+++ b/plugin/tests/security/paths.test.ts
@@ -46,6 +46,14 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webhook: { enabled: false, host: '127.0.0.1', port: 0 },
     permission_relay: { enabled: true, allowed_user_ids: [164795011], bash_only_proof: true },
     commands: { help: true, status: true, stop: true, reset: true, new: true },
+    memory: {
+      enabled: false,
+      source_tag: 'tg',
+      max_hot_bytes: 20480,
+      trim_keep_lines: 600,
+      buffer_ttl_ms: 5 * 60 * 1000,
+      buffer_max_entries: 100,
+    },
     ...overrides,
   }
 }

--- a/plugin/tests/status/status-manager.test.ts
+++ b/plugin/tests/status/status-manager.test.ts
@@ -31,6 +31,14 @@ function makeConfig(overrides: Partial<AppConfig['status']> = {}): AppConfig {
     webhook: { enabled: false, host: '127.0.0.1', port: 0 },
     permission_relay: { enabled: true, allowed_user_ids: [164795011], bash_only_proof: true },
     commands: { help: true, status: true, stop: true, reset: true, new: true },
+    memory: {
+      enabled: false,
+      source_tag: 'tg',
+      max_hot_bytes: 20480,
+      trim_keep_lines: 600,
+      buffer_ttl_ms: 5 * 60 * 1000,
+      buffer_max_entries: 100,
+    },
   }
 }
 

--- a/plugin/tests/telegram/gate.test.ts
+++ b/plugin/tests/telegram/gate.test.ts
@@ -22,6 +22,14 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webhook: { enabled: false, host: '127.0.0.1', port: 0 },
     permission_relay: { enabled: true, allowed_user_ids: [164795011], bash_only_proof: true },
     commands: { help: true, status: true, stop: true, reset: true, new: true },
+    memory: {
+      enabled: false,
+      source_tag: 'tg',
+      max_hot_bytes: 20480,
+      trim_keep_lines: 600,
+      buffer_ttl_ms: 5 * 60 * 1000,
+      buffer_max_entries: 100,
+    },
     ...overrides,
   }
 }

--- a/plugin/tests/telegram/handlers.test.ts
+++ b/plugin/tests/telegram/handlers.test.ts
@@ -40,6 +40,14 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     webhook: { enabled: false, host: '127.0.0.1', port: 0 },
     permission_relay: { enabled: true, allowed_user_ids: [164795011], bash_only_proof: true },
     commands: { help: true, status: true, stop: true, reset: true, new: true },
+    memory: {
+      enabled: false,
+      source_tag: 'tg',
+      max_hot_bytes: 20480,
+      trim_keep_lines: 600,
+      buffer_ttl_ms: 5 * 60 * 1000,
+      buffer_max_entries: 100,
+    },
     ...overrides,
   }
 }

--- a/plugin/tests/webhook/server.test.ts
+++ b/plugin/tests/webhook/server.test.ts
@@ -897,6 +897,64 @@ describe('POST /hooks/agent — memoryWriter branch (Phase 8 T7)', () => {
     expect(status.calls.length).toBe(1)
   })
 
+  test('memoryWriter throw is logged via log.warn with [memory] prefix (review LOW)', async () => {
+    // Pre-fix: the swallow-and-200 contract was correct, but there was
+    // no test that the error actually surfaced as a warn-level log line
+    // — silent loss of writer errors would defeat operator triage.
+    // Capture the logger stream and assert a `[memory]` prefix line was
+    // written. Mirrors the silent-stream pattern used in other webhook /
+    // status-manager tests, but accumulates instead of dropping.
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const captured: string[] = []
+    const capturingLog = createLogger('test', {
+      stream: {
+        write: (chunk: string | Buffer): boolean => {
+          captured.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'))
+          return true
+        },
+      } as unknown as NodeJS.WritableStream,
+    })
+
+    const mcp = makeMcpStub()
+    const status = makeStatusStub()
+    const memory = makeMemoryStub({ throws: true })
+    const cfg = withMemoryEnabled(enabledConfig())
+    const h = await startWebhookServer(cfg, {
+      mcpServer: mcp.server,
+      config: cfg,
+      statePaths: paths,
+      log: capturingLog,
+      statusManager: status.manager,
+      memoryWriter: memory.writer as never,
+    })
+    if (!h) throw new Error('expected handle')
+    handle = h
+
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        hook_event_name: 'Stop',
+        session_id: 'sid-1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+      }),
+    })
+    expect(resp.status).toBe(200)
+
+    // At least one [warn] line containing the [memory] prefix must
+    // appear. The throwing stub message ('memory disk full') should
+    // also be embedded so the operator can grep it.
+    const joined = captured.join('')
+    expect(joined).toMatch(/\[warn\]/)
+    expect(joined).toContain('[memory]')
+    expect(joined).toContain('memory disk full')
+  })
+
   test('memoryWriter undefined: 200 returned, no-op (other branches unaffected)', async () => {
     process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
     // No memoryWriter passed — using existing startEnabledWithStatus.

--- a/plugin/tests/webhook/server.test.ts
+++ b/plugin/tests/webhook/server.test.ts
@@ -743,3 +743,242 @@ describe('POST /hooks/agent — Claude hook payload branch', () => {
     expect(status.calls.length).toBe(0)
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────
+// Phase 8 / T7: memoryWriter dispatch in claude_hook branch.
+// ─────────────────────────────────────────────────────────────────────
+
+interface MemoryStubCall { hook: string; chatId: string; raw: unknown }
+function makeMemoryStub(opts: { throws?: boolean } = {}): {
+  writer: { onHook: (p: unknown) => Promise<void> }
+  calls: MemoryStubCall[]
+} {
+  const calls: MemoryStubCall[] = []
+  return {
+    writer: {
+      onHook: async (p: unknown) => {
+        const obj = p as { hook_event_name?: string; chatId?: string }
+        calls.push({
+          hook: obj.hook_event_name ?? '',
+          chatId: obj.chatId ?? '',
+          raw: p,
+        })
+        if (opts.throws) throw new Error('memory disk full')
+      },
+    },
+    calls,
+  }
+}
+
+function withMemoryEnabled(cfg: AppConfig, opts: { enabled?: boolean } = {}): AppConfig {
+  return {
+    ...cfg,
+    memory: {
+      enabled: opts.enabled ?? true,
+      workspace_path: '/tmp/dashi-test-workspace',
+      source_tag: 'tg',
+      max_hot_bytes: 20480,
+      trim_keep_lines: 600,
+      buffer_ttl_ms: 5 * 60 * 1000,
+      buffer_max_entries: 100,
+    },
+  }
+}
+
+describe('POST /hooks/agent — memoryWriter branch (Phase 8 T7)', () => {
+  test('UserPromptSubmit with memoryWriter wired: writer.onHook called, status no-op', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const mcp = makeMcpStub()
+    const status = makeStatusStub()
+    const memory = makeMemoryStub()
+    const cfg = withMemoryEnabled(enabledConfig())
+    const h = await startWebhookServer(cfg, {
+      mcpServer: mcp.server,
+      config: cfg,
+      statePaths: paths,
+      log: createLogger('test'),
+      statusManager: status.manager,
+      memoryWriter: memory.writer as never,
+    })
+    if (!h) throw new Error('expected handle')
+    handle = h
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        hook_event_name: 'UserPromptSubmit',
+        session_id: 'sid-1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+        prompt: 'secret prompt body',
+      }),
+    })
+    expect(resp.status).toBe(200)
+    expect(memory.calls.length).toBe(1)
+    expect(memory.calls[0]!.hook).toBe('UserPromptSubmit')
+    expect(memory.calls[0]!.chatId).toBe('164795011')
+    // Status STILL fires (it owns Telegram visibility) — memory is sibling, not replacement.
+    expect(status.calls.length).toBe(1)
+    expect(mcp.calls.length).toBe(0)
+  })
+
+  test('Stop with memoryWriter wired: writer.onHook called', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const mcp = makeMcpStub()
+    const status = makeStatusStub()
+    const memory = makeMemoryStub()
+    const cfg = withMemoryEnabled(enabledConfig())
+    const h = await startWebhookServer(cfg, {
+      mcpServer: mcp.server,
+      config: cfg,
+      statePaths: paths,
+      log: createLogger('test'),
+      statusManager: status.manager,
+      memoryWriter: memory.writer as never,
+    })
+    if (!h) throw new Error('expected handle')
+    handle = h
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        hook_event_name: 'Stop',
+        session_id: 'sid-1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+      }),
+    })
+    expect(resp.status).toBe(200)
+    expect(memory.calls.length).toBe(1)
+    expect(memory.calls[0]!.hook).toBe('Stop')
+  })
+
+  test('memoryWriter throwing → 200 still returned, error logged, status still fires', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const mcp = makeMcpStub()
+    const status = makeStatusStub()
+    const memory = makeMemoryStub({ throws: true })
+    const cfg = withMemoryEnabled(enabledConfig())
+    const h = await startWebhookServer(cfg, {
+      mcpServer: mcp.server,
+      config: cfg,
+      statePaths: paths,
+      log: createLogger('test'),
+      statusManager: status.manager,
+      memoryWriter: memory.writer as never,
+    })
+    if (!h) throw new Error('expected handle')
+    handle = h
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        hook_event_name: 'Stop',
+        session_id: 'sid-1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+      }),
+    })
+    expect(resp.status).toBe(200)
+    expect(memory.calls.length).toBe(1)
+    // Status branch still runs after memory throw.
+    expect(status.calls.length).toBe(1)
+  })
+
+  test('memoryWriter undefined: 200 returned, no-op (other branches unaffected)', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    // No memoryWriter passed — using existing startEnabledWithStatus.
+    const { handle: h, status } = await startEnabledWithStatus(enabledConfig())
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        hook_event_name: 'Stop',
+        session_id: 'sid-1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+      }),
+    })
+    expect(resp.status).toBe(200)
+    expect(status.calls.length).toBe(1)
+  })
+
+  test('config.memory.enabled=false + memoryWriter present: writer NOT called', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const mcp = makeMcpStub()
+    const status = makeStatusStub()
+    const memory = makeMemoryStub()
+    // memory.enabled=false despite writer being present — the runtime
+    // gate in webhook/server.ts must skip the dispatch.
+    const cfg = withMemoryEnabled(enabledConfig(), { enabled: false })
+    const h = await startWebhookServer(cfg, {
+      mcpServer: mcp.server,
+      config: cfg,
+      statePaths: paths,
+      log: createLogger('test'),
+      statusManager: status.manager,
+      memoryWriter: memory.writer as never,
+    })
+    if (!h) throw new Error('expected handle')
+    handle = h
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        hook_event_name: 'Stop',
+        session_id: 'sid-1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+      }),
+    })
+    expect(resp.status).toBe(200)
+    expect(memory.calls.length).toBe(0)
+  })
+
+  test('memoryWriter does NOT fire on message-variant payload (only claude_hook branch)', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const mcp = makeMcpStub()
+    const memory = makeMemoryStub()
+    const cfg = withMemoryEnabled(enabledConfig())
+    const h = await startWebhookServer(cfg, {
+      mcpServer: mcp.server,
+      config: cfg,
+      statePaths: paths,
+      log: createLogger('test'),
+      memoryWriter: memory.writer as never,
+    })
+    if (!h) throw new Error('expected handle')
+    handle = h
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ message: 'plain message', chatId: 164795011 }),
+    })
+    expect(resp.status).toBe(200)
+    expect(memory.calls.length).toBe(0)
+    expect(mcp.calls.length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 8 of dashi-channel canary plugin. Brings Jarvis (Python gateway.py) memory parity: after a Claude Code session completes a turn, the plugin persists the turn to two on-disk artifacts in the agent's workspace:

1. `<workspace>/core/hot/recent.md` — 200-char per-line summary (human scan)
2. `<workspace_parent>/logs/verbose-YYYY-MM-DD.jsonl` — full-text record (consumed by Cognee cron)

Pipeline: agent UserPromptSubmit hook → plugin buffers prompt per chatId → agent Stop hook → plugin reads last assistant text from transcript_path JSONL → appends to both files. Matches Python gateway.py byte-for-byte where it matters (header, entry format, trim heuristic).

## What's in

- **T1** — `memory` config group in `AppConfigSchema` + env overrides (`TELEGRAM_MEMORY_ENABLED`, `_WORKSPACE`, `_LOGS_PATH`, `_SOURCE_TAG`, `_AGENT_LABEL`)
- **T2** — `hot-writer.ts` with intra-process `Mutex` per path, 20KB emergency trim (keep last 600 lines, advance to first `### ` header)
- **T3** — `verbose-writer.ts` with day-roll derived from `record.ts.slice(0,10)` (UTC midnight race avoided)
- **T4** — `prompt-buffer.ts` with TTL (5 min) + LRU cap (100 entries), fake-clock injectable
- **T5** — `transcript-reader.ts` tail-reads last 256KB, walks JSONL backward, returns text from last assistant message
- **T6** — `MemoryWriter` facade — `onHook(payload)` dispatches UserPromptSubmit→buffer / Stop→write
- **T7** — Wire into `webhook/server.ts` (before status branch, independent) and `server.ts` bootstrap
- **T8** — End-to-end test: real tmp workspace + webhook server + UserPromptSubmit+Stop → assert files produced

## Review-loop fixes

Dual-model parallel review (Codex GPT-5.5 + Opus subagent) on the 8-commit diff. 6 fixes applied:

**High:**
- `verbose.jsonl` mutex-serialized — macOS doesn't guarantee O_APPEND atomicity for multi-KB records, and verbose records routinely exceed PIPE_BUF (4KB). Under burst → corrupted JSONL → silent Cognee loss. Shared `_mutex.ts` module now serializes both hot and verbose writers.
- Trim header ASCII `--` parity with gateway.py:1973 — was em-dash, broke byte-for-byte compatibility.

**Medium:**
- `transcript-reader` permissive on `null` / non-object JSON lines — old code would throw outside per-line catch, outer catch returned null, skipping earlier valid assistant text.
- Trim tmp file cleanup on rename failure — wrap `writeFile+rename` in try/catch with `unlink(tmp).catch()`.

**Low:**
- Code-point snippet for astral Unicode — `Array.from().slice()` instead of UTF-16 `.slice()`. Emoji-heavy Telegram prompts no longer split surrogate pairs.
- Mutex map JSDoc + log.warn capture test on memoryWriter throw.

## Dismissals (justified)

- **"await memoryWriter.onHook blocks 200"** — parity match with Python gateway; retry-dup is preferable to silent loss when FS is healthy. Followup: add duration log for slow FS visibility.
- **SIGTERM drain** — followup BACKLOG item.
- **UTC-midnight day-roll concurrent race** — sequential test sufficient; race is benign (two files, two writers, both succeed).

## Tests

- **425 pass / 0 fail / 2150 expect() calls** across 27 files (was 416/0 before Phase 8 → +9 new tests in fix iter)
- `bun run typecheck` clean (strict + exactOptionalPropertyTypes + noUncheckedIndexedAccess)
- New test files: `tests/memory/hot-writer.test.ts`, `verbose-writer.test.ts`, `prompt-buffer.test.ts`, `transcript-reader.test.ts`, `writer.test.ts`, `e2e-webhook.test.ts`
- Webhook integration: `tests/webhook/server.test.ts` extended with UserPromptSubmit buffering, Stop write, disabled fallback, throw → 200 + log.warn

## Stress test highlights

- 50× concurrent appends with 10KB records → all lines present, every line round-trips through `JSON.parse` (catches the multi-KB interleave that motivated the high finding).
- 200× concurrent intra-process appends to recent.md → all unique entries, no interleave, no duplication.
- 30KB pre-seeded recent.md + append → trim runs, final size ≤ maxBytes, no `.tmp.*` orphan.

## Loop-coding run

`.claude-lab/silvana/.claude/loop-coding-runs/2026-05-15-memory-hooks-parity/` — RESEARCH.md, PLAN.md (with deviations table), REVIEW.md (merged Codex + Opus), per-reviewer raw outputs.

## Out of scope (followups)

- Per-source classification (own_text / own_voice / forwarded) — needs Telegram inbound side to emit hooks with `source_tag` override
- recent.md compaction beyond 20KB emergency trim — separate cron in workspace handles WARM→COLD rotation
- Cognee dual-write — separate cron already consumes verbose.jsonl
- Production cutover (5 launchd plists, per-agent tokens, legacy gateway.py decom) — separate RED-tagged run, requires explicit prince approval

## Test plan

- [ ] CI: `bun test` green on Ubuntu + macOS
- [ ] CI: `tsc --noEmit` clean
- [ ] Manual smoke: configure `memory.workspace_path=~/.claude-lab/test-agent/.claude`, send Telegram message, run a Claude Code session, check `core/hot/recent.md` for new `### YYYY-MM-DD HH:MM [tg]` entry and `logs/verbose-YYYY-MM-DD.jsonl` for full-text record
- [ ] Format check: byte-diff a sample entry vs Python gateway.py output for the same turn
- [ ] Cognee cron consumes the new verbose.jsonl without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)