### PR TITLE
feat: noise-filter в ProgressReporter + расширил TaskMirror на TaskCreate/TaskUpdate

### DIFF
--- a/plugin/src/hooks/claude-events.ts
+++ b/plugin/src/hooks/claude-events.ts
@@ -7,7 +7,14 @@
 // Telegram or our logs.
 
 import type { ClaudeHookPayload } from '../schemas.js'
-import { TodoWriteInputSchema, type TodoItem } from '../schemas.js'
+import {
+  TodoWriteInputSchema,
+  TaskCreateInputSchema,
+  TaskUpdateInputSchema,
+  type TodoItem,
+  type TaskCreateInput,
+  type TaskUpdateInput,
+} from '../schemas.js'
 import type { Logger } from '../log.js'
 
 // Tool-call lifecycle pair used by the rolling activity window. PreToolUse
@@ -66,6 +73,29 @@ export interface TodoWriteEvent {
   readonly todos: ReadonlyArray<TodoItem>
 }
 
+// TaskCreate / TaskUpdate hooks emitted by the newer Claude Code harness.
+// Unlike TodoWrite (which carries the full list per call), these are
+// incremental — TaskMirror accumulates them in an internal Map<taskId, TodoItem>
+// and renders the synthesised snapshot. PreToolUse of TaskCreate fires before
+// the harness assigns a real numeric id, so we pass `toolUseId` as the
+// provisional handle and reconcile with the real id in the PostToolUse pass
+// (Phase 2 — for now the provisional id stays).
+export interface TaskCreateEvent {
+  readonly kind: 'task_create'
+  readonly toolUseId: string
+  readonly input: TaskCreateInput
+  // Populated on PostToolUse when the harness has materialised the task; null
+  // on PreToolUse. Format: usually `Task #<n> created` — TaskMirror runs the
+  // same regex extract as the warchief's terminal renderer.
+  readonly toolResult?: unknown
+}
+
+export interface TaskUpdateEvent {
+  readonly kind: 'task_update'
+  readonly toolUseId: string
+  readonly input: TaskUpdateInput
+}
+
 // Session-stop signal for TaskMirror specifically. Renamed from the
 // ActivityStatusEvent variant so the TaskMirror dispatcher does not
 // accidentally consume a non-todo Stop hook.
@@ -73,7 +103,11 @@ export interface TodoSessionStopEvent {
   readonly kind: 'todo_session_stop'
 }
 
-export type TaskMirrorEvent = TodoWriteEvent | TodoSessionStopEvent
+export type TaskMirrorEvent =
+  | TodoWriteEvent
+  | TaskCreateEvent
+  | TaskUpdateEvent
+  | TodoSessionStopEvent
 
 /**
  * Convert a validated Claude hook payload to an ActivityStatusEvent.
@@ -145,5 +179,48 @@ export function toTodoWriteEvent(
     }
     return { kind: 'todo_write', todos: parsed.data.todos }
   }
+
+  // TaskCreate -- emit on PreToolUse so the milestone shows up the moment the
+  // warchief sees it spawn, and again on PostToolUse with `toolResult` so
+  // TaskMirror can reconcile the provisional id with the harness-assigned one.
+  if (
+    (payload.hook_event_name === 'PreToolUse' || payload.hook_event_name === 'PostToolUse') &&
+    payload.tool_name === 'TaskCreate'
+  ) {
+    const parsed = TaskCreateInputSchema.safeParse(payload.tool_input)
+    if (!parsed.success) {
+      log?.warn('TaskCreate tool_input failed schema validation (ignored)', {
+        issues: parsed.error.issues.map((i) => i.message).slice(0, 5),
+      })
+      return null
+    }
+    const event: TaskCreateEvent = {
+      kind: 'task_create',
+      toolUseId: payload.tool_use_id,
+      input: parsed.data,
+    }
+    return payload.hook_event_name === 'PostToolUse' && payload.tool_result !== undefined
+      ? { ...event, toolResult: payload.tool_result }
+      : event
+  }
+
+  // TaskUpdate -- mutations carry the real taskId in tool_input. We fire on
+  // PostToolUse only: PreToolUse status is what the call WANTS to set, the
+  // harness can still reject, so we wait for the post-call confirmation.
+  if (payload.hook_event_name === 'PostToolUse' && payload.tool_name === 'TaskUpdate') {
+    const parsed = TaskUpdateInputSchema.safeParse(payload.tool_input)
+    if (!parsed.success) {
+      log?.warn('TaskUpdate tool_input failed schema validation (ignored)', {
+        issues: parsed.error.issues.map((i) => i.message).slice(0, 5),
+      })
+      return null
+    }
+    return {
+      kind: 'task_update',
+      toolUseId: payload.tool_use_id,
+      input: parsed.data,
+    }
+  }
+
   return null
 }

--- a/plugin/src/schemas.ts
+++ b/plugin/src/schemas.ts
@@ -121,6 +121,34 @@ export const TodoWriteInputSchema = z
   .passthrough()
 export type TodoWriteInput = z.infer<typeof TodoWriteInputSchema>
 
+// Newer Claude Code harness uses TaskCreate/TaskUpdate/TaskList instead of a
+// single TodoWrite tool. The shapes below capture only the fields TaskMirror
+// renders; passthrough preserves the rest (metadata, owner, etc.) without
+// fragilising the parse on harness version bumps. `taskId` on TaskUpdate is
+// always a string in the harness output but we coerce defensively so a
+// numeric id from a future version still parses.
+export const TaskCreateInputSchema = z
+  .object({
+    subject: z.string().min(1),
+    description: z.string().optional(),
+    activeForm: z.string().optional(),
+  })
+  .passthrough()
+export type TaskCreateInput = z.infer<typeof TaskCreateInputSchema>
+
+export const TaskUpdateInputSchema = z
+  .object({
+    taskId: z.union([z.string(), z.number()]).transform((v) => String(v)),
+    status: z
+      .enum(['pending', 'in_progress', 'completed', 'deleted'])
+      .optional(),
+    subject: z.string().optional(),
+    description: z.string().optional(),
+    activeForm: z.string().optional(),
+  })
+  .passthrough()
+export type TaskUpdateInput = z.infer<typeof TaskUpdateInputSchema>
+
 export const ClaudePreToolUseSchema = z
   .object({
     ...ClaudeHookCommonShape,

--- a/plugin/src/status/progress-reporter.ts
+++ b/plugin/src/status/progress-reporter.ts
@@ -93,6 +93,28 @@ interface ChatProgressEntry {
 // inline tags (<b>, <code>, <pre>) are rendered.
 const HTML_OPTS = { parse_mode: 'HTML' as const }
 
+// Tools that should never appear in the rolling activity card. Reads, greps,
+// globs, and deferred-tool lookups are bookkeeping; the dashi-channel MCP
+// reply tools are the channel itself (mirroring them would recurse), and
+// gbrain-recall is background context fetching the warchief does not need to
+// see. Bash/Edit/Write/WebFetch/WebSearch/Agent and gbrain mutations
+// (memory/swarm/tasks) keep flowing through.
+const NOISY_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'Read',
+  'Grep',
+  'Glob',
+  'ToolSearch',
+])
+const NOISY_TOOL_PREFIXES: ReadonlyArray<string> = [
+  'mcp__dashi-channel__',
+  'mcp__dashi-gbrain-recall__',
+]
+
+export function shouldSkipTool(toolName: string): boolean {
+  if (NOISY_TOOL_NAMES.has(toolName)) return true
+  return NOISY_TOOL_PREFIXES.some((p) => toolName.startsWith(p))
+}
+
 export class ProgressReporter {
   private readonly telegramApi: TelegramApiForProgress
   private readonly config: AppConfig
@@ -247,10 +269,16 @@ export class ProgressReporter {
   /**
    * Mutate `entry.calls` based on the event. tool_start appends; other
    * non-Stop events are render-only (move the elapsed counter forward).
+   *
+   * Noise-filter: tool names in `NOISY_TOOLS` (Read/Grep/Glob/ToolSearch and
+   * the dashi-channel + recall MCP prefixes) update `lastActivityMs` upstream
+   * but never enter `entry.calls`, so the rolling card stays focused on
+   * meaningful actions (Bash, Edit, Write, WebFetch, Agent, gbrain mutations).
    */
   private applyEvent(entry: ChatProgressEntry, event: ActivityStatusEvent): void {
     switch (event.kind) {
       case 'tool_start': {
+        if (shouldSkipTool(event.toolName)) break
         const detail = buildActivityDetail(event.toolName, event.toolInput)
         const humanized = buildHumanizedActivityLine(event.toolName, event.toolInput)
         const call: ActivityCall = { toolName: event.toolName, detail, humanized }

--- a/plugin/src/status/task-mirror.ts
+++ b/plugin/src/status/task-mirror.ts
@@ -63,6 +63,12 @@ interface ChatTaskEntry {
   // Latest TodoWrite snapshot from Claude. Replaced wholesale on each event
   // — TodoWrite is itself the full list, so we never merge incrementally.
   todos: ReadonlyArray<TodoItem>
+  // Incremental task map for the TaskCreate/TaskUpdate path (newer Claude Code
+  // harness). Key is the harness taskId once reconciled from `toolResult`, or
+  // the provisional `toolUseId` until then. `todos` is rebuilt from this map
+  // after every mutation so `scheduleFlush` keeps using the existing renderer.
+  // Insertion-order Map keeps the visual ordering stable across renders.
+  taskMap: Map<string, TodoItem>
   // Last text we actually sent / edited. Idempotency gate.
   lastRenderedText?: string
   // Timestamp of the last successful send or edit. Used for throttle.
@@ -77,6 +83,16 @@ interface ChatTaskEntry {
   pendingTimer: NodeJS.Timeout | null
   // True once todo_session_stop has been processed. Idempotency guard.
   stopped: boolean
+}
+
+// Extract the harness-assigned task id from a TaskCreate PostToolUse
+// `tool_result`. The harness emits `Task #<n> created successfully...`; we
+// pull out the first `#<digits>` token. Returns null if the shape doesn't
+// match — caller falls back to the provisional `toolUseId`.
+function parseCreatedTaskId(toolResult: unknown): string | null {
+  if (typeof toolResult !== 'string') return null
+  const match = toolResult.match(/#(\d+)/)
+  return match ? (match[1] ?? null) : null
 }
 
 export class TaskMirror {
@@ -102,6 +118,15 @@ export class TaskMirror {
    * Main entry point. Called by the webhook handler for every Claude hook
    * that mapped to a TaskMirrorEvent. Never throws — top-level try/catch
    * swallows any failure so the webhook 200 path stays open.
+   *
+   * Three input shapes:
+   *   - `todo_write`: full list snapshot (legacy TodoWrite tool). Replaces
+   *     `todos` wholesale AND clears `taskMap` so a mid-session switch from
+   *     TodoWrite to TaskCreate/Update starts cleanly.
+   *   - `task_create` / `task_update`: incremental events from the newer
+   *     TaskCreate/TaskUpdate tools. Mutate `taskMap`, then synthesise the
+   *     `todos` array from it.
+   *   - `todo_session_stop`: terminal signal, handled separately.
    */
   async recordEvent(chatId: string, event: TaskMirrorEvent): Promise<void> {
     if (!this.config.task_mirror.enabled) return
@@ -113,8 +138,22 @@ export class TaskMirror {
       const entry = this.getOrCreate(chatId)
       if (entry.stopped) return
       entry.lastActivityMs = this.now()
-      // Replace the snapshot wholesale. TodoWrite payloads ARE the full list.
-      entry.todos = event.todos
+
+      switch (event.kind) {
+        case 'todo_write':
+          // Replace the snapshot wholesale. TodoWrite payloads ARE the full list.
+          entry.taskMap.clear()
+          entry.todos = event.todos
+          break
+        case 'task_create':
+          this.applyTaskCreate(entry, event)
+          entry.todos = Array.from(entry.taskMap.values())
+          break
+        case 'task_update':
+          this.applyTaskUpdate(entry, event)
+          entry.todos = Array.from(entry.taskMap.values())
+          break
+      }
       this.scheduleFlush(entry)
     } catch (err) {
       this.log.warn('task mirror recordEvent failed (ignored)', {
@@ -122,6 +161,81 @@ export class TaskMirror {
         error: err instanceof Error ? err.message : String(err),
       })
     }
+  }
+
+  /**
+   * TaskCreate handler. PreToolUse adds the task to `taskMap` keyed on
+   * `toolUseId` (provisional id, always present). The follow-up PostToolUse
+   * carries `toolResult`; if we can parse a real `#<n>` id we re-key the
+   * entry so subsequent `TaskUpdate` events (which use the real id) can find
+   * it. Two arrivals are idempotent — a TaskCreate that has already been
+   * recorded under its provisional id and a matching PostToolUse with the
+   * same toolUseId find the entry and reconcile without duplicating.
+   *
+   * Note: the harness convention is `Task #N created successfully` — see
+   * TaskCreate tool description. `parseCreatedTaskId` extracts the first
+   * `#<digits>` substring and returns null on shape mismatch.
+   */
+  private applyTaskCreate(
+    entry: ChatTaskEntry,
+    event: Extract<TaskMirrorEvent, { kind: 'task_create' }>,
+  ): void {
+    const realId =
+      event.toolResult !== undefined ? parseCreatedTaskId(event.toolResult) : null
+    const provisionalId = event.toolUseId
+    const provisional = entry.taskMap.get(provisionalId)
+    const item: TodoItem = {
+      id: realId ?? provisional?.id ?? provisionalId,
+      content: event.input.subject,
+      status: provisional?.status ?? 'pending',
+      ...(event.input.activeForm !== undefined
+        ? { activeForm: event.input.activeForm }
+        : provisional?.activeForm !== undefined
+          ? { activeForm: provisional.activeForm }
+          : {}),
+    }
+    // Drop the provisional entry, insert under the canonical id. This re-keys
+    // the Map without dropping anything else; insertion-order semantics mean
+    // the task moves to the tail on reconciliation, which is the right place
+    // visually (most recently activated).
+    entry.taskMap.delete(provisionalId)
+    if (realId !== null && realId !== provisionalId) {
+      entry.taskMap.delete(realId)
+    }
+    entry.taskMap.set(item.id ?? provisionalId, item)
+  }
+
+  /**
+   * TaskUpdate handler. `taskId` from the harness is always a string after
+   * the schema coerce. If the entry exists, mutate in place; if not (e.g.
+   * TaskMirror missed the TaskCreate due to a webhook drop), synthesise a
+   * minimal placeholder so the list stays consistent.
+   */
+  private applyTaskUpdate(
+    entry: ChatTaskEntry,
+    event: Extract<TaskMirrorEvent, { kind: 'task_update' }>,
+  ): void {
+    const id = event.input.taskId
+    // Drop 'deleted' before constructing the TodoItem -- the rendered TodoItem
+    // type accepts only pending/in_progress/completed, and the schema-coerced
+    // 'deleted' value would not narrow correctly otherwise.
+    if (event.input.status === 'deleted') {
+      entry.taskMap.delete(id)
+      return
+    }
+    const existing = entry.taskMap.get(id)
+    const status = event.input.status ?? existing?.status ?? 'pending'
+    const next: TodoItem = {
+      id,
+      content: event.input.subject ?? existing?.content ?? `task ${id}`,
+      status,
+      ...(event.input.activeForm !== undefined
+        ? { activeForm: event.input.activeForm }
+        : existing?.activeForm !== undefined
+          ? { activeForm: existing.activeForm }
+          : {}),
+    }
+    entry.taskMap.set(id, next)
   }
 
   /**
@@ -162,6 +276,7 @@ export class TaskMirror {
       startedAtMs: this.now(),
       lastActivityMs: this.now(),
       todos: [],
+      taskMap: new Map(),
       lastEditAtMs: 0,
       flushPromise: null,
       pendingTimer: null,

--- a/plugin/tests/hooks/claude-events.test.ts
+++ b/plugin/tests/hooks/claude-events.test.ts
@@ -8,7 +8,7 @@ import {
   WebhookMessagePayloadSchema,
   type WebhookPayload,
 } from '../../src/schemas.js'
-import { toActivityEvent } from '../../src/hooks/claude-events.js'
+import { toActivityEvent, toTodoWriteEvent } from '../../src/hooks/claude-events.js'
 
 function parse(value: unknown): WebhookPayload {
   return WebhookPayloadSchema.parse(value)
@@ -239,5 +239,81 @@ describe('toActivityEvent mapping', () => {
       hook_event_name: 'SessionStart',
     })
     expect(event.kind).toBe('session_start')
+  })
+})
+
+describe('toTodoWriteEvent mapping', () => {
+  const common = {
+    chatId: '1',
+    session_id: 's',
+    transcript_path: '/t',
+    cwd: '/',
+  } as const
+
+  test('PreToolUse TaskCreate → task_create event (no toolResult yet)', () => {
+    const event = toTodoWriteEvent({
+      ...common,
+      hook_event_name: 'PreToolUse',
+      tool_name: 'TaskCreate',
+      tool_use_id: 'tu-create-1',
+      tool_input: { subject: 'Implement X', description: 'why', activeForm: 'Implementing X' },
+    })
+    expect(event?.kind).toBe('task_create')
+    if (event?.kind !== 'task_create') throw new Error('unreachable')
+    expect(event.toolUseId).toBe('tu-create-1')
+    expect(event.input.subject).toBe('Implement X')
+    expect(event.input.activeForm).toBe('Implementing X')
+    expect('toolResult' in event).toBe(false)
+  })
+
+  test('PostToolUse TaskCreate → task_create event with toolResult', () => {
+    const event = toTodoWriteEvent({
+      ...common,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'TaskCreate',
+      tool_use_id: 'tu-create-1',
+      tool_input: { subject: 'Implement X' },
+      tool_result: 'Task #7 created successfully',
+    })
+    expect(event?.kind).toBe('task_create')
+    if (event?.kind !== 'task_create') throw new Error('unreachable')
+    expect(event.toolResult).toBe('Task #7 created successfully')
+  })
+
+  test('PostToolUse TaskUpdate → task_update event with coerced string taskId', () => {
+    const event = toTodoWriteEvent({
+      ...common,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'TaskUpdate',
+      tool_use_id: 'tu-update-1',
+      // Pass numeric taskId to exercise the union+transform path in the schema.
+      tool_input: { taskId: 7, status: 'in_progress' },
+    })
+    expect(event?.kind).toBe('task_update')
+    if (event?.kind !== 'task_update') throw new Error('unreachable')
+    expect(event.input.taskId).toBe('7')
+    expect(event.input.status).toBe('in_progress')
+  })
+
+  test('PreToolUse TaskUpdate → null (we only mirror PostToolUse for updates)', () => {
+    const event = toTodoWriteEvent({
+      ...common,
+      hook_event_name: 'PreToolUse',
+      tool_name: 'TaskUpdate',
+      tool_use_id: 'tu-update-1',
+      tool_input: { taskId: '7', status: 'in_progress' },
+    })
+    expect(event).toBeNull()
+  })
+
+  test('non-Task tools still return null (Bash, Edit, etc.)', () => {
+    const event = toTodoWriteEvent({
+      ...common,
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_use_id: 'tu-bash-1',
+      tool_input: { command: 'ls' },
+    })
+    expect(event).toBeNull()
   })
 })

--- a/plugin/tests/status/progress-reporter.test.ts
+++ b/plugin/tests/status/progress-reporter.test.ts
@@ -214,10 +214,13 @@ function bashStart(toolUseId = 'tool-1', command = 'echo hi'): ActivityStatusEve
   }
 }
 
+// Editing is on the kept-tools list (Read is skipped by the noise filter
+// added 2026-05-20); these tests rely on the second tool_start actually
+// landing in `entry.calls`, so we use Edit as the "second tool" stand-in.
 function readStart(toolUseId = 'tool-2', file_path = '/abs/path/foo.ts'): ActivityStatusEvent {
   return {
     kind: 'tool_start',
-    toolName: 'Read',
+    toolName: 'Edit',
     toolInput: { file_path },
     toolUseId,
   }
@@ -513,7 +516,7 @@ describe('ProgressReporter', () => {
     const { reporter } = makeReporter()
     await reporter.recordEvent('chat-tools', bashStart('t1'))
     await reporter.recordEvent('chat-tools', readStart('t2'))
-    expect(reporter.getActiveToolName('chat-tools')).toBe('Read')
+    expect(reporter.getActiveToolName('chat-tools')).toBe('Edit')
   })
 
   test('getActiveToolName returns undefined when no entry exists', () => {

--- a/plugin/tests/status/task-mirror.test.ts
+++ b/plugin/tests/status/task-mirror.test.ts
@@ -178,6 +178,42 @@ function todoEvent(todos: TodoItem[]): TaskMirrorEvent {
   return { kind: 'todo_write', todos }
 }
 
+function taskCreateEvent(
+  toolUseId: string,
+  subject: string,
+  opts: { activeForm?: string; toolResult?: string } = {},
+): TaskMirrorEvent {
+  const event: Extract<TaskMirrorEvent, { kind: 'task_create' }> = {
+    kind: 'task_create',
+    toolUseId,
+    input: {
+      subject,
+      ...(opts.activeForm !== undefined ? { activeForm: opts.activeForm } : {}),
+    },
+  }
+  return opts.toolResult !== undefined
+    ? { ...event, toolResult: opts.toolResult }
+    : event
+}
+
+function taskUpdateEvent(
+  taskId: string,
+  patch: Partial<{
+    status: 'pending' | 'in_progress' | 'completed' | 'deleted'
+    subject: string
+    activeForm: string
+  }>,
+): TaskMirrorEvent {
+  return {
+    kind: 'task_update',
+    toolUseId: `tu-update-${taskId}`,
+    input: {
+      taskId,
+      ...patch,
+    },
+  }
+}
+
 const STOP: TaskMirrorEvent = { kind: 'todo_session_stop' }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -386,6 +422,88 @@ describe('TaskMirror', () => {
     ]))
     const sends = api.calls.filter((c) => c.kind === 'send')
     expect(sends.length).toBe(1)
+  })
+
+  // ─────────────────────────────────────────────────────────────────────
+  // TaskCreate / TaskUpdate (incremental events, newer Claude Code harness)
+  // ─────────────────────────────────────────────────────────────────────
+
+  test('task_create: PreToolUse adds a pending task to the snapshot', async () => {
+    const { mirror, api } = makeMirror()
+    await mirror.recordEvent('chat-1', taskCreateEvent('tu-1', 'Implement X'))
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(1)
+    expect(sends[0]!.text).toContain('Implement X')
+    expect(sends[0]!.text).toContain('1 pending')
+  })
+
+  test('task_update: status change moves the item from pending to in_progress', async () => {
+    const { mirror, api, clock } = makeMirror()
+    await mirror.recordEvent('chat-1', taskCreateEvent('tu-1', 'Build feature'))
+    clock.advance(10)
+    // PostToolUse of TaskCreate carries the harness-assigned id via toolResult.
+    await mirror.recordEvent(
+      'chat-1',
+      taskCreateEvent('tu-1', 'Build feature', { toolResult: 'Task #7 created successfully' }),
+    )
+    clock.advance(5000)
+    await mirror.recordEvent('chat-1', taskUpdateEvent('7', { status: 'in_progress' }))
+    await mirror._idleForTests('chat-1')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(edits.length).toBeGreaterThanOrEqual(1)
+    expect(edits[edits.length - 1]!.text).toContain('Build feature')
+    expect(edits[edits.length - 1]!.text).toContain('1 in progress')
+  })
+
+  test('task_update: completing the task moves it to the completed bucket', async () => {
+    const { mirror, api, clock } = makeMirror()
+    await mirror.recordEvent(
+      'chat-1',
+      taskCreateEvent('tu-1', 'Ship it', { toolResult: 'Task #3 created' }),
+    )
+    clock.advance(5000)
+    await mirror.recordEvent('chat-1', taskUpdateEvent('3', { status: 'completed' }))
+    await mirror._idleForTests('chat-1')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(edits[edits.length - 1]!.text).toContain('1 done')
+    expect(edits[edits.length - 1]!.text).toContain('Ship it')
+  })
+
+  test('task_update: status=deleted removes the entry entirely', async () => {
+    const { mirror, api, clock } = makeMirror()
+    await mirror.recordEvent(
+      'chat-1',
+      taskCreateEvent('tu-1', 'Maybe', { toolResult: 'Task #9 created' }),
+    )
+    clock.advance(5000)
+    await mirror.recordEvent('chat-1', taskUpdateEvent('9', { status: 'deleted' }))
+    await mirror._idleForTests('chat-1')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    const finalText = edits[edits.length - 1]?.text ?? ''
+    expect(finalText).not.toContain('Maybe')
+    expect(finalText).toContain('задач нет')
+  })
+
+  test('todo_write after task_create wipes the incremental Map (no double-counting)', async () => {
+    const { mirror, api, clock } = makeMirror()
+    await mirror.recordEvent('chat-1', taskCreateEvent('tu-1', 'Stale via Task*'))
+    clock.advance(5000)
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Fresh via TodoWrite', status: 'in_progress' }]))
+    await mirror._idleForTests('chat-1')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    const finalText = edits[edits.length - 1]?.text ?? ''
+    expect(finalText).toContain('Fresh via TodoWrite')
+    expect(finalText).not.toContain('Stale via Task*')
+  })
+
+  test('task_update: missing TaskCreate synthesises placeholder so the list stays consistent', async () => {
+    const { mirror, api } = makeMirror()
+    // TaskUpdate arrives without preceding TaskCreate (webhook drop scenario).
+    await mirror.recordEvent('chat-1', taskUpdateEvent('42', { status: 'in_progress', subject: 'Recovered' }))
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(1)
+    expect(sends[0]!.text).toContain('Recovered')
+    expect(sends[0]!.text).toContain('1 in progress')
   })
 
   // ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

**ProgressReporter (noise-filter):**
- `NOISY_TOOL_NAMES = {Read, Grep, Glob, ToolSearch}` + prefixes `mcp__dashi-channel__`, `mcp__dashi-gbrain-recall__` пропускаются — обновляют `lastActivityMs` (watcher видит что не idle), но не попадают в `entry.calls`. Карточка фокусируется на содержательных действиях: Bash/Edit/Write/WebFetch/WebSearch/Agent/gbrain-write/swarm/tasks.

**TaskMirror (TaskCreate/TaskUpdate parity):**
- В новой версии Claude Code todo-list идёт через `TaskCreate`/`TaskUpdate` инкрементально, а не через `TodoWrite` snapshot. Без этого PR `TaskMirror` ловил только `TodoWrite` и в новой среде milestone-карточка в TG не работала вовсе.
- `schemas.ts`: `TaskCreateInputSchema`, `TaskUpdateInputSchema`.
- `hooks/claude-events.ts:toTodoWriteEvent`: маппит `PreToolUse TaskCreate`, `PostToolUse TaskCreate` (с tool_result) и `PostToolUse TaskUpdate` в новые kinds `task_create`/`task_update`. Ветка `TodoWrite` нетронута.
- `status/task-mirror.ts`: `ChatTaskEntry.taskMap: Map<taskId, TodoItem>` — внутренний накопитель. `applyTaskCreate` использует `toolUseId` как provisional key, на PostToolUse парсит `Task #N created` из `tool_result` и перекидывает запись на реальный id. `applyTaskUpdate` мутирует by taskId; `status=deleted` удаляет запись. `todo_write` ветка теперь чистит `taskMap` при переключении (чтобы не было двойного учёта).
- Renderer (`renderTodoList`) не изменён — он уже принимает `ReadonlyArray<TodoItem>`.

## Why

После брейншторма UX 2026-05-20 (вариант A — Rolling activity card) обнаружились два пробела, которые делали фичу неполной:
1. Шум — Read/Grep/Glob спамят карточку низкоценными событиями.
2. Milestone-карточка через TaskMirror дед-код в новой среде Claude Code, потому что использует TodoWrite, а у нас TaskCreate/TaskUpdate.

Закрываем оба сразу — фича становится usable в продакшене.

## Test plan

- [x] `bun test tests/status/ tests/hooks/` — 174 pass / 0 fail
- [x] 6 новых тестов TaskMirror: create flow, update→in_progress, completed bucket, deleted удаление, todo_write resets taskMap, missing-TaskCreate fallback
- [x] 5 новых тестов claude-events маппера: PreToolUse/PostToolUse TaskCreate, TaskUpdate (with numeric→string coerce), PreToolUse TaskUpdate (null), non-Task tool (null)
- [x] `bun run typecheck` — no new errors в моих файлах (pre-existing baseline в server.ts/poller.ts/webhook/server.ts — НЕ затронуто)
- [ ] Live verification после рестарта `channel-thrall.service` (warchief OK pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)