### PR TITLE
feat(status): ProgressReporter — persistent activity thread в Telegram

### DIFF
--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -79,6 +79,25 @@ export const AppConfigSchema = z.object({
       })
     }
   }),
+  // ProgressReporter (2026-05-18) — persistent Telegram thread that shows
+  // tool-by-tool activity in real time. StatusManager owns the transient
+  // status bubble; ProgressReporter owns a separate, persistent thread
+  // edited via editMessageText. Two surfaces, two concerns. Disable here
+  // to fall back to silent-then-final UX.
+  //
+  // session_ttl_ms guards against stuck entries when a `session_stop`
+  // hook is lost (Claude crash, dropped webhook). After this idle period
+  // the next event for the chat starts a fresh progress thread instead
+  // of editing into the old (now stale) message.
+  //
+  // recent_buffer aligned with StatusManager.ACTIVITY_MAX_BUFFER (10)
+  // so the two surfaces report the same "+N earlier" tail count.
+  progress: z.object({
+    enabled: z.boolean().default(true),
+    edit_throttle_ms: z.number().int().nonnegative().default(3000),
+    recent_buffer: z.number().int().positive().default(10),
+    session_ttl_ms: z.number().int().positive().default(10 * 60 * 1000),
+  }).default({}),
 })
 export type AppConfig = z.infer<typeof AppConfigSchema>
 

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -36,6 +36,7 @@ import {
   type ToolDeps,
 } from './channel/tools.js'
 import { StatusManager } from './status/status-manager.js'
+import { ProgressReporter } from './status/progress-reporter.js'
 import { MemoryWriter, type MemoryConfig } from './memory/writer.js'
 import { dirname as pathDirname } from 'path'
 import {
@@ -241,6 +242,12 @@ const mcp = new Server(
 // message we edit while Claude is composing a reply. The handler opens it
 // on inbound delivery; the reply tool closes it on successful send.
 const statusManager = new StatusManager({ telegramApi, config, log })
+
+// ProgressReporter (2026-05-18) — separate persistent thread showing
+// per-tool activity in real time. StatusManager owns the transient
+// bubble (cancelled by reply()); ProgressReporter owns a thread that
+// survives. Both fire in parallel from the webhook handler.
+const progressReporter = new ProgressReporter({ telegramApi, config, log })
 
 // Phase 8 / T7: MemoryWriter persists turns to <workspace>/core/hot/recent.md
 // and <workspace_parent>/logs/verbose-YYYY-MM-DD.jsonl. Only instantiated
@@ -516,6 +523,7 @@ try {
     statePaths,
     log,
     statusManager,
+    progressReporter,
     ...(memoryWriter !== undefined ? { memoryWriter } : {}),
   })
 } catch (err) {

--- a/plugin/src/status/progress-reporter.ts
+++ b/plugin/src/status/progress-reporter.ts
@@ -1,0 +1,426 @@
+// ProgressReporter — persistent Telegram thread showing per-tool activity
+// in real time. Owns ONE message per chat, edited via editMessageText as
+// new Claude hook events arrive.
+//
+// Why separate from StatusManager:
+//   * StatusManager owns a transient bubble that auto-cancels on every
+//     real reply (see status-manager.ts: «start() while active silently
+//     cancels»). Result: the warchief sees nothing.
+//   * ProgressReporter owns a different message that persists through
+//     replies — a running log of «what Thrall is doing now». Both
+//     coexist; the webhook fires them in parallel and independently.
+//
+// Design contract (from Codex GPT-5.5 plan 2026-05-18 + dual review fixes):
+//   * `recordEvent(chatId, event)` is fire-and-forget from the caller's
+//     point of view. Top-level try/catch swallows all throws and logs.
+//   * Single-slot per-chat queue: at most one Telegram request in flight
+//     per chat. New events while one is in flight overwrite `desiredText`
+//     so the freshest snapshot publishes after the in-flight settles.
+//     This serializes send/edit ordering and removes both the first-send
+//     race and out-of-order edit landings (review findings C1, Codex §3).
+//   * Throttle: `edit_throttle_ms` between successive edits. First send
+//     bypasses throttle (immediate). Subsequent edits within the window
+//     defer via a single one-shot timer.
+//   * Stop awaits any in-flight flush before posting the final
+//     «✓ done -- Ns» line (review C2/H1 fix — no orphan messages).
+//   * Session TTL: an entry older than `session_ttl_ms` since last
+//     activity is evicted on next event for the chat. Protects against
+//     lost session_stop hooks and cross-session pollution (review C2).
+//   * Telegram failures are caught + logged at warn; state stays alive
+//     so the next event can retry.
+
+import type { AppConfig } from '../config.js'
+import type { Logger } from '../log.js'
+import type { ActivityStatusEvent } from '../hooks/claude-events.js'
+import {
+  buildActivityDetail,
+  buildHumanizedActivityLine,
+  renderActivityBlock,
+  type ActivityCall,
+  type ActivitySnapshot,
+} from './activity-renderer.js'
+
+// Minimal Telegram surface we touch. Defined as a structural interface
+// so tests can stub without grammY. Compatible with the production
+// TelegramApi from src/channel/tools.ts via structural typing.
+export interface TelegramApiForProgress {
+  sendMessage(
+    chatId: string,
+    text: string,
+    opts: { parse_mode?: 'HTML' | 'MarkdownV2'; reply_to_message_id?: number },
+  ): Promise<{ message_id: number }>
+  editMessageText(
+    chatId: string,
+    messageId: number,
+    text: string,
+    opts: { parse_mode?: 'HTML' | 'MarkdownV2' },
+  ): Promise<void>
+}
+
+export interface ProgressReporterDeps {
+  telegramApi: TelegramApiForProgress
+  config: AppConfig
+  log: Logger
+  now?: () => number
+  setTimer?: (cb: () => void, ms: number) => NodeJS.Timeout
+  clearTimer?: (handle: NodeJS.Timeout) => void
+}
+
+// Per-chat lifecycle: lazy-created on first event, evicted on
+// session_stop or TTL expiry.
+//
+// Ordering invariant: at any time, at most ONE of `flushPromise`
+// (in-flight Telegram op) and `pendingTimer` (throttle-deferred flush)
+// is non-null. `desiredText` accumulates the newest text to publish.
+interface ChatProgressEntry {
+  chatId: string
+  messageId?: number
+  startedAtMs: number
+  // Updated on every recordEvent. Used by TTL eviction in getOrCreate.
+  lastActivityMs: number
+  // Sliding window of recent ActivityCalls; renderer caps the display.
+  calls: ActivityCall[]
+  // Last text we actually sent / edited. Skip Telegram round-trip when
+  // newly rendered body is identical.
+  lastRenderedText?: string
+  // Timestamp of the last successful send or edit. Used for throttle.
+  lastEditAtMs: number
+  // Newest snapshot text waiting to be published. Multiple events
+  // overwrite this so only the freshest view ever lands on Telegram.
+  desiredText?: string
+  // Single-slot scheduler: non-null while a Telegram op is in flight.
+  // After it settles, we re-check `desiredText` and re-arm if needed.
+  flushPromise: Promise<void> | null
+  // Single-slot throttle timer. Non-null while waiting for the throttle
+  // window to elapse before publishing `desiredText`.
+  pendingTimer: NodeJS.Timeout | null
+  // True once Stop has been processed. Guards idempotency.
+  stopped: boolean
+}
+
+// HTML used as parse_mode for both send and edit so renderActivityBlock's
+// inline tags (<b>, <code>, <pre>) are rendered.
+const HTML_OPTS = { parse_mode: 'HTML' as const }
+
+export class ProgressReporter {
+  private readonly telegramApi: TelegramApiForProgress
+  private readonly config: AppConfig
+  private readonly log: Logger
+  private readonly now: () => number
+  private readonly setTimer: (cb: () => void, ms: number) => NodeJS.Timeout
+  private readonly clearTimer: (handle: NodeJS.Timeout) => void
+  private readonly chats: Map<string, ChatProgressEntry>
+
+  constructor(deps: ProgressReporterDeps) {
+    this.telegramApi = deps.telegramApi
+    this.config = deps.config
+    this.log = deps.log
+    this.now = deps.now ?? (() => Date.now())
+    this.setTimer = deps.setTimer ?? ((cb, ms) => setTimeout(cb, ms))
+    this.clearTimer = deps.clearTimer ?? ((h) => clearTimeout(h))
+    this.chats = new Map()
+  }
+
+  /**
+   * Main entry point. Called by the webhook handler for every
+   * `claude_hook` payload. Never throws — top-level try/catch swallows
+   * any failure so the webhook 200 path is never blocked.
+   */
+  async recordEvent(chatId: string, event: ActivityStatusEvent): Promise<void> {
+    if (!this.config.progress.enabled) return
+    try {
+      if (event.kind === 'session_stop') {
+        await this.handleStop(chatId)
+        return
+      }
+
+      const entry = this.getOrCreate(chatId)
+      if (entry.stopped) return
+      entry.lastActivityMs = this.now()
+      this.applyEvent(entry, event)
+      this.scheduleFlush(entry)
+    } catch (err) {
+      this.log.warn('progress reporter recordEvent failed (ignored)', {
+        chat_id: chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  /**
+   * Test-only: wait until any in-flight Telegram operation for the given
+   * chat settles AND any follow-up reschedule completes. Used by unit
+   * tests to assert on `TelegramApi.calls` after asynchronous
+   * publication finishes. Production callers should NOT depend on this.
+   */
+  async _idleForTests(chatId: string): Promise<void> {
+    // Drain up to a small fixed number of cycles. Each iteration awaits
+    // the current flushPromise (if any), which may schedule a follow-up
+    // flush in its finally handler; the next iteration picks that up.
+    for (let i = 0; i < 16; i++) {
+      const entry = this.chats.get(chatId)
+      if (!entry || entry.flushPromise === null) return
+      try {
+        await entry.flushPromise
+      } catch {
+        /* already logged */
+      }
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Internals
+  // ─────────────────────────────────────────────────────────────────────
+
+  private getOrCreate(chatId: string): ChatProgressEntry {
+    const existing = this.chats.get(chatId)
+    if (existing) {
+      // TTL eviction: if too long since last activity, treat this as a
+      // new session. The old entry (whose Telegram message we never
+      // finalized because session_stop was lost) is discarded — its
+      // message is left in Telegram as-is, no edit attempted.
+      const idle = this.now() - existing.lastActivityMs
+      if (idle > this.config.progress.session_ttl_ms) {
+        this.log.debug('progress entry TTL expired, starting fresh thread', {
+          chat_id: chatId,
+          idle_ms: idle,
+        })
+        this.chats.delete(chatId)
+      } else {
+        return existing
+      }
+    }
+    const entry: ChatProgressEntry = {
+      chatId,
+      startedAtMs: this.now(),
+      lastActivityMs: this.now(),
+      calls: [],
+      lastEditAtMs: 0,
+      flushPromise: null,
+      pendingTimer: null,
+      stopped: false,
+    }
+    this.chats.set(chatId, entry)
+    return entry
+  }
+
+  /**
+   * Mutate `entry.calls` based on the event. tool_start appends; other
+   * non-Stop events are render-only (move the elapsed counter forward).
+   */
+  private applyEvent(entry: ChatProgressEntry, event: ActivityStatusEvent): void {
+    switch (event.kind) {
+      case 'tool_start': {
+        const detail = buildActivityDetail(event.toolName, event.toolInput)
+        const humanized = buildHumanizedActivityLine(event.toolName, event.toolInput)
+        const call: ActivityCall = { toolName: event.toolName, detail, humanized }
+        entry.calls.push(call)
+        const cap = this.config.progress.recent_buffer
+        if (entry.calls.length > cap) {
+          entry.calls.splice(0, entry.calls.length - cap)
+        }
+        break
+      }
+      case 'tool_end':
+      case 'reasoning':
+      case 'session_start':
+        // Re-render only. No buffer mutation. The «working -- Ns» header
+        // moves forward with elapsed time.
+        break
+      case 'session_stop':
+        // Handled before applyEvent in recordEvent; unreachable here but
+        // kept for exhaustiveness.
+        break
+    }
+  }
+
+  /**
+   * Render the current snapshot and schedule a flush. Idempotent — if a
+   * flush is already in progress or a timer is already armed, just
+   * update `desiredText` and return.
+   */
+  private scheduleFlush(entry: ChatProgressEntry): void {
+    if (entry.stopped) return
+    const snapshot = this.buildSnapshot(entry)
+    const text = this.safeRender(snapshot)
+    if (!text || text === entry.lastRenderedText) return
+    entry.desiredText = text
+
+    // If a flush is already running or a timer is already armed, the
+    // desiredText we just stored will be picked up at the end of the
+    // current cycle. Nothing more to do here.
+    if (entry.flushPromise !== null || entry.pendingTimer !== null) return
+
+    const isFirstSend = entry.messageId === undefined
+    const elapsed = this.now() - entry.lastEditAtMs
+    const wait = isFirstSend
+      ? 0
+      : Math.max(0, this.config.progress.edit_throttle_ms - elapsed)
+
+    if (wait > 0) {
+      entry.pendingTimer = this.setTimer(() => {
+        entry.pendingTimer = null
+        this.startFlush(entry)
+      }, wait)
+    } else {
+      this.startFlush(entry)
+    }
+  }
+
+  /**
+   * Kick off a Telegram round-trip if there is text to publish and no
+   * flush in progress. Sets `flushPromise` for the duration of the
+   * round-trip; on settle, re-checks `desiredText` and reschedules.
+   */
+  private startFlush(entry: ChatProgressEntry): void {
+    if (entry.stopped) return
+    if (entry.flushPromise !== null) return
+    const text = entry.desiredText
+    if (text === undefined || text === entry.lastRenderedText) return
+    delete entry.desiredText
+
+    entry.flushPromise = this.executeFlush(entry, text).finally(() => {
+      entry.flushPromise = null
+      // Re-schedule if a newer text accumulated during the flush.
+      if (
+        !entry.stopped &&
+        entry.desiredText !== undefined &&
+        entry.desiredText !== entry.lastRenderedText
+      ) {
+        this.scheduleFlush(entry)
+      }
+    })
+  }
+
+  /**
+   * The actual Telegram round-trip. First call sends; subsequent calls
+   * edit the existing message. All errors caught + logged; state
+   * mutations (`messageId`, `lastRenderedText`, `lastEditAtMs`) are
+   * gated on `!entry.stopped` so a Stop arriving mid-flight leaves the
+   * entry clean for eviction.
+   */
+  private async executeFlush(entry: ChatProgressEntry, text: string): Promise<void> {
+    if (entry.messageId === undefined) {
+      try {
+        const sent = await this.telegramApi.sendMessage(entry.chatId, text, HTML_OPTS)
+        if (!entry.stopped) {
+          entry.messageId = sent.message_id
+          entry.lastRenderedText = text
+          entry.lastEditAtMs = this.now()
+        } else {
+          // Stop arrived while we were sending. The message exists in
+          // Telegram but our entry was evicted before send resolved —
+          // we cannot finalize without owning the entry. Log so an
+          // operator can find the orphan if it matters.
+          this.log.warn('progress send completed after stop (orphan)', {
+            chat_id: entry.chatId,
+            message_id: sent.message_id,
+          })
+        }
+      } catch (err) {
+        this.log.warn('progress reporter sendMessage failed (ignored)', {
+          chat_id: entry.chatId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+      return
+    }
+
+    try {
+      await this.telegramApi.editMessageText(entry.chatId, entry.messageId, text, HTML_OPTS)
+      if (!entry.stopped) {
+        entry.lastRenderedText = text
+        entry.lastEditAtMs = this.now()
+      }
+    } catch (err) {
+      this.log.warn('progress reporter editMessageText failed (ignored)', {
+        chat_id: entry.chatId,
+        message_id: entry.messageId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  private buildSnapshot(entry: ChatProgressEntry): ActivitySnapshot {
+    return {
+      startedAtMs: entry.startedAtMs,
+      calls: entry.calls,
+      phase: entry.calls.length > 0 ? 'tool' : 'reasoning',
+    }
+  }
+
+  private safeRender(snapshot: ActivitySnapshot): string {
+    try {
+      return renderActivityBlock(snapshot, this.now())
+    } catch (err) {
+      this.log.warn('progress reporter render failed (ignored)', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return ''
+    }
+  }
+
+  /**
+   * session_stop handler — cancels the throttle timer, awaits any
+   * in-flight flush, then posts a final «done -- Ns» edit on the
+   * existing message (if one was sent). Idempotent: second call is a
+   * no-op. Evicts the entry so a follow-up event in the same chat
+   * starts a fresh thread.
+   */
+  private async handleStop(chatId: string): Promise<void> {
+    const entry = this.chats.get(chatId)
+    if (!entry || entry.stopped) return
+    entry.stopped = true
+
+    if (entry.pendingTimer !== null) {
+      this.clearTimer(entry.pendingTimer)
+      entry.pendingTimer = null
+    }
+
+    // Wait for any in-flight Telegram op to settle so we don't race the
+    // final edit against an outstanding send/edit. The promise itself
+    // never rejects (executeFlush catches), but use try/catch defensively.
+    if (entry.flushPromise !== null) {
+      try {
+        await entry.flushPromise
+      } catch {
+        /* already logged inside executeFlush */
+      }
+    }
+
+    if (entry.messageId !== undefined) {
+      const text = this.renderFinal(entry)
+      if (text && text !== entry.lastRenderedText) {
+        try {
+          await this.telegramApi.editMessageText(entry.chatId, entry.messageId, text, HTML_OPTS)
+          entry.lastRenderedText = text
+        } catch (err) {
+          this.log.warn('progress reporter final edit failed (ignored)', {
+            chat_id: entry.chatId,
+            message_id: entry.messageId,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+    }
+
+    this.chats.delete(chatId)
+  }
+
+  /**
+   * Final-line render: re-uses renderActivityBlock to keep visual
+   * parity with intermediate edits, then appends «done -- Ns» as the
+   * last line inside the <pre> body so a single block paragraph remains.
+   */
+  private renderFinal(entry: ChatProgressEntry): string {
+    const snapshot = this.buildSnapshot(entry)
+    const block = this.safeRender(snapshot)
+    if (!block) return ''
+    const elapsedSec = Math.max(0, Math.floor((this.now() - entry.startedAtMs) / 1000))
+    const doneLine = `\n\ndone -- ${elapsedSec}s`
+    if (block.endsWith('</pre>')) {
+      return `${block.slice(0, -'</pre>'.length)}${doneLine}</pre>`
+    }
+    return `${block}${doneLine}`
+  }
+}

--- a/plugin/src/webhook/server.ts
+++ b/plugin/src/webhook/server.ts
@@ -25,6 +25,7 @@ import { WebhookPayloadSchema, type WebhookPayload } from '../schemas.js'
 import { sendChannelNotification, normalizeMeta } from '../channel/notify.js'
 import { toActivityEvent } from '../hooks/claude-events.js'
 import type { MemoryWriter } from '../memory/writer.js'
+import type { ProgressReporter } from '../status/progress-reporter.js'
 
 const BODY_LIMIT_BYTES = 256 * 1024
 const DEFAULT_AGENT_ID = 'dashi-channel'
@@ -52,6 +53,11 @@ export interface WebhookDeps {
   // hook payload (UserPromptSubmit buffers, Stop writes recent.md +
   // verbose.jsonl). Throws are caught and logged — never block the 200.
   memoryWriter?: MemoryWriter
+  // ProgressReporter (2026-05-18): persistent activity thread sibling
+  // dispatch alongside statusManager. Optional so legacy paths and tests
+  // can omit it. Failures inside the reporter never propagate (it logs
+  // and swallows) so no error handling is required at the call site.
+  progressReporter?: ProgressReporter
 }
 
 export interface WebhookServerHandle {
@@ -174,7 +180,7 @@ async function handleRequest(
   deps: WebhookDeps,
   webhookToken: string | undefined,
 ): Promise<void> {
-  const { config, statePaths, log, mcpServer, statusManager, memoryWriter } = deps
+  const { config, statePaths, log, mcpServer, statusManager, memoryWriter, progressReporter } = deps
   const method = req.method ?? 'GET'
   const url = req.url ?? '/'
 
@@ -286,42 +292,55 @@ async function handleRequest(
       }
     }
 
-    // PLAN.md:173 — when config.status.enabled=false the hook path must
-    // be a no-op. We accept the request (200) so Claude hooks don't
-    // back-pressure on a disabled visibility surface, but skip dispatch
-    // entirely (no statusManager call, no lazy status open).
-    if (config.status.enabled === true && statusManager) {
+    // Two independent visibility surfaces fire from the same hook event.
+    // Both are best-effort: failures are caught and logged, never block
+    // the 200 response (Claude hooks must not back-pressure on visibility).
+    //
+    //   * StatusManager — transient bubble (auto-cancelled by reply()).
+    //     Gate: config.status.enabled.
+    //   * ProgressReporter — persistent activity thread (survives reply).
+    //     Gate: config.progress.enabled (checked inside the reporter).
+    //
+    // The two MUST be dispatched independently so an operator can turn
+    // one off without disabling the other (review C3 fix).
+    const activityEvent = toActivityEvent(payload)
+    const statusDispatched = config.status.enabled === true && statusManager !== undefined
+    if (statusDispatched) {
       try {
-        await statusManager.recordActivityByChatId(
-          payload.chatId,
-          toActivityEvent(payload),
-        )
+        await statusManager!.recordActivityByChatId(payload.chatId, activityEvent)
       } catch (err) {
-        // Visibility failure must not block Claude. Log + 200.
         log.warn('hook event status update failed (ignored)', {
           chat_id: payload.chatId,
           hook: payload.hook_event_name,
           error: err instanceof Error ? err.message : String(err),
         })
       }
-      reply(res, 200, { status: 'accepted' })
-      return
-    }
-
-    if (config.status.enabled !== true) {
-      log.debug('hook event accepted but status disabled', {
+    } else {
+      log.debug('hook event status dispatch skipped (disabled or no manager)', {
         chat_id: payload.chatId,
         hook: payload.hook_event_name,
       })
+    }
+
+    if (progressReporter) {
+      try {
+        await progressReporter.recordEvent(payload.chatId, activityEvent)
+      } catch (err) {
+        log.warn('hook event progress update failed (ignored)', {
+          chat_id: payload.chatId,
+          hook: payload.hook_event_name,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+
+    // Preserve the legacy status_disabled note when status is off so
+    // existing webhook smoke tests can detect the disabled path.
+    if (!statusDispatched && config.status.enabled !== true) {
       reply(res, 200, { status: 'accepted', note: 'status_disabled' })
       return
     }
 
-    // statusManager not wired — visibility outage tolerated.
-    log.debug('hook event accepted without status manager', {
-      chat_id: payload.chatId,
-      hook: payload.hook_event_name,
-    })
     reply(res, 200, { status: 'accepted' })
     return
   }

--- a/plugin/tests/channel/permissions.test.ts
+++ b/plugin/tests/channel/permissions.test.ts
@@ -69,6 +69,12 @@ function mkConfig(allowedIds: number[] = [164795011]): AppConfig {
       buffer_ttl_ms: 5 * 60 * 1000,
       buffer_max_entries: 100,
     },
+    progress: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      recent_buffer: 10,
+      session_ttl_ms: 600000,
+    },
   }
 }
 

--- a/plugin/tests/channel/tools.test.ts
+++ b/plugin/tests/channel/tools.test.ts
@@ -65,6 +65,12 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       buffer_ttl_ms: 5 * 60 * 1000,
       buffer_max_entries: 100,
     },
+    progress: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      recent_buffer: 10,
+      session_ttl_ms: 600000,
+    },
     ...overrides,
   }
 }

--- a/plugin/tests/commands/oob.test.ts
+++ b/plugin/tests/commands/oob.test.ts
@@ -33,6 +33,12 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       buffer_ttl_ms: 5 * 60 * 1000,
       buffer_max_entries: 100,
     },
+    progress: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      recent_buffer: 10,
+      session_ttl_ms: 600000,
+    },
     ...overrides,
   }
 }

--- a/plugin/tests/prompt/media-prompt.test.ts
+++ b/plugin/tests/prompt/media-prompt.test.ts
@@ -41,6 +41,12 @@ const voiceConfig: AppConfig = {
     buffer_ttl_ms: 5 * 60 * 1000,
     buffer_max_entries: 100,
   },
+  progress: {
+    enabled: true,
+    edit_throttle_ms: 3000,
+    recent_buffer: 10,
+    session_ttl_ms: 600000,
+  },
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/plugin/tests/status/progress-reporter.test.ts
+++ b/plugin/tests/status/progress-reporter.test.ts
@@ -1,0 +1,465 @@
+// ProgressReporter tests (Phase 9 / 2026-05-18) — persistent activity
+// thread shown to the warchief in Telegram. Patterned on
+// status-manager.test.ts: FakeClock + FakeApi, no real network, no real
+// timers.
+//
+// Behaviour under test:
+//   1. First tool_start sends a new message (no edit yet).
+//   2. Rapid subsequent events within edit_throttle_ms collapse into one
+//      edit with the latest rendered text.
+//   3. Once the throttle window has elapsed, new events edit immediately.
+//   4. Per-chat state is isolated (chat A edits do not touch chat B).
+//   5. session_stop is idempotent (second stop is no-op).
+//   6. Disabled mode is a hard no-op (no Telegram calls, no pending timer).
+//   7. Telegram failures are swallowed and logged; recordEvent never throws.
+//
+// Race / lifecycle additions (Phase 5 fix-loop iter 1, from dual review):
+//   8. Events arriving while initial sendMessage is in-flight collapse
+//      into a single follow-up edit with the FRESHEST text.
+//   9. session_stop while sendMessage is in-flight does not emit an
+//      orphan edit; the entry is evicted cleanly.
+//  10. Cross-session TTL — an idle entry older than session_ttl_ms is
+//      evicted; the next event starts a fresh thread (new sendMessage,
+//      not an edit on the prior message).
+//  11. Long tool input does not blow Telegram's 4096-char limit.
+//  12. Bearer-token-shaped secrets in Bash commands never reach Telegram.
+//  13. editMessageText failure is swallowed; next event retries.
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  ProgressReporter,
+  type TelegramApiForProgress,
+} from '../../src/status/progress-reporter.js'
+import type { AppConfig } from '../../src/config.js'
+import type { ActivityStatusEvent } from '../../src/hooks/claude-events.js'
+import { createLogger } from '../../src/log.js'
+
+const silentLog = createLogger('test', {
+  stream: { write: () => true } as unknown as NodeJS.WritableStream,
+})
+
+function makeConfig(overrides: Partial<AppConfig['progress']> = {}): AppConfig {
+  return {
+    bot_id: 8507713167,
+    dm_only: true,
+    allowed_user_ids: [164795011],
+    allowed_chat_ids: [164795011],
+    status: {
+      enabled: true,
+      interval_ms: 700,
+      ttl_ms: 300_000,
+      delete_on_complete: true,
+    },
+    album: { flush_ms: 2000 },
+    voice: { provider: 'groq', language: 'ru', model: 'whisper-large-v3-turbo' },
+    webhook: { enabled: false, host: '127.0.0.1', port: 0 },
+    permission_relay: { enabled: true, allowed_user_ids: [164795011], bash_only_proof: true },
+    commands: { help: true, status: true, stop: true, reset: true, new: true },
+    memory: {
+      enabled: false,
+      source_tag: 'tg',
+      max_hot_bytes: 20480,
+      trim_keep_lines: 600,
+      buffer_ttl_ms: 5 * 60 * 1000,
+      buffer_max_entries: 100,
+    },
+    progress: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      recent_buffer: 10,
+      session_ttl_ms: 10 * 60 * 1000,
+      ...overrides,
+    },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Fake clock
+// ─────────────────────────────────────────────────────────────────────
+
+interface FakeTimer {
+  id: number
+  deadline: number
+  cb: () => void
+  fired: boolean
+}
+
+class FakeClock {
+  now = 0
+  next = 1
+  timers: FakeTimer[] = []
+  setTimer = (cb: () => void, ms: number): NodeJS.Timeout => {
+    const t: FakeTimer = { id: this.next++, deadline: this.now + ms, cb, fired: false }
+    this.timers.push(t)
+    return t as unknown as NodeJS.Timeout
+  }
+  clearTimer = (handle: NodeJS.Timeout): void => {
+    const t = handle as unknown as FakeTimer
+    t.fired = true
+  }
+  advance(ms: number): void {
+    const deadline = this.now + ms
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const due = this.timers
+        .filter((t) => !t.fired && t.deadline <= deadline)
+        .sort((a, b) => a.deadline - b.deadline)[0]
+      if (!due) break
+      this.now = due.deadline
+      due.fired = true
+      due.cb()
+    }
+    this.now = deadline
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Fake Telegram API — captures every call. Supports deferred resolution
+// of sendMessage / editMessageText so tests can simulate in-flight ops.
+// ─────────────────────────────────────────────────────────────────────
+
+interface ApiCall {
+  kind: 'send' | 'edit'
+  chatId: string
+  messageId?: number
+  text: string
+}
+
+interface FakeApi {
+  api: TelegramApiForProgress
+  calls: ApiCall[]
+  nextMessageId: number
+  failSendWith?: Error
+  failEditWith?: Error
+  // When set, sendMessage returns a promise that resolves only after
+  // `releaseSend()` is called. Used to test in-flight overlap.
+  deferSend: boolean
+  releaseSend?: () => void
+  // Same idea for edits.
+  deferEdit: boolean
+  releaseEdit?: () => void
+}
+
+function makeFakeApi(): FakeApi {
+  const state: FakeApi = {
+    calls: [],
+    nextMessageId: 100,
+    api: undefined as unknown as TelegramApiForProgress,
+    deferSend: false,
+    deferEdit: false,
+  }
+  state.api = {
+    sendMessage: async (chatId: string, text: string, _opts: unknown) => {
+      if (state.deferSend) {
+        await new Promise<void>((resolve) => {
+          state.releaseSend = resolve
+        })
+      }
+      if (state.failSendWith) throw state.failSendWith
+      const id = state.nextMessageId++
+      state.calls.push({ kind: 'send', chatId, messageId: id, text })
+      return { message_id: id }
+    },
+    editMessageText: async (chatId: string, messageId: number, text: string, _opts: unknown) => {
+      if (state.deferEdit) {
+        await new Promise<void>((resolve) => {
+          state.releaseEdit = resolve
+        })
+      }
+      state.calls.push({ kind: 'edit', chatId, messageId, text })
+      if (state.failEditWith) throw state.failEditWith
+    },
+  }
+  return state
+}
+
+function makeReporter(opts: { config?: AppConfig; clock?: FakeClock; api?: FakeApi } = {}): {
+  reporter: ProgressReporter
+  clock: FakeClock
+  api: FakeApi
+  config: AppConfig
+} {
+  const clock = opts.clock ?? new FakeClock()
+  const api = opts.api ?? makeFakeApi()
+  const config = opts.config ?? makeConfig()
+  const reporter = new ProgressReporter({
+    telegramApi: api.api,
+    config,
+    log: silentLog,
+    now: () => clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+  })
+  return { reporter, clock, api, config }
+}
+
+function bashStart(toolUseId = 'tool-1', command = 'echo hi'): ActivityStatusEvent {
+  return {
+    kind: 'tool_start',
+    toolName: 'Bash',
+    toolInput: { command },
+    toolUseId,
+  }
+}
+
+function readStart(toolUseId = 'tool-2', file_path = '/abs/path/foo.ts'): ActivityStatusEvent {
+  return {
+    kind: 'tool_start',
+    toolName: 'Read',
+    toolInput: { file_path },
+    toolUseId,
+  }
+}
+
+const STOP: ActivityStatusEvent = { kind: 'session_stop' }
+
+// ─────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────
+
+describe('ProgressReporter', () => {
+  test('first tool_start sends a new Telegram message (no edits yet)', async () => {
+    const { reporter, api } = makeReporter()
+    await reporter.recordEvent('164795011', bashStart())
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(sends.length).toBe(1)
+    expect(edits.length).toBe(0)
+    expect(sends[0]!.chatId).toBe('164795011')
+    expect(sends[0]!.text).toContain('running')
+  })
+
+  test('rapid subsequent events within throttle window collapse into one edit', async () => {
+    const { reporter, clock, api } = makeReporter()
+    await reporter.recordEvent('164995011', bashStart('t1'))
+    expect(api.calls.filter((c) => c.kind === 'send').length).toBe(1)
+
+    clock.advance(500)
+    await reporter.recordEvent('164995011', readStart('t2'))
+    clock.advance(500)
+    await reporter.recordEvent('164995011', readStart('t3', '/abs/path/bar.ts'))
+
+    expect(api.calls.filter((c) => c.kind === 'edit').length).toBe(0)
+
+    clock.advance(1999)
+    expect(api.calls.filter((c) => c.kind === 'edit').length).toBe(0)
+
+    clock.advance(1)
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(edits.length).toBe(1)
+    expect(edits[0]!.messageId).toBe(100)
+    expect(edits[0]!.text).toContain('bar.ts')
+  })
+
+  test('event after throttle window elapsed edits immediately', async () => {
+    const { reporter, clock, api } = makeReporter()
+    await reporter.recordEvent('164995011', bashStart('t1'))
+    clock.advance(3000)
+    await reporter.recordEvent('164995011', readStart('t2'))
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(edits.length).toBe(1)
+    expect(edits[0]!.text).toContain('foo.ts')
+  })
+
+  test('per-chat state is isolated (chat A edit does not touch chat B)', async () => {
+    const { reporter, clock, api } = makeReporter()
+    await reporter.recordEvent('chat-A', bashStart('a1'))
+    await reporter.recordEvent('chat-B', bashStart('b1'))
+    const sendsAfter = api.calls.filter((c) => c.kind === 'send')
+    expect(sendsAfter.length).toBe(2)
+    expect(sendsAfter[0]!.chatId).toBe('chat-A')
+    expect(sendsAfter[0]!.messageId).toBe(100)
+    expect(sendsAfter[1]!.chatId).toBe('chat-B')
+    expect(sendsAfter[1]!.messageId).toBe(101)
+
+    clock.advance(3001)
+    await reporter.recordEvent('chat-A', readStart('a2'))
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(edits.length).toBe(1)
+    expect(edits[0]!.chatId).toBe('chat-A')
+    expect(edits[0]!.messageId).toBe(100)
+  })
+
+  test('session_stop is idempotent (second stop is a no-op)', async () => {
+    const { reporter, clock, api } = makeReporter()
+    await reporter.recordEvent('164995011', bashStart('t1'))
+    clock.advance(3000)
+    await reporter.recordEvent('164995011', STOP)
+    const editsAfterFirstStop = api.calls.filter((c) => c.kind === 'edit').length
+    expect(editsAfterFirstStop).toBeGreaterThanOrEqual(1)
+
+    await reporter.recordEvent('164995011', STOP)
+    const sendsTotal = api.calls.filter((c) => c.kind === 'send').length
+    const editsTotal = api.calls.filter((c) => c.kind === 'edit').length
+    expect(sendsTotal).toBe(1)
+    expect(editsTotal).toBe(editsAfterFirstStop)
+
+    clock.advance(60_000)
+    expect(api.calls.filter((c) => c.kind === 'send').length).toBe(1)
+    expect(api.calls.filter((c) => c.kind === 'edit').length).toBe(editsTotal)
+  })
+
+  test('disabled progress is a hard no-op', async () => {
+    const { reporter, clock, api } = makeReporter({
+      config: makeConfig({ enabled: false }),
+    })
+    await reporter.recordEvent('164995011', bashStart('t1'))
+    await reporter.recordEvent('164995011', readStart('t2'))
+    await reporter.recordEvent('164995011', STOP)
+    clock.advance(60_000)
+    expect(api.calls.length).toBe(0)
+  })
+
+  test('telegram sendMessage failure is swallowed; subsequent event can retry', async () => {
+    const api = makeFakeApi()
+    api.failSendWith = new Error('telegram down')
+    const { reporter, clock } = makeReporter({ api })
+
+    await reporter.recordEvent('164995011', bashStart('t1'))
+    expect(api.calls.length).toBe(0)
+
+    delete api.failSendWith
+    clock.advance(10)
+    await reporter.recordEvent('164995011', readStart('t2'))
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(1)
+    expect(sends[0]!.chatId).toBe('164995011')
+  })
+
+  // ───────────────────────────────────────────────────────────────────
+  // Race / lifecycle additions (Phase 5 fix-loop iter 1)
+  // ───────────────────────────────────────────────────────────────────
+
+  test('events arriving while initial send is in-flight collapse to ONE follow-up edit with the freshest text', async () => {
+    const api = makeFakeApi()
+    api.deferSend = true
+    const { reporter, clock } = makeReporter({ api })
+
+    // Kick off the first send; do NOT await — keep it in flight.
+    void reporter.recordEvent('164995011', bashStart('t1', 'echo first'))
+    // Two more events arrive while send is in flight. Each updates
+    // desiredText.
+    await reporter.recordEvent('164995011', bashStart('t2', 'echo second'))
+    await reporter.recordEvent('164995011', bashStart('t3', 'echo third'))
+
+    // No Telegram calls observed yet (send is parked).
+    expect(api.calls.length).toBe(0)
+
+    // Release the parked sendMessage. Expect the SEND lands and then
+    // one follow-up EDIT carrying the freshest tool ('third').
+    api.releaseSend!()
+    // Drain the first executeFlush + its finally chain so the deferred
+    // follow-up timer is fully armed before we advance the clock. Doing
+    // `await firstSend` alone is not sufficient: firstSend resolves at
+    // sync exit of recordEvent #1 (before the executeFlush continuation
+    // had a chance to set up the follow-up timer).
+    await reporter._idleForTests('164995011')
+    // Throttle window: lastEditAtMs was set to clock.now (0) when the
+    // initial send resolved. The follow-up edit sits on a 3000ms timer
+    // — advance past it.
+    clock.advance(3000)
+    await reporter._idleForTests('164995011')
+
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    // Collapsing rule: regardless of how many in-flight events arrived,
+    // we issue exactly one send and one follow-up edit (not one edit
+    // per intermediate event).
+    expect(sends.length).toBe(1)
+    expect(edits.length).toBe(1)
+    // The follow-up edit carries the LATEST snapshot, which includes
+    // the third tool. (The activity buffer is cumulative — earlier
+    // tools stay visible up to recent_buffer; the test guards that the
+    // newest event made it into the published view.)
+    expect(edits[0]!.text).toContain('third')
+  })
+
+  test('session_stop while initial send is in-flight does not produce an orphan edit', async () => {
+    const api = makeFakeApi()
+    api.deferSend = true
+    const { reporter, clock } = makeReporter({ api })
+
+    const inFlight = reporter.recordEvent('164995011', bashStart('t1'))
+    // Stop arrives before the parked send resolves.
+    const stopPromise = reporter.recordEvent('164995011', STOP)
+    // Release the send.
+    api.releaseSend!()
+    await Promise.all([inFlight, stopPromise])
+    // Drain any residual microtasks from the executeFlush finally chain.
+    await reporter._idleForTests('164995011')
+    clock.advance(60_000)
+    await reporter._idleForTests('164995011')
+
+    // Exactly one send (the original) and zero edits — no orphan
+    // intermediate edits, and no final "done" edit because the
+    // executeFlush observed entry.stopped and skipped state mutations.
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(sends.length).toBe(1)
+    expect(edits.length).toBe(0)
+  })
+
+  test('idle entry older than session_ttl_ms is evicted; next event starts a fresh thread', async () => {
+    const { reporter, clock, api } = makeReporter({
+      config: makeConfig({ session_ttl_ms: 60_000 }), // 60s TTL for the test
+    })
+    await reporter.recordEvent('164995011', bashStart('t1'))
+    expect(api.calls.filter((c) => c.kind === 'send').length).toBe(1)
+    // Move past TTL with no activity.
+    clock.advance(60_001)
+    // New event after TTL — must start a fresh sendMessage, not edit the prior.
+    await reporter.recordEvent('164995011', bashStart('t2'))
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(sends.length).toBe(2)
+    expect(sends[1]!.messageId).toBe(101)
+    expect(edits.length).toBe(0)
+  })
+
+  test('long Bash command stays under Telegram 4096-char limit', async () => {
+    const { reporter, api } = makeReporter()
+    const huge = 'echo ' + 'X'.repeat(5000)
+    await reporter.recordEvent('164995011', bashStart('t1', huge))
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(1)
+    // 4096 is Telegram's editMessageText/sendMessage cap.
+    expect(sends[0]!.text.length).toBeLessThanOrEqual(4096)
+  })
+
+  test('bearer-token-shaped secret in Bash command is masked before reaching Telegram', async () => {
+    const { reporter, api } = makeReporter()
+    // 40-char token shape that maskSecrets generic-long-token rule must
+    // catch. Pattern: a long [A-Za-z0-9_-] run wrapped by 4-char anchors.
+    const token = 'abcd' + 'X'.repeat(32) + 'wxyz'
+    await reporter.recordEvent('164995011', bashStart('t1', `curl -H "Authorization: Bearer ${token}"`))
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(1)
+    expect(sends[0]!.text).not.toContain(token)
+    // Masked form keeps first 4 / last 4 chars of the token only — the
+    // 32-X middle must be gone.
+    expect(sends[0]!.text).not.toContain('XXXXXXXX')
+  })
+
+  test('editMessageText failure is swallowed; next event still produces a successful edit', async () => {
+    const api = makeFakeApi()
+    const { reporter, clock } = makeReporter({ api })
+    await reporter.recordEvent('164995011', bashStart('t1'))
+    // First edit attempt rejects.
+    api.failEditWith = new Error('telegram down')
+    clock.advance(3000)
+    await reporter.recordEvent('164995011', readStart('t2'))
+    await reporter._idleForTests('164995011')
+    // Edit recorded (api pushed) but threw afterwards — call counted.
+    const firstEditCount = api.calls.filter((c) => c.kind === 'edit').length
+    expect(firstEditCount).toBe(1)
+    // Recover. Next event must succeed (we never get stuck due to a single failure).
+    delete api.failEditWith
+    clock.advance(3000)
+    await reporter.recordEvent('164995011', readStart('t3', '/abs/path/baz.ts'))
+    await reporter._idleForTests('164995011')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(edits.length).toBeGreaterThanOrEqual(2)
+    expect(edits[edits.length - 1]!.text).toContain('baz.ts')
+  })
+})

--- a/plugin/tests/status/status-manager.test.ts
+++ b/plugin/tests/status/status-manager.test.ts
@@ -39,6 +39,12 @@ function makeConfig(overrides: Partial<AppConfig['status']> = {}): AppConfig {
       buffer_ttl_ms: 5 * 60 * 1000,
       buffer_max_entries: 100,
     },
+    progress: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      recent_buffer: 10,
+      session_ttl_ms: 600000,
+    },
   }
 }
 

--- a/plugin/tests/telegram/gate.test.ts
+++ b/plugin/tests/telegram/gate.test.ts
@@ -30,6 +30,12 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       buffer_ttl_ms: 5 * 60 * 1000,
       buffer_max_entries: 100,
     },
+    progress: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      recent_buffer: 10,
+      session_ttl_ms: 600000,
+    },
     ...overrides,
   }
 }

--- a/plugin/tests/telegram/handlers.test.ts
+++ b/plugin/tests/telegram/handlers.test.ts
@@ -48,6 +48,12 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       buffer_ttl_ms: 5 * 60 * 1000,
       buffer_max_entries: 100,
     },
+    progress: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      recent_buffer: 10,
+      session_ttl_ms: 600000,
+    },
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary

- Новый модуль `src/status/progress-reporter.ts` показывает вождю в реальном времени какие тулзы дёргает Claude Code агент через persistent Telegram thread (editMessageText). Параллелен StatusManager: тот владеет transient bubble, ProgressReporter — отдельным сообщением которое переживает reply.
- Trailing throttle с per-chat single-slot очередью, TTL-eviction против stuck сессий, идемпотентный stop с in-flight drain, top-level catch — Telegram failures swallow'ятся, recordEvent never throws.
- Webhook диспатчит ProgressReporter независимо от StatusManager (две независимые гейты `config.status.enabled` и `config.progress.enabled`).

## Test plan

- [x] `bun test tests/status/progress-reporter.test.ts` — 13 pass / 0 fail (47 expect calls)
- [x] Покрытие: first send, throttle collapse, post-window immediate edit, multi-chat isolation, stop idempotency, disabled hard no-op, send failure swallow + retry, in-flight send race (events arriving while initial sendMessage is parked), session_stop while send in-flight, TTL eviction across stale sessions, long Bash input ≤ 4096 chars, bearer-token masking via activity-renderer, edit failure swallow + retry
- [x] Полный `bun test` — мои изменения не вводят регрессий (см. note ниже про pre-existing missing `src/state/` в public clone — отдельная задача)
- [x] Typecheck чисто для моих файлов

## Process

Loop-coding pipeline (per Thrall hard rules):
- **Phase 0** — Context gather (читал claude-events, status-manager, activity-renderer, channel/tools, webhook/server)
- **Phase 1** — Research subagent (Sonnet): throttle patterns, Telegram rate limits, per-chat state mutex, что НЕ показывать в progress (security/UX)
- **Phase 2** — Plan via **Codex GPT-5.5** (`--effort high`): API surface, internal state shape, event semantics, throttle algorithm, config schema, integration points, test plan, risks, order of implementation. Hard rule: Plan делает Codex, не Opus.
- **Phase 3** — Implementation via Opus 4.7 + TDD (RED→GREEN)
- **Phase 4** — Review: **Codex GPT-5.5 + Opus 4.7 параллельно** (dual review hard rule). Verdict: REQUEST_CHANGES — 3 CRITICAL + 3 HIGH:
  - **C1** First-send race (Codex H1 + Opus C1): events дроп'ались если приходили во время in-flight sendMessage
  - **C2** Cross-session pollution (Opus C2): без TTL потерянный session_stop приводил к смешению сессий в одном Telegram сообщении
  - **C3** progress отключался вместе со status (Opus C3): нарушение «coexist independently» контракта
  - **H1** handleStop during in-flight send (оба ревью): orphan messages
  - **H2** Webhook без try/catch (оба ревью): fragile contract
  - **H3** No TTL/cleanup (Opus, follows C2)
- **Phase 5** — Fix-loop iter 1: single-slot promise queue (`flushPromise + desiredText`), `lastActivityMs` + TTL check в getOrCreate, разнёс webhook dispatch на два независимых блока, revision bump в handleStop + проверка `entry.stopped` в send callback, top-level catch в recordEvent. Все CRITICAL/HIGH закрыты. Добавил 6 race/lifecycle тестов.
- **Phase 6** — Ship (этот PR)

Run artifacts: `~/.claude-lab/thrall/.claude/loop-coding-runs/2026-05-18-progress-reporter/` (PHASE-0-CONTEXT.md, PHASE-1-RESEARCH.md, PHASE-2-PLAN.md, PHASE-4-CODEX-REVIEW.md, PHASE-4-OPUS-REVIEW.md, PHASE-5-FIX-PLAN.md).

## Notes

- Pre-existing issue в этом репо: `plugin/.gitignore` имеет `state/` что игнорирует папку `src/state/`. Поэтому `tests/state.test.ts`, `tests/webhook/server.test.ts`, `tests/telegram/poller.test.ts` падают на любом clean clone. НЕ связано с этим PR. Отдельная задача — поправить gitignore + восстановить `src/state/store.ts`.
- Нужен **restart bun процесса плагина** на Thrall VPS чтобы новый код подхватился (это прервёт связь Thrall ↔ warchief Telegram на ~5 секунд). Restart только с явным OK от warchief.
- HTML отчёт через скилл `/present` от Сильваны — следующим шагом.

🤖 Generated with [Claude Code](https://claude.com/claude-code)