### PR TITLE
feat: TaskMirror (PR-A2) + InboundWatcher (PR-A3) + Phase 4 review fixes

### DIFF
--- a/plugin/docs/PLAN-A2-A3.md
+++ b/plugin/docs/PLAN-A2-A3.md
@@ -1,0 +1,591 @@
+# Plan: PR-A2 (TaskMirror) + PR-A3 (Watcher/Auto-Responder)
+
+> Codex GPT-5.5 architectural plan — 2026-05-20
+> Branch: `feature/task-mirror-and-watcher`
+> Shipping as ONE PR on top of merged PR-A1 (`b3ad729`).
+
+---
+
+## 1. AUDIT
+
+### 1.1 `src/status/progress-reporter.ts`
+
+**Architectural model for TaskMirror.** Key findings:
+
+- `ChatProgressEntry` (line 85–107): per-chat state. Fields: `messageId?`, `startedAtMs`, `lastActivityMs`, `calls[]`, `lastRenderedText?`, `lastEditAtMs`, `desiredText?`, `flushPromise`, `pendingTimer`, `stopped`. TaskMirror will mirror this shape exactly (with `todos[]` instead of `calls[]`).
+- `TelegramApiForProgress` (line 47–55): minimal structural interface for `sendMessage` + `editMessageText`. TaskMirror reuses this same interface — no new interface needed.
+- `ProgressReporterDeps` (line 57–65): injectable clock (`now`) + timer (`setTimer`/`clearTimer`) for deterministic tests. TaskMirror copies this pattern.
+- Single-slot queue (line 261–280, `scheduleFlush`): `flushPromise !== null` guard prevents double-flight. Timer slot (`pendingTimer`) for throttle deferral.
+- Idempotency gate (line 265): `text === entry.lastRenderedText` early-return.
+- `handleStop` (line 357–404): cancels timer, awaits in-flight, posts final edit, evicts entry. TaskMirror copies this pattern for session_stop.
+- `_idleForTests` (line 144–156): drain loop for test assertions. TaskMirror must expose the same.
+- `getOrCreate` (line 168–194): TTL eviction via `lastActivityMs`. `session_ttl_ms` from `config.progress`. TaskMirror shares the same TTL value.
+
+**Key invariant:** three independent rolling messages per chat — StatusManager (transient bubble), ProgressReporter (tool activity thread), TaskMirror (todo list thread). They never share state.
+
+### 1.2 `src/hooks/claude-events.ts`
+
+- `ActivityStatusEvent` union (line 49): `ToolStartEvent | ToolEndEvent | ReasoningEvent | SessionStartEvent | SessionStopEvent`.
+- `toActivityEvent` (line 56–86): maps `ClaudeHookPayload` → `ActivityStatusEvent`. **Only `PostToolUse` with `tool_name === 'TodoWrite'` is relevant for TaskMirror** — but `toActivityEvent` currently returns a `ToolEndEvent` for ALL `PostToolUse` events, including `TodoWrite`. The TaskMirror dispatch must happen ALONGSIDE the existing `toActivityEvent` call, not inside it.
+- A **new `TodoWriteEvent`** type must be added to this file. It is NOT a subtype of `ActivityStatusEvent` — it is a parallel union used only by TaskMirror. This keeps StatusManager and ProgressReporter untouched.
+- New export needed: `toTodoWriteEvent(payload: ClaudeHookPayload): TodoWriteEvent | null` — returns non-null only when `hook_event_name === 'PostToolUse'` and `tool_name === 'TodoWrite'` OR `hook_event_name === 'Stop'`.
+
+### 1.3 `src/schemas.ts`
+
+- `ToolInputSchema` (line 119): `z.record(z.unknown())` — already `passthrough`-compatible.
+- `ClaudePostToolUseSchema` (line 121–131): `tool_input: ToolInputSchema`. The `tool_input` for `TodoWrite` carries `{ todos: [...] }` — but `ToolInputSchema` is `z.record(z.unknown())`, so it parses fine.
+- **New export needed:** `TodoWriteInputSchema` — validates `tool_input` when `tool_name === 'TodoWrite'`. Must use `.passthrough()` on the todo item shape. Placement: after `ToolInputSchema` definition (~line 119).
+
+```ts
+// Pseudocode shape:
+const TodoItemSchema = z.object({
+  id: z.string().optional(),
+  content: z.string(),
+  status: z.enum(['pending', 'in_progress', 'completed']),
+  priority: z.enum(['high', 'medium', 'low']).optional(),
+}).passthrough()
+
+export const TodoWriteInputSchema = z.object({
+  todos: z.array(TodoItemSchema),
+}).passthrough()
+export type TodoWriteInput = z.infer<typeof TodoWriteInputSchema>
+export type TodoItem = z.infer<typeof TodoItemSchema>
+```
+
+### 1.4 `src/server.ts` (lines 221–320)
+
+- Line 232: `createSafeTelegramApi(rawTelegramApi, log, apiSecrets)` — the safe-wrapped `telegramApi` is the only reference passed downstream. **TaskMirror must receive this same `telegramApi`.**
+- Line 243: `statusManager = new StatusManager({ telegramApi, config, log })`.
+- Line 249: `progressReporter = new ProgressReporter({ telegramApi, config, log })`.
+- **Insertion point for TaskMirror:** after line 249, same pattern:
+  ```ts
+  const taskMirror = new TaskMirror({ telegramApi, config, log })
+  ```
+- `WebhookDeps` (in `webhook/server.ts` line 47): needs `taskMirror?: TaskMirror` added.
+- `WebhookDeps` instantiation in `server.ts` (~line 300): add `taskMirror`.
+- **Watcher insertion point:** the watcher needs a reference to `progressReporter` to query busy state. It runs in `handlers.ts`, so `progressReporter` must be threaded into `HandlerDeps` or the watcher is a standalone module that receives `progressReporter` via closure in `server.ts` when setting up grammy handlers.
+
+### 1.5 `src/webhook/server.ts`
+
+- `WebhookDeps` (line 47–65): has `statusManager?`, `memoryWriter?`, `progressReporter?`. Needs `taskMirror?: TaskMirror` added.
+- Dispatch block for `claude_hook` (lines 293–338): currently calls `toActivityEvent(payload)` once, then routes to `statusManager` and `progressReporter`. **TaskMirror dispatch** goes after progressReporter dispatch, same try/catch pattern:
+  ```ts
+  if (taskMirror) {
+    const todoEvent = toTodoWriteEvent(payload)
+    if (todoEvent !== null) {
+      try {
+        await taskMirror.recordEvent(payload.chatId, todoEvent)
+      } catch (err) { ... }
+    }
+  }
+  ```
+  Gate: `config.task_mirror.enabled` (checked inside `taskMirror.recordEvent` like ProgressReporter checks `config.progress.enabled`).
+
+### 1.6 `src/telegram/handlers.ts`
+
+- `HandlerDeps` (line 76–111): does NOT currently contain `progressReporter`. The watcher needs to query `progressReporter.isBusy(chatId)`. **Two options:**
+  - Option A: add `progressReporter?: ProgressReporter` to `HandlerDeps` and pass it from `server.ts`.
+  - Option B: inject a narrow `WatcherService` interface into `HandlerDeps` that exposes only `isBusy(chatId): boolean` and `autoReply(chatId, ctx)`.
+  - **Decision: Option B** — keeps HandlerDeps decoupled from ProgressReporter internals. `WatcherService` is a thin structural interface.
+- `handleInboundText` (line 394–503): watcher hook goes **AFTER OOB check returns** but **BEFORE `gateAndNotify`**. Flow:
+  1. Permission-text short-circuit (line 413–452) — unchanged.
+  2. OOB short-circuit (line 453–502) — unchanged, returns early if OOB.
+  3. **NEW: watcher check** — if watcher present AND chat is busy → auto-reply (fire-and-forget) → **fall through to `gateAndNotify`** (do NOT return early; Claude must still get the message).
+  4. `gateAndNotify` (line 503) — unchanged.
+
+### 1.7 `src/commands/oob.ts`
+
+- `parseOobCommand` (line 52): returns a `ParsedOobCommand | null`. When non-null, OOB handling runs and the function returns **before** watcher check (line 458–502 in handlers.ts). This is correct — OOB takes strict priority. Watcher never fires for OOB commands.
+- `OobCommandName` (line 33): `'help' | 'status' | 'stop' | 'reset' | 'new'`. All handled inline; watcher is irrelevant for these.
+- **No changes to oob.ts.**
+
+### 1.8 `src/status/status-manager.ts`
+
+- `isActive(chatId)` (line 176): returns `this.entries.has(chatId)`. This is the StatusManager bubble, separate from ProgressReporter.
+- `cancel(chatId, reason)` (line 466): cancels the transient bubble and edits to a cancelled label. When watcher auto-replies, it should NOT call `statusManager.cancel` — the status bubble follows its own lifecycle. The watcher is read-only w.r.t. StatusManager.
+- `entries: Map<string, InternalEntry>` — private. The watcher must not reach into StatusManager for busy detection; it uses `progressReporter.isBusy(chatId)` instead.
+- **No changes to status-manager.ts.**
+
+---
+
+## 2. ARCHITECTURE
+
+### 2.1 TaskMirror Module
+
+**Location:** `src/status/task-mirror.ts`
+
+**Public API:**
+```ts
+export interface TaskMirrorDeps {
+  telegramApi: TelegramApiForProgress  // reuse existing interface from progress-reporter.ts
+  config: AppConfig
+  log: Logger
+  now?: () => number
+  setTimer?: (cb: () => void, ms: number) => NodeJS.Timeout
+  clearTimer?: (handle: NodeJS.Timeout) => void
+}
+
+export class TaskMirror {
+  constructor(deps: TaskMirrorDeps)
+  async recordEvent(chatId: string, event: TodoWriteEvent): Promise<void>
+  async _idleForTests(chatId: string): Promise<void>  // test drain
+}
+```
+
+**State shape** (per-chat, private):
+```ts
+interface ChatTaskEntry {
+  chatId: string
+  messageId?: number
+  startedAtMs: number
+  lastActivityMs: number
+  todos: TodoItem[]          // latest snapshot from TodoWrite
+  lastRenderedText?: string  // idempotency gate
+  lastEditAtMs: number
+  desiredText?: string       // freshest pending text
+  flushPromise: Promise<void> | null
+  pendingTimer: NodeJS.Timeout | null
+  stopped: boolean
+}
+```
+
+**Config keys** (new in `AppConfigSchema`):
+```ts
+task_mirror: z.object({
+  enabled: z.boolean().default(true),
+  edit_throttle_ms: z.number().int().nonnegative().default(3000),
+  session_ttl_ms: z.number().int().positive().default(10 * 60 * 1000),
+  collapse_completed_after: z.number().int().nonnegative().default(5),
+  max_message_chars: z.number().int().positive().default(3000),
+}).default({})
+```
+
+**Throttle/TTL:** identical pattern to ProgressReporter. `edit_throttle_ms` default 3000ms. `session_ttl_ms` default 10min. Eviction on `session_stop` or TTL breach.
+
+**Render strategy:**
+- Status icons: `◻` pending, `◐` in_progress, `☑` completed.
+- Header: `<b>📋 Задачи</b>` + total count line.
+- Completed tasks: show last `collapse_completed_after` completed items, prepend `+N выполнено` if more exist.
+- In-progress first, then pending, then recent completed.
+- Each todo line: `{icon} {content_escaped}` — `escapeHtml` from `src/format/html.ts`.
+- Content truncation: max 80 chars per todo (append `…`).
+- Total message cap: `max_message_chars` (3000). Truncate with `… (+N more)` at bottom.
+- `parse_mode: 'HTML'` (same as ProgressReporter).
+
+**TodoWriteEvent shape** (new in `claude-events.ts`):
+```ts
+export interface TodoWriteEvent {
+  readonly kind: 'todo_write'
+  readonly todos: TodoItem[]  // from TodoWriteInputSchema
+}
+
+export interface TodoSessionStopEvent {
+  readonly kind: 'session_stop'
+}
+
+export type TaskMirrorEvent = TodoWriteEvent | TodoSessionStopEvent
+```
+
+`toTodoWriteEvent(payload: ClaudeHookPayload): TaskMirrorEvent | null`:
+- `PostToolUse` + `tool_name === 'TodoWrite'`: parse `tool_input` via `TodoWriteInputSchema.safeParse`. If success → `{ kind: 'todo_write', todos }`. If fail → log warn, return null.
+- `Stop` → `{ kind: 'session_stop' }`.
+- All other events → `null`.
+
+**Instantiation in `server.ts`** (after `progressReporter`, ~line 252):
+```ts
+const taskMirror = new TaskMirror({ telegramApi, config, log })
+```
+
+**Routing in `webhook/server.ts`** (after progressReporter dispatch, ~line 330):
+```ts
+if (taskMirror) {
+  const todoEvent = toTodoWriteEvent(payload)
+  if (todoEvent !== null) {
+    try { await taskMirror.recordEvent(payload.chatId, todoEvent) }
+    catch (err) { log.warn('task mirror error (ignored)', ...) }
+  }
+}
+```
+
+### 2.2 Watcher / Auto-Responder Module
+
+**Location:** `src/telegram/watcher.ts`
+
+**Public API:**
+```ts
+export interface WatcherConfig {
+  enabled: boolean
+  busy_threshold_ms: number   // default 30_000 — how recent a tool_start must be to count as busy
+  debounce_ms: number         // default 10_000 — min interval between auto-replies per chat
+}
+
+export interface WatcherDeps {
+  telegramApi: TelegramApi   // full TelegramApi (safe-wrapped, passed from HandlerDeps)
+  progressReporter: ProgressReporterForWatcher
+  log: Logger
+  config: AppConfig
+  now?: () => number
+}
+
+// Narrow read interface — watcher never mutates ProgressReporter
+export interface ProgressReporterForWatcher {
+  isBusy(chatId: string, thresholdMs: number): boolean
+  getActiveToolName(chatId: string): string | null  // last tool in entry.calls, or null
+}
+
+export class Watcher {
+  constructor(deps: WatcherDeps)
+  // Returns true if auto-reply was sent. Does NOT suppress the channel notification.
+  async maybeAutoReply(chatId: string, msgId: number): Promise<boolean>
+}
+```
+
+**`ProgressReporter` additions** (minimal — add to public API):
+```ts
+// Queries lastActivityMs < thresholdMs ago AND entry exists AND !stopped
+isBusy(chatId: string, thresholdMs: number): boolean
+
+// Returns last entry.calls[last].toolName, or null if no calls or no entry
+getActiveToolName(chatId: string): string | null
+```
+
+**Busy definition:**
+```
+entry = chats.get(chatId)
+entry exists AND !entry.stopped AND (now() - entry.lastActivityMs) < thresholdMs
+```
+
+**Auto-reply text composition:**
+```
+🔧 Тралл занят, активный инструмент: <code>{toolName}</code>. Ждать или /stop.
+```
+If no active tool name: `🔧 Тралл занят (думает). Ждать или /stop.`
+
+Uses `parse_mode: 'HTML'`. Goes through the safe-wrapped `telegramApi` from `HandlerDeps.telegramApi`.
+
+**Debounce:** per-chat Map `lastAutoReplyMs: Map<string, number>`. If `now() - lastAutoReplyMs.get(chatId) < debounce_ms`, skip sending but still return false (no-op, not an error).
+
+**Insertion point in `handleInboundText`** (handlers.ts, after OOB block ~line 502, before `gateAndNotify`):
+```ts
+// Watcher: if busy, send auto-reply (fire-and-forget).
+// DO NOT return early — Claude must still receive the message.
+if (deps.watcher) {
+  const chatId = ctx.chat?.id !== undefined ? String(ctx.chat.id) : undefined
+  const msgId = ctx.message?.message_id
+  if (chatId !== undefined && msgId !== undefined) {
+    void deps.watcher.maybeAutoReply(chatId, msgId)
+  }
+}
+await gateAndNotify(...)
+```
+
+**Config keys** (new in `AppConfigSchema`):
+```ts
+watcher: z.object({
+  enabled: z.boolean().default(true),
+  busy_threshold_ms: z.number().int().positive().default(30_000),
+  debounce_ms: z.number().int().nonnegative().default(10_000),
+}).default({})
+```
+
+**`HandlerDeps` addition:**
+```ts
+watcher?: Watcher
+```
+
+**`WatcherService` narrow interface in `handlers.ts`** — since `Watcher` is already narrow enough (one method), inject `Watcher` directly. No extra interface wrapper needed.
+
+**Instantiation in `server.ts`** (after `progressReporter`, ~line 253):
+```ts
+const watcher = new Watcher({ telegramApi, progressReporter, config, log })
+```
+
+Add `watcher` to `handlerDeps` in `server.ts`.
+
+### 2.3 HTML Rendering Details
+
+- Reuse `escapeHtml` from `src/format/html.ts`.
+- Status icon map:
+  ```ts
+  const ICONS = { pending: '◻', in_progress: '◐', completed: '☑' } as const
+  ```
+- Sort order: `in_progress` first, then `pending`, then `completed`.
+- Completed collapse: keep last `collapse_completed_after` completed items from the sorted tail. Show `+N выполнено ранее` above if any were dropped.
+- Per-item line: `{icon} {escapeHtml(content.slice(0, 80))}{content.length > 80 ? '…' : ''}`
+- Full message structure:
+  ```html
+  <b>📋 Задачи</b>
+  Выполнено: {doneCount}/{total}
+
+  {todo lines}
+  ```
+- Total cap: 3000 chars. If render exceeds cap, drop trailing todos and append `… (+N не показано)`.
+
+---
+
+## 3. FILE-LEVEL PLAN
+
+**Dependency order:**
+
+| # | File | Action | Purpose |
+|---|------|---------|---------|
+| 1 | `src/schemas.ts` | Modify | Add `TodoItemSchema`, `TodoWriteInputSchema`, exported types |
+| 2 | `src/hooks/claude-events.ts` | Modify | Add `TodoWriteEvent`, `TodoSessionStopEvent`, `TaskMirrorEvent`, `toTodoWriteEvent` |
+| 3 | `src/config.ts` | Modify | Add `task_mirror` and `watcher` blocks to `AppConfigSchema` |
+| 4 | `src/status/task-mirror.ts` | Create | `TaskMirror` class — owns rolling todo-list message per chat |
+| 5 | `src/status/progress-reporter.ts` | Modify | Add `isBusy(chatId, thresholdMs)` and `getActiveToolName(chatId)` public methods |
+| 6 | `src/telegram/watcher.ts` | Create | `Watcher` class — auto-responder when Claude is busy |
+| 7 | `src/telegram/handlers.ts` | Modify | Add `watcher?: Watcher` to `HandlerDeps`; insert watcher call in `handleInboundText` |
+| 8 | `src/webhook/server.ts` | Modify | Add `taskMirror?: TaskMirror` to `WebhookDeps`; dispatch `toTodoWriteEvent` after progressReporter |
+| 9 | `src/server.ts` | Modify | Instantiate `TaskMirror` and `Watcher`; thread into deps |
+
+---
+
+### File 1 — `src/schemas.ts`
+
+**Purpose:** add TodoWrite input validation schema.
+
+- After `ToolInputSchema` (~line 119): add `TodoItemSchema` with `.passthrough()`.
+- Add `TodoWriteInputSchema = z.object({ todos: z.array(TodoItemSchema) }).passthrough()`.
+- Export `TodoWriteInput`, `TodoItem` types.
+- No changes to existing schemas — `ClaudePostToolUseSchema` stays as-is (`tool_input: ToolInputSchema`). Parsing of `TodoWrite`-specific shape happens in `toTodoWriteEvent`, not in the wire schema.
+
+---
+
+### File 2 — `src/hooks/claude-events.ts`
+
+**Purpose:** add TodoWrite event types and mapper.
+
+- Add `TodoWriteEvent` interface after `SessionStopEvent` (~line 47).
+- Add `TaskMirrorEvent = TodoWriteEvent | SessionStopEvent` union (reuse existing `SessionStopEvent`).
+- Add `toTodoWriteEvent(payload: ClaudeHookPayload): TaskMirrorEvent | null`.
+  - Only handles `PostToolUse` (tool_name === `'TodoWrite'`) and `Stop`.
+  - Parses `payload.tool_input` via `TodoWriteInputSchema.safeParse`. On failure: log warn + return null.
+  - No changes to existing `toActivityEvent` or `ActivityStatusEvent`.
+
+---
+
+### File 3 — `src/config.ts`
+
+**Purpose:** extend config schema with `task_mirror` and `watcher` blocks.
+
+- After `progress` block (~line 101): add `task_mirror` object with `enabled`, `edit_throttle_ms`, `session_ttl_ms`, `collapse_completed_after`, `max_message_chars`.
+- After `task_mirror`: add `watcher` object with `enabled`, `busy_threshold_ms`, `debounce_ms`.
+- Both have `.default({})` so existing config files with no new keys continue to parse.
+
+---
+
+### File 4 — `src/status/task-mirror.ts` (NEW)
+
+**Purpose:** rolling Telegram message showing Claude's todo list.
+
+- Import `TelegramApiForProgress` from `./progress-reporter.js` (structural reuse).
+- Import `TodoItem`, `TaskMirrorEvent` from `../hooks/claude-events.js`.
+- Import `escapeHtml` from `../format/html.js`.
+- `ChatTaskEntry` private interface (fields: `chatId`, `messageId?`, `startedAtMs`, `lastActivityMs`, `todos`, `lastRenderedText?`, `lastEditAtMs`, `desiredText?`, `flushPromise`, `pendingTimer`, `stopped`).
+- `TaskMirror` class: same single-slot queue pattern as `ProgressReporter`.
+- `renderTodoList(todos: TodoItem[], config): string` — private renderer using icons, sort, collapse.
+- `recordEvent(chatId, event)` — fire-and-forget, top-level try/catch.
+- `handleStop(chatId)` — cancel timer, await flush, final edit `☑ Список задач завершён — Ns`, evict.
+- `getOrCreate(chatId)` — TTL eviction via `lastActivityMs` using `config.task_mirror.session_ttl_ms`.
+- `_idleForTests(chatId)` — drain loop, same as ProgressReporter.
+
+---
+
+### File 5 — `src/status/progress-reporter.ts`
+
+**Purpose:** expose narrow read API for the watcher.
+
+- Add `isBusy(chatId: string, thresholdMs: number): boolean` — public method.
+  - Returns `(entry exists) AND (!entry.stopped) AND ((now() - entry.lastActivityMs) < thresholdMs)`.
+- Add `getActiveToolName(chatId: string): string | null` — public method.
+  - Returns `entry?.calls[entry.calls.length - 1]?.toolName ?? null`.
+- No changes to existing behavior.
+
+---
+
+### File 6 — `src/telegram/watcher.ts` (NEW)
+
+**Purpose:** auto-responder when Claude is busy.
+
+- `ProgressReporterForWatcher` interface: `isBusy(chatId, thresholdMs): boolean`, `getActiveToolName(chatId): string | null`.
+- `WatcherDeps` interface: `telegramApi: TelegramApi`, `progressReporter: ProgressReporterForWatcher`, `log: Logger`, `config: AppConfig`, `now?: () => number`.
+- `Watcher` class.
+  - Private `lastAutoReplyMs: Map<string, number>`.
+  - `maybeAutoReply(chatId: string, msgId: number): Promise<boolean>`:
+    1. Check `config.watcher.enabled`. If false → return false.
+    2. Check `progressReporter.isBusy(chatId, config.watcher.busy_threshold_ms)`. If not busy → return false.
+    3. Check debounce: `now() - (lastAutoReplyMs.get(chatId) ?? 0) < config.watcher.debounce_ms` → return false (suppress, no-op).
+    4. Compose text (see §2.2).
+    5. `await telegramApi.sendMessage(chatId, text, { parse_mode: 'HTML', reply_to_message_id: msgId })`.
+    6. Update `lastAutoReplyMs.set(chatId, now())`.
+    7. Return true. Errors: catch, log warn, return false.
+
+---
+
+### File 7 — `src/telegram/handlers.ts`
+
+**Purpose:** wire watcher into inbound text path.
+
+- Import `Watcher` from `./watcher.js`.
+- Add `watcher?: Watcher` to `HandlerDeps` interface (~line 110, after `albumBuffer?`).
+- In `handleInboundText` (~line 502, after OOB block, before `gateAndNotify`): insert watcher call (fire-and-forget via `void`, never delays channel notification).
+
+---
+
+### File 8 — `src/webhook/server.ts`
+
+**Purpose:** dispatch `TodoWrite` events to `TaskMirror`.
+
+- Import `TaskMirror` from `../status/task-mirror.js`.
+- Import `toTodoWriteEvent` from `../hooks/claude-events.js`.
+- Add `taskMirror?: TaskMirror` to `WebhookDeps` interface (~line 65).
+- In `handleRequest`, after `progressReporter` dispatch (~line 330): add TaskMirror dispatch block (call `toTodoWriteEvent(payload)`, dispatch if non-null).
+
+---
+
+### File 9 — `src/server.ts`
+
+**Purpose:** instantiate and wire TaskMirror + Watcher.
+
+- Import `TaskMirror` from `./status/task-mirror.js`.
+- Import `Watcher` from `./telegram/watcher.js`.
+- After `progressReporter` instantiation (~line 250): instantiate `taskMirror` and `watcher`.
+- Add to `webhookDeps`: `taskMirror`.
+- Add to `handlerDeps`: `watcher`.
+
+---
+
+## 4. TEST PLAN
+
+### 4.1 `tests/status/task-mirror.test.ts` (NEW)
+
+Mirrors `tests/status/progress-reporter.test.ts` structure.
+
+| Test case | What it verifies |
+|-----------|-----------------|
+| happy path — todo_write event | `sendMessage` called with rendered HTML on first event |
+| idempotency | same todos snapshot → no second `sendMessage`/`editMessageText` |
+| update — new snapshot | `editMessageText` called when todos change |
+| throttle | second event within `edit_throttle_ms` does not fire Telegram immediately; fires after timer |
+| session TTL | event after `session_ttl_ms` idle starts fresh entry, does not edit old `messageId` |
+| session_stop — eviction | `handleStop` posts final edit, evicts entry; subsequent event starts fresh thread |
+| malformed input (bad todos shape) | `toTodoWriteEvent` returns null; no error thrown, no Telegram call |
+| multi-chat isolation | chat A stop does not affect chat B's entry |
+| collapse_completed_after | more than N completed items shows `+M выполнено ранее` prefix |
+| max_message_chars | oversized render is truncated with `… (+N не показано)` |
+| disabled config | `config.task_mirror.enabled = false` → no Telegram calls |
+| `_idleForTests` drain | confirms flush settles before assertions |
+
+### 4.2 `tests/telegram/watcher.test.ts` (NEW)
+
+| Test case | What it verifies |
+|-----------|-----------------|
+| busy + auto-reply | `progressReporter.isBusy` returns true → `sendMessage` called with correct text |
+| not busy + no auto-reply | `isBusy` returns false → no `sendMessage` |
+| OOB takes priority | OOB handler returns before watcher is called (integration: watcher not present in OOB path) |
+| channel notification still emitted | `gateAndNotify` called even after auto-reply (use spy on `gateAndNotify`) |
+| auto-reply uses safe API | `sendMessage` is called on the injected `telegramApi`, not a bypassed raw instance |
+| debounce | two rapid messages in same chat → only one `sendMessage` within `debounce_ms` |
+| debounce expires | message after `debounce_ms` → new `sendMessage` |
+| disabled config | `config.watcher.enabled = false` → no auto-reply |
+| sendMessage failure is swallowed | `telegramApi.sendMessage` throws → `maybeAutoReply` returns false, no uncaught |
+| active tool name in message | when `getActiveToolName` returns `'Bash'`, auto-reply text includes `Bash` |
+| no active tool name | when `getActiveToolName` returns null, text says `(думает)` |
+
+### 4.3 `tests/status/progress-reporter.test.ts` (REGRESSION)
+
+- Add two new test cases for the new public methods:
+  - `isBusy` — returns true within threshold, false after threshold, false when stopped.
+  - `getActiveToolName` — returns last tool name or null.
+- All existing tests must continue to pass unchanged.
+
+---
+
+## 5. ROLLOUT
+
+**One PR** with 5 commits:
+
+| # | Commit | Files |
+|---|--------|-------|
+| 1 | `feat(schemas): add TodoWriteInputSchema + TodoItem types` | `src/schemas.ts` |
+| 2 | `feat(hooks): add TodoWriteEvent + toTodoWriteEvent mapper` | `src/hooks/claude-events.ts` |
+| 3 | `feat(config): add task_mirror and watcher config blocks` | `src/config.ts` |
+| 4 | `feat(status): TaskMirror — rolling todo-list message (PR-A2)` | `src/status/task-mirror.ts`, `tests/status/task-mirror.test.ts`, `src/status/progress-reporter.ts` (isBusy + getActiveToolName), `tests/status/progress-reporter.test.ts` (regression additions) |
+| 5 | `feat(telegram): Watcher auto-responder when busy (PR-A3)` | `src/telegram/watcher.ts`, `tests/telegram/watcher.test.ts`, `src/telegram/handlers.ts`, `src/webhook/server.ts`, `src/server.ts` |
+
+**Dual review required (rules.md §Model role split 2026-04-24):**
+- Codex GPT-5.5 audit pass (adversarial-review on the PR diff).
+- Opus review pass (code correctness + Russian comment quality).
+- Both must approve before `task-board review`.
+
+---
+
+## 6. RISKS / OPEN QUESTIONS
+
+### 6.1 Auto-reply debounce — recommendation: YES, debounce per chat
+
+If the warchief sends 5 messages in 10 seconds while Claude is working, the watcher should send only ONE auto-reply (the first) and suppress the next 4 until `debounce_ms` elapses. Rationale: 5 auto-replies in 5 seconds is noise that buries the actual conversation. Recommended `debounce_ms = 10_000` (10 seconds). This means the warchief gets instant acknowledgement on the first message, then silence for 10s even if he keeps typing.
+
+**Action required from warchief:** confirm `debounce_ms = 10_000` or adjust.
+
+### 6.2 /stop while busy — recommendation: no special coupling
+
+When the warchief types `/stop` while Claude is working:
+- `/stop` is an OOB command → handled before watcher (see §1.6 above, OOB short-circuit at line 453).
+- Watcher is never reached for `/stop`.
+- Result: `/stop` cancels the StatusManager bubble and emits the Stop hook; Claude receives it and stops. No auto-reply is sent.
+- TaskMirror receives `session_stop` via the webhook path (Claude hooks fire `Stop`) and finalizes its message.
+- No explicit coupling between `/stop` and the watcher debounce map needed — they operate on different code paths.
+
+### 6.3 TaskMirror completed task collapse — recommendation: N=5
+
+After `collapse_completed_after = 5` completed items, older ones are replaced with `+N выполнено ранее`. This keeps the message short during long pipelines. The warchief explicitly wants to see where Thrall is; completed items beyond the last 5 are noise.
+
+**Action required from warchief:** confirm N=5 or adjust.
+
+### 6.4 `task_mirror.enabled` default — confirmed TRUE
+
+Warchief explicitly said «enable by default». `enabled: z.boolean().default(true)`.
+
+### 6.5 `watcher.enabled` default — recommendation: TRUE
+
+Rationale: the warchief's primary pain point (silence during long pipelines) is exactly what the watcher solves. Debounce prevents noise. Auto-reply goes through safe-wrapped API so no safety regression. Recommendation: `enabled: z.boolean().default(true)`.
+
+**Action required from warchief:** confirm or flip to false if he prefers opt-in.
+
+### 6.6 `TelegramApiForProgress` reuse in TaskMirror
+
+`TelegramApiForProgress` is defined in `progress-reporter.ts` (line 47–55). TaskMirror needs the same interface. Options:
+- Option A: import `TelegramApiForProgress` from `./progress-reporter.js` (creates cross-dep between two status modules).
+- Option B: move `TelegramApiForProgress` to a shared `src/status/types.ts` and import from both.
+- Option C: re-declare a structurally identical interface in `task-mirror.ts` (TS structural typing makes it compatible; avoids coupling).
+
+**Recommendation: Option B** — move to `src/status/types.ts`. Avoids duplication and coupling, makes it clear the interface is shared infrastructure. One additional file but cleaner dependency graph.
+
+### 6.7 `sendMessage` reply_to_message_id in auto-reply
+
+The watcher calls `telegramApi.sendMessage(chatId, text, { parse_mode: 'HTML', reply_to_message_id: msgId })`. This makes the auto-reply visually quote the warchief's message in Telegram — helpful signal. Confirm with warchief: **quote-reply the original message** (recommended) or plain reply without quote?
+
+### 6.8 TaskMirror final edit text on session_stop
+
+On `session_stop`, TaskMirror should post a final edit. Two options:
+- Keep the last rendered todo list as-is (static, shows completion state).
+- Append `☑ Список задач завершён — Ns` as a suffix line inside the message.
+
+**Recommendation: append suffix** (mirrors ProgressReporter's `done -- Ns` pattern, consistent UX).
+
+---
+
+## Summary
+
+| Feature | New files | Modified files |
+|---------|-----------|----------------|
+| TodoWrite schema | — | `src/schemas.ts` |
+| TaskMirrorEvent | — | `src/hooks/claude-events.ts` |
+| Config extension | — | `src/config.ts` |
+| TaskMirror class | `src/status/task-mirror.ts` + `tests/status/task-mirror.test.ts` | `src/status/progress-reporter.ts` (2 methods), `src/status/types.ts` (new shared interface) |
+| Watcher class | `src/telegram/watcher.ts` + `tests/telegram/watcher.test.ts` | `src/telegram/handlers.ts`, `src/webhook/server.ts`, `src/server.ts` |
+| Tests (regression) | — | `tests/status/progress-reporter.test.ts` |
+
+Total: **4 new files**, **7 modified files**, **5 commits**, **1 PR**.

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -98,6 +98,35 @@ export const AppConfigSchema = z.object({
     recent_buffer: z.number().int().positive().default(10),
     session_ttl_ms: z.number().int().positive().default(10 * 60 * 1000),
   }).default({}),
+  // TaskMirror (PR-A2, 2026-05-20) — third rolling Telegram message per chat,
+  // showing Claude's TodoWrite milestones (in-progress / pending / completed).
+  // Coexists with StatusManager bubble and ProgressReporter activity thread —
+  // never shares state. Single-slot queue + throttle + TTL exactly mirror
+  // ProgressReporter so behaviour stays predictable.
+  //
+  // collapse_completed_after: keep last N completed items in the rendered
+  // list, older ones collapse to «+M завершено ранее» — the warchief wants
+  // to see the active milestone, not a wall of done items.
+  task_mirror: z.object({
+    enabled: z.boolean().default(true),
+    edit_throttle_ms: z.number().int().nonnegative().default(3000),
+    session_ttl_ms: z.number().int().positive().default(10 * 60 * 1000),
+    collapse_completed_after: z.number().int().nonnegative().default(5),
+  }).default({}),
+  // InboundWatcher (PR-A3, 2026-05-20) — auto-reply «Тралл занят» when the
+  // warchief sends plain text while a Claude session is mid-tool. Debounced
+  // per chat (debounce_ms = 10s by default) so a burst of messages doesn't
+  // bury the conversation in auto-acks. Busy threshold is the ProgressReporter
+  // lastActivityMs window — anything more recent than busy_threshold_ms
+  // counts as «still working».
+  //
+  // The watcher NEVER replaces the channel notification — it auto-replies
+  // AND lets the original message flow to Claude through the normal path.
+  watcher: z.object({
+    enabled: z.boolean().default(true),
+    debounce_ms: z.number().int().nonnegative().default(10_000),
+    busy_threshold_ms: z.number().int().positive().default(30_000),
+  }).default({}),
 })
 export type AppConfig = z.infer<typeof AppConfigSchema>
 

--- a/plugin/src/hooks/claude-events.ts
+++ b/plugin/src/hooks/claude-events.ts
@@ -7,6 +7,8 @@
 // Telegram or our logs.
 
 import type { ClaudeHookPayload } from '../schemas.js'
+import { TodoWriteInputSchema, type TodoItem } from '../schemas.js'
+import type { Logger } from '../log.js'
 
 // Tool-call lifecycle pair used by the rolling activity window. PreToolUse
 // emits `tool_start`; PostToolUse emits `tool_end`. The renderer collapses
@@ -51,6 +53,28 @@ export type ActivityStatusEvent =
   | SessionStartEvent
   | SessionStopEvent
 
+// ─────────────────────────────────────────────────────────────────────
+// TodoWrite events — consumed by TaskMirror (separate rolling Telegram
+// message showing Claude's milestone list). Deliberately NOT folded into
+// ActivityStatusEvent: StatusManager / ProgressReporter must stay unaware
+// of TodoWrite so the three rolling messages (status bubble, activity
+// thread, todo list) keep independent lifecycles.
+// ─────────────────────────────────────────────────────────────────────
+
+export interface TodoWriteEvent {
+  readonly kind: 'todo_write'
+  readonly todos: ReadonlyArray<TodoItem>
+}
+
+// Session-stop signal for TaskMirror specifically. Renamed from the
+// ActivityStatusEvent variant so the TaskMirror dispatcher does not
+// accidentally consume a non-todo Stop hook.
+export interface TodoSessionStopEvent {
+  readonly kind: 'todo_session_stop'
+}
+
+export type TaskMirrorEvent = TodoWriteEvent | TodoSessionStopEvent
+
 /**
  * Convert a validated Claude hook payload to an ActivityStatusEvent.
  *
@@ -87,4 +111,39 @@ export function toActivityEvent(payload: ClaudeHookPayload): ActivityStatusEvent
     case 'SessionStart':
       return { kind: 'session_start' }
   }
+}
+
+/**
+ * Convert a validated Claude hook payload to a TaskMirrorEvent.
+ *
+ * Returns non-null ONLY for events TaskMirror cares about:
+ *   - PostToolUse with tool_name === 'TodoWrite' → parses tool_input via
+ *     TodoWriteInputSchema. On parse failure, logs a warning and returns
+ *     null (graceful degradation — the rolling activity thread still
+ *     renders correctly because toActivityEvent handles the same payload
+ *     independently).
+ *   - Stop → returns `{ kind: 'todo_session_stop' }` so TaskMirror can
+ *     finalize and evict its per-chat entry.
+ *
+ * Every other hook event returns null so the caller can short-circuit
+ * before touching TaskMirror.
+ */
+export function toTodoWriteEvent(
+  payload: ClaudeHookPayload,
+  log?: Logger,
+): TaskMirrorEvent | null {
+  if (payload.hook_event_name === 'Stop') {
+    return { kind: 'todo_session_stop' }
+  }
+  if (payload.hook_event_name === 'PostToolUse' && payload.tool_name === 'TodoWrite') {
+    const parsed = TodoWriteInputSchema.safeParse(payload.tool_input)
+    if (!parsed.success) {
+      log?.warn('TodoWrite tool_input failed schema validation (ignored)', {
+        issues: parsed.error.issues.map((i) => i.message).slice(0, 5),
+      })
+      return null
+    }
+    return { kind: 'todo_write', todos: parsed.data.todos }
+  }
+  return null
 }

--- a/plugin/src/schemas.ts
+++ b/plugin/src/schemas.ts
@@ -92,6 +92,35 @@ const ClaudeHookCommonShape = {
 // downstream without forcing schema churn on every Claude version bump.
 const ToolInputSchema = z.record(z.unknown())
 
+// TodoWrite tool_input shape. Used by TaskMirror to render Claude's
+// in-progress / pending / completed milestone list as a rolling Telegram
+// thread. The wire `ClaudePostToolUseSchema.tool_input` stays as the
+// permissive `ToolInputSchema` (opaque record) so we don't reject unknown
+// TodoWrite shape variants at the webhook boundary — instead, the mapper
+// in `src/hooks/claude-events.ts` calls `TodoWriteInputSchema.safeParse`
+// on `tool_input` when `tool_name === 'TodoWrite'` and degrades gracefully
+// when parsing fails.
+//
+// `.passthrough()` is mandatory on both schemas so the Claude Code harness
+// can add fields (e.g. metadata, scheduling hints) without breaking parsing.
+export const TodoItemSchema = z
+  .object({
+    id: z.string().optional(),
+    content: z.string(),
+    status: z.enum(['pending', 'in_progress', 'completed']),
+    priority: z.enum(['high', 'medium', 'low']).optional(),
+    activeForm: z.string().optional(),
+  })
+  .passthrough()
+export type TodoItem = z.infer<typeof TodoItemSchema>
+
+export const TodoWriteInputSchema = z
+  .object({
+    todos: z.array(TodoItemSchema),
+  })
+  .passthrough()
+export type TodoWriteInput = z.infer<typeof TodoWriteInputSchema>
+
 export const ClaudePreToolUseSchema = z
   .object({
     ...ClaudeHookCommonShape,

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -39,6 +39,8 @@ import { createSafeTelegramApi } from './safety/safe-telegram-api.js'
 import { redactSecrets } from './safety/redact.js'
 import { StatusManager } from './status/status-manager.js'
 import { ProgressReporter } from './status/progress-reporter.js'
+import { TaskMirror } from './status/task-mirror.js'
+import { InboundWatcher } from './telegram/watcher.js'
 import { MemoryWriter, type MemoryConfig } from './memory/writer.js'
 import { dirname as pathDirname } from 'path'
 import {
@@ -264,6 +266,24 @@ const statusManager = new StatusManager({ telegramApi, config, log })
 // survives. Both fire in parallel from the webhook handler.
 const progressReporter = new ProgressReporter({ telegramApi, config, log })
 
+// TaskMirror (PR-A2, 2026-05-20) — third rolling Telegram message per chat
+// showing Claude's TodoWrite milestones. Independent of the two surfaces
+// above; uses the same safe-wrapped telegramApi so every text/edit goes
+// through redact + HTML validation before leaving the process.
+const taskMirror = new TaskMirror({ telegramApi, config, log })
+
+// InboundWatcher (PR-A3, 2026-05-20) — auto-reply «Тралл занят» when the
+// warchief sends plain text while ProgressReporter says the session is
+// mid-tool. The watcher receives `progressReporter` for read-only busy
+// detection — never mutates reporter state. Debounce + safe-api enforced
+// inside the watcher.
+const inboundWatcher = new InboundWatcher({
+  telegramApi,
+  config,
+  log,
+  progressReporter,
+})
+
 // Phase 8 / T7: MemoryWriter persists turns to <workspace>/core/hot/recent.md
 // and <workspace_parent>/logs/verbose-YYYY-MM-DD.jsonl. Only instantiated
 // when config.memory.enabled === true AND workspace_path is set — schema
@@ -405,6 +425,7 @@ const handlerDeps: HandlerDeps = {
   permissionHooks,
   statusManager,
   albumBuffer,
+  watcher: inboundWatcher,
 }
 
 bot.on('message:text', ctx => handleInboundText(ctx, handlerDeps))
@@ -546,6 +567,7 @@ try {
     log,
     statusManager,
     progressReporter,
+    taskMirror,
     ...(memoryWriter !== undefined ? { memoryWriter } : {}),
   })
 } catch (err) {

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -568,6 +568,7 @@ try {
     statusManager,
     progressReporter,
     taskMirror,
+    watcher: inboundWatcher,
     ...(memoryWriter !== undefined ? { memoryWriter } : {}),
   })
 } catch (err) {

--- a/plugin/src/status/progress-reporter.ts
+++ b/plugin/src/status/progress-reporter.ts
@@ -150,18 +150,23 @@ export class ProgressReporter {
   /**
    * Read-only: returns true if a Claude session is actively running tools
    * for this chat — used by InboundWatcher to decide whether to auto-reply
-   * «Тралл занят». Definition (per PR-A3 spec):
+   * «Тралл занят». Definition:
    *   entry exists AND !entry.stopped AND (now - lastActivityMs) < threshold
    *
-   * `thresholdMs` defaults to `config.watcher.busy_threshold_ms` so the
-   * watcher can call this without re-resolving the config every time, but
-   * the explicit override remains for tests and future callers.
+   * `thresholdMs` is REQUIRED — the watcher owns the threshold via its
+   * own config slice and passes it in. This module deliberately does NOT
+   * reach into `config.watcher` to keep the dependency direction one-way
+   * (status module is upstream of watcher; watcher reads from us, not the
+   * other way around).
+   *
+   * Boundary semantics: strict `<` so a tick at exactly the threshold is
+   * already considered idle — matches the natural «more than N ms idle =
+   * not busy» reading.
    */
-  isBusy(chatId: string, thresholdMs?: number): boolean {
+  isBusy(chatId: string, thresholdMs: number): boolean {
     const entry = this.chats.get(chatId)
     if (!entry || entry.stopped) return false
-    const limit = thresholdMs ?? this.config.watcher.busy_threshold_ms
-    return this.now() - entry.lastActivityMs <= limit
+    return this.now() - entry.lastActivityMs < thresholdMs
   }
 
   /**

--- a/plugin/src/status/progress-reporter.ts
+++ b/plugin/src/status/progress-reporter.ts
@@ -170,10 +170,25 @@ export class ProgressReporter {
   }
 
   /**
-   * Read-only: returns the most recent tool name in the rolling activity
-   * window for this chat, or `undefined` if no entry exists / no tools
-   * have been recorded. Used by InboundWatcher to compose the auto-reply
-   * body — «активный инструмент: Bash».
+   * Returns the most recently OBSERVED tool name from the calls window for
+   * this chat, or `undefined` if no entry exists / no tools have been
+   * recorded. Used by InboundWatcher to compose the auto-reply body —
+   * «активный инструмент: Bash».
+   *
+   * Important semantic note for future maintainers:
+   *   The name STAYS POPULATED after `tool_end`. We do NOT clear it on
+   *   tool completion. This is intentional — the watcher's busy-threshold
+   *   accounts for the gap between `tool_end` and the next `tool_start`.
+   *   Returning `undefined` here during that brief idle window would cause
+   *   false-negative auto-replies (the watcher would see «not busy» and
+   *   suppress the «Тралл занят» message even though Claude is about to
+   *   call the next tool any millisecond now).
+   *
+   *   `tool_end` is render-only inside this module (see applyEvent) — it
+   *   moves the elapsed counter forward without mutating `entry.calls`.
+   *   The latest call therefore continues to anchor the «active tool»
+   *   answer until either (a) a fresh `tool_start` overwrites it or
+   *   (b) the chat is evicted by session_stop / TTL.
    */
   getActiveToolName(chatId: string): string | undefined {
     const entry = this.chats.get(chatId)

--- a/plugin/src/status/progress-reporter.ts
+++ b/plugin/src/status/progress-reporter.ts
@@ -40,22 +40,13 @@ import {
   type ActivitySnapshot,
 } from './activity-renderer.js'
 
-// Minimal Telegram surface we touch. Defined as a structural interface
-// so tests can stub without grammY. Compatible with the production
-// TelegramApi from src/channel/tools.ts via structural typing.
-export interface TelegramApiForProgress {
-  sendMessage(
-    chatId: string,
-    text: string,
-    opts: { parse_mode?: 'HTML' | 'MarkdownV2'; reply_to_message_id?: number },
-  ): Promise<{ message_id: number }>
-  editMessageText(
-    chatId: string,
-    messageId: number,
-    text: string,
-    opts: { parse_mode?: 'HTML' | 'MarkdownV2' },
-  ): Promise<void>
-}
+// Telegram surface shared with task-mirror. Canonical definition lives in
+// `./telegram-api.ts` so both modules depend on it instead of on each
+// other. Re-exported here for back-compat with existing imports
+// (`from './progress-reporter.js'` is still legal but new code should
+// import from `./telegram-api.js` directly).
+export type { TelegramApiForProgress } from './telegram-api.js'
+import type { TelegramApiForProgress } from './telegram-api.js'
 
 export interface ProgressReporterDeps {
   telegramApi: TelegramApiForProgress

--- a/plugin/src/status/progress-reporter.ts
+++ b/plugin/src/status/progress-reporter.ts
@@ -148,6 +148,35 @@ export class ProgressReporter {
   }
 
   /**
+   * Read-only: returns true if a Claude session is actively running tools
+   * for this chat — used by InboundWatcher to decide whether to auto-reply
+   * «Тралл занят». Definition (per PR-A3 spec):
+   *   entry exists AND !entry.stopped AND (now - lastActivityMs) < threshold
+   *
+   * `thresholdMs` defaults to `config.watcher.busy_threshold_ms` so the
+   * watcher can call this without re-resolving the config every time, but
+   * the explicit override remains for tests and future callers.
+   */
+  isBusy(chatId: string, thresholdMs?: number): boolean {
+    const entry = this.chats.get(chatId)
+    if (!entry || entry.stopped) return false
+    const limit = thresholdMs ?? this.config.watcher.busy_threshold_ms
+    return this.now() - entry.lastActivityMs <= limit
+  }
+
+  /**
+   * Read-only: returns the most recent tool name in the rolling activity
+   * window for this chat, or `undefined` if no entry exists / no tools
+   * have been recorded. Used by InboundWatcher to compose the auto-reply
+   * body — «активный инструмент: Bash».
+   */
+  getActiveToolName(chatId: string): string | undefined {
+    const entry = this.chats.get(chatId)
+    if (!entry || entry.calls.length === 0) return undefined
+    return entry.calls[entry.calls.length - 1]?.toolName
+  }
+
+  /**
    * Test-only: wait until any in-flight Telegram operation for the given
    * chat settles AND any follow-up reschedule completes. Used by unit
    * tests to assert on `TelegramApi.calls` after asynchronous

--- a/plugin/src/status/task-mirror.ts
+++ b/plugin/src/status/task-mirror.ts
@@ -25,7 +25,7 @@ import type { AppConfig } from '../config.js'
 import type { Logger } from '../log.js'
 import type { TaskMirrorEvent } from '../hooks/claude-events.js'
 import type { TodoItem } from '../schemas.js'
-import type { TelegramApiForProgress } from './progress-reporter.js'
+import type { TelegramApiForProgress } from './telegram-api.js'
 import { escapeHtml } from '../format/html.js'
 
 // Telegram editMessageText cap (4096 chars). Default render budget below it

--- a/plugin/src/status/task-mirror.ts
+++ b/plugin/src/status/task-mirror.ts
@@ -1,0 +1,457 @@
+// TaskMirror — third rolling Telegram message per chat. Where StatusManager
+// owns the transient «Печатает.../🔧 tool» bubble and ProgressReporter owns
+// the per-tool activity thread, TaskMirror owns a separate persistent message
+// that mirrors Claude's TodoWrite milestone list: in-progress / pending /
+// completed items.
+//
+// The three surfaces NEVER share state — each Map entry is keyed on chatId
+// inside its own class. This isolation is intentional: an operator can flip
+// any of (status.enabled / progress.enabled / task_mirror.enabled) without
+// disturbing the others.
+//
+// Architectural mirror of ProgressReporter (see plan §2.1):
+//   * Single-slot queue per chat — `flushPromise !== null` guards in-flight
+//     ops. Multiple TodoWrite events while a flush runs overwrite
+//     `desiredText`; only the freshest snapshot ever publishes.
+//   * Throttle via `edit_throttle_ms`. First send bypasses throttle, subsequent
+//     edits within the window defer onto a single timer slot.
+//   * Idempotency: same rendered text → no Telegram round-trip.
+//   * TTL eviction on `session_ttl_ms` of idleness — protects against lost
+//     `session_stop` hooks the way ProgressReporter does.
+//   * `recordEvent` is fire-and-forget; top-level try/catch swallows every
+//     throw so the webhook 200 path is never blocked.
+
+import type { AppConfig } from '../config.js'
+import type { Logger } from '../log.js'
+import type { TaskMirrorEvent } from '../hooks/claude-events.js'
+import type { TodoItem } from '../schemas.js'
+import type { TelegramApiForProgress } from './progress-reporter.js'
+import { escapeHtml } from '../format/html.js'
+
+// Telegram editMessageText cap (4096 chars). Default render budget below it
+// — the spec asks for ~3500-char headroom (see plan §3 file 4).
+const DEFAULT_MAX_CHARS = 3500
+const TRUNCATE_MARGIN = 100 // safety cushion below MAX_CHARS for tail strings
+
+// Status icons. Unicode glyphs match the plan §2.3 spec.
+const ICONS = {
+  in_progress: '◐',
+  pending: '◻',
+  completed: '☑',
+} as const
+
+// HTML used as parse_mode for both send and edit — same as ProgressReporter.
+const HTML_OPTS = { parse_mode: 'HTML' as const }
+
+export interface TaskMirrorDeps {
+  telegramApi: TelegramApiForProgress
+  config: AppConfig
+  log: Logger
+  now?: () => number
+  setTimer?: (cb: () => void, ms: number) => NodeJS.Timeout
+  clearTimer?: (handle: NodeJS.Timeout) => void
+}
+
+// Per-chat lifecycle entry. Field-for-field parallel to ChatProgressEntry,
+// only `calls[]` is replaced with `todos[]` (latest snapshot, not a window).
+interface ChatTaskEntry {
+  chatId: string
+  messageId?: number
+  startedAtMs: number
+  // Updated on every recordEvent. Used by TTL eviction in getOrCreate.
+  lastActivityMs: number
+  // Latest TodoWrite snapshot from Claude. Replaced wholesale on each event
+  // — TodoWrite is itself the full list, so we never merge incrementally.
+  todos: ReadonlyArray<TodoItem>
+  // Last text we actually sent / edited. Idempotency gate.
+  lastRenderedText?: string
+  // Timestamp of the last successful send or edit. Used for throttle.
+  lastEditAtMs: number
+  // Newest snapshot text waiting to be published. Multiple events overwrite
+  // so only the freshest view ever lands on Telegram.
+  desiredText?: string
+  // Single-slot scheduler: non-null while a Telegram op is in flight.
+  flushPromise: Promise<void> | null
+  // Single-slot throttle timer. Non-null while waiting for the throttle
+  // window to elapse before publishing.
+  pendingTimer: NodeJS.Timeout | null
+  // True once todo_session_stop has been processed. Idempotency guard.
+  stopped: boolean
+}
+
+export class TaskMirror {
+  private readonly telegramApi: TelegramApiForProgress
+  private readonly config: AppConfig
+  private readonly log: Logger
+  private readonly now: () => number
+  private readonly setTimer: (cb: () => void, ms: number) => NodeJS.Timeout
+  private readonly clearTimer: (handle: NodeJS.Timeout) => void
+  private readonly chats: Map<string, ChatTaskEntry>
+
+  constructor(deps: TaskMirrorDeps) {
+    this.telegramApi = deps.telegramApi
+    this.config = deps.config
+    this.log = deps.log
+    this.now = deps.now ?? (() => Date.now())
+    this.setTimer = deps.setTimer ?? ((cb, ms) => setTimeout(cb, ms))
+    this.clearTimer = deps.clearTimer ?? ((h) => clearTimeout(h))
+    this.chats = new Map()
+  }
+
+  /**
+   * Main entry point. Called by the webhook handler for every Claude hook
+   * that mapped to a TaskMirrorEvent. Never throws — top-level try/catch
+   * swallows any failure so the webhook 200 path stays open.
+   */
+  async recordEvent(chatId: string, event: TaskMirrorEvent): Promise<void> {
+    if (!this.config.task_mirror.enabled) return
+    try {
+      if (event.kind === 'todo_session_stop') {
+        await this.handleStop(chatId)
+        return
+      }
+      const entry = this.getOrCreate(chatId)
+      if (entry.stopped) return
+      entry.lastActivityMs = this.now()
+      // Replace the snapshot wholesale. TodoWrite payloads ARE the full list.
+      entry.todos = event.todos
+      this.scheduleFlush(entry)
+    } catch (err) {
+      this.log.warn('task mirror recordEvent failed (ignored)', {
+        chat_id: chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  /**
+   * Test-only drain — same contract as ProgressReporter._idleForTests.
+   */
+  async _idleForTests(chatId: string): Promise<void> {
+    for (let i = 0; i < 16; i++) {
+      const entry = this.chats.get(chatId)
+      if (!entry || entry.flushPromise === null) return
+      try {
+        await entry.flushPromise
+      } catch {
+        /* already logged */
+      }
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Internals
+  // ─────────────────────────────────────────────────────────────────────
+
+  private getOrCreate(chatId: string): ChatTaskEntry {
+    const existing = this.chats.get(chatId)
+    if (existing) {
+      const idle = this.now() - existing.lastActivityMs
+      if (idle > this.config.task_mirror.session_ttl_ms) {
+        this.log.debug('task mirror entry TTL expired, starting fresh thread', {
+          chat_id: chatId,
+          idle_ms: idle,
+        })
+        this.chats.delete(chatId)
+      } else {
+        return existing
+      }
+    }
+    const entry: ChatTaskEntry = {
+      chatId,
+      startedAtMs: this.now(),
+      lastActivityMs: this.now(),
+      todos: [],
+      lastEditAtMs: 0,
+      flushPromise: null,
+      pendingTimer: null,
+      stopped: false,
+    }
+    this.chats.set(chatId, entry)
+    return entry
+  }
+
+  /**
+   * Render the current snapshot and schedule a flush. Idempotent — if a
+   * flush is already in flight or a timer is armed, just update
+   * `desiredText` and return.
+   */
+  private scheduleFlush(entry: ChatTaskEntry): void {
+    if (entry.stopped) return
+    const text = this.safeRender(entry.todos)
+    if (!text || text === entry.lastRenderedText) return
+    entry.desiredText = text
+
+    if (entry.flushPromise !== null || entry.pendingTimer !== null) return
+
+    const isFirstSend = entry.messageId === undefined
+    const elapsed = this.now() - entry.lastEditAtMs
+    const wait = isFirstSend
+      ? 0
+      : Math.max(0, this.config.task_mirror.edit_throttle_ms - elapsed)
+
+    if (wait > 0) {
+      entry.pendingTimer = this.setTimer(() => {
+        entry.pendingTimer = null
+        this.startFlush(entry)
+      }, wait)
+    } else {
+      this.startFlush(entry)
+    }
+  }
+
+  private startFlush(entry: ChatTaskEntry): void {
+    if (entry.stopped) return
+    if (entry.flushPromise !== null) return
+    const text = entry.desiredText
+    if (text === undefined || text === entry.lastRenderedText) return
+    delete entry.desiredText
+
+    entry.flushPromise = this.executeFlush(entry, text).finally(() => {
+      entry.flushPromise = null
+      if (
+        !entry.stopped &&
+        entry.desiredText !== undefined &&
+        entry.desiredText !== entry.lastRenderedText
+      ) {
+        this.scheduleFlush(entry)
+      }
+    })
+  }
+
+  private async executeFlush(entry: ChatTaskEntry, text: string): Promise<void> {
+    if (entry.messageId === undefined) {
+      try {
+        const sent = await this.telegramApi.sendMessage(entry.chatId, text, HTML_OPTS)
+        if (!entry.stopped) {
+          entry.messageId = sent.message_id
+          entry.lastRenderedText = text
+          entry.lastEditAtMs = this.now()
+        } else {
+          this.log.warn('task mirror send completed after stop (orphan)', {
+            chat_id: entry.chatId,
+            message_id: sent.message_id,
+          })
+        }
+      } catch (err) {
+        this.log.warn('task mirror sendMessage failed (ignored)', {
+          chat_id: entry.chatId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+      return
+    }
+    try {
+      await this.telegramApi.editMessageText(entry.chatId, entry.messageId, text, HTML_OPTS)
+      if (!entry.stopped) {
+        entry.lastRenderedText = text
+        entry.lastEditAtMs = this.now()
+      }
+    } catch (err) {
+      this.log.warn('task mirror editMessageText failed (ignored)', {
+        chat_id: entry.chatId,
+        message_id: entry.messageId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  /**
+   * Eviction handler — mirrors ProgressReporter.handleStop. Cancels timers,
+   * awaits any in-flight flush, posts a final edit (if a message exists)
+   * with the latest snapshot, then deletes the entry.
+   */
+  private async handleStop(chatId: string): Promise<void> {
+    const entry = this.chats.get(chatId)
+    if (!entry || entry.stopped) return
+    entry.stopped = true
+
+    if (entry.pendingTimer !== null) {
+      this.clearTimer(entry.pendingTimer)
+      entry.pendingTimer = null
+    }
+
+    if (entry.flushPromise !== null) {
+      try {
+        await entry.flushPromise
+      } catch {
+        /* already logged */
+      }
+    }
+
+    if (entry.messageId !== undefined) {
+      const text = this.safeRender(entry.todos)
+      if (text && text !== entry.lastRenderedText) {
+        try {
+          await this.telegramApi.editMessageText(entry.chatId, entry.messageId, text, HTML_OPTS)
+          entry.lastRenderedText = text
+        } catch (err) {
+          this.log.warn('task mirror final edit failed (ignored)', {
+            chat_id: entry.chatId,
+            message_id: entry.messageId,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+    }
+
+    this.chats.delete(chatId)
+  }
+
+  private safeRender(todos: ReadonlyArray<TodoItem>): string {
+    try {
+      return renderTodoList(todos, this.config.task_mirror.collapse_completed_after)
+    } catch (err) {
+      this.log.warn('task mirror render failed (ignored)', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return ''
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Renderer (exported for tests)
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Render a TodoWrite snapshot as Telegram-friendly HTML. Section order:
+ *   1. Header — bold «milestones» + counts.
+ *   2. In-progress items — icon ◐.
+ *   3. Pending items — icon ◻.
+ *   4. Last `collapseCompletedAfter` completed items — icon ☑.
+ *   5. Tail line if more completed exist: `<i>+M завершено ранее</i>`.
+ *
+ * Edge cases:
+ *   - Empty list: `<i>задач нет</i>` (don't delete the message).
+ *   - Total length cap at ~DEFAULT_MAX_CHARS: pending list truncates first,
+ *     then completed, with `<i>+N ещё…</i>` tail.
+ *
+ * Every dynamic string passes through `escapeHtml` so user-supplied todo
+ * content can't break out of the message.
+ */
+export function renderTodoList(
+  todos: ReadonlyArray<TodoItem>,
+  collapseCompletedAfter: number,
+  maxChars: number = DEFAULT_MAX_CHARS,
+): string {
+  if (todos.length === 0) {
+    return '<b>milestones</b>\n<i>задач нет</i>'
+  }
+
+  let doneCount = 0
+  let inProgressCount = 0
+  let pendingCount = 0
+  const inProgress: TodoItem[] = []
+  const pending: TodoItem[] = []
+  const completed: TodoItem[] = []
+  for (const t of todos) {
+    switch (t.status) {
+      case 'in_progress':
+        inProgressCount++
+        inProgress.push(t)
+        break
+      case 'pending':
+        pendingCount++
+        pending.push(t)
+        break
+      case 'completed':
+        doneCount++
+        completed.push(t)
+        break
+    }
+  }
+
+  const header = '<b>milestones</b>'
+  const counts = `${doneCount} done / ${inProgressCount} in progress / ${pendingCount} pending`
+
+  // Show only the last N completed items; older ones collapse into a tail
+  // notice. `collapseCompletedAfter=0` means «hide all completed» — render
+  // none, then the tail says how many were hidden.
+  const visibleCompleted = collapseCompletedAfter > 0
+    ? completed.slice(-collapseCompletedAfter)
+    : []
+  const hiddenCompletedCount = completed.length - visibleCompleted.length
+
+  const lines: string[] = [header, counts, '']
+  for (const t of inProgress) lines.push(`${ICONS.in_progress} ${escapeTodoLine(t)}`)
+  for (const t of pending) lines.push(`${ICONS.pending} ${escapeTodoLine(t)}`)
+  if (hiddenCompletedCount > 0) {
+    lines.push(`<i>+${hiddenCompletedCount} завершено ранее</i>`)
+  }
+  for (const t of visibleCompleted) lines.push(`${ICONS.completed} ${escapeTodoLine(t)}`)
+
+  let body = lines.join('\n')
+  if (body.length <= maxChars) return body
+
+  // Over budget. Truncation pass: drop trailing pending lines first, then
+  // completed. Always keep header + counts + at least the in-progress block.
+  const safeBudget = maxChars - TRUNCATE_MARGIN
+  // Header block (header + counts + blank line) is mandatory.
+  const headerBlock = [header, counts, ''].join('\n')
+  const inProgressBlock = inProgress
+    .map((t) => `${ICONS.in_progress} ${escapeTodoLine(t)}`)
+    .join('\n')
+  let used = headerBlock.length + (inProgressBlock.length > 0 ? 1 + inProgressBlock.length : 0)
+  const out: string[] = [headerBlock]
+  if (inProgressBlock.length > 0) out.push(inProgressBlock)
+
+  // Add pending lines one by one until budget runs out.
+  let droppedPending = 0
+  const pendingLines = pending.map((t) => `${ICONS.pending} ${escapeTodoLine(t)}`)
+  const pendingKept: string[] = []
+  for (const line of pendingLines) {
+    // +1 for the joining newline.
+    if (used + 1 + line.length > safeBudget) {
+      droppedPending = pendingLines.length - pendingKept.length
+      break
+    }
+    pendingKept.push(line)
+    used += 1 + line.length
+  }
+  if (pendingKept.length > 0) out.push(pendingKept.join('\n'))
+  if (droppedPending > 0) {
+    const tail = `<i>+${droppedPending} ещё…</i>`
+    out.push(tail)
+    used += 1 + tail.length
+  }
+
+  // Completed: respect collapse rule first, then truncate visible block.
+  let droppedCompleted = hiddenCompletedCount
+  if (hiddenCompletedCount > 0) {
+    const tail = `<i>+${hiddenCompletedCount} завершено ранее</i>`
+    if (used + 1 + tail.length <= safeBudget) {
+      out.push(tail)
+      used += 1 + tail.length
+    }
+  }
+  const completedLines = visibleCompleted.map(
+    (t) => `${ICONS.completed} ${escapeTodoLine(t)}`,
+  )
+  const completedKept: string[] = []
+  for (const line of completedLines) {
+    if (used + 1 + line.length > safeBudget) {
+      droppedCompleted += completedLines.length - completedKept.length
+      break
+    }
+    completedKept.push(line)
+    used += 1 + line.length
+  }
+  if (completedKept.length > 0) out.push(completedKept.join('\n'))
+  if (droppedCompleted > hiddenCompletedCount) {
+    const extraDropped = droppedCompleted - hiddenCompletedCount
+    const tail = `<i>+${extraDropped} ещё…</i>`
+    out.push(tail)
+  }
+
+  return out.join('\n')
+}
+
+function escapeTodoLine(todo: TodoItem): string {
+  // Prefer `activeForm` for in-progress items (Claude convention is
+  // gerund — «Reading file» vs «Read file»), otherwise show `content`.
+  const raw = todo.status === 'in_progress' && todo.activeForm
+    ? todo.activeForm
+    : todo.content
+  return escapeHtml(raw)
+}

--- a/plugin/src/status/task-mirror.ts
+++ b/plugin/src/status/task-mirror.ts
@@ -336,7 +336,7 @@ export class TaskMirror {
 
 /**
  * Render a TodoWrite snapshot as Telegram-friendly HTML. Section order:
- *   1. Header — bold «milestones» + counts.
+ *   1. Header — bold «Задачи» + counts.
  *   2. In-progress items — icon ◐.
  *   3. Pending items — icon ◻.
  *   4. Last `collapseCompletedAfter` completed items — icon ☑.
@@ -356,7 +356,7 @@ export function renderTodoList(
   maxChars: number = DEFAULT_MAX_CHARS,
 ): string {
   if (todos.length === 0) {
-    return '<b>milestones</b>\n<i>задач нет</i>'
+    return '<b>Задачи</b>\n<i>задач нет</i>'
   }
 
   let doneCount = 0
@@ -382,7 +382,7 @@ export function renderTodoList(
     }
   }
 
-  const header = '<b>milestones</b>'
+  const header = '<b>Задачи</b>'
   const counts = `${doneCount} done / ${inProgressCount} in progress / ${pendingCount} pending`
 
   // Show only the last N completed items; older ones collapse into a tail

--- a/plugin/src/status/task-mirror.ts
+++ b/plugin/src/status/task-mirror.ts
@@ -259,7 +259,13 @@ export class TaskMirror {
   /**
    * Eviction handler — mirrors ProgressReporter.handleStop. Cancels timers,
    * awaits any in-flight flush, posts a final edit (if a message exists)
-   * with the latest snapshot, then deletes the entry.
+   * with the latest snapshot AND a «сессия завершена» marker line, then
+   * deletes the entry.
+   *
+   * Why the marker: without it, if the last TodoWrite snapshot was already
+   * rendered the idempotency gate (`text === lastRenderedText`) skips the
+   * final edit — the warchief never sees a visual «session ended» signal.
+   * Appending a non-empty marker line guarantees the final text differs.
    */
   private async handleStop(chatId: string): Promise<void> {
     const entry = this.chats.get(chatId)
@@ -280,7 +286,7 @@ export class TaskMirror {
     }
 
     if (entry.messageId !== undefined) {
-      const text = this.safeRender(entry.todos)
+      const text = this.renderFinal(entry)
       if (text && text !== entry.lastRenderedText) {
         try {
           await this.telegramApi.editMessageText(entry.chatId, entry.messageId, text, HTML_OPTS)
@@ -296,6 +302,20 @@ export class TaskMirror {
     }
 
     this.chats.delete(chatId)
+  }
+
+  /**
+   * Final-edit body: current snapshot + «сессия завершена» marker. The
+   * marker ALWAYS differs from any intermediate render so idempotency
+   * never skips this edit (otherwise the warchief might never see a
+   * session-end signal). Same DEFAULT_MAX_CHARS budget applies — if the
+   * snapshot already pushes against the cap, the marker still fits inside
+   * the safety margin renderTodoList reserves.
+   */
+  private renderFinal(entry: ChatTaskEntry): string {
+    const block = this.safeRender(entry.todos)
+    if (!block) return ''
+    return `${block}\n<i>сессия завершена</i>`
   }
 
   private safeRender(todos: ReadonlyArray<TodoItem>): string {

--- a/plugin/src/status/telegram-api.ts
+++ b/plugin/src/status/telegram-api.ts
@@ -1,0 +1,22 @@
+// Shared structural surface for the rolling-message modules (status,
+// progress, task-mirror). Defining it here — outside any consumer — lets
+// progress-reporter.ts and task-mirror.ts both depend on it without one
+// having to import from the other. Avoids the cross-module dependency we
+// previously had (task-mirror imported the interface from progress-reporter).
+//
+// Compatible by structural typing with the production `TelegramApi` from
+// `src/channel/tools.ts`. Tests can stub it with a plain object literal.
+
+export interface TelegramApiForProgress {
+  sendMessage(
+    chatId: string,
+    text: string,
+    opts: { parse_mode?: 'HTML' | 'MarkdownV2'; reply_to_message_id?: number },
+  ): Promise<{ message_id: number }>
+  editMessageText(
+    chatId: string,
+    messageId: number,
+    text: string,
+    opts: { parse_mode?: 'HTML' | 'MarkdownV2' },
+  ): Promise<void>
+}

--- a/plugin/src/telegram/handlers.ts
+++ b/plugin/src/telegram/handlers.ts
@@ -137,6 +137,45 @@ function adaptReply(
   return out
 }
 
+// PR-A3 — auto-reply gate. The InboundWatcher must never fire for
+// senders/chats that aren't on the allowlist: a future group-chat use of
+// the bot would otherwise leak bot activity to non-allowed senders. We
+// mirror the OOB short-circuit's allowlist check (allowed_user_ids AND
+// allowed_chat_ids — defence in depth even when the gate lets the message
+// through). DM-only is NOT required here; auto-reply makes sense in any
+// allowlisted chat. Returns true when the watcher is permitted to fire.
+function watcherAllowed(ctx: Context, config: AppConfig): boolean {
+  const senderNum = ctx.from?.id
+  const chatNum = ctx.chat?.id
+  if (senderNum === undefined || chatNum === undefined) return false
+  if (!config.allowed_user_ids.includes(senderNum)) return false
+  // allowed_chat_ids may be a mix of strings and numbers — coerce both
+  // sides to string for comparison, same as the OOB block does.
+  const allowedChatSet = new Set(config.allowed_chat_ids.map((v) => String(v)))
+  if (!allowedChatSet.has(String(chatNum))) return false
+  return true
+}
+
+// Fire-and-forget watcher trigger. Encapsulates the allowlist gate +
+// `void`/`.catch` boilerplate so every inbound handler (text + media) can
+// invoke the watcher with one call. Optional `deps.watcher` makes this a
+// no-op when the watcher isn't configured — older tests stay compatible.
+function maybeTriggerWatcher(ctx: Context, deps: HandlerDeps): void {
+  if (!deps.watcher) return
+  if (!watcherAllowed(ctx, deps.config)) return
+  const chatNum = ctx.chat?.id
+  const msgId = ctx.message?.message_id
+  if (chatNum === undefined || msgId === undefined) return
+  void deps.watcher
+    .maybeAutoReply({ chatId: String(chatNum), messageId: msgId, text: '' })
+    .catch((err) => {
+      deps.log.warn('watcher auto-reply error (ignored)', {
+        chat_id: String(chatNum),
+        error: err instanceof Error ? err.message : String(err),
+      })
+    })
+}
+
 // Extract the four fields the gate cares about from a grammY Context. Kept
 // separate so unit tests for gate.ts don't need a real Context shape.
 function gateInputFromContext(ctx: Context): GateInput {
@@ -505,26 +544,12 @@ export async function handleInboundText(ctx: Context, deps: HandlerDeps): Promis
   }
 
   // PR-A3 watcher hook (after OOB resolution, before gate/notify): if Claude
-  // is mid-tool for this chat, auto-reply «Тралл занят». Fire-and-forget via
-  // `void` — channel-notification latency must NOT depend on the auto-reply
-  // round-trip. The watcher itself never throws (it logs send failures and
-  // returns `replied: false`); the `.catch` here is a belt-and-braces guard.
-  // Auto-reply does NOT replace the channel notification — gateAndNotify
-  // still runs below so Claude sees the message normally.
-  if (deps.watcher) {
-    const chatNum = ctx.chat?.id
-    const msgId = ctx.message?.message_id
-    if (chatNum !== undefined && msgId !== undefined) {
-      void deps.watcher
-        .maybeAutoReply({ chatId: String(chatNum), messageId: msgId, text })
-        .catch((err) => {
-          deps.log.warn('watcher auto-reply error (ignored)', {
-            chat_id: String(chatNum),
-            error: err instanceof Error ? err.message : String(err),
-          })
-        })
-    }
-  }
+  // is mid-tool for this chat, auto-reply «Тралл занят». Gated on the
+  // allowlist — only allowed senders in allowed chats can trigger it.
+  // Fire-and-forget — channel-notification latency must NOT depend on the
+  // auto-reply round-trip. Auto-reply does NOT replace the channel notification
+  // — gateAndNotify still runs below so Claude sees the message normally.
+  maybeTriggerWatcher(ctx, deps)
 
   await gateAndNotify(ctx, deps, () => text, undefined, 'text')
 }

--- a/plugin/src/telegram/handlers.ts
+++ b/plugin/src/telegram/handlers.ts
@@ -167,7 +167,7 @@ function maybeTriggerWatcher(ctx: Context, deps: HandlerDeps): void {
   const msgId = ctx.message?.message_id
   if (chatNum === undefined || msgId === undefined) return
   void deps.watcher
-    .maybeAutoReply({ chatId: String(chatNum), messageId: msgId, text: '' })
+    .maybeAutoReply({ chatId: String(chatNum), messageId: msgId })
     .catch((err) => {
       deps.log.warn('watcher auto-reply error (ignored)', {
         chat_id: String(chatNum),

--- a/plugin/src/telegram/handlers.ts
+++ b/plugin/src/telegram/handlers.ts
@@ -48,6 +48,7 @@ import {
   type PermissionRelayHooks,
 } from '../channel/permissions.js'
 import { AlbumBuffer, type Album } from './album-buffer.js'
+import type { InboundWatcher } from './watcher.js'
 
 // A single buffered album item — one Telegram update that belongs to an
 // album. We capture everything needed to emit a combined channel notification
@@ -103,6 +104,13 @@ export interface HandlerDeps {
   // tests still compile — when absent, every media message goes through
   // the single-media path (no album merging).
   albumBuffer?: AlbumBuffer<AlbumEntry>
+  // PR-A3 (2026-05-20): InboundWatcher fires an auto-reply «Тралл занят»
+  // when the warchief sends plain text mid-tool. Optional so older tests
+  // compile — when absent, the watcher branch is skipped and behaviour
+  // matches the pre-A3 path. Insertion point in handleInboundText sits
+  // AFTER OOB resolution and BEFORE gateAndNotify: OOB still wins, and
+  // Claude still receives the channel notification regardless.
+  watcher?: InboundWatcher
 }
 
 // Coerce grammY's reply_to_message Message shape into the narrower
@@ -495,6 +503,29 @@ export async function handleInboundText(ctx: Context, deps: HandlerDeps): Promis
       return
     }
   }
+
+  // PR-A3 watcher hook (after OOB resolution, before gate/notify): if Claude
+  // is mid-tool for this chat, auto-reply «Тралл занят». Fire-and-forget via
+  // `void` — channel-notification latency must NOT depend on the auto-reply
+  // round-trip. The watcher itself never throws (it logs send failures and
+  // returns `replied: false`); the `.catch` here is a belt-and-braces guard.
+  // Auto-reply does NOT replace the channel notification — gateAndNotify
+  // still runs below so Claude sees the message normally.
+  if (deps.watcher) {
+    const chatNum = ctx.chat?.id
+    const msgId = ctx.message?.message_id
+    if (chatNum !== undefined && msgId !== undefined) {
+      void deps.watcher
+        .maybeAutoReply({ chatId: String(chatNum), messageId: msgId, text })
+        .catch((err) => {
+          deps.log.warn('watcher auto-reply error (ignored)', {
+            chat_id: String(chatNum),
+            error: err instanceof Error ? err.message : String(err),
+          })
+        })
+    }
+  }
+
   await gateAndNotify(ctx, deps, () => text, undefined, 'text')
 }
 

--- a/plugin/src/telegram/handlers.ts
+++ b/plugin/src/telegram/handlers.ts
@@ -559,6 +559,9 @@ export async function handleInboundText(ctx: Context, deps: HandlerDeps): Promis
 // ─────────────────────────────────────────────────────────────────────
 
 export async function handleInboundPhoto(ctx: Context, deps: HandlerDeps): Promise<void> {
+  // PR-A3: same watcher hook as text. Media handlers must surface
+  // «Тралл занят» too — otherwise a busy-session photo/voice silently waits.
+  maybeTriggerWatcher(ctx, deps)
   const buildPhoto = async (): Promise<MediaDescriptor[]> => {
     const sizes = ctx.message?.photo
     if (!sizes || sizes.length === 0) return []
@@ -594,6 +597,7 @@ export async function handleInboundPhoto(ctx: Context, deps: HandlerDeps): Promi
 // ─────────────────────────────────────────────────────────────────────
 
 export async function handleInboundDocument(ctx: Context, deps: HandlerDeps): Promise<void> {
+  maybeTriggerWatcher(ctx, deps)
   const buildDoc = async (): Promise<MediaDescriptor[]> => {
     const doc = ctx.message?.document
     if (!doc) return []
@@ -616,6 +620,7 @@ export async function handleInboundDocument(ctx: Context, deps: HandlerDeps): Pr
 // ─────────────────────────────────────────────────────────────────────
 
 export async function handleInboundVoice(ctx: Context, deps: HandlerDeps): Promise<void> {
+  maybeTriggerWatcher(ctx, deps)
   await gateAndNotify(
     ctx,
     deps,
@@ -666,6 +671,7 @@ export async function handleInboundVoice(ctx: Context, deps: HandlerDeps): Promi
 // ─────────────────────────────────────────────────────────────────────
 
 export async function handleInboundAudio(ctx: Context, deps: HandlerDeps): Promise<void> {
+  maybeTriggerWatcher(ctx, deps)
   const buildAudio = async (): Promise<MediaDescriptor[]> => {
     const audio = ctx.message?.audio
     if (!audio) return []
@@ -690,6 +696,7 @@ export async function handleInboundAudio(ctx: Context, deps: HandlerDeps): Promi
 // ─────────────────────────────────────────────────────────────────────
 
 export async function handleInboundVideo(ctx: Context, deps: HandlerDeps): Promise<void> {
+  maybeTriggerWatcher(ctx, deps)
   const buildVideo = async (): Promise<MediaDescriptor[]> => {
     const video = ctx.message?.video
     if (!video) return []
@@ -715,6 +722,7 @@ export async function handleInboundVideo(ctx: Context, deps: HandlerDeps): Promi
 // ─────────────────────────────────────────────────────────────────────
 
 export async function handleInboundVideoNote(ctx: Context, deps: HandlerDeps): Promise<void> {
+  maybeTriggerWatcher(ctx, deps)
   await gateAndNotify(
     ctx,
     deps,
@@ -739,6 +747,7 @@ export async function handleInboundVideoNote(ctx: Context, deps: HandlerDeps): P
 // ─────────────────────────────────────────────────────────────────────
 
 export async function handleInboundSticker(ctx: Context, deps: HandlerDeps): Promise<void> {
+  maybeTriggerWatcher(ctx, deps)
   await gateAndNotify(
     ctx,
     deps,

--- a/plugin/src/telegram/watcher.ts
+++ b/plugin/src/telegram/watcher.ts
@@ -79,19 +79,33 @@ export class InboundWatcher {
    * Fire-and-forget entry point — caller MUST schedule via `void` so
    * channel-notification latency never depends on Telegram round-trips.
    * The method itself never throws: send failures are caught and logged.
+   *
+   * Race-safe debounce: lastReplyMs is set BEFORE the await on sendMessage,
+   * so a second invocation arriving in the same event-loop turn observes the
+   * marker and short-circuits as `debounced`. On send failure we roll the
+   * marker back to its previous value, so the next retry can still proceed
+   * iff the prior successful send (if any) is now out of window.
    */
   async maybeAutoReply(input: AutoReplyInput): Promise<AutoReplyResult> {
     try {
       if (!this.config.watcher.enabled) {
         return { replied: false, reason: 'disabled' }
       }
-      if (!this.progressReporter.isBusy(input.chatId)) {
+      if (!this.progressReporter.isBusy(input.chatId, this.config.watcher.busy_threshold_ms)) {
         return { replied: false, reason: 'not-busy' }
       }
-      const last = this.lastReplyMs.get(input.chatId)
-      if (last !== undefined && this.now() - last < this.config.watcher.debounce_ms) {
+      const now = this.now()
+      const prev = this.lastReplyMs.get(input.chatId)
+      if (prev !== undefined && now - prev < this.config.watcher.debounce_ms) {
         return { replied: false, reason: 'debounced' }
       }
+
+      // Set the marker FIRST so a concurrent invocation (same event-loop
+      // turn) sees the debounce window and returns reason='debounced' before
+      // it even reaches the Telegram round-trip. Without this, two messages
+      // arriving in the same tick could both pass the debounce guard and
+      // both call sendMessage — duplicate auto-replies on bursts.
+      this.lastReplyMs.set(input.chatId, now)
 
       const toolName = this.progressReporter.getActiveToolName(input.chatId)
       const text = composeAutoReply(toolName)
@@ -102,6 +116,14 @@ export class InboundWatcher {
           reply_to_message_id: input.messageId,
         })
       } catch (err) {
+        // Rollback the optimistic marker so the next message can retry. If
+        // there was no prior successful send for this chat, remove the entry
+        // entirely (the next call will be a true first-send).
+        if (prev === undefined) {
+          this.lastReplyMs.delete(input.chatId)
+        } else {
+          this.lastReplyMs.set(input.chatId, prev)
+        }
         this.log.warn('watcher sendMessage failed (ignored)', {
           chat_id: input.chatId,
           error: err instanceof Error ? err.message : String(err),
@@ -109,7 +131,6 @@ export class InboundWatcher {
         return { replied: false, reason: 'send-failed' }
       }
 
-      this.lastReplyMs.set(input.chatId, this.now())
       return { replied: true }
     } catch (err) {
       // Outer safety net — never escape recordEvent-style guard.
@@ -119,6 +140,18 @@ export class InboundWatcher {
       })
       return { replied: false, reason: 'send-failed' }
     }
+  }
+
+  /**
+   * Clear the debounce marker for a chat. Used by the webhook server when a
+   * `session_stop` hook fires for the chat: a fresh session should be able
+   * to receive the first auto-reply immediately, without waiting for the
+   * debounce window of the previous session to expire.
+   *
+   * Idempotent — no-op if no marker exists.
+   */
+  clearDebounce(chatId: string): void {
+    this.lastReplyMs.delete(chatId)
   }
 }
 

--- a/plugin/src/telegram/watcher.ts
+++ b/plugin/src/telegram/watcher.ts
@@ -29,8 +29,11 @@ import { escapeHtml } from '../format/html.js'
 // Narrow read-only view of ProgressReporter — watcher must not mutate
 // reporter state. Both methods are implemented in `progress-reporter.ts`
 // as plain accessors over `chats: Map<string, ChatProgressEntry>`.
+// `thresholdMs` on isBusy is REQUIRED: ProgressReporter never reads
+// `config.watcher` (dependency direction is one-way), so the watcher
+// owns the threshold and passes it in every call.
 export interface ProgressReporterForWatcher {
-  isBusy(chatId: string, thresholdMs?: number): boolean
+  isBusy(chatId: string, thresholdMs: number): boolean
   getActiveToolName(chatId: string): string | undefined
 }
 

--- a/plugin/src/telegram/watcher.ts
+++ b/plugin/src/telegram/watcher.ts
@@ -1,0 +1,132 @@
+// InboundWatcher — auto-reply «Тралл занят» when the warchief sends plain
+// text while a Claude session is mid-tool. Sits between OOB resolution and
+// the gate/notify call in `handleInboundText` — OOB always takes priority,
+// and the watcher NEVER replaces the channel notification (auto-reply AND
+// gate-and-notify both fire on a busy chat).
+//
+// Behaviour contract (plan §2.2, warchief defaults 2026-05-20):
+//   * Disabled (`config.watcher.enabled === false`) → no-op, reason='disabled'.
+//   * Not busy (per ProgressReporter.isBusy) → no-op, reason='not-busy'.
+//   * Debounced — within `config.watcher.debounce_ms` of the last successful
+//     auto-reply for THIS chat → no-op, reason='debounced'.
+//   * Send fails — caught, reason='send-failed', lastReplyMs NOT updated so
+//     the next message can retry.
+//   * Otherwise — `sendMessage` quote-replies the warchief's message via
+//     `reply_to_message_id`, lastReplyMs updates, return `{ replied: true }`.
+//
+// Tone constraints (rules.md):
+//   * No emoji in production paths. The warchief explicitly asked for «🔧»
+//     prefix on auto-reply (visual cue that Тралл is mid-tool — single
+//     character, anchored, NOT a decorative emoji string).
+//   * HTML output through `escapeHtml` for the tool name; the safe-wrapper
+//     also validates HTML before send.
+
+import type { AppConfig } from '../config.js'
+import type { Logger } from '../log.js'
+import type { TelegramApi } from '../channel/tools.js'
+import { escapeHtml } from '../format/html.js'
+
+// Narrow read-only view of ProgressReporter — watcher must not mutate
+// reporter state. Both methods are implemented in `progress-reporter.ts`
+// as plain accessors over `chats: Map<string, ChatProgressEntry>`.
+export interface ProgressReporterForWatcher {
+  isBusy(chatId: string, thresholdMs?: number): boolean
+  getActiveToolName(chatId: string): string | undefined
+}
+
+export interface WatcherDeps {
+  telegramApi: TelegramApi
+  config: AppConfig
+  log: Logger
+  progressReporter: ProgressReporterForWatcher
+  now?: () => number
+}
+
+export interface AutoReplyInput {
+  readonly chatId: string
+  readonly messageId: number
+  readonly text: string
+}
+
+export type AutoReplyResult =
+  | { readonly replied: true }
+  | { readonly replied: false; readonly reason: AutoReplyReason }
+
+export type AutoReplyReason =
+  | 'disabled'
+  | 'not-busy'
+  | 'debounced'
+  | 'send-failed'
+
+export class InboundWatcher {
+  private readonly telegramApi: TelegramApi
+  private readonly config: AppConfig
+  private readonly log: Logger
+  private readonly progressReporter: ProgressReporterForWatcher
+  private readonly now: () => number
+  private readonly lastReplyMs: Map<string, number>
+
+  constructor(deps: WatcherDeps) {
+    this.telegramApi = deps.telegramApi
+    this.config = deps.config
+    this.log = deps.log
+    this.progressReporter = deps.progressReporter
+    this.now = deps.now ?? (() => Date.now())
+    this.lastReplyMs = new Map()
+  }
+
+  /**
+   * Fire-and-forget entry point — caller MUST schedule via `void` so
+   * channel-notification latency never depends on Telegram round-trips.
+   * The method itself never throws: send failures are caught and logged.
+   */
+  async maybeAutoReply(input: AutoReplyInput): Promise<AutoReplyResult> {
+    try {
+      if (!this.config.watcher.enabled) {
+        return { replied: false, reason: 'disabled' }
+      }
+      if (!this.progressReporter.isBusy(input.chatId)) {
+        return { replied: false, reason: 'not-busy' }
+      }
+      const last = this.lastReplyMs.get(input.chatId)
+      if (last !== undefined && this.now() - last < this.config.watcher.debounce_ms) {
+        return { replied: false, reason: 'debounced' }
+      }
+
+      const toolName = this.progressReporter.getActiveToolName(input.chatId)
+      const text = composeAutoReply(toolName)
+
+      try {
+        await this.telegramApi.sendMessage(input.chatId, text, {
+          parse_mode: 'HTML',
+          reply_to_message_id: input.messageId,
+        })
+      } catch (err) {
+        this.log.warn('watcher sendMessage failed (ignored)', {
+          chat_id: input.chatId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+        return { replied: false, reason: 'send-failed' }
+      }
+
+      this.lastReplyMs.set(input.chatId, this.now())
+      return { replied: true }
+    } catch (err) {
+      // Outer safety net — never escape recordEvent-style guard.
+      this.log.warn('watcher maybeAutoReply failed (ignored)', {
+        chat_id: input.chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return { replied: false, reason: 'send-failed' }
+    }
+  }
+}
+
+/**
+ * Compose the auto-reply body. Exposed for tests so the HTML shape is
+ * pinned without invoking the full class.
+ */
+export function composeAutoReply(toolName: string | undefined): string {
+  const tool = toolName ?? '…'
+  return `🔧 Тралл занят, активный инструмент: <code>${escapeHtml(tool)}</code>. Жди или /stop.`
+}

--- a/plugin/src/telegram/watcher.ts
+++ b/plugin/src/telegram/watcher.ts
@@ -48,7 +48,6 @@ export interface WatcherDeps {
 export interface AutoReplyInput {
   readonly chatId: string
   readonly messageId: number
-  readonly text: string
 }
 
 export type AutoReplyResult =

--- a/plugin/src/webhook/server.ts
+++ b/plugin/src/webhook/server.ts
@@ -23,9 +23,10 @@ import type { Logger } from '../log.js'
 import { writeDeadLetter } from '../state/store.js'
 import { WebhookPayloadSchema, type WebhookPayload } from '../schemas.js'
 import { sendChannelNotification, normalizeMeta } from '../channel/notify.js'
-import { toActivityEvent } from '../hooks/claude-events.js'
+import { toActivityEvent, toTodoWriteEvent } from '../hooks/claude-events.js'
 import type { MemoryWriter } from '../memory/writer.js'
 import type { ProgressReporter } from '../status/progress-reporter.js'
+import type { TaskMirror } from '../status/task-mirror.js'
 
 const BODY_LIMIT_BYTES = 256 * 1024
 const DEFAULT_AGENT_ID = 'dashi-channel'
@@ -58,6 +59,12 @@ export interface WebhookDeps {
   // can omit it. Failures inside the reporter never propagate (it logs
   // and swallows) so no error handling is required at the call site.
   progressReporter?: ProgressReporter
+  // TaskMirror (PR-A2, 2026-05-20): third sibling that owns a rolling
+  // TodoWrite milestone message per chat. Optional — when absent, the
+  // dispatch block below is skipped. Errors inside `recordEvent` are
+  // logged and swallowed; we still defensively wrap in try/catch here
+  // to match the statusManager / progressReporter pattern.
+  taskMirror?: TaskMirror
 }
 
 export interface WebhookServerHandle {
@@ -180,7 +187,7 @@ async function handleRequest(
   deps: WebhookDeps,
   webhookToken: string | undefined,
 ): Promise<void> {
-  const { config, statePaths, log, mcpServer, statusManager, memoryWriter, progressReporter } = deps
+  const { config, statePaths, log, mcpServer, statusManager, memoryWriter, progressReporter, taskMirror } = deps
   const method = req.method ?? 'GET'
   const url = req.url ?? '/'
 
@@ -331,6 +338,24 @@ async function handleRequest(
           hook: payload.hook_event_name,
           error: err instanceof Error ? err.message : String(err),
         })
+      }
+    }
+
+    // PR-A2 (2026-05-20): TaskMirror handles TodoWrite + Stop hooks. The
+    // mapper returns null for every other event, so the cost when no
+    // TodoWrite is in flight is one schema test per hook — negligible.
+    if (taskMirror) {
+      const todoEvent = toTodoWriteEvent(payload, log)
+      if (todoEvent !== null) {
+        try {
+          await taskMirror.recordEvent(payload.chatId, todoEvent)
+        } catch (err) {
+          log.warn('hook event task mirror update failed (ignored)', {
+            chat_id: payload.chatId,
+            hook: payload.hook_event_name,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
       }
     }
 

--- a/plugin/src/webhook/server.ts
+++ b/plugin/src/webhook/server.ts
@@ -27,6 +27,7 @@ import { toActivityEvent, toTodoWriteEvent } from '../hooks/claude-events.js'
 import type { MemoryWriter } from '../memory/writer.js'
 import type { ProgressReporter } from '../status/progress-reporter.js'
 import type { TaskMirror } from '../status/task-mirror.js'
+import type { InboundWatcher } from '../telegram/watcher.js'
 
 const BODY_LIMIT_BYTES = 256 * 1024
 const DEFAULT_AGENT_ID = 'dashi-channel'
@@ -65,6 +66,11 @@ export interface WebhookDeps {
   // logged and swallowed; we still defensively wrap in try/catch here
   // to match the statusManager / progressReporter pattern.
   taskMirror?: TaskMirror
+  // PR-A3 (M3 fix): InboundWatcher — on session_stop the webhook clears
+  // the per-chat debounce marker so a fresh session can auto-reply on its
+  // very first inbound message without waiting for the previous session's
+  // debounce window to expire. Optional so tests/legacy paths can omit.
+  watcher?: InboundWatcher
 }
 
 export interface WebhookServerHandle {
@@ -187,7 +193,17 @@ async function handleRequest(
   deps: WebhookDeps,
   webhookToken: string | undefined,
 ): Promise<void> {
-  const { config, statePaths, log, mcpServer, statusManager, memoryWriter, progressReporter, taskMirror } = deps
+  const {
+    config,
+    statePaths,
+    log,
+    mcpServer,
+    statusManager,
+    memoryWriter,
+    progressReporter,
+    taskMirror,
+    watcher,
+  } = deps
   const method = req.method ?? 'GET'
   const url = req.url ?? '/'
 
@@ -356,6 +372,22 @@ async function handleRequest(
             error: err instanceof Error ? err.message : String(err),
           })
         }
+      }
+    }
+
+    // PR-A3 (M3 fix): on session_stop, clear the watcher's debounce marker
+    // for this chat so the next session can fire its first auto-reply
+    // immediately. Without this, a stale marker from the previous session
+    // would block the auto-reply for up to debounce_ms.
+    if (watcher && payload.hook_event_name === 'Stop') {
+      try {
+        watcher.clearDebounce(payload.chatId)
+      } catch (err) {
+        // clearDebounce is a Map.delete() under the hood — should never throw.
+        log.warn('watcher clearDebounce failed (ignored)', {
+          chat_id: payload.chatId,
+          error: err instanceof Error ? err.message : String(err),
+        })
       }
     }
 

--- a/plugin/tests/channel/permissions.test.ts
+++ b/plugin/tests/channel/permissions.test.ts
@@ -75,6 +75,17 @@ function mkConfig(allowedIds: number[] = [164795011]): AppConfig {
       recent_buffer: 10,
       session_ttl_ms: 600000,
     },
+    task_mirror: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      session_ttl_ms: 600000,
+      collapse_completed_after: 5,
+    },
+    watcher: {
+      enabled: true,
+      debounce_ms: 10_000,
+      busy_threshold_ms: 30_000,
+    },
   }
 }
 

--- a/plugin/tests/channel/tools.test.ts
+++ b/plugin/tests/channel/tools.test.ts
@@ -71,6 +71,17 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       recent_buffer: 10,
       session_ttl_ms: 600000,
     },
+    task_mirror: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      session_ttl_ms: 600000,
+      collapse_completed_after: 5,
+    },
+    watcher: {
+      enabled: true,
+      debounce_ms: 10_000,
+      busy_threshold_ms: 30_000,
+    },
     ...overrides,
   }
 }

--- a/plugin/tests/commands/oob.test.ts
+++ b/plugin/tests/commands/oob.test.ts
@@ -39,6 +39,17 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       recent_buffer: 10,
       session_ttl_ms: 600000,
     },
+    task_mirror: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      session_ttl_ms: 600000,
+      collapse_completed_after: 5,
+    },
+    watcher: {
+      enabled: true,
+      debounce_ms: 10_000,
+      busy_threshold_ms: 30_000,
+    },
     ...overrides,
   }
 }

--- a/plugin/tests/prompt/media-prompt.test.ts
+++ b/plugin/tests/prompt/media-prompt.test.ts
@@ -47,6 +47,17 @@ const voiceConfig: AppConfig = {
     recent_buffer: 10,
     session_ttl_ms: 600000,
   },
+  task_mirror: {
+    enabled: true,
+    edit_throttle_ms: 3000,
+    session_ttl_ms: 600000,
+    collapse_completed_after: 5,
+  },
+  watcher: {
+    enabled: true,
+    debounce_ms: 10_000,
+    busy_threshold_ms: 30_000,
+  },
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/plugin/tests/status/progress-reporter.test.ts
+++ b/plugin/tests/status/progress-reporter.test.ts
@@ -458,23 +458,35 @@ describe('ProgressReporter', () => {
 
   test('isBusy returns false for an unknown chat', () => {
     const { reporter } = makeReporter()
-    expect(reporter.isBusy('unknown-chat')).toBe(false)
+    expect(reporter.isBusy('unknown-chat', 30_000)).toBe(false)
   })
 
-  test('isBusy returns true within busy_threshold_ms after a tool_start', async () => {
+  test('isBusy returns true within thresholdMs after a tool_start', async () => {
     const { reporter, clock } = makeReporter()
     await reporter.recordEvent('chat-busy', bashStart('t1'))
-    // Default busy_threshold_ms is 30_000 — at t+10ms we must still be busy.
+    // At t+10ms with a 30s threshold we must still be busy.
     clock.advance(10)
-    expect(reporter.isBusy('chat-busy')).toBe(true)
+    expect(reporter.isBusy('chat-busy', 30_000)).toBe(true)
   })
 
-  test('isBusy returns false after busy_threshold_ms with no further activity', async () => {
+  test('isBusy returns false after thresholdMs with no further activity', async () => {
     const { reporter, clock } = makeReporter()
     await reporter.recordEvent('chat-cooling', bashStart('t1'))
-    // Default threshold = 30_000ms — at t+30_001ms we must look idle.
+    // At t+30_001ms with a 30s threshold we must look idle.
     clock.advance(30_001)
-    expect(reporter.isBusy('chat-cooling')).toBe(false)
+    expect(reporter.isBusy('chat-cooling', 30_000)).toBe(false)
+  })
+
+  test('isBusy uses strict < for boundary: elapsed === threshold is NOT busy', async () => {
+    const { reporter, clock } = makeReporter()
+    await reporter.recordEvent('chat-edge', bashStart('t1'))
+    clock.advance(30_000)
+    expect(reporter.isBusy('chat-edge', 30_000)).toBe(false)
+    // One tick under the boundary — still busy.
+    const { reporter: r2, clock: c2 } = makeReporter()
+    await r2.recordEvent('chat-edge2', bashStart('t1'))
+    c2.advance(29_999)
+    expect(r2.isBusy('chat-edge2', 30_000)).toBe(true)
   })
 
   test('isBusy returns false after session_stop even within the threshold', async () => {
@@ -484,17 +496,17 @@ describe('ProgressReporter', () => {
     await reporter.recordEvent('chat-stopping', STOP)
     // Entry is fully evicted on stop — same observable outcome as a
     // never-seen chat.
-    expect(reporter.isBusy('chat-stopping')).toBe(false)
+    expect(reporter.isBusy('chat-stopping', 30_000)).toBe(false)
   })
 
-  test('isBusy accepts an explicit threshold override', async () => {
+  test('isBusy with tight threshold marks a recent chat as idle', async () => {
     const { reporter, clock } = makeReporter()
     await reporter.recordEvent('chat-tight', bashStart('t1'))
     clock.advance(100)
-    // Override to 50ms; we are at t+100, so the chat is past the override.
+    // 50ms threshold; we are at t+100, so the chat is past the override.
     expect(reporter.isBusy('chat-tight', 50)).toBe(false)
-    // Default 30s still considers it busy.
-    expect(reporter.isBusy('chat-tight')).toBe(true)
+    // 30s threshold still considers it busy.
+    expect(reporter.isBusy('chat-tight', 30_000)).toBe(true)
   })
 
   test('getActiveToolName returns the most recent tool', async () => {

--- a/plugin/tests/status/progress-reporter.test.ts
+++ b/plugin/tests/status/progress-reporter.test.ts
@@ -521,6 +521,25 @@ describe('ProgressReporter', () => {
     expect(reporter.getActiveToolName('nobody')).toBeUndefined()
   })
 
+  test('getActiveToolName stays populated after a matching tool_end (semantic pin)', async () => {
+    // Documented intentional behaviour: tool_end does NOT clear the active
+    // tool. The brief idle gap between tool_end and the next tool_start
+    // would otherwise cause false-negative auto-replies (watcher sees
+    // «not busy» even though Claude is in the middle of a multi-step chain).
+    const { reporter } = makeReporter()
+    await reporter.recordEvent('chat-x', bashStart('t1'))
+    expect(reporter.getActiveToolName('chat-x')).toBe('Bash')
+    await reporter.recordEvent('chat-x', {
+      kind: 'tool_end',
+      toolName: 'Bash',
+      toolInput: { command: 'echo hi' },
+      toolUseId: 't1',
+    })
+    // After tool_end, the name is unchanged — calls window is render-only
+    // for non-start events.
+    expect(reporter.getActiveToolName('chat-x')).toBe('Bash')
+  })
+
   test('editMessageText failure is swallowed; next event still produces a successful edit', async () => {
     const api = makeFakeApi()
     const { reporter, clock } = makeReporter({ api })

--- a/plugin/tests/status/progress-reporter.test.ts
+++ b/plugin/tests/status/progress-reporter.test.ts
@@ -71,6 +71,17 @@ function makeConfig(overrides: Partial<AppConfig['progress']> = {}): AppConfig {
       session_ttl_ms: 10 * 60 * 1000,
       ...overrides,
     },
+    task_mirror: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      session_ttl_ms: 10 * 60 * 1000,
+      collapse_completed_after: 5,
+    },
+    watcher: {
+      enabled: true,
+      debounce_ms: 10_000,
+      busy_threshold_ms: 30_000,
+    },
   }
 }
 

--- a/plugin/tests/status/progress-reporter.test.ts
+++ b/plugin/tests/status/progress-reporter.test.ts
@@ -452,6 +452,63 @@ describe('ProgressReporter', () => {
     expect(sends[0]!.text).not.toContain('XXXXXXXX')
   })
 
+  // ───────────────────────────────────────────────────────────────────
+  // Public read API for the watcher (PR-A3 prerequisite).
+  // ───────────────────────────────────────────────────────────────────
+
+  test('isBusy returns false for an unknown chat', () => {
+    const { reporter } = makeReporter()
+    expect(reporter.isBusy('unknown-chat')).toBe(false)
+  })
+
+  test('isBusy returns true within busy_threshold_ms after a tool_start', async () => {
+    const { reporter, clock } = makeReporter()
+    await reporter.recordEvent('chat-busy', bashStart('t1'))
+    // Default busy_threshold_ms is 30_000 — at t+10ms we must still be busy.
+    clock.advance(10)
+    expect(reporter.isBusy('chat-busy')).toBe(true)
+  })
+
+  test('isBusy returns false after busy_threshold_ms with no further activity', async () => {
+    const { reporter, clock } = makeReporter()
+    await reporter.recordEvent('chat-cooling', bashStart('t1'))
+    // Default threshold = 30_000ms — at t+30_001ms we must look idle.
+    clock.advance(30_001)
+    expect(reporter.isBusy('chat-cooling')).toBe(false)
+  })
+
+  test('isBusy returns false after session_stop even within the threshold', async () => {
+    const { reporter, clock } = makeReporter()
+    await reporter.recordEvent('chat-stopping', bashStart('t1'))
+    clock.advance(100)
+    await reporter.recordEvent('chat-stopping', STOP)
+    // Entry is fully evicted on stop — same observable outcome as a
+    // never-seen chat.
+    expect(reporter.isBusy('chat-stopping')).toBe(false)
+  })
+
+  test('isBusy accepts an explicit threshold override', async () => {
+    const { reporter, clock } = makeReporter()
+    await reporter.recordEvent('chat-tight', bashStart('t1'))
+    clock.advance(100)
+    // Override to 50ms; we are at t+100, so the chat is past the override.
+    expect(reporter.isBusy('chat-tight', 50)).toBe(false)
+    // Default 30s still considers it busy.
+    expect(reporter.isBusy('chat-tight')).toBe(true)
+  })
+
+  test('getActiveToolName returns the most recent tool', async () => {
+    const { reporter } = makeReporter()
+    await reporter.recordEvent('chat-tools', bashStart('t1'))
+    await reporter.recordEvent('chat-tools', readStart('t2'))
+    expect(reporter.getActiveToolName('chat-tools')).toBe('Read')
+  })
+
+  test('getActiveToolName returns undefined when no entry exists', () => {
+    const { reporter } = makeReporter()
+    expect(reporter.getActiveToolName('nobody')).toBeUndefined()
+  })
+
   test('editMessageText failure is swallowed; next event still produces a successful edit', async () => {
     const api = makeFakeApi()
     const { reporter, clock } = makeReporter({ api })

--- a/plugin/tests/status/status-manager.test.ts
+++ b/plugin/tests/status/status-manager.test.ts
@@ -45,6 +45,17 @@ function makeConfig(overrides: Partial<AppConfig['status']> = {}): AppConfig {
       recent_buffer: 10,
       session_ttl_ms: 600000,
     },
+    task_mirror: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      session_ttl_ms: 600000,
+      collapse_completed_after: 5,
+    },
+    watcher: {
+      enabled: true,
+      debounce_ms: 10_000,
+      busy_threshold_ms: 30_000,
+    },
   }
 }
 

--- a/plugin/tests/status/task-mirror.test.ts
+++ b/plugin/tests/status/task-mirror.test.ts
@@ -23,7 +23,7 @@ import {
   TaskMirror,
   renderTodoList,
 } from '../../src/status/task-mirror.js'
-import type { TelegramApiForProgress } from '../../src/status/progress-reporter.js'
+import type { TelegramApiForProgress } from '../../src/status/telegram-api.js'
 import type { AppConfig } from '../../src/config.js'
 import type { TaskMirrorEvent } from '../../src/hooks/claude-events.js'
 import type { TodoItem } from '../../src/schemas.js'

--- a/plugin/tests/status/task-mirror.test.ts
+++ b/plugin/tests/status/task-mirror.test.ts
@@ -1,0 +1,445 @@
+// TaskMirror tests (PR-A2 / 2026-05-20) — third rolling Telegram message
+// per chat, showing Claude's TodoWrite milestone list. Patterned on
+// tests/status/progress-reporter.test.ts: FakeClock + FakeApi, no real
+// network or timers.
+//
+// Behaviour under test:
+//   1. First TodoWrite event sends a new Telegram message.
+//   2. Second event with a different snapshot edits the existing message.
+//   3. Same snapshot replayed (idempotency) is a no-op.
+//   4. Throttle: rapid events collapse to a single deferred edit.
+//   5. session_stop: posts a final edit, evicts entry. Next event starts fresh.
+//   6. TTL eviction: idle entry past session_ttl_ms → fresh thread.
+//   7. Multi-chat isolation.
+//   8. Malformed tool_input is handled upstream — TaskMirror sees only valid
+//      events.
+//   9. Empty todos array renders «задач нет».
+//  10. collapse_completed_after: «+M завершено ранее» tail.
+//  11. Long todo lines stay under Telegram's 4096-char cap.
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  TaskMirror,
+  renderTodoList,
+} from '../../src/status/task-mirror.js'
+import type { TelegramApiForProgress } from '../../src/status/progress-reporter.js'
+import type { AppConfig } from '../../src/config.js'
+import type { TaskMirrorEvent } from '../../src/hooks/claude-events.js'
+import type { TodoItem } from '../../src/schemas.js'
+import { createLogger } from '../../src/log.js'
+
+const silentLog = createLogger('test', {
+  stream: { write: () => true } as unknown as NodeJS.WritableStream,
+})
+
+function makeConfig(overrides: Partial<AppConfig['task_mirror']> = {}): AppConfig {
+  return {
+    bot_id: 8507713167,
+    dm_only: true,
+    allowed_user_ids: [164795011],
+    allowed_chat_ids: [164795011],
+    status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true },
+    album: { flush_ms: 2000 },
+    voice: { provider: 'groq', language: 'ru', model: 'whisper-large-v3-turbo' },
+    webhook: { enabled: false, host: '127.0.0.1', port: 0 },
+    permission_relay: { enabled: true, allowed_user_ids: [164795011], bash_only_proof: true },
+    commands: { help: true, status: true, stop: true, reset: true, new: true },
+    memory: {
+      enabled: false,
+      source_tag: 'tg',
+      max_hot_bytes: 20480,
+      trim_keep_lines: 600,
+      buffer_ttl_ms: 5 * 60 * 1000,
+      buffer_max_entries: 100,
+    },
+    progress: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      recent_buffer: 10,
+      session_ttl_ms: 10 * 60 * 1000,
+    },
+    task_mirror: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      session_ttl_ms: 10 * 60 * 1000,
+      collapse_completed_after: 5,
+      ...overrides,
+    },
+    watcher: {
+      enabled: true,
+      debounce_ms: 10_000,
+      busy_threshold_ms: 30_000,
+    },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Fake clock (copy of the helper from progress-reporter.test.ts)
+// ─────────────────────────────────────────────────────────────────────
+
+interface FakeTimer {
+  id: number
+  deadline: number
+  cb: () => void
+  fired: boolean
+}
+
+class FakeClock {
+  now = 0
+  next = 1
+  timers: FakeTimer[] = []
+  setTimer = (cb: () => void, ms: number): NodeJS.Timeout => {
+    const t: FakeTimer = { id: this.next++, deadline: this.now + ms, cb, fired: false }
+    this.timers.push(t)
+    return t as unknown as NodeJS.Timeout
+  }
+  clearTimer = (handle: NodeJS.Timeout): void => {
+    const t = handle as unknown as FakeTimer
+    t.fired = true
+  }
+  advance(ms: number): void {
+    const deadline = this.now + ms
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const due = this.timers
+        .filter((t) => !t.fired && t.deadline <= deadline)
+        .sort((a, b) => a.deadline - b.deadline)[0]
+      if (!due) break
+      this.now = due.deadline
+      due.fired = true
+      due.cb()
+    }
+    this.now = deadline
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Fake Telegram API
+// ─────────────────────────────────────────────────────────────────────
+
+interface ApiCall {
+  kind: 'send' | 'edit'
+  chatId: string
+  messageId?: number
+  text: string
+}
+
+interface FakeApi {
+  api: TelegramApiForProgress
+  calls: ApiCall[]
+  nextMessageId: number
+  failSendWith?: Error
+  failEditWith?: Error
+}
+
+function makeFakeApi(): FakeApi {
+  const state: FakeApi = {
+    calls: [],
+    nextMessageId: 200,
+    api: undefined as unknown as TelegramApiForProgress,
+  }
+  state.api = {
+    sendMessage: async (chatId: string, text: string, _opts: unknown) => {
+      if (state.failSendWith) throw state.failSendWith
+      const id = state.nextMessageId++
+      state.calls.push({ kind: 'send', chatId, messageId: id, text })
+      return { message_id: id }
+    },
+    editMessageText: async (chatId: string, messageId: number, text: string, _opts: unknown) => {
+      state.calls.push({ kind: 'edit', chatId, messageId, text })
+      if (state.failEditWith) throw state.failEditWith
+    },
+  }
+  return state
+}
+
+function makeMirror(opts: { config?: AppConfig; clock?: FakeClock; api?: FakeApi } = {}): {
+  mirror: TaskMirror
+  clock: FakeClock
+  api: FakeApi
+  config: AppConfig
+} {
+  const clock = opts.clock ?? new FakeClock()
+  const api = opts.api ?? makeFakeApi()
+  const config = opts.config ?? makeConfig()
+  const mirror = new TaskMirror({
+    telegramApi: api.api,
+    config,
+    log: silentLog,
+    now: () => clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+  })
+  return { mirror, clock, api, config }
+}
+
+function todoEvent(todos: TodoItem[]): TaskMirrorEvent {
+  return { kind: 'todo_write', todos }
+}
+
+const STOP: TaskMirrorEvent = { kind: 'todo_session_stop' }
+
+// ─────────────────────────────────────────────────────────────────────
+// Tests — recordEvent / lifecycle
+// ─────────────────────────────────────────────────────────────────────
+
+describe('TaskMirror', () => {
+  test('first TodoWrite event sends a new Telegram message', async () => {
+    const { mirror, api } = makeMirror()
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Implement feature X', status: 'in_progress' },
+      { content: 'Tests', status: 'pending' },
+    ]))
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(1)
+    expect(sends[0]!.chatId).toBe('chat-1')
+    expect(sends[0]!.text).toContain('milestones')
+    expect(sends[0]!.text).toContain('Implement feature X')
+    expect(sends[0]!.text).toContain('Tests')
+  })
+
+  test('second event with a different snapshot edits the existing message', async () => {
+    const { mirror, clock, api } = makeMirror()
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Step A', status: 'in_progress' },
+    ]))
+    clock.advance(3000)
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Step A', status: 'completed' },
+      { content: 'Step B', status: 'in_progress' },
+    ]))
+    await mirror._idleForTests('chat-1')
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(sends.length).toBe(1)
+    expect(edits.length).toBe(1)
+    expect(edits[0]!.text).toContain('Step B')
+  })
+
+  test('same snapshot replayed is a no-op (idempotency)', async () => {
+    const { mirror, clock, api } = makeMirror()
+    const todos: TodoItem[] = [
+      { content: 'Build', status: 'in_progress' },
+      { content: 'Ship', status: 'pending' },
+    ]
+    await mirror.recordEvent('chat-1', todoEvent(todos))
+    clock.advance(3000)
+    // Same shape, fresh array — TaskMirror compares the rendered text, so
+    // structural equality of content is what matters.
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Build', status: 'in_progress' },
+      { content: 'Ship', status: 'pending' },
+    ]))
+    await mirror._idleForTests('chat-1')
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(sends.length).toBe(1)
+    expect(edits.length).toBe(0)
+  })
+
+  test('rapid events within throttle window collapse into a single deferred edit', async () => {
+    const { mirror, clock, api } = makeMirror()
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Step A', status: 'in_progress' },
+    ]))
+    // Within throttle: 3 fast events. None should fire an immediate edit.
+    clock.advance(500)
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Step A', status: 'completed' },
+      { content: 'Step B', status: 'in_progress' },
+    ]))
+    clock.advance(500)
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Step A', status: 'completed' },
+      { content: 'Step B', status: 'completed' },
+      { content: 'Step C', status: 'in_progress' },
+    ]))
+    expect(api.calls.filter((c) => c.kind === 'edit').length).toBe(0)
+
+    // Past throttle — single coalesced edit lands with the freshest snapshot.
+    clock.advance(2001)
+    await mirror._idleForTests('chat-1')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(edits.length).toBe(1)
+    expect(edits[0]!.text).toContain('Step C')
+  })
+
+  test('session_stop ships final edit and evicts entry; next event starts a fresh thread', async () => {
+    const { mirror, clock, api } = makeMirror()
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Step A', status: 'in_progress' },
+    ]))
+    clock.advance(3000)
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Step A', status: 'completed' },
+    ]))
+    await mirror._idleForTests('chat-1')
+    const editsBeforeStop = api.calls.filter((c) => c.kind === 'edit').length
+    expect(editsBeforeStop).toBeGreaterThanOrEqual(1)
+
+    await mirror.recordEvent('chat-1', STOP)
+    // Subsequent event after stop: must send a NEW message (msg_id 201, since
+    // 200 was the original send).
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'New task', status: 'in_progress' },
+    ]))
+    await mirror._idleForTests('chat-1')
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(2)
+    expect(sends[1]!.messageId).toBe(201)
+  })
+
+  test('TTL eviction: idle entry past session_ttl_ms starts a fresh thread', async () => {
+    const { mirror, clock, api } = makeMirror({
+      config: makeConfig({ session_ttl_ms: 60_000 }),
+    })
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Step A', status: 'in_progress' },
+    ]))
+    expect(api.calls.filter((c) => c.kind === 'send').length).toBe(1)
+
+    clock.advance(60_001)
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Step B', status: 'in_progress' },
+    ]))
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(sends.length).toBe(2)
+    expect(sends[1]!.messageId).toBe(201)
+    expect(edits.length).toBe(0)
+  })
+
+  test('multi-chat isolation: chat A stop does not affect chat B', async () => {
+    const { mirror, clock, api } = makeMirror()
+    await mirror.recordEvent('chat-A', todoEvent([
+      { content: 'A1', status: 'in_progress' },
+    ]))
+    await mirror.recordEvent('chat-B', todoEvent([
+      { content: 'B1', status: 'in_progress' },
+    ]))
+    const sendsAfterInit = api.calls.filter((c) => c.kind === 'send')
+    expect(sendsAfterInit.length).toBe(2)
+
+    await mirror.recordEvent('chat-A', STOP)
+    clock.advance(3001)
+    // Chat B still owns its message.
+    await mirror.recordEvent('chat-B', todoEvent([
+      { content: 'B1', status: 'completed' },
+      { content: 'B2', status: 'in_progress' },
+    ]))
+    await mirror._idleForTests('chat-B')
+    const editsB = api.calls.filter((c) => c.kind === 'edit' && c.chatId === 'chat-B')
+    expect(editsB.length).toBeGreaterThanOrEqual(1)
+    expect(editsB[editsB.length - 1]!.text).toContain('B2')
+  })
+
+  test('disabled config is a hard no-op', async () => {
+    const { mirror, api } = makeMirror({
+      config: makeConfig({ enabled: false }),
+    })
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'X', status: 'in_progress' },
+    ]))
+    await mirror.recordEvent('chat-1', STOP)
+    expect(api.calls.length).toBe(0)
+  })
+
+  test('sendMessage failure is swallowed; next event retries', async () => {
+    const api = makeFakeApi()
+    api.failSendWith = new Error('telegram down')
+    const { mirror, clock } = makeMirror({ api })
+
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'X', status: 'in_progress' },
+    ]))
+    expect(api.calls.length).toBe(0)
+
+    delete api.failSendWith
+    clock.advance(10)
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Y', status: 'in_progress' },
+    ]))
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(1)
+  })
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Renderer tests
+  // ─────────────────────────────────────────────────────────────────────
+
+  test('renderTodoList: empty list renders «задач нет»', () => {
+    const text = renderTodoList([], 5)
+    expect(text).toContain('milestones')
+    expect(text).toContain('задач нет')
+  })
+
+  test('renderTodoList: collapse_completed_after=2 with 5 completed + 1 in_progress shows tail', () => {
+    const todos: TodoItem[] = [
+      { content: 'In flight', status: 'in_progress' },
+      { content: 'Done 1', status: 'completed' },
+      { content: 'Done 2', status: 'completed' },
+      { content: 'Done 3', status: 'completed' },
+      { content: 'Done 4', status: 'completed' },
+      { content: 'Done 5', status: 'completed' },
+    ]
+    const text = renderTodoList(todos, 2)
+    // Last two completed remain, three are collapsed.
+    expect(text).toContain('In flight')
+    expect(text).toContain('Done 4')
+    expect(text).toContain('Done 5')
+    expect(text).toContain('+3 завершено ранее')
+    expect(text).not.toContain('Done 1')
+    expect(text).not.toContain('Done 2')
+    expect(text).not.toContain('Done 3')
+  })
+
+  test('renderTodoList: escapes HTML in content', () => {
+    const todos: TodoItem[] = [
+      { content: 'Read <script>alert(1)</script>', status: 'in_progress' },
+    ]
+    const text = renderTodoList(todos, 5)
+    expect(text).not.toContain('<script>')
+    expect(text).toContain('&lt;script&gt;')
+  })
+
+  test('renderTodoList: in_progress prefers activeForm when present', () => {
+    const todos: TodoItem[] = [
+      { content: 'Read file', activeForm: 'Reading file', status: 'in_progress' },
+    ]
+    const text = renderTodoList(todos, 5)
+    expect(text).toContain('Reading file')
+  })
+
+  test('renderTodoList: counts header reports done/in_progress/pending', () => {
+    const todos: TodoItem[] = [
+      { content: 'a', status: 'completed' },
+      { content: 'b', status: 'completed' },
+      { content: 'c', status: 'in_progress' },
+      { content: 'd', status: 'pending' },
+      { content: 'e', status: 'pending' },
+      { content: 'f', status: 'pending' },
+    ]
+    const text = renderTodoList(todos, 5)
+    expect(text).toContain('2 done / 1 in progress / 3 pending')
+  })
+
+  test('renderTodoList: 100 long todos respect the 3500-char budget', () => {
+    const todos: TodoItem[] = []
+    for (let i = 0; i < 100; i++) {
+      todos.push({
+        content: `Task #${i}: ${'x'.repeat(200)}`,
+        status: i < 5 ? 'completed' : 'pending',
+      })
+    }
+    const text = renderTodoList(todos, 5)
+    expect(text.length).toBeLessThanOrEqual(3500)
+    // Must contain at least the header and SOME indication of truncation.
+    expect(text).toContain('milestones')
+    // No malformed HTML — angle brackets balance via our explicit emission
+    // of <b>/<i> only; nothing else should appear.
+    const opens = (text.match(/<(b|i)>/g) ?? []).length
+    const closes = (text.match(/<\/(b|i)>/g) ?? []).length
+    expect(opens).toBe(closes)
+  })
+})

--- a/plugin/tests/status/task-mirror.test.ts
+++ b/plugin/tests/status/task-mirror.test.ts
@@ -265,7 +265,7 @@ describe('TaskMirror', () => {
     expect(edits[0]!.text).toContain('Step C')
   })
 
-  test('session_stop ships final edit and evicts entry; next event starts a fresh thread', async () => {
+  test('session_stop ships final edit with «сессия завершена» marker and evicts entry', async () => {
     const { mirror, clock, api } = makeMirror()
     await mirror.recordEvent('chat-1', todoEvent([
       { content: 'Step A', status: 'in_progress' },
@@ -279,6 +279,11 @@ describe('TaskMirror', () => {
     expect(editsBeforeStop).toBeGreaterThanOrEqual(1)
 
     await mirror.recordEvent('chat-1', STOP)
+    // Final edit contains the «сессия завершена» marker.
+    const editsAfterStop = api.calls.filter((c) => c.kind === 'edit')
+    const finalEdit = editsAfterStop[editsAfterStop.length - 1]
+    expect(finalEdit!.text).toContain('сессия завершена')
+
     // Subsequent event after stop: must send a NEW message (msg_id 201, since
     // 200 was the original send).
     await mirror.recordEvent('chat-1', todoEvent([
@@ -288,6 +293,25 @@ describe('TaskMirror', () => {
     const sends = api.calls.filter((c) => c.kind === 'send')
     expect(sends.length).toBe(2)
     expect(sends[1]!.messageId).toBe(201)
+  })
+
+  test('session_stop on an unchanged snapshot STILL fires a final edit (marker breaks idempotency)', async () => {
+    const { mirror, clock, api } = makeMirror()
+    // One TodoWrite — establishes the message.
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Solo task', status: 'in_progress' },
+    ]))
+    clock.advance(3000)
+    await mirror._idleForTests('chat-1')
+    // No intermediate edits — snapshot has not changed.
+    expect(api.calls.filter((c) => c.kind === 'edit').length).toBe(0)
+
+    // STOP: even though the snapshot is byte-for-byte the same as the initial
+    // send, the marker guarantees the final text differs, so an edit fires.
+    await mirror.recordEvent('chat-1', STOP)
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(edits.length).toBe(1)
+    expect(edits[0]!.text).toContain('сессия завершена')
   })
 
   test('TTL eviction: idle entry past session_ttl_ms starts a fresh thread', async () => {

--- a/plugin/tests/status/task-mirror.test.ts
+++ b/plugin/tests/status/task-mirror.test.ts
@@ -194,7 +194,7 @@ describe('TaskMirror', () => {
     const sends = api.calls.filter((c) => c.kind === 'send')
     expect(sends.length).toBe(1)
     expect(sends[0]!.chatId).toBe('chat-1')
-    expect(sends[0]!.text).toContain('milestones')
+    expect(sends[0]!.text).toContain('Задачи')
     expect(sends[0]!.text).toContain('Implement feature X')
     expect(sends[0]!.text).toContain('Tests')
   })
@@ -394,7 +394,7 @@ describe('TaskMirror', () => {
 
   test('renderTodoList: empty list renders «задач нет»', () => {
     const text = renderTodoList([], 5)
-    expect(text).toContain('milestones')
+    expect(text).toContain('Задачи')
     expect(text).toContain('задач нет')
   })
 
@@ -459,7 +459,7 @@ describe('TaskMirror', () => {
     const text = renderTodoList(todos, 5)
     expect(text.length).toBeLessThanOrEqual(3500)
     // Must contain at least the header and SOME indication of truncation.
-    expect(text).toContain('milestones')
+    expect(text).toContain('Задачи')
     // No malformed HTML — angle brackets balance via our explicit emission
     // of <b>/<i> only; nothing else should appear.
     const opens = (text.match(/<(b|i)>/g) ?? []).length

--- a/plugin/tests/telegram/gate.test.ts
+++ b/plugin/tests/telegram/gate.test.ts
@@ -36,6 +36,17 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       recent_buffer: 10,
       session_ttl_ms: 600000,
     },
+    task_mirror: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      session_ttl_ms: 600000,
+      collapse_completed_after: 5,
+    },
+    watcher: {
+      enabled: true,
+      debounce_ms: 10_000,
+      busy_threshold_ms: 30_000,
+    },
     ...overrides,
   }
 }

--- a/plugin/tests/telegram/handlers.test.ts
+++ b/plugin/tests/telegram/handlers.test.ts
@@ -440,6 +440,90 @@ describe('handleInboundText — InboundWatcher (PR-A3)', () => {
     rmSync(statePaths.root, { recursive: true, force: true })
   })
 
+  test('plain text from NOT allowed sender + busy session → watcher does NOT fire', async () => {
+    // Sender NOT in allowed_user_ids. The watcher must NOT auto-reply
+    // even though the session is «busy», because the warchief explicitly
+    // gated the watcher on the allowlist (Fix #3 — prevents future group-chat
+    // bot activity from leaking to non-allowed senders).
+    const sendCalls: Array<{ chatId: string; text: string }> = []
+    const tg = makeTelegramApi()
+    const api: TelegramApi = {
+      ...tg.api,
+      sendMessage: async (chatId, text) => {
+        sendCalls.push({ chatId, text })
+        return { message_id: 500 }
+      },
+    }
+    const watcher = new InboundWatcher({
+      telegramApi: api,
+      config: makeConfig(),
+      log: silentLog,
+      progressReporter: makeFakeProgress(true, 'Bash'),
+    })
+    const serverSpy = makeServerSpy()
+    const { deps, statePaths } = makeDeps({
+      server: serverSpy.server,
+      telegramApi: api,
+      watcher,
+    })
+    // Sender id NOT in default allowed_user_ids ([164795011]).
+    const ctx = makeCtx({
+      text: 'hi from random user',
+      chatId: 164795011,
+      chatType: 'private',
+      fromId: 99999,
+    })
+
+    await handleInboundText(ctx, deps)
+    // Drain the fire-and-forget watcher microtask.
+    await new Promise((r) => setTimeout(r, 0))
+
+    // Watcher did NOT fire — no auto-reply.
+    expect(sendCalls.length).toBe(0)
+    // The channel notification path is gated independently — gateAndNotify
+    // also drops a non-allowed sender, so serverSpy is empty too.
+    expect(serverSpy.calls.length).toBe(0)
+    rmSync(statePaths.root, { recursive: true, force: true })
+  })
+
+  test('plain text from allowed sender + chat NOT in allowlist + busy → watcher does NOT fire', async () => {
+    const sendCalls: Array<{ chatId: string; text: string }> = []
+    const tg = makeTelegramApi()
+    const api: TelegramApi = {
+      ...tg.api,
+      sendMessage: async (chatId, text) => {
+        sendCalls.push({ chatId, text })
+        return { message_id: 600 }
+      },
+    }
+    const watcher = new InboundWatcher({
+      telegramApi: api,
+      config: makeConfig(),
+      log: silentLog,
+      progressReporter: makeFakeProgress(true, 'Bash'),
+    })
+    const serverSpy = makeServerSpy()
+    const { deps, statePaths } = makeDeps({
+      server: serverSpy.server,
+      telegramApi: api,
+      watcher,
+    })
+    // Sender is allowed but chat id 88888 is NOT.
+    const ctx = makeCtx({
+      text: 'hi from allowed user in wrong chat',
+      chatId: 88888,
+      chatType: 'private',
+      fromId: 164795011,
+    })
+
+    await handleInboundText(ctx, deps)
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(sendCalls.length).toBe(0)
+    expect(serverSpy.calls.length).toBe(0)
+    rmSync(statePaths.root, { recursive: true, force: true })
+  })
+
   test('plain text + NOT busy → watcher no-ops, channel notify still runs', async () => {
     const sendCalls: Array<{ chatId: string; text: string }> = []
     const tg = makeTelegramApi()

--- a/plugin/tests/telegram/handlers.test.ts
+++ b/plugin/tests/telegram/handlers.test.ts
@@ -54,6 +54,17 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       recent_buffer: 10,
       session_ttl_ms: 600000,
     },
+    task_mirror: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      session_ttl_ms: 600000,
+      collapse_completed_after: 5,
+    },
+    watcher: {
+      enabled: true,
+      debounce_ms: 10_000,
+      busy_threshold_ms: 30_000,
+    },
     ...overrides,
   }
 }

--- a/plugin/tests/telegram/handlers.test.ts
+++ b/plugin/tests/telegram/handlers.test.ts
@@ -13,7 +13,13 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import type { Context } from 'grammy'
 
-import { handleInboundText, type HandlerDeps } from '../../src/telegram/handlers.js'
+import {
+  handleInboundText,
+  handleInboundDocument,
+  handleInboundSticker,
+  handleInboundVideoNote,
+  type HandlerDeps,
+} from '../../src/telegram/handlers.js'
 import {
   InboundWatcher,
   type ProgressReporterForWatcher,
@@ -221,6 +227,39 @@ function makeCtx(opts: {
       chat: { id: opts.chatId, type: opts.chatType },
       from: { id: opts.fromId, is_bot: false, first_name: 'x' },
     },
+  } as unknown as Context
+}
+
+// Minimal Context with a media payload — for media handler tests. Mirrors
+// makeCtx but attaches a typed media field instead of `text`.
+function makeMediaCtx(opts: {
+  kind: 'document' | 'sticker' | 'video_note'
+  chatId: number
+  chatType: 'private' | 'group' | 'supergroup'
+  fromId: number
+}): Context {
+  const base = {
+    message_id: 42,
+    date: 1700000000,
+    chat: { id: opts.chatId, type: opts.chatType },
+    from: { id: opts.fromId, is_bot: false, first_name: 'x' },
+  }
+  let payload: Record<string, unknown>
+  switch (opts.kind) {
+    case 'document':
+      payload = { document: { file_id: 'doc-fid', file_name: 'a.txt' } }
+      break
+    case 'sticker':
+      payload = { sticker: { file_id: 'st-fid', emoji: '👍' } }
+      break
+    case 'video_note':
+      payload = { video_note: { file_id: 'vn-fid', duration: 5 } }
+      break
+  }
+  return {
+    chat: base.chat,
+    from: base.from,
+    message: { ...base, ...payload },
   } as unknown as Context
 }
 
@@ -523,6 +562,98 @@ describe('handleInboundText — InboundWatcher (PR-A3)', () => {
     expect(serverSpy.calls.length).toBe(0)
     rmSync(statePaths.root, { recursive: true, force: true })
   })
+
+  test.each([
+    ['document', handleInboundDocument],
+    ['sticker', handleInboundSticker],
+    ['video_note', handleInboundVideoNote],
+  ] as const)(
+    'media %s from allowed sender + busy session → watcher fires',
+    async (kind, handler) => {
+      const sendCalls: Array<{ chatId: string; text: string; replyTo?: number }> = []
+      const tg = makeTelegramApi()
+      const api: TelegramApi = {
+        ...tg.api,
+        sendMessage: async (chatId, text, opts) => {
+          const entry: { chatId: string; text: string; replyTo?: number } = { chatId, text }
+          if (opts.reply_to_message_id !== undefined) entry.replyTo = opts.reply_to_message_id
+          sendCalls.push(entry)
+          return { message_id: 700 }
+        },
+      }
+      const watcher = new InboundWatcher({
+        telegramApi: api,
+        config: makeConfig(),
+        log: silentLog,
+        progressReporter: makeFakeProgress(true, 'Bash'),
+      })
+      const serverSpy = makeServerSpy()
+      const { deps, statePaths } = makeDeps({
+        server: serverSpy.server,
+        telegramApi: api,
+        watcher,
+      })
+      const ctx = makeMediaCtx({
+        kind,
+        chatId: 164795011,
+        chatType: 'private',
+        fromId: 164795011,
+      })
+
+      await handler(ctx, deps)
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(sendCalls.length).toBe(1)
+      expect(sendCalls[0]!.replyTo).toBe(42)
+      expect(sendCalls[0]!.text).toContain('Bash')
+      // Channel notification also fired — the watcher does not replace it.
+      expect(serverSpy.calls.length).toBe(1)
+      rmSync(statePaths.root, { recursive: true, force: true })
+    },
+  )
+
+  test.each([
+    ['document', handleInboundDocument],
+    ['sticker', handleInboundSticker],
+  ] as const)(
+    'media %s from NOT allowed sender + busy → watcher does NOT fire',
+    async (kind, handler) => {
+      const sendCalls: Array<{ chatId: string; text: string }> = []
+      const tg = makeTelegramApi()
+      const api: TelegramApi = {
+        ...tg.api,
+        sendMessage: async (chatId, text) => {
+          sendCalls.push({ chatId, text })
+          return { message_id: 800 }
+        },
+      }
+      const watcher = new InboundWatcher({
+        telegramApi: api,
+        config: makeConfig(),
+        log: silentLog,
+        progressReporter: makeFakeProgress(true, 'Bash'),
+      })
+      const serverSpy = makeServerSpy()
+      const { deps, statePaths } = makeDeps({
+        server: serverSpy.server,
+        telegramApi: api,
+        watcher,
+      })
+      const ctx = makeMediaCtx({
+        kind,
+        chatId: 164795011,
+        chatType: 'private',
+        fromId: 99999, // NOT in allowlist
+      })
+
+      await handler(ctx, deps)
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(sendCalls.length).toBe(0)
+      expect(serverSpy.calls.length).toBe(0)
+      rmSync(statePaths.root, { recursive: true, force: true })
+    },
+  )
 
   test('plain text + NOT busy → watcher no-ops, channel notify still runs', async () => {
     const sendCalls: Array<{ chatId: string; text: string }> = []

--- a/plugin/tests/telegram/handlers.test.ts
+++ b/plugin/tests/telegram/handlers.test.ts
@@ -14,6 +14,10 @@ import { join } from 'path'
 import type { Context } from 'grammy'
 
 import { handleInboundText, type HandlerDeps } from '../../src/telegram/handlers.js'
+import {
+  InboundWatcher,
+  type ProgressReporterForWatcher,
+} from '../../src/telegram/watcher.js'
 import type { AppConfig, StatePaths } from '../../src/config.js'
 import { createLogger } from '../../src/log.js'
 import type {
@@ -165,6 +169,7 @@ function makeDeps(
     permissionHooks?: PermissionRelayHooks
     telegramApi?: TelegramApi
     server?: ServerSpy['server']
+    watcher?: InboundWatcher
   } = {},
 ): { deps: HandlerDeps; statePaths: StatePaths } {
   const config = overrides.config ?? makeConfig()
@@ -183,8 +188,19 @@ function makeDeps(
     botToken: 'fake-token',
     env: {},
     ...(overrides.permissionHooks ? { permissionHooks: overrides.permissionHooks } : {}),
+    ...(overrides.watcher ? { watcher: overrides.watcher } : {}),
   }
   return { deps, statePaths }
+}
+
+// Build a fake ProgressReporter view for watcher tests. The watcher only
+// reads two methods; this stub is enough to exercise the busy / not-busy
+// branches end-to-end.
+function makeFakeProgress(busy: boolean, toolName?: string): ProgressReporterForWatcher {
+  return {
+    isBusy: () => busy,
+    getActiveToolName: () => toolName,
+  }
 }
 
 // Build a minimal grammY Context. Handlers read chat, from, message; we
@@ -329,6 +345,136 @@ describe('handleInboundText — OOB allowed_chat_ids gate (Fix 6)', () => {
 
     // OOB handled inline — no channel notify for /help.
     expect(serverSpy.calls.length).toBe(0)
+    rmSync(statePaths.root, { recursive: true, force: true })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// PR-A3 — InboundWatcher integration
+// ─────────────────────────────────────────────────────────────────────
+
+describe('handleInboundText — InboundWatcher (PR-A3)', () => {
+  test('plain text + busy session → watcher.maybeAutoReply fires and channel notify still runs', async () => {
+    const sendCalls: Array<{ chatId: string; text: string; replyTo?: number }> = []
+    const tg = makeTelegramApi()
+    const api: TelegramApi = {
+      ...tg.api,
+      sendMessage: async (chatId, text, opts) => {
+        const entry: { chatId: string; text: string; replyTo?: number } = { chatId, text }
+        if (opts.reply_to_message_id !== undefined) entry.replyTo = opts.reply_to_message_id
+        sendCalls.push(entry)
+        return { message_id: 999 }
+      },
+    }
+    const watcher = new InboundWatcher({
+      telegramApi: api,
+      config: makeConfig(),
+      log: silentLog,
+      progressReporter: makeFakeProgress(true, 'Bash'),
+    })
+    const serverSpy = makeServerSpy()
+    const { deps, statePaths } = makeDeps({
+      server: serverSpy.server,
+      telegramApi: api,
+      watcher,
+    })
+    const ctx = makeCtx({
+      text: 'hi there',
+      chatId: 164795011,
+      chatType: 'private',
+      fromId: 164795011,
+    })
+
+    await handleInboundText(ctx, deps)
+    // Drain the fire-and-forget watcher microtask.
+    await new Promise((r) => setTimeout(r, 0))
+
+    // Auto-reply went out via the safe api.
+    expect(sendCalls.length).toBe(1)
+    expect(sendCalls[0]!.replyTo).toBe(42)
+    expect(sendCalls[0]!.text).toContain('Bash')
+    // Channel notification ALSO fired — auto-reply does not replace it.
+    expect(serverSpy.calls.length).toBe(1)
+    rmSync(statePaths.root, { recursive: true, force: true })
+  })
+
+  test('OOB command (/help) bypasses watcher — no auto-reply even when busy', async () => {
+    const sendCalls: Array<{ chatId: string; text: string }> = []
+    const tg = makeTelegramApi()
+    const api: TelegramApi = {
+      ...tg.api,
+      sendMessage: async (chatId, text) => {
+        sendCalls.push({ chatId, text })
+        return { message_id: 100 }
+      },
+    }
+    const watcher = new InboundWatcher({
+      telegramApi: api,
+      config: makeConfig(),
+      log: silentLog,
+      progressReporter: makeFakeProgress(true, 'Bash'),
+    })
+    const serverSpy = makeServerSpy()
+    const { deps, statePaths } = makeDeps({
+      server: serverSpy.server,
+      telegramApi: api,
+      watcher,
+    })
+    const ctx = makeCtx({
+      text: '/help',
+      chatId: 164795011,
+      chatType: 'private',
+      fromId: 164795011,
+    })
+
+    await handleInboundText(ctx, deps)
+    await new Promise((r) => setTimeout(r, 0))
+
+    // /help replies via sendMessage but the auto-reply «🔧 Тралл занят» must
+    // NOT appear — OOB short-circuits before the watcher hook. The single
+    // sendMessage we see is the /help body itself.
+    expect(sendCalls.length).toBe(1)
+    expect(sendCalls[0]!.text).not.toContain('Тралл занят')
+    // OOB handled inline — no channel notify.
+    expect(serverSpy.calls.length).toBe(0)
+    rmSync(statePaths.root, { recursive: true, force: true })
+  })
+
+  test('plain text + NOT busy → watcher no-ops, channel notify still runs', async () => {
+    const sendCalls: Array<{ chatId: string; text: string }> = []
+    const tg = makeTelegramApi()
+    const api: TelegramApi = {
+      ...tg.api,
+      sendMessage: async (chatId, text) => {
+        sendCalls.push({ chatId, text })
+        return { message_id: 200 }
+      },
+    }
+    const watcher = new InboundWatcher({
+      telegramApi: api,
+      config: makeConfig(),
+      log: silentLog,
+      progressReporter: makeFakeProgress(false),
+    })
+    const serverSpy = makeServerSpy()
+    const { deps, statePaths } = makeDeps({
+      server: serverSpy.server,
+      telegramApi: api,
+      watcher,
+    })
+    const ctx = makeCtx({
+      text: 'hello',
+      chatId: 164795011,
+      chatType: 'private',
+      fromId: 164795011,
+    })
+
+    await handleInboundText(ctx, deps)
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(sendCalls.length).toBe(0)
+    // Channel notification still fired.
+    expect(serverSpy.calls.length).toBe(1)
     rmSync(statePaths.root, { recursive: true, force: true })
   })
 })

--- a/plugin/tests/telegram/watcher.test.ts
+++ b/plugin/tests/telegram/watcher.test.ts
@@ -212,7 +212,7 @@ describe('InboundWatcher', () => {
     expect(api.calls.length).toBe(0)
   })
 
-  test('send failure → { replied: false, reason: "send-failed" }, lastReplyMs not updated', async () => {
+  test('send failure → { replied: false, reason: "send-failed" }, lastReplyMs rolls back', async () => {
     const api = makeFakeApi()
     api.failSendWith = new Error('telegram down')
     const { watcher, clock } = makeWatcher({
@@ -223,11 +223,100 @@ describe('InboundWatcher', () => {
     expect(res).toEqual({ replied: false, reason: 'send-failed' })
 
     // Recovery: next call within debounce window must STILL retry, because
-    // the failed call did not update lastReplyMs.
+    // the failed call rolled the marker back to its previous value
+    // (`undefined`, since this was the very first attempt for the chat).
     delete api.failSendWith
     clock.advance(100)
     const second = await watcher.maybeAutoReply({ chatId: '111', messageId: 43, text: 'retry' })
     expect(second).toEqual({ replied: true })
+  })
+
+  test('send failure after a successful send rolls back to the previous timestamp', async () => {
+    const api = makeFakeApi()
+    const { watcher, clock } = makeWatcher({
+      api,
+      progress: makeFakeProgress({ busy: true, toolName: 'Bash' }),
+    })
+    // First call succeeds — establishes lastReplyMs.
+    const first = await watcher.maybeAutoReply({ chatId: '111', messageId: 1, text: 'a' })
+    expect(first).toEqual({ replied: true })
+    // Advance past the debounce window so the next call would otherwise pass.
+    clock.advance(15_000)
+    // Second call fails — marker must NOT advance to the failed-call time,
+    // it must stay at the timestamp of the prior successful send.
+    api.failSendWith = new Error('telegram down')
+    const second = await watcher.maybeAutoReply({ chatId: '111', messageId: 2, text: 'b' })
+    expect(second).toEqual({ replied: false, reason: 'send-failed' })
+    // Recovery: a third call right after the failure should succeed (the
+    // previous successful send is now ~15s old, past the 10s debounce).
+    delete api.failSendWith
+    const third = await watcher.maybeAutoReply({ chatId: '111', messageId: 3, text: 'c' })
+    expect(third).toEqual({ replied: true })
+    // Sanity: api recorded two successful sends.
+    expect(api.calls.length).toBe(2)
+  })
+
+  test('concurrent calls collapse to exactly one sendMessage (debounce race)', async () => {
+    // Critical race regression test: two messages arriving in the same
+    // event-loop turn must NOT both trigger sendMessage. The marker is set
+    // before the await — the second invocation observes it and short-circuits.
+    let resolveSend: (() => void) | undefined
+    const api: FakeApi = makeFakeApi()
+    // Replace sendMessage with a version that parks on the first call so we
+    // can stage a true concurrent invocation. The second invocation must
+    // observe the marker BEFORE the parked send resolves.
+    api.api = {
+      ...api.api,
+      sendMessage: async (chatId: string, text: string, opts) => {
+        await new Promise<void>((resolve) => {
+          resolveSend = resolve
+        })
+        const entry: ApiCall = { chatId, text }
+        if (opts.parse_mode !== undefined) entry.parse_mode = opts.parse_mode
+        if (opts.reply_to_message_id !== undefined) {
+          entry.reply_to_message_id = opts.reply_to_message_id
+        }
+        api.calls.push(entry)
+        return { message_id: 999 }
+      },
+    } as TelegramApi
+    const { watcher } = makeWatcher({
+      api,
+      progress: makeFakeProgress({ busy: true, toolName: 'Bash' }),
+    })
+
+    const [r1, r2] = await Promise.all([
+      // Kick the parked send.
+      watcher
+        .maybeAutoReply({ chatId: 'X', messageId: 1, text: 'a' })
+        .finally(() => undefined),
+      // Stage the second call in the same tick. Microtask ordering: r2
+      // schedules synchronously before the parked send resolves.
+      (async () => {
+        const res = await watcher.maybeAutoReply({ chatId: 'X', messageId: 2, text: 'b' })
+        // Release the parked send only after the second result is observed,
+        // proving the second call short-circuited without waiting on Telegram.
+        resolveSend?.()
+        return res
+      })(),
+    ])
+    expect(r2).toEqual({ replied: false, reason: 'debounced' })
+    expect(r1).toEqual({ replied: true })
+    expect(api.calls.length).toBe(1)
+  })
+
+  test('clearDebounce resets the marker so a debounced chat can reply again', async () => {
+    const { watcher, api, clock } = makeWatcher({
+      progress: makeFakeProgress({ busy: true, toolName: 'Bash' }),
+    })
+    const first = await watcher.maybeAutoReply({ chatId: '111', messageId: 1, text: 'a' })
+    expect(first).toEqual({ replied: true })
+    // Within debounce window → would normally be blocked.
+    clock.advance(100)
+    watcher.clearDebounce('111')
+    const second = await watcher.maybeAutoReply({ chatId: '111', messageId: 2, text: 'b' })
+    expect(second).toEqual({ replied: true })
+    expect(api.calls.length).toBe(2)
   })
 
   test('HTML special chars in tool name are escaped', async () => {

--- a/plugin/tests/telegram/watcher.test.ts
+++ b/plugin/tests/telegram/watcher.test.ts
@@ -160,7 +160,7 @@ describe('InboundWatcher', () => {
     const { watcher, api } = makeWatcher({
       progress: makeFakeProgress({ busy: false }),
     })
-    const res = await watcher.maybeAutoReply({ chatId: '111', messageId: 42, text: 'hi' })
+    const res = await watcher.maybeAutoReply({ chatId: '111', messageId: 42 })
     expect(res).toEqual({ replied: false, reason: 'not-busy' })
     expect(api.calls.length).toBe(0)
   })
@@ -169,7 +169,7 @@ describe('InboundWatcher', () => {
     const { watcher, api } = makeWatcher({
       progress: makeFakeProgress({ busy: true, toolName: 'Bash' }),
     })
-    const res = await watcher.maybeAutoReply({ chatId: '111', messageId: 42, text: 'hi' })
+    const res = await watcher.maybeAutoReply({ chatId: '111', messageId: 42 })
     expect(res).toEqual({ replied: true })
     expect(api.calls.length).toBe(1)
     expect(api.calls[0]!.chatId).toBe('111')
@@ -182,11 +182,11 @@ describe('InboundWatcher', () => {
     const { watcher, api, clock } = makeWatcher({
       progress: makeFakeProgress({ busy: true, toolName: 'Bash' }),
     })
-    const first = await watcher.maybeAutoReply({ chatId: '111', messageId: 42, text: 'hi' })
+    const first = await watcher.maybeAutoReply({ chatId: '111', messageId: 42 })
     expect(first).toEqual({ replied: true })
 
     clock.advance(5000) // < 10_000 debounce
-    const second = await watcher.maybeAutoReply({ chatId: '111', messageId: 43, text: 'hello again' })
+    const second = await watcher.maybeAutoReply({ chatId: '111', messageId: 43 })
     expect(second).toEqual({ replied: false, reason: 'debounced' })
     expect(api.calls.length).toBe(1)
   })
@@ -195,9 +195,9 @@ describe('InboundWatcher', () => {
     const { watcher, api, clock } = makeWatcher({
       progress: makeFakeProgress({ busy: true, toolName: 'Read' }),
     })
-    await watcher.maybeAutoReply({ chatId: '111', messageId: 42, text: 'hi' })
+    await watcher.maybeAutoReply({ chatId: '111', messageId: 42 })
     clock.advance(10_001)
-    const res = await watcher.maybeAutoReply({ chatId: '111', messageId: 43, text: 'still there?' })
+    const res = await watcher.maybeAutoReply({ chatId: '111', messageId: 43 })
     expect(res).toEqual({ replied: true })
     expect(api.calls.length).toBe(2)
   })
@@ -207,7 +207,7 @@ describe('InboundWatcher', () => {
       config: makeConfig({ enabled: false }),
       progress: makeFakeProgress({ busy: true, toolName: 'Bash' }),
     })
-    const res = await watcher.maybeAutoReply({ chatId: '111', messageId: 42, text: 'hi' })
+    const res = await watcher.maybeAutoReply({ chatId: '111', messageId: 42 })
     expect(res).toEqual({ replied: false, reason: 'disabled' })
     expect(api.calls.length).toBe(0)
   })
@@ -219,7 +219,7 @@ describe('InboundWatcher', () => {
       api,
       progress: makeFakeProgress({ busy: true, toolName: 'Bash' }),
     })
-    const res = await watcher.maybeAutoReply({ chatId: '111', messageId: 42, text: 'hi' })
+    const res = await watcher.maybeAutoReply({ chatId: '111', messageId: 42 })
     expect(res).toEqual({ replied: false, reason: 'send-failed' })
 
     // Recovery: next call within debounce window must STILL retry, because
@@ -227,7 +227,7 @@ describe('InboundWatcher', () => {
     // (`undefined`, since this was the very first attempt for the chat).
     delete api.failSendWith
     clock.advance(100)
-    const second = await watcher.maybeAutoReply({ chatId: '111', messageId: 43, text: 'retry' })
+    const second = await watcher.maybeAutoReply({ chatId: '111', messageId: 43 })
     expect(second).toEqual({ replied: true })
   })
 
@@ -238,19 +238,19 @@ describe('InboundWatcher', () => {
       progress: makeFakeProgress({ busy: true, toolName: 'Bash' }),
     })
     // First call succeeds — establishes lastReplyMs.
-    const first = await watcher.maybeAutoReply({ chatId: '111', messageId: 1, text: 'a' })
+    const first = await watcher.maybeAutoReply({ chatId: '111', messageId: 1 })
     expect(first).toEqual({ replied: true })
     // Advance past the debounce window so the next call would otherwise pass.
     clock.advance(15_000)
     // Second call fails — marker must NOT advance to the failed-call time,
     // it must stay at the timestamp of the prior successful send.
     api.failSendWith = new Error('telegram down')
-    const second = await watcher.maybeAutoReply({ chatId: '111', messageId: 2, text: 'b' })
+    const second = await watcher.maybeAutoReply({ chatId: '111', messageId: 2 })
     expect(second).toEqual({ replied: false, reason: 'send-failed' })
     // Recovery: a third call right after the failure should succeed (the
     // previous successful send is now ~15s old, past the 10s debounce).
     delete api.failSendWith
-    const third = await watcher.maybeAutoReply({ chatId: '111', messageId: 3, text: 'c' })
+    const third = await watcher.maybeAutoReply({ chatId: '111', messageId: 3 })
     expect(third).toEqual({ replied: true })
     // Sanity: api recorded two successful sends.
     expect(api.calls.length).toBe(2)
@@ -288,12 +288,12 @@ describe('InboundWatcher', () => {
     const [r1, r2] = await Promise.all([
       // Kick the parked send.
       watcher
-        .maybeAutoReply({ chatId: 'X', messageId: 1, text: 'a' })
+        .maybeAutoReply({ chatId: 'X', messageId: 1 })
         .finally(() => undefined),
       // Stage the second call in the same tick. Microtask ordering: r2
       // schedules synchronously before the parked send resolves.
       (async () => {
-        const res = await watcher.maybeAutoReply({ chatId: 'X', messageId: 2, text: 'b' })
+        const res = await watcher.maybeAutoReply({ chatId: 'X', messageId: 2 })
         // Release the parked send only after the second result is observed,
         // proving the second call short-circuited without waiting on Telegram.
         resolveSend?.()
@@ -309,12 +309,12 @@ describe('InboundWatcher', () => {
     const { watcher, api, clock } = makeWatcher({
       progress: makeFakeProgress({ busy: true, toolName: 'Bash' }),
     })
-    const first = await watcher.maybeAutoReply({ chatId: '111', messageId: 1, text: 'a' })
+    const first = await watcher.maybeAutoReply({ chatId: '111', messageId: 1 })
     expect(first).toEqual({ replied: true })
     // Within debounce window → would normally be blocked.
     clock.advance(100)
     watcher.clearDebounce('111')
-    const second = await watcher.maybeAutoReply({ chatId: '111', messageId: 2, text: 'b' })
+    const second = await watcher.maybeAutoReply({ chatId: '111', messageId: 2 })
     expect(second).toEqual({ replied: true })
     expect(api.calls.length).toBe(2)
   })
@@ -323,7 +323,7 @@ describe('InboundWatcher', () => {
     const { watcher, api } = makeWatcher({
       progress: makeFakeProgress({ busy: true, toolName: '<Bash>&"evil"' }),
     })
-    await watcher.maybeAutoReply({ chatId: '111', messageId: 42, text: 'hi' })
+    await watcher.maybeAutoReply({ chatId: '111', messageId: 42 })
     expect(api.calls[0]!.text).not.toContain('<Bash>')
     expect(api.calls[0]!.text).toContain('&lt;Bash&gt;')
     expect(api.calls[0]!.text).toContain('&amp;')
@@ -334,8 +334,8 @@ describe('InboundWatcher', () => {
     const { watcher, api } = makeWatcher({
       progress: makeFakeProgress({ busy: true, toolName: 'Bash' }),
     })
-    const a = await watcher.maybeAutoReply({ chatId: 'A', messageId: 42, text: 'hi' })
-    const b = await watcher.maybeAutoReply({ chatId: 'B', messageId: 99, text: 'hello' })
+    const a = await watcher.maybeAutoReply({ chatId: 'A', messageId: 42 })
+    const b = await watcher.maybeAutoReply({ chatId: 'B', messageId: 99 })
     expect(a).toEqual({ replied: true })
     expect(b).toEqual({ replied: true })
     expect(api.calls.length).toBe(2)

--- a/plugin/tests/telegram/watcher.test.ts
+++ b/plugin/tests/telegram/watcher.test.ts
@@ -1,0 +1,263 @@
+// InboundWatcher tests (PR-A3 / 2026-05-20) — auto-reply when busy.
+// Patterned on the FakeApi style used in progress-reporter.test.ts.
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  InboundWatcher,
+  composeAutoReply,
+  type ProgressReporterForWatcher,
+} from '../../src/telegram/watcher.js'
+import type { TelegramApi } from '../../src/channel/tools.js'
+import type { AppConfig } from '../../src/config.js'
+import { createLogger } from '../../src/log.js'
+
+const silentLog = createLogger('test', {
+  stream: { write: () => true } as unknown as NodeJS.WritableStream,
+})
+
+function makeConfig(overrides: Partial<AppConfig['watcher']> = {}): AppConfig {
+  return {
+    bot_id: 8507713167,
+    dm_only: true,
+    allowed_user_ids: [164795011],
+    allowed_chat_ids: [164795011],
+    status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true },
+    album: { flush_ms: 2000 },
+    voice: { provider: 'groq', language: 'ru', model: 'whisper-large-v3-turbo' },
+    webhook: { enabled: false, host: '127.0.0.1', port: 0 },
+    permission_relay: { enabled: true, allowed_user_ids: [164795011], bash_only_proof: true },
+    commands: { help: true, status: true, stop: true, reset: true, new: true },
+    memory: {
+      enabled: false,
+      source_tag: 'tg',
+      max_hot_bytes: 20480,
+      trim_keep_lines: 600,
+      buffer_ttl_ms: 5 * 60 * 1000,
+      buffer_max_entries: 100,
+    },
+    progress: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      recent_buffer: 10,
+      session_ttl_ms: 10 * 60 * 1000,
+    },
+    task_mirror: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      session_ttl_ms: 10 * 60 * 1000,
+      collapse_completed_after: 5,
+    },
+    watcher: {
+      enabled: true,
+      debounce_ms: 10_000,
+      busy_threshold_ms: 30_000,
+      ...overrides,
+    },
+  }
+}
+
+interface ApiCall {
+  chatId: string
+  text: string
+  parse_mode?: string
+  reply_to_message_id?: number
+}
+
+interface FakeApi {
+  api: TelegramApi
+  calls: ApiCall[]
+  failSendWith?: Error
+}
+
+function makeFakeApi(): FakeApi {
+  const state: FakeApi = {
+    calls: [],
+    api: undefined as unknown as TelegramApi,
+  }
+  const noop = async (): Promise<never> => {
+    throw new Error('unexpected api call in watcher test')
+  }
+  state.api = {
+    sendMessage: async (chatId, text, opts) => {
+      if (state.failSendWith) throw state.failSendWith
+      const entry: ApiCall = { chatId, text }
+      if (opts.parse_mode !== undefined) entry.parse_mode = opts.parse_mode
+      if (opts.reply_to_message_id !== undefined) {
+        entry.reply_to_message_id = opts.reply_to_message_id
+      }
+      state.calls.push(entry)
+      return { message_id: 999 }
+    },
+    editMessageText: noop as unknown as TelegramApi['editMessageText'],
+    setMessageReaction: noop as unknown as TelegramApi['setMessageReaction'],
+    sendChatAction: noop as unknown as TelegramApi['sendChatAction'],
+    sendDocument: noop as unknown as TelegramApi['sendDocument'],
+    sendPhoto: noop as unknown as TelegramApi['sendPhoto'],
+    downloadFile: noop as unknown as TelegramApi['downloadFile'],
+    deleteMessage: noop as unknown as TelegramApi['deleteMessage'],
+  }
+  return state
+}
+
+interface FakeProgress {
+  busy: boolean
+  toolName: string | undefined
+  reporter: ProgressReporterForWatcher
+}
+
+function makeFakeProgress(opts: { busy?: boolean; toolName?: string } = {}): FakeProgress {
+  const state: FakeProgress = {
+    busy: opts.busy ?? false,
+    toolName: opts.toolName,
+    reporter: undefined as unknown as ProgressReporterForWatcher,
+  }
+  state.reporter = {
+    isBusy: () => state.busy,
+    getActiveToolName: () => state.toolName,
+  }
+  return state
+}
+
+function makeClock(initial = 1_000_000): { now: () => number; advance: (ms: number) => void } {
+  let cur = initial
+  return {
+    now: () => cur,
+    advance: (ms: number) => {
+      cur += ms
+    },
+  }
+}
+
+function makeWatcher(opts: {
+  config?: AppConfig
+  api?: FakeApi
+  progress?: FakeProgress
+  clock?: { now: () => number; advance: (ms: number) => void }
+} = {}): {
+  watcher: InboundWatcher
+  config: AppConfig
+  api: FakeApi
+  progress: FakeProgress
+  clock: { now: () => number; advance: (ms: number) => void }
+} {
+  const config = opts.config ?? makeConfig()
+  const api = opts.api ?? makeFakeApi()
+  const progress = opts.progress ?? makeFakeProgress()
+  const clock = opts.clock ?? makeClock()
+  const watcher = new InboundWatcher({
+    telegramApi: api.api,
+    config,
+    log: silentLog,
+    progressReporter: progress.reporter,
+    now: clock.now,
+  })
+  return { watcher, config, api, progress, clock }
+}
+
+describe('InboundWatcher', () => {
+  test('not busy → { replied: false, reason: "not-busy" }, no sendMessage', async () => {
+    const { watcher, api } = makeWatcher({
+      progress: makeFakeProgress({ busy: false }),
+    })
+    const res = await watcher.maybeAutoReply({ chatId: '111', messageId: 42, text: 'hi' })
+    expect(res).toEqual({ replied: false, reason: 'not-busy' })
+    expect(api.calls.length).toBe(0)
+  })
+
+  test('busy + first call → replied: true with reply_to_message_id', async () => {
+    const { watcher, api } = makeWatcher({
+      progress: makeFakeProgress({ busy: true, toolName: 'Bash' }),
+    })
+    const res = await watcher.maybeAutoReply({ chatId: '111', messageId: 42, text: 'hi' })
+    expect(res).toEqual({ replied: true })
+    expect(api.calls.length).toBe(1)
+    expect(api.calls[0]!.chatId).toBe('111')
+    expect(api.calls[0]!.reply_to_message_id).toBe(42)
+    expect(api.calls[0]!.parse_mode).toBe('HTML')
+    expect(api.calls[0]!.text).toContain('Bash')
+  })
+
+  test('busy + second call within debounce → debounced, no second sendMessage', async () => {
+    const { watcher, api, clock } = makeWatcher({
+      progress: makeFakeProgress({ busy: true, toolName: 'Bash' }),
+    })
+    const first = await watcher.maybeAutoReply({ chatId: '111', messageId: 42, text: 'hi' })
+    expect(first).toEqual({ replied: true })
+
+    clock.advance(5000) // < 10_000 debounce
+    const second = await watcher.maybeAutoReply({ chatId: '111', messageId: 43, text: 'hello again' })
+    expect(second).toEqual({ replied: false, reason: 'debounced' })
+    expect(api.calls.length).toBe(1)
+  })
+
+  test('busy + after debounce window → replied: true again', async () => {
+    const { watcher, api, clock } = makeWatcher({
+      progress: makeFakeProgress({ busy: true, toolName: 'Read' }),
+    })
+    await watcher.maybeAutoReply({ chatId: '111', messageId: 42, text: 'hi' })
+    clock.advance(10_001)
+    const res = await watcher.maybeAutoReply({ chatId: '111', messageId: 43, text: 'still there?' })
+    expect(res).toEqual({ replied: true })
+    expect(api.calls.length).toBe(2)
+  })
+
+  test('disabled config → { replied: false, reason: "disabled" } even when busy', async () => {
+    const { watcher, api } = makeWatcher({
+      config: makeConfig({ enabled: false }),
+      progress: makeFakeProgress({ busy: true, toolName: 'Bash' }),
+    })
+    const res = await watcher.maybeAutoReply({ chatId: '111', messageId: 42, text: 'hi' })
+    expect(res).toEqual({ replied: false, reason: 'disabled' })
+    expect(api.calls.length).toBe(0)
+  })
+
+  test('send failure → { replied: false, reason: "send-failed" }, lastReplyMs not updated', async () => {
+    const api = makeFakeApi()
+    api.failSendWith = new Error('telegram down')
+    const { watcher, clock } = makeWatcher({
+      api,
+      progress: makeFakeProgress({ busy: true, toolName: 'Bash' }),
+    })
+    const res = await watcher.maybeAutoReply({ chatId: '111', messageId: 42, text: 'hi' })
+    expect(res).toEqual({ replied: false, reason: 'send-failed' })
+
+    // Recovery: next call within debounce window must STILL retry, because
+    // the failed call did not update lastReplyMs.
+    delete api.failSendWith
+    clock.advance(100)
+    const second = await watcher.maybeAutoReply({ chatId: '111', messageId: 43, text: 'retry' })
+    expect(second).toEqual({ replied: true })
+  })
+
+  test('HTML special chars in tool name are escaped', async () => {
+    const { watcher, api } = makeWatcher({
+      progress: makeFakeProgress({ busy: true, toolName: '<Bash>&"evil"' }),
+    })
+    await watcher.maybeAutoReply({ chatId: '111', messageId: 42, text: 'hi' })
+    expect(api.calls[0]!.text).not.toContain('<Bash>')
+    expect(api.calls[0]!.text).toContain('&lt;Bash&gt;')
+    expect(api.calls[0]!.text).toContain('&amp;')
+    expect(api.calls[0]!.text).toContain('&quot;evil&quot;')
+  })
+
+  test('multi-chat isolation: debounce on chat A does not block chat B', async () => {
+    const { watcher, api } = makeWatcher({
+      progress: makeFakeProgress({ busy: true, toolName: 'Bash' }),
+    })
+    const a = await watcher.maybeAutoReply({ chatId: 'A', messageId: 42, text: 'hi' })
+    const b = await watcher.maybeAutoReply({ chatId: 'B', messageId: 99, text: 'hello' })
+    expect(a).toEqual({ replied: true })
+    expect(b).toEqual({ replied: true })
+    expect(api.calls.length).toBe(2)
+  })
+
+  test('composeAutoReply: undefined tool name renders «…» placeholder', () => {
+    const text = composeAutoReply(undefined)
+    expect(text).toContain('<code>…</code>')
+  })
+
+  test('composeAutoReply: known tool name appears wrapped in <code>', () => {
+    expect(composeAutoReply('Read')).toContain('<code>Read</code>')
+  })
+})


### PR DESCRIPTION
## Summary

Two bundled features on top of PR-A1 «Safety boundary» (#8):

**TaskMirror (PR-A2)** — separate per-chat rolling Telegram message showing TodoWrite milestones. Status icons (◐ in_progress, ◻ pending, ☑ completed). Last 5 completed shown, older as «+N выполнено ранее» counter. Header: «Задачи». Final-edit «сессия завершена» marker on session_stop. Same throttle/TTL/idempotency machinery as ProgressReporter.

**InboundWatcher (PR-A3)** — when warchief writes to Telegram while session is busy, plugin auto-replies «🔧 Тралл занят, активный инструмент: `X`. Жди или /stop.» without waking Claude. Quote-reply via `reply_to_message_id`. Debounce 10s per chat. Hooked into text + photo + voice + document + video + audio + sticker + video_note handlers. OOB priority preserved. Channel notification to Claude still emitted regardless — watcher does NOT swallow.

**All three rolling messages per chat coexist** (StatusManager bubble, ProgressReporter activity, TaskMirror todos) — independent state, distinct messageIds.

**Approved warchief defaults:** `task_mirror.enabled=true`, `watcher.enabled=true`, `debounce_ms=10000`, `collapse_completed_after=5`, `busy_threshold_ms=30000`.

## Phase 4 review fixes (after first dual-review pass)

Codex GPT-5.5 + Opus 4.7 reviewed — both REQUEST_CHANGES. Consensus must-fixes applied:

- **H1 (Opus): debounce race** — `lastReplyMs.set()` now runs BEFORE `await sendMessage` with rollback on failure. Two concurrent calls now collapse to exactly one `sendMessage`.
- **H2 (Opus): coupling** — `ProgressReporter.isBusy` now requires explicit `thresholdMs` arg. Watcher passes `config.watcher.busy_threshold_ms` directly. ProgressReporter no longer imports watcher config.
- **M2 (Opus): allowlist gate** — watcher only fires for senders/chats in the existing allowlist. Mirrors the OOB gate. Prevents info-leak in future group-chat use.
- **H2 (Codex): media handlers** — watcher extended to photo / voice / document / video / audio / sticker / video_note handlers via shared `maybeTriggerWatcher` helper.
- **M3 (Codex): clearDebounce on session_stop** — new public method called from webhook on Stop event.
- **M1 (Opus): final-edit marker** — TaskMirror appends «сессия завершена» on session_stop so the edit always differs from prior render.
- **M4 (Opus): header text** — «milestones» → «Задачи» (RU consistency).
- **H1 (Codex): doc** — `getActiveToolName` now documents «last seen tool» semantics (busy threshold covers the gap).
- **L1 (Opus): dead field** — `text` removed from `AutoReplyInput`.
- **L2 (Opus): cross-import** — `TelegramApiForProgress` extracted to `src/status/telegram-api.ts`, imported by both modules.

## Test plan

- [x] `bun test` → 550 pass / 16 pre-existing fail (same 16 baseline failures from `tests/state/`, `tests/telegram/poller.test.ts`, `tests/webhook/server.test.ts`; verified by `git stash && bun test && git stash pop`)
- [x] `bun run typecheck` → 39 pre-existing errors, zero new
- [x] `grep -rn "bot.api.sendMessage\|bot.api.editMessageText" src/` → only `src/channel/tools.ts` (the safe API factory). Zero bypass paths.
- [x] Plan reference: `docs/PLAN-A2-A3.md` (591 lines, Codex GPT-5.5)
- [ ] Manual smoke after warchief restarts session: TodoWrite from Claude → milestones message appears; inbound while in Bash → auto-reply once, second within 10s debounced; `/help` while busy → no auto-reply (OOB priority).

## Commit history

18 atomic commits (1 plan + 7 implementation + 10 fix-loop). Each commit passes `bun test` + `bun run typecheck` with no new failures.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>