### PR TITLE
feat: smoke-test-progress.sh + setup-doc для rolling activity

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -84,6 +84,17 @@ Local pre-flight (детерминистично, без сети):
 
 Live smoke против `@testmyfirsttmuxbot` (15-row matrix, operator-driven): см. [`docs/canary-smoke.md`](docs/canary-smoke.md). Покрывает text, HTML chunking, reply anti-spoof, photo/document/voice/album, OOB (`/status`, `/help`, `/stop`, `/reset`), permission relay (allow/deny), webhook путь. Включает rollback procedure на Python canary.
 
+End-to-end Progress Reporter (после установки хуков):
+
+```bash
+TELEGRAM_HOOK_CHAT_ID=<chat_id> \
+TELEGRAM_WEBHOOK_URL=http://127.0.0.1:<port>/hooks/agent \
+TELEGRAM_WEBHOOK_TOKEN=<token> \
+bash scripts/smoke-test-progress.sh --bot-id <expected_bot_id>
+```
+
+Прогоняет 5 синтетических hook-event-ов (PreToolUse/PostToolUse для Bash и Edit, плюс Stop) через `post-hook.ts` → webhook → ProgressReporter. Печатает табличный pass/fail summary. См. [`docs/progress-reporter-setup.md`](docs/progress-reporter-setup.md) — установка в 3 шага, troubleshooting, что работает / чего ещё нет.
+
 ## Tests
 
 - `bun test` — все 425 тестов
@@ -91,6 +102,7 @@ Live smoke против `@testmyfirsttmuxbot` (15-row matrix, operator-driven): 
 - `bun test tests/hooks/` — Phase 7 (hooks + claude-events + install-hooks + post-hook)
 - `bun test tests/status/activity-renderer.test.ts` — Phase 7 humanization + secret masking + rolling render
 - `bun run typecheck` — `tsc --noEmit` strict
+- `bash scripts/smoke-test-progress.sh` — end-to-end webhook + ProgressReporter check (см. секцию Smoke test выше)
 
 ## Architecture (per-agent process model)
 

--- a/plugin/docs/progress-reporter-setup.md
+++ b/plugin/docs/progress-reporter-setup.md
@@ -1,0 +1,151 @@
+# Progress Reporter — установка и smoke-test
+
+Этот гайд позволяет за пару кликов включить в своём агенте «rolling activity card» — одно сообщение в Telegram, которое обновляется по мере исполнения tool-calls (`Bash`, `Edit`, `Write`, ...) и в конце сессии превращается в финальное `done -- Ns`.
+
+Это **вариант A** из брейншторма UX 2026-05-20.
+
+---
+
+## Что должно работать после установки
+
+| # | Фича | Где смотреть |
+|---|---|---|
+| 1 | Webhook сервер плагина слушает локально на `127.0.0.1:<port>/hooks/agent` | `/health` GET → `{"status":"ok"}` |
+| 2 | Claude Code шлёт каждое событие `PreToolUse`/`PostToolUse`/`Stop` на этот endpoint | hooks в `settings.json` с marker `dashi-channel-hook` |
+| 3 | `ProgressReporter` редактирует одно Telegram-сообщение per chat по мере событий | визуально в чате с ботом |
+| 4 | `Stop` финализирует сообщение строкой `done -- Ns` | визуально |
+| 5 | Бэкенд игнорирует ошибки и не блокирует агента | хук всегда выходит с `0`, агент продолжает работу даже если webhook упал |
+
+Что **не реализовано** в этой итерации:
+- Фильтр шумных tools (Read/Grep/Glob/ToolSearch). Сейчас все события летят на webhook, рендер ловит самые недавние 5 (`config.progress.recent_buffer`).
+- Per-tool emoji-free статусы (`[ok]`/`[run]`) в самой карточке. Текущий renderer использует typographic маркер `▸` для строки.
+- Mirror в TG для MCP-инструментов (`mcp__dashi-channel__*`, `mcp__dashi-gbrain-*`). Сейчас они идут как обычные `tool_name = mcp__...` — рендерер для них даст generic-summary.
+
+Эти пункты — следующий PR.
+
+---
+
+## Зависимости
+
+- `bun >= 1.0`
+- Запущенный экземпляр dashi-channel плагина (например через `channel-thrall.service` systemd unit)
+- `TELEGRAM_WEBHOOK_TOKEN`, `TELEGRAM_WEBHOOK_HOST`, `TELEGRAM_WEBHOOK_PORT`, `TELEGRAM_BOT_TOKEN` в env плагина (обычно в `channel.env`)
+- В конфиге плагина (`<state_dir>/config.json`) — блок `"webhook": { "enabled": true, "host": "127.0.0.1", "port": <port> }`
+
+---
+
+## Установка в 3 шага
+
+### 1. Получить параметры
+
+```bash
+# Какой токен у webhook
+TOKEN=$(grep '^TELEGRAM_WEBHOOK_TOKEN=' ~/.claude-lab/<agent>/secrets/channel.env | cut -d= -f2)
+
+# Какой URL слушает webhook
+URL="http://127.0.0.1:8093/hooks/agent"   # подставь свой port
+
+# Chat ID (твой Telegram user id)
+CHAT_ID="164795011"
+```
+
+### 2. Запатчить settings.json
+
+Скрипт `plugin/scripts/install-hooks.sh` идемпотентно добавляет 5 хуков (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop) и НЕ записывает токен в settings.json:
+
+```bash
+bash plugin/scripts/install-hooks.sh \
+  --settings ~/.claude-lab/<agent>/.claude/settings.json \
+  --chat-id $CHAT_ID \
+  --webhook-url $URL \
+  --agent-id dashi-channel
+```
+
+Результат: в settings.json появятся entries с `"marker": "dashi-channel-hook"`. Прогон скрипта повторно — заменит существующие entries, не задублирует.
+
+### 3. Рестартнуть агента
+
+Хуки читаются Claude Code только при старте сессии:
+
+```bash
+sudo systemctl restart channel-<agent>.service
+```
+
+После рестарта любой tool-call в новой сессии начнёт рисовать карточку в Telegram.
+
+---
+
+## Smoke-test
+
+```bash
+TELEGRAM_HOOK_CHAT_ID=$CHAT_ID \
+TELEGRAM_WEBHOOK_URL=$URL \
+TELEGRAM_WEBHOOK_TOKEN=$TOKEN \
+bash plugin/scripts/smoke-test-progress.sh --bot-id <expected_bot_id>
+```
+
+Скрипт проверит:
+- env переменные выставлены
+- `bun` на PATH
+- `/health` отвечает
+- `bot_id` соответствует ожидаемому (опционально)
+- post-hook.ts успешно отправляет PreToolUse Bash, PostToolUse Bash, PreToolUse Edit, PostToolUse Edit, Stop
+- в settings.json присутствует marker `dashi-channel-hook` минимум 5 раз
+
+Выход:
+- `0` — все проверки прошли
+- `1` — хотя бы один critical check упал (token, URL, webhook response)
+- `2` — usage / config error
+
+Флаг `--quiet` показывает только финальную таблицу.
+
+Ручная проверка после smoke-test: открой Telegram, должно прийти сообщение вида:
+
+```
+<pre>working -- 0s
+
+▸ Bash · ls -la /tmp
+▸ editing smoke.md
+
+done -- Ns</pre>
+```
+
+Если сообщение не пришло — смотри в лог плагина (`<state_dir>/logs/server.log`) на предмет `progress reporter ... failed`.
+
+---
+
+## Troubleshooting
+
+| Симптом | Причина | Что делать |
+|---|---|---|
+| `webhook responded 400` | post-hook.ts отправил невалидный envelope | проверь что Claude Code посылает `transcript_path`, `cwd`, `session_id` — это поля от Claude Code, генерируются автоматически |
+| `webhook responded 401` | bearer token не совпадает | проверь `TELEGRAM_WEBHOOK_TOKEN` в env агента vs `channel.env` плагина |
+| `webhook responded 403` | chat_id не в allowlist | добавь `chat_id` в `config.json` плагина → `allowed_chat_ids` |
+| Сообщение в TG не приходит | `config.progress.enabled = false` | поставь `true` в `<state_dir>/config.json` → `progress: { enabled: true }` |
+| Сообщение приходит, но всегда новое (не редактируется) | session_ttl_ms экспайрил | events отправляются с разрывом > `session_ttl_ms` (default 10m) — это by design |
+| Все события для одного tool сливаются в одну карточку, новая сессия их не сбрасывает | `Stop` hook не доходит до webhook | проверь что Stop hook есть в settings.json с marker `dashi-channel-hook` |
+
+---
+
+## Архитектурная схема
+
+```
+Claude Code (любой agent)
+   |
+   v
+hooks (settings.json)  ──[stdin envelope]──>  post-hook.ts
+                                                  |
+                                                  v
+                                       POST /hooks/agent (Bearer + JSON)
+                                                  |
+                                                  v
+                                       dashi-channel plugin (bun)
+                                              |       |        |
+                                              v       v        v
+                                        Memory  Status  ProgressReporter
+                                                          |
+                                                          v
+                                               edit_message (Telegram)
+```
+
+`ProgressReporter` — стейтмашина: per-chat ровно одно сообщение, throttle через `edit_throttle_ms`, single-flight queue, TTL eviction, финал на Stop.

--- a/plugin/scripts/smoke-test-progress.sh
+++ b/plugin/scripts/smoke-test-progress.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# smoke-test-progress.sh -- End-to-end check for the rolling activity card.
+#
+# Sends a synthetic PreToolUse/PostToolUse/Stop sequence into the local
+# webhook endpoint and prints a pass/skip/fail table.
+#
+# Required env (or pass via flags):
+#   TELEGRAM_WEBHOOK_URL    e.g. http://127.0.0.1:8093/hooks/agent
+#   TELEGRAM_WEBHOOK_TOKEN  bearer token configured on the plugin
+#   TELEGRAM_HOOK_CHAT_ID   target chat id (numeric string)
+#
+# Optional flags:
+#   --bot-id 1234567   Expect /health to report this bot_id (sanity check)
+#   --no-stop          Skip the final Stop event (leave the card "in progress")
+#   --quiet            Only print the summary table at the end
+#
+# Exit codes:
+#   0 -- all critical checks passed
+#   1 -- at least one critical check failed (token, URL, webhook response)
+#   2 -- usage / config error
+#
+# Usage examples:
+#   TELEGRAM_HOOK_CHAT_ID=164795011 \
+#   TELEGRAM_WEBHOOK_URL=http://127.0.0.1:8093/hooks/agent \
+#   TELEGRAM_WEBHOOK_TOKEN=... \
+#   bash scripts/smoke-test-progress.sh
+#
+#   bash scripts/smoke-test-progress.sh --quiet
+
+set -uo pipefail
+
+QUIET=0
+NO_STOP=0
+EXPECT_BOT_ID=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --bot-id)   EXPECT_BOT_ID="$2"; shift 2;;
+    --no-stop)  NO_STOP=1; shift;;
+    --quiet)    QUIET=1; shift;;
+    -h|--help)
+      sed -n 's/^# \{0,1\}//p' "$0" | head -n 30
+      exit 0;;
+    *)
+      echo "smoke-test-progress.sh: unknown arg '$1'" >&2
+      exit 2;;
+  esac
+done
+
+URL="${TELEGRAM_WEBHOOK_URL:-}"
+TOKEN="${TELEGRAM_WEBHOOK_TOKEN:-}"
+CHAT="${TELEGRAM_HOOK_CHAT_ID:-}"
+AGENT="${TELEGRAM_HOOK_AGENT_ID:-dashi-channel}"
+HELPER_DEFAULT="$(cd "$(dirname "$0")" && pwd)/post-hook.ts"
+HELPER="${POST_HOOK_HELPER:-$HELPER_DEFAULT}"
+
+# Results table: name | status | note
+results=()
+
+record() {
+  local name="$1" status="$2" note="${3:-}"
+  results+=("$name|$status|$note")
+  if [ "$QUIET" -eq 0 ]; then
+    printf '%-40s [%s] %s\n' "$name" "$status" "$note"
+  fi
+}
+
+# ─────────────────────────────────────────────────────────────────────
+# 1. Pre-flight checks
+# ─────────────────────────────────────────────────────────────────────
+
+if [ -z "$URL" ]; then
+  record "env TELEGRAM_WEBHOOK_URL" "fail" "not set"
+  echo "Missing TELEGRAM_WEBHOOK_URL. Aborting." >&2
+  exit 2
+fi
+record "env TELEGRAM_WEBHOOK_URL" "ok" "$URL"
+
+if [ -z "$TOKEN" ]; then
+  record "env TELEGRAM_WEBHOOK_TOKEN" "fail" "not set"
+  echo "Missing TELEGRAM_WEBHOOK_TOKEN. Aborting." >&2
+  exit 2
+fi
+record "env TELEGRAM_WEBHOOK_TOKEN" "ok" "redacted"
+
+if [ -z "$CHAT" ]; then
+  record "env TELEGRAM_HOOK_CHAT_ID" "fail" "not set"
+  echo "Missing TELEGRAM_HOOK_CHAT_ID. Aborting." >&2
+  exit 2
+fi
+record "env TELEGRAM_HOOK_CHAT_ID" "ok" "$CHAT"
+
+if [ ! -f "$HELPER" ]; then
+  record "helper post-hook.ts present" "fail" "$HELPER"
+  exit 2
+fi
+record "helper post-hook.ts present" "ok" "$HELPER"
+
+if ! command -v bun >/dev/null 2>&1; then
+  record "bun on PATH" "fail" "install bun >= 1.0"
+  exit 2
+fi
+record "bun on PATH" "ok" "$(bun --version 2>/dev/null)"
+
+# Derive /health URL from /hooks/agent URL.
+HEALTH_URL="${URL%/hooks/agent}/health"
+
+# ─────────────────────────────────────────────────────────────────────
+# 2. Webhook /health
+# ─────────────────────────────────────────────────────────────────────
+
+HEALTH_JSON="$(curl -sS --max-time 5 "$HEALTH_URL" 2>/dev/null || true)"
+HEALTH_STATUS_FIELD="$(printf '%s' "$HEALTH_JSON" | grep -oE '"status"[[:space:]]*:[[:space:]]*"[a-z]+"' | head -n1)"
+if [ -z "$HEALTH_STATUS_FIELD" ]; then
+  record "webhook /health" "fail" "no response from $HEALTH_URL"
+  exit 1
+fi
+record "webhook /health" "ok" "$HEALTH_STATUS_FIELD"
+
+if [ -n "$EXPECT_BOT_ID" ]; then
+  if echo "$HEALTH_JSON" | grep -q "\"bot_id\":$EXPECT_BOT_ID"; then
+    record "bot_id match" "ok" "$EXPECT_BOT_ID"
+  else
+    record "bot_id match" "fail" "expected $EXPECT_BOT_ID"
+  fi
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# 3. Synthesise hook envelopes and fire them through post-hook.ts
+# ─────────────────────────────────────────────────────────────────────
+
+SESSION_ID="smoke-$(date +%s)-$$"
+CWD_VAL="$(pwd)"
+TRANSCRIPT_VAL="/tmp/smoke-${SESSION_ID}.transcript.json"
+TUID1="tu-${SESSION_ID}-1"
+TUID2="tu-${SESSION_ID}-2"
+
+fire_event() {
+  local name="$1" payload="$2"
+  local out
+  if ! out=$(printf '%s' "$payload" | \
+      TELEGRAM_HOOK_CHAT_ID="$CHAT" \
+      TELEGRAM_HOOK_AGENT_ID="$AGENT" \
+      TELEGRAM_WEBHOOK_URL="$URL" \
+      TELEGRAM_WEBHOOK_TOKEN="$TOKEN" \
+      bun "$HELPER" 2>&1); then
+    record "$name" "fail" "$(printf '%s' "$out" | head -c 120)"
+    return 1
+  fi
+  if printf '%s' "$out" | grep -q "telegram-hook: webhook responded"; then
+    record "$name" "fail" "$(printf '%s' "$out" | head -c 120)"
+    return 1
+  fi
+  record "$name" "ok"
+  return 0
+}
+
+ok_count=0
+fail_count=0
+
+pre_bash=$(cat <<EOF
+{"hook_event_name":"PreToolUse","session_id":"$SESSION_ID","transcript_path":"$TRANSCRIPT_VAL","cwd":"$CWD_VAL","tool_name":"Bash","tool_use_id":"$TUID1","tool_input":{"command":"ls -la /tmp"}}
+EOF
+)
+post_bash=$(cat <<EOF
+{"hook_event_name":"PostToolUse","session_id":"$SESSION_ID","transcript_path":"$TRANSCRIPT_VAL","cwd":"$CWD_VAL","tool_name":"Bash","tool_use_id":"$TUID1","tool_input":{"command":"ls -la /tmp"}}
+EOF
+)
+pre_edit=$(cat <<EOF
+{"hook_event_name":"PreToolUse","session_id":"$SESSION_ID","transcript_path":"$TRANSCRIPT_VAL","cwd":"$CWD_VAL","tool_name":"Edit","tool_use_id":"$TUID2","tool_input":{"file_path":"/tmp/smoke.md","old_string":"a","new_string":"b"}}
+EOF
+)
+post_edit=$(cat <<EOF
+{"hook_event_name":"PostToolUse","session_id":"$SESSION_ID","transcript_path":"$TRANSCRIPT_VAL","cwd":"$CWD_VAL","tool_name":"Edit","tool_use_id":"$TUID2","tool_input":{"file_path":"/tmp/smoke.md","old_string":"a","new_string":"b"}}
+EOF
+)
+stop_event=$(cat <<EOF
+{"hook_event_name":"Stop","session_id":"$SESSION_ID","transcript_path":"$TRANSCRIPT_VAL","cwd":"$CWD_VAL"}
+EOF
+)
+
+fire_event "PreToolUse  Bash" "$pre_bash"   && ok_count=$((ok_count+1)) || fail_count=$((fail_count+1))
+sleep 1
+fire_event "PostToolUse Bash" "$post_bash"  && ok_count=$((ok_count+1)) || fail_count=$((fail_count+1))
+sleep 1
+fire_event "PreToolUse  Edit" "$pre_edit"   && ok_count=$((ok_count+1)) || fail_count=$((fail_count+1))
+sleep 1
+fire_event "PostToolUse Edit" "$post_edit"  && ok_count=$((ok_count+1)) || fail_count=$((fail_count+1))
+
+if [ "$NO_STOP" -eq 0 ]; then
+  sleep 1
+  fire_event "Stop"              "$stop_event" && ok_count=$((ok_count+1)) || fail_count=$((fail_count+1))
+else
+  record "Stop" "skip" "--no-stop"
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# 4. Per-agent settings.json sanity (does NOT require live session)
+# ─────────────────────────────────────────────────────────────────────
+
+SETTINGS="${CLAUDE_SETTINGS_FILE:-$HOME/.claude-lab/thrall/.claude/settings.json}"
+if [ -f "$SETTINGS" ]; then
+  has_marker=$(grep -c '"marker": "dashi-channel-hook"' "$SETTINGS" 2>/dev/null || echo 0)
+  if [ "$has_marker" -ge 5 ]; then
+    record "settings.json hooks installed" "ok" "$has_marker entries"
+  elif [ "$has_marker" -gt 0 ]; then
+    record "settings.json hooks installed" "warn" "$has_marker / 5 entries"
+  else
+    record "settings.json hooks installed" "fail" "no dashi-channel-hook marker -- run install-hooks.sh"
+  fi
+else
+  record "settings.json hooks installed" "skip" "$SETTINGS not found"
+fi
+
+# ─────────────────────────────────────────────────────────────────────
+# 5. Summary
+# ─────────────────────────────────────────────────────────────────────
+
+echo
+echo "================== smoke-test-progress.sh summary =================="
+printf '%-40s %-8s %s\n' "CHECK" "STATUS" "NOTE"
+printf '%-40s %-8s %s\n' "----------------------------------------" "--------" "----"
+for row in "${results[@]}"; do
+  IFS='|' read -r name status note <<< "$row"
+  printf '%-40s [%-4s]  %s\n' "$name" "$status" "$note"
+done
+echo "===================================================================="
+echo "events: $ok_count ok, $fail_count failed"
+echo
+echo "Manual verification: open Telegram chat $CHAT and confirm a"
+echo "  <pre>working -- Ns ... done -- Ns</pre> block appeared with"
+echo "  two recent tool lines (Bash + Edit)."
+
+if [ "$fail_count" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Добавил `plugin/scripts/smoke-test-progress.sh` — end-to-end smoke в одну команду, печатает табличный pass/fail summary по 13 проверкам (env vars, /health, бот id, 5 синтетических hook events через `post-hook.ts`, наличие `dashi-channel-hook` marker в settings.json)
- Добавил `plugin/docs/progress-reporter-setup.md` — установка в 3 шага, что работает / чего ещё нет, troubleshooting-таблица, архитектурная схема
- Обновил `plugin/README.md` — упоминание smoke-test-progress.sh в секциях Smoke test и Tests

## Why

После того как warchief выбрал «Variant A — Rolling activity card» для отображения tool-calls в Telegram, ProgressReporter был фактически готов в плагине (PR #11 + предыдущие), но не было способа за пару кликов проверить, всё ли подключено правильно у нового агента. Этот PR закрывает gap.

## Test plan

- [x] `bash scripts/smoke-test-progress.sh --bot-id 8338508613` против локального dashi-channel webhook на 127.0.0.1:8093 — 13/13 проверок passed
- [x] `--quiet` — печатает только финальную таблицу
- [x] Pre-flight checks (missing env vars) — выходит с кодом 2 и понятным сообщением
- [ ] Прогнать на свежей системе после merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)