### PR TITLE
feat(config): support TELEGRAM_ALLOWED_CHAT_IDS env override

### DIFF
--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -111,6 +111,12 @@ export const RuntimeEnvSchema = z.object({
   TELEGRAM_CONFIG_FILE: z.string().optional(),
   TELEGRAM_EXPECTED_BOT_ID: z.coerce.number().int().positive().optional(),
   TELEGRAM_ALLOWED_USER_IDS: z.string().optional(), // CSV
+  // CSV of chat ids; entries may be integers (user/group/channel id, possibly
+  // negative for supergroups) or @username strings. In a Telegram DM
+  // `chat.id == user.id`, so a DM-only deployment typically sets this to the
+  // same value as TELEGRAM_ALLOWED_USER_IDS — without this, gate.ts:
+  // chat_not_allowed silently drops every inbound DM.
+  TELEGRAM_ALLOWED_CHAT_IDS: z.string().optional(),
   TELEGRAM_WORKSPACE_ROOT: z.string().optional(),
   TELEGRAM_STATUS_INTERVAL_MS: z.coerce.number().int().positive().optional(),
   TELEGRAM_ALBUM_FLUSH_MS: z.coerce.number().int().positive().optional(),
@@ -187,6 +193,28 @@ function parseCsvUserIds(csv: string): number[] {
   return ids
 }
 
+// Chat ids are heterogeneous: groups/supergroups are negative ints, users
+// are positive ints, channels can be referenced as @username strings. We
+// keep @-prefixed entries as strings and require everything else to be a
+// non-zero integer.
+function parseCsvChatIds(csv: string): Array<number | string> {
+  const ids: Array<number | string> = []
+  for (const raw of csv.split(',')) {
+    const trimmed = raw.trim()
+    if (!trimmed) continue
+    if (trimmed.startsWith('@')) {
+      ids.push(trimmed)
+      continue
+    }
+    const n = Number(trimmed)
+    if (!Number.isInteger(n) || n === 0) {
+      throw new Error(`invalid chat id in CSV: ${JSON.stringify(trimmed)}`)
+    }
+    ids.push(n)
+  }
+  return ids
+}
+
 export function loadConfig(env: NodeJS.ProcessEnv): AppConfig {
   let parsedEnv: RuntimeEnv
   try {
@@ -226,6 +254,9 @@ export function loadConfig(env: NodeJS.ProcessEnv): AppConfig {
   }
   if (parsedEnv.TELEGRAM_ALLOWED_USER_IDS !== undefined) {
     merged.allowed_user_ids = parseCsvUserIds(parsedEnv.TELEGRAM_ALLOWED_USER_IDS)
+  }
+  if (parsedEnv.TELEGRAM_ALLOWED_CHAT_IDS !== undefined) {
+    merged.allowed_chat_ids = parseCsvChatIds(parsedEnv.TELEGRAM_ALLOWED_CHAT_IDS)
   }
   if (parsedEnv.TELEGRAM_WORKSPACE_ROOT !== undefined) {
     merged.workspace_root = parsedEnv.TELEGRAM_WORKSPACE_ROOT

--- a/plugin/tests/config.test.ts
+++ b/plugin/tests/config.test.ts
@@ -42,6 +42,32 @@ describe('loadConfig', () => {
     expect(cfg.allowed_user_ids).toEqual([111, 222, 333])
   })
 
+  test('parses CSV TELEGRAM_ALLOWED_CHAT_IDS into mixed int/string array', () => {
+    // Mix: positive int (user/private chat), negative int (supergroup),
+    // @username (channel reference). All three are valid chat-id shapes
+    // per the Bot API.
+    const cfg = loadConfig(env({
+      TELEGRAM_ALLOWED_CHAT_IDS: '111, -1001234567890 , @my_channel',
+    }))
+    expect(cfg.allowed_chat_ids).toEqual([111, -1001234567890, '@my_channel'])
+  })
+
+  test('TELEGRAM_ALLOWED_CHAT_IDS rejects zero and non-integers', () => {
+    expect(() => loadConfig(env({ TELEGRAM_ALLOWED_CHAT_IDS: '0' })))
+      .toThrow(/invalid chat id/i)
+    expect(() => loadConfig(env({ TELEGRAM_ALLOWED_CHAT_IDS: 'abc' })))
+      .toThrow(/invalid chat id/i)
+  })
+
+  test('TELEGRAM_ALLOWED_CHAT_IDS env wins over config.json', () => {
+    writeFileSync(join(stateDir, 'config.json'), JSON.stringify({
+      allowed_user_ids: [999],
+      allowed_chat_ids: [999],
+    }))
+    const cfg = loadConfig(env({ TELEGRAM_ALLOWED_CHAT_IDS: '888,-100777' }))
+    expect(cfg.allowed_chat_ids).toEqual([888, -100777])
+  })
+
   test('env overrides win over config.json', () => {
     writeFileSync(join(stateDir, 'config.json'), JSON.stringify({
       bot_id: 11111,


### PR DESCRIPTION
## Summary

`TELEGRAM_ALLOWED_USER_IDS` has both a `RuntimeEnvSchema` entry and a matching merge branch in `loadConfig`, but `allowed_chat_ids` had neither. Operators setting `TELEGRAM_ALLOWED_CHAT_IDS=...` got it silently ignored, and `cfg.allowed_chat_ids` stayed at the schema default `[164795011]`.

In a Telegram DM `chat.id == user.id`, so without a chat allowlist the inbound gate (`src/telegram/gate.ts:60-62`) returns `{kind: 'drop', reason: 'chat_not_allowed'}` for every message. The bot reads updates, advances `update-offset`, but nothing reaches the Claude session. The drop is logged at `debug` only — making the failure mode hard to find unless `LOG_LEVEL=debug` is set up front.

## Repro before fix

```
export TELEGRAM_BOT_TOKEN=<your_bot>
export TELEGRAM_ALLOWED_USER_IDS=12345          # your user id
export TELEGRAM_ALLOWED_CHAT_IDS=12345          # silently ignored
claude --dangerously-load-development-channels server:dashi-channel
```

→ DM your bot. `pending_update_count` drains, `update-offset` ticks up, eyes-react fires, but Claude sees no inbound and nothing lands in `inbox/` or `dead-letter/`.

Workaround that operators have to discover: create `\$TELEGRAM_STATE_DIR/config.json` with `{\"allowed_chat_ids\": [12345]}`. Works, but the env vs config.json mismatch is non-obvious.

## Changes

1. **Schema** — add `TELEGRAM_ALLOWED_CHAT_IDS: z.string().optional()` to `RuntimeEnvSchema` next to the user-ids entry, with a comment explaining the gate interaction.

2. **Parser** — new `parseCsvChatIds` helper that mirrors `parseCsvUserIds` but:
   - keeps `@username` entries as strings (`allowed_chat_ids` schema is `z.array(z.union([z.number(), z.string()]))`),
   - accepts negative integers (supergroup ids are `-100…`),
   - rejects `0` and non-integers with a clear `invalid chat id in CSV: ...` error.

3. **Merge** — add the missing branch in `loadConfig`. Precedence stays env > config.json > defaults, matching every other override in the same block.

4. **Tests** — three new cases in `plugin/tests/config.test.ts`:
   - parses mixed CSV with positive int + negative supergroup + `@channel`,
   - rejects `0` and non-numeric input,
   - env wins over a config.json that sets `allowed_chat_ids`.

## Verification

```
bun test
```

→ **521/521 pass** (518 prior + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)