### PR TITLE
Фикс: 👀 реакция только на сообщения адресованные боту

### DIFF
--- a/plugin/src/telegram/addressing.ts
+++ b/plugin/src/telegram/addressing.ts
@@ -1,0 +1,46 @@
+// Inbound addressing helper.
+//
+// Decides whether a Telegram update is "addressed" to this bot — meaning
+// the prince intends the bot to notice it. Used to gate visibility signals
+// (e.g. 👀 reactions) so the bot does not spam reactions on every message
+// in groups it happens to be a member of.
+//
+// Rules (mirror Python gateway helper at gateway.py:753-793):
+//   - Private chat → always addressed (DM is the primary channel).
+//   - Group/supergroup with text or caption that @-mentions the bot → addressed.
+//   - Group/supergroup with reply_to_message authored by the bot itself → addressed.
+//   - Group/supergroup voice/video_note reply (no text to @-mention with) → addressed
+//     if the parent message is from the bot.
+//   - Anything else → not addressed.
+//
+// We deliberately do NOT consult the allowlist here — that is the gate's job.
+// This helper is about intent ("is the user talking to me?"), not authorization
+// ("is the user allowed to talk to me?"). The reaction is harmless either way.
+import type { Context } from 'grammy'
+
+export function isAddressedToBot(ctx: Context): boolean {
+  const chatType = ctx.chat?.type
+  if (chatType === 'private') return true
+  if (chatType !== 'group' && chatType !== 'supergroup') return false
+
+  const botUsername = ctx.me?.username?.toLowerCase()
+  if (!botUsername) return false
+
+  const text = (ctx.message?.text ?? ctx.message?.caption ?? '').toLowerCase()
+  if (text.length > 0 && text.includes(`@${botUsername}`)) return true
+
+  const replyTo = ctx.message?.reply_to_message
+  if (replyTo?.from?.is_bot && replyTo.from?.username?.toLowerCase() === botUsername) {
+    return true
+  }
+
+  // Voice / video_note replies have no text to @-mention with — any reply
+  // to the bot counts. Mirrors gateway.py:783-784.
+  if (replyTo && (ctx.message?.voice || ctx.message?.video_note)) {
+    const replyUsername = replyTo.from?.username?.toLowerCase()
+    if (replyTo.from?.is_bot && replyUsername === botUsername) {
+      return true
+    }
+  }
+  return false
+}

--- a/plugin/src/telegram/handlers.ts
+++ b/plugin/src/telegram/handlers.ts
@@ -23,6 +23,7 @@ import type { TelegramApi } from '../channel/tools.js'
 import type { StatusManager } from '../status/status-manager.js'
 import { sendChannelNotification, type ChannelEvent } from '../channel/notify.js'
 import { gateTelegramMessage, type GateInput } from './gate.js'
+import { isAddressedToBot } from './addressing.js'
 import {
   buildChannelContent,
   type BotIdentity,
@@ -392,6 +393,20 @@ export async function sendAlbumNotification(
 
 export async function handleInboundText(ctx: Context, deps: HandlerDeps): Promise<void> {
   const text = ctx.message?.text ?? ''
+
+  // Auto-react 👀 on inbound — prince visibility signal, replaces typing indicator.
+  // ONLY for messages addressed to this bot (DM, @mention, or reply to bot).
+  // Without this gate the bot would react to every group message it sees.
+  if (isAddressedToBot(ctx)) {
+    try {
+      const _chatId = ctx.chat?.id
+      const _msgId = ctx.message?.message_id
+      if (_chatId !== undefined && _msgId !== undefined) {
+        await deps.telegramApi.setMessageReaction(String(_chatId), _msgId, '👀')
+      }
+    } catch (_e) { /* react best-effort */ }
+  }
+
   // Permission-text short-circuit. BEFORE the OOB check: when the sender is
   // an approver AND text matches `yes <id>` / `no <id>` AND that id is
   // currently pending, emit the verdict and DO NOT forward as a channel


### PR DESCRIPTION
## Проблема

@trallvibecoderbot в группе ставил реакцию 👀 на ВСЕ сообщения от ВСЕХ участников. В DM это нормально, в группах — визуальный шум для всех.

## Корень

`src/telegram/handlers.ts:handleInboundText` ставит `setMessageReaction(👀)` ПЕРВЫМ шагом, до gate-фильтрации. Gate дропает group messages позже (`not_dm`), но реакция уже ушла.

Введено в коммите F2 phased reactions (`F2: phased reactions 👀 inbound → ⚙️ tool → ✅/❌ stop`) — без учёта group context.

## Решение

1. Новый `src/telegram/addressing.ts` с `isAddressedToBot(ctx)`:
   - DM (chat.type === private) → `true` (всегда адресовано)
   - group/supergroup с `@bot_username` в text/caption → `true`
   - group/supergroup reply на бота (text reply OR voice/video_note reply) → `true`
   - всё остальное → `false`
   - Зеркалирует `gateway.py:753-793 is_addressed_to_agent` (Python sister-проект)

2. В `handlers.ts` auto-react блок обёрнут в `if (isAddressedToBot(ctx))`.

3. `✅`/`❌` permission verdicts (handlers.ts:426) уже были корректно gated через `ctx.chat?.type === private` — НЕ ТРОГАЕМ.

## Проверка

- typecheck: ошибки в src/ — pre-existing (server.ts, poller.ts, webhook/server.ts), не от этого PR
- channel-thrall.service restart 12:07 UTC — патч загружен в runtime
- live: ждём smoke от принца (DM @trallvibecoderbot → 👀; в группе без @mention → нет 👀)

## Безопасность

- Не консультируется allowlist — isAddressedToBot про intent ("меня зовут?"), не authorization ("можно ли мне отвечать?"). Authorization — это gate.ts job. React всё равно safe-by-default.

## Out of scope

- Восстановить tests/ typecheck (pre-existing)
- Mirror `qwwiwi/dashi-plugin-claude-code` (public) тоже отстаёт — отдельный sync