### PR TITLE
feat(safety): outbound token-bucket queue + 429 retry в safe-telegram-api

### DIFF
--- a/plugin/src/safety/rate-limited-telegram-api.ts
+++ b/plugin/src/safety/rate-limited-telegram-api.ts
@@ -1,0 +1,290 @@
+// Outbound rate-limit wrapper around TelegramApi.
+//
+// Goal: make Telegram's per-chat / per-bot rate limits invisible to callers.
+// A burst of replies (e.g. a multi-part report) used to surface as a 429
+// from Bot API with retry_after ≈ 300s — long enough that the warchief lost
+// sight of what the agent was doing. This wrapper enforces pacing BEFORE
+// the request leaves the process and transparently retries on 429.
+//
+// Layers (independent, all consulted on every text-send):
+//   1. Per-chat token bucket (default: 1 msg/sec sustained, burst 3).
+//      Same-chat ordering is preserved via a FIFO tail-promise chain — a
+//      second sendMessage to the same chat awaits the first before checking
+//      its bucket. Different chats run in parallel.
+//   2. Global token bucket (default: 25 msg/sec, burst 25). Caps total
+//      throughput across all chats under Telegram's 30/sec bot-wide limit.
+//   3. 429 retry: on a grammY-shaped 429 (`error_code: 429`, optional
+//      `parameters.retry_after`), sleep the requested seconds + a small
+//      jitter and retry the SAME call. Bounded by `maxRetries` (default 3).
+//
+// Methods that don't consume the send-bucket: editMessageText (Telegram's
+// edit limits are far more lenient), setMessageReaction, sendChatAction,
+// deleteMessage, downloadFile. They still get the 429 retry wrapper so a
+// stray 429 on an edit can recover without the caller seeing it.
+//
+// Test seams: `opts.now` and `opts.sleep` replace the real clock and
+// setTimeout-based sleep, so tests can run instantly with deterministic
+// virtual time.
+
+import type { Logger } from '../log.js'
+import type {
+  ChatAction,
+  DownloadResult,
+  EditOpts,
+  SendDocumentOpts,
+  SendMessageOpts,
+  TelegramApi,
+} from '../channel/tools.js'
+
+interface TokenBucket {
+  tokens: number
+  capacity: number
+  refillPerMs: number
+  lastRefill: number
+}
+
+function makeBucket(capacity: number, refillPerSec: number, now: number): TokenBucket {
+  return {
+    tokens: capacity,
+    capacity,
+    refillPerMs: refillPerSec / 1000,
+    lastRefill: now,
+  }
+}
+
+function refill(b: TokenBucket, now: number): void {
+  const dt = now - b.lastRefill
+  if (dt <= 0) return
+  b.tokens = Math.min(b.capacity, b.tokens + dt * b.refillPerMs)
+  b.lastRefill = now
+}
+
+// ms to wait before consuming one token; 0 means available now.
+function waitMs(b: TokenBucket, now: number): number {
+  refill(b, now)
+  if (b.tokens >= 1) return 0
+  return Math.ceil((1 - b.tokens) / b.refillPerMs)
+}
+
+function consume(b: TokenBucket): void {
+  b.tokens -= 1
+}
+
+interface ChatState {
+  bucket: TokenBucket
+  // FIFO tail: every enqueued op awaits this before checking the bucket.
+  // Replaced with a fresh deferred at each enqueue. Errors do NOT propagate
+  // (we use `.catch(() => {})` on the await) so one failed send cannot
+  // permanently break the chain for a chat.
+  //
+  // HEAD-OF-LINE BLOCKING: a slow op (e.g. a 429 retry holding the lock)
+  // delays all subsequent sends to the SAME chat. That's intentional —
+  // ordering matters more than throughput for a conversational channel.
+  // Different chats run in parallel (separate ChatState entries) so a stuck
+  // chat does not affect others. Worst-case per-chat stall is bounded by
+  // `maxRetries * MAX_RETRY_AFTER_S`.
+  tail: Promise<void>
+}
+
+export interface RateLimitOptions {
+  perChatRefillPerSec?: number
+  perChatBurstCapacity?: number
+  globalRefillPerSec?: number
+  globalBurstCapacity?: number
+  maxRetries?: number
+  jitterMaxMs?: number
+  /** Test seam: replace Date.now() for deterministic virtual time. */
+  now?: () => number
+  /** Test seam: replace setTimeout-based sleep. */
+  sleep?: (ms: number) => Promise<void>
+}
+
+interface Grammy429 {
+  error_code: 429
+  parameters?: { retry_after?: number }
+}
+
+// Cap retry_after so one giant value from Telegram (or a hostile-shaped
+// error) can't lock a chat's FIFO queue for minutes on end. The per-chat
+// tail-promise chain blocks all subsequent sends to the same chat until the
+// in-flight op finishes, so worst-case stall = maxRetries × MAX_RETRY_AFTER_S.
+// With defaults (3 × 60s) that's a 3-minute ceiling; if Telegram really
+// needs longer, the bounded retries exhaust and the caller sees the 429.
+const MAX_RETRY_AFTER_S = 60
+
+function parse429(err: unknown): { retryAfter: number } | null {
+  if (typeof err !== 'object' || err === null) return null
+  const e = err as Grammy429
+  if (e.error_code !== 429) return null
+  const after = e.parameters?.retry_after
+  // Telegram's retry_after is in seconds. Coerce to a sane positive integer
+  // and clamp into [1, MAX_RETRY_AFTER_S].
+  if (typeof after !== 'number' || !Number.isFinite(after) || after < 1) {
+    return { retryAfter: 1 }
+  }
+  return { retryAfter: Math.min(MAX_RETRY_AFTER_S, Math.ceil(after)) }
+}
+
+export function createRateLimitedTelegramApi(
+  raw: TelegramApi,
+  log: Logger,
+  opts: RateLimitOptions = {},
+): TelegramApi {
+  const cfg = {
+    perChatRefillPerSec: opts.perChatRefillPerSec ?? 1,
+    perChatBurstCapacity: opts.perChatBurstCapacity ?? 3,
+    globalRefillPerSec: opts.globalRefillPerSec ?? 25,
+    globalBurstCapacity: opts.globalBurstCapacity ?? 25,
+    maxRetries: opts.maxRetries ?? 3,
+    jitterMaxMs: opts.jitterMaxMs ?? 150,
+  }
+  const now = opts.now ?? ((): number => Date.now())
+  const sleep =
+    opts.sleep ??
+    ((ms: number): Promise<void> =>
+      ms <= 0 ? Promise.resolve() : new Promise((r) => setTimeout(r, ms)))
+
+  const globalBucket = makeBucket(cfg.globalBurstCapacity, cfg.globalRefillPerSec, now())
+  const chatState = new Map<string, ChatState>()
+
+  function getChatState(chatId: string): ChatState {
+    let s = chatState.get(chatId)
+    if (!s) {
+      s = {
+        bucket: makeBucket(cfg.perChatBurstCapacity, cfg.perChatRefillPerSec, now()),
+        tail: Promise.resolve(),
+      }
+      chatState.set(chatId, s)
+    }
+    return s
+  }
+
+  // Wait until both the per-chat and global buckets have a token, then
+  // consume one from each. Caller is responsible for holding the per-chat
+  // FIFO lock so two enqueues for the same chat can't race this check.
+  async function waitForCapacity(state: ChatState): Promise<void> {
+    // Loop because after waking from sleep, another global consumer may
+    // have stolen the token we expected. Recompute and re-sleep if so.
+    // In single-threaded JS this is rare but the loop keeps invariants
+    // robust against future async interleaving.
+    for (;;) {
+      const t = now()
+      const chatWait = waitMs(state.bucket, t)
+      const globalWait = waitMs(globalBucket, t)
+      const w = Math.max(chatWait, globalWait)
+      if (w === 0) {
+        consume(state.bucket)
+        consume(globalBucket)
+        return
+      }
+      await sleep(w)
+    }
+  }
+
+  // `maxRetries` is the MAX NUMBER OF ATTEMPTS including the initial call.
+  // Semantically: budget of how many times we hit Telegram for this op.
+  // maxRetries=3 → up to 3 attempts (2 retries after the first failure).
+  async function withRetry<T>(method: string, op: () => Promise<T>): Promise<T> {
+    let attempt = 0
+    let lastErr: unknown
+    while (true) {
+      attempt += 1
+      try {
+        return await op()
+      } catch (err) {
+        const r = parse429(err)
+        if (r === null) throw err
+        lastErr = err
+        if (attempt >= cfg.maxRetries) break
+        const jitter =
+          cfg.jitterMaxMs > 0 ? Math.floor(Math.random() * cfg.jitterMaxMs) : 0
+        const waitTotalMs = r.retryAfter * 1000 + jitter
+        log.warn('telegram 429, backing off', {
+          method,
+          retry_after_s: r.retryAfter,
+          attempt,
+          wait_ms: waitTotalMs,
+        })
+        await sleep(waitTotalMs)
+      }
+    }
+    throw lastErr
+  }
+
+  // Serialize per-chat outbound work: each new op awaits the previous op
+  // (without inheriting its error), then runs under the rate-limit gate.
+  async function enqueueSend<T>(chatId: string, op: () => Promise<T>): Promise<T> {
+    const state = getChatState(chatId)
+    const prev = state.tail
+    let release!: () => void
+    state.tail = new Promise<void>((r) => {
+      release = r
+    })
+    try {
+      await prev.catch(() => {})
+      await waitForCapacity(state)
+      return await withRetry('send', op)
+    } finally {
+      release()
+    }
+  }
+
+  return {
+    async sendMessage(
+      chatId: string,
+      text: string,
+      sendOpts: SendMessageOpts,
+    ): Promise<{ message_id: number }> {
+      return enqueueSend(chatId, () => raw.sendMessage(chatId, text, sendOpts))
+    },
+
+    async editMessageText(
+      chatId: string,
+      messageId: number,
+      text: string,
+      editOpts: EditOpts,
+    ): Promise<void> {
+      return withRetry('editMessageText', () =>
+        raw.editMessageText(chatId, messageId, text, editOpts),
+      )
+    },
+
+    async setMessageReaction(
+      chatId: string,
+      messageId: number,
+      emoji: string,
+    ): Promise<void> {
+      return withRetry('setMessageReaction', () =>
+        raw.setMessageReaction(chatId, messageId, emoji),
+      )
+    },
+
+    async sendChatAction(chatId: string, action: ChatAction): Promise<void> {
+      return withRetry('sendChatAction', () => raw.sendChatAction(chatId, action))
+    },
+
+    async sendDocument(
+      chatId: string,
+      filePath: string,
+      docOpts: SendDocumentOpts,
+    ): Promise<{ message_id: number }> {
+      return enqueueSend(chatId, () => raw.sendDocument(chatId, filePath, docOpts))
+    },
+
+    async sendPhoto(
+      chatId: string,
+      filePath: string,
+      photoOpts: SendDocumentOpts,
+    ): Promise<{ message_id: number }> {
+      return enqueueSend(chatId, () => raw.sendPhoto(chatId, filePath, photoOpts))
+    },
+
+    async downloadFile(fileId: string, destDir: string): Promise<DownloadResult> {
+      return raw.downloadFile(fileId, destDir)
+    },
+
+    async deleteMessage(chatId: string, messageId: number): Promise<void> {
+      return withRetry('deleteMessage', () => raw.deleteMessage(chatId, messageId))
+    },
+  }
+}

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -36,6 +36,7 @@ import {
   type ToolDeps,
 } from './channel/tools.js'
 import { createSafeTelegramApi } from './safety/safe-telegram-api.js'
+import { createRateLimitedTelegramApi } from './safety/rate-limited-telegram-api.js'
 import { redactSecrets } from './safety/redact.js'
 import { StatusManager } from './status/status-manager.js'
 import { ProgressReporter } from './status/progress-reporter.js'
@@ -232,11 +233,18 @@ const bot = new Bot(env.TELEGRAM_BOT_TOKEN)
 // after this line. Anything that imports TelegramApi from channel/tools
 // receives the wrapped instance via toolDeps / handlerDeps / StatusManager.
 const rawTelegramApi = createTelegramApi(bot, env.TELEGRAM_BOT_TOKEN)
+// Composition: caller → safeTelegramApi (sanitize) → rateLimitedTelegramApi
+// (queue + 429 retry) → rawTelegramApi (grammY). Sanitize runs FIRST so the
+// queue holds already-redacted/validated payloads (no secret leak if a
+// queued op gets logged; no time wasted enqueueing text that would later be
+// downgraded). A burst of replies now paces itself instead of surfacing as
+// a 429 to the agent.
+const rateLimitedTelegramApi = createRateLimitedTelegramApi(rawTelegramApi, log)
 // The bot token itself is included in extraSecrets so any code path that
 // accidentally tries to ship the token (e.g. error message including a
 // URL-with-token from grammy) gets it scrubbed before the bytes leave us.
 const apiSecrets: string[] = [...logSecrets, env.TELEGRAM_BOT_TOKEN]
-const telegramApi = createSafeTelegramApi(rawTelegramApi, log, apiSecrets)
+const telegramApi = createSafeTelegramApi(rateLimitedTelegramApi, log, apiSecrets)
 
 const mcp = new Server(
   { name: 'dashi-channel', version: '1.0.0' },

--- a/plugin/tests/safety/rate-limited-telegram-api.test.ts
+++ b/plugin/tests/safety/rate-limited-telegram-api.test.ts
@@ -1,0 +1,477 @@
+// Tests for createRateLimitedTelegramApi — the wrapper that enforces
+// per-chat FIFO ordering, a per-chat token bucket, a global token bucket,
+// and 429 retry-after backoff on every outbound API call.
+//
+// The wrapper is transport-agnostic; we feed it a hand-rolled stub
+// TelegramApi that records every call and can be programmed to throw
+// grammY-shaped 429 errors. A fake clock + fake sleep give deterministic
+// tests with no real wall-clock waits.
+
+import { describe, expect, test } from 'bun:test'
+import type {
+  ChatAction,
+  DownloadResult,
+  EditOpts,
+  SendDocumentOpts,
+  SendMessageOpts,
+  TelegramApi,
+} from '../../src/channel/tools.js'
+import type { Logger } from '../../src/log.js'
+import {
+  createRateLimitedTelegramApi,
+  type RateLimitOptions,
+} from '../../src/safety/rate-limited-telegram-api.js'
+
+interface SentCall {
+  method:
+    | 'sendMessage'
+    | 'editMessageText'
+    | 'setMessageReaction'
+    | 'sendChatAction'
+    | 'sendDocument'
+    | 'sendPhoto'
+    | 'deleteMessage'
+    | 'downloadFile'
+  chatId?: string
+  messageId?: number
+  text?: string
+  emoji?: string
+  action?: ChatAction
+  filePath?: string
+  fileId?: string
+  opts?: SendMessageOpts | EditOpts | SendDocumentOpts
+  ts: number
+}
+
+class FakeClock {
+  // ms since start of test. Tests advance by calling `tick(ms)`.
+  private t = 0
+  now = (): number => this.t
+  // Pending sleep resolvers, keyed by absolute wake time.
+  private pending: Array<{ wakeAt: number; resolve: () => void }> = []
+  sleep = (ms: number): Promise<void> => {
+    if (ms <= 0) return Promise.resolve()
+    return new Promise<void>((resolve) => {
+      this.pending.push({ wakeAt: this.t + ms, resolve })
+    })
+  }
+  async tick(ms: number): Promise<void> {
+    this.t += ms
+    // Resolve any sleeps whose wake time has passed. Resolve in order so
+    // FIFO ordering is preserved.
+    const due = this.pending
+      .filter((p) => p.wakeAt <= this.t)
+      .sort((a, b) => a.wakeAt - b.wakeAt)
+    this.pending = this.pending.filter((p) => p.wakeAt > this.t)
+    for (const p of due) p.resolve()
+    // Yield to event loop so resolved promises propagate.
+    await flushMicrotasks()
+  }
+}
+
+// Drain microtask queue so awaiting code can advance.
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve))
+}
+
+// Build a grammY-shaped 429 error.
+function make429Error(retryAfter: number | undefined): Error {
+  const err = new Error('Too Many Requests') as Error & {
+    error_code: number
+    parameters: { retry_after?: number }
+  }
+  err.error_code = 429
+  err.parameters = retryAfter !== undefined ? { retry_after: retryAfter } : {}
+  return err
+}
+
+interface StubApi {
+  api: TelegramApi
+  calls: SentCall[]
+  // Programmed errors per method/chat. When an error is set, the next
+  // matching call throws it and the entry is consumed.
+  queueError(method: SentCall['method'], err: Error): void
+}
+
+function makeStubApi(clock: FakeClock): StubApi {
+  const calls: SentCall[] = []
+  const errorQueue: Map<SentCall['method'], Error[]> = new Map()
+  const maybeThrow = (method: SentCall['method']): void => {
+    const list = errorQueue.get(method)
+    if (list && list.length > 0) {
+      const err = list.shift()
+      if (err) throw err
+    }
+  }
+  const api: TelegramApi = {
+    async sendMessage(chatId, text, opts) {
+      maybeThrow('sendMessage')
+      calls.push({ method: 'sendMessage', chatId, text, opts, ts: clock.now() })
+      return { message_id: calls.length }
+    },
+    async editMessageText(chatId, messageId, text, opts) {
+      maybeThrow('editMessageText')
+      calls.push({ method: 'editMessageText', chatId, messageId, text, opts, ts: clock.now() })
+    },
+    async setMessageReaction(chatId, messageId, emoji) {
+      maybeThrow('setMessageReaction')
+      calls.push({ method: 'setMessageReaction', chatId, messageId, emoji, ts: clock.now() })
+    },
+    async sendChatAction(chatId, action) {
+      maybeThrow('sendChatAction')
+      calls.push({ method: 'sendChatAction', chatId, action, ts: clock.now() })
+    },
+    async sendDocument(chatId, filePath, opts) {
+      maybeThrow('sendDocument')
+      calls.push({ method: 'sendDocument', chatId, filePath, opts, ts: clock.now() })
+      return { message_id: calls.length }
+    },
+    async sendPhoto(chatId, filePath, opts) {
+      maybeThrow('sendPhoto')
+      calls.push({ method: 'sendPhoto', chatId, filePath, opts, ts: clock.now() })
+      return { message_id: calls.length }
+    },
+    async downloadFile(fileId, _destDir) {
+      maybeThrow('downloadFile')
+      calls.push({ method: 'downloadFile', fileId, ts: clock.now() })
+      return { path: '/tmp/x', size: 0 } satisfies DownloadResult
+    },
+    async deleteMessage(chatId, messageId) {
+      maybeThrow('deleteMessage')
+      calls.push({ method: 'deleteMessage', chatId, messageId, ts: clock.now() })
+    },
+  }
+  return {
+    api,
+    calls,
+    queueError(method, err) {
+      const list = errorQueue.get(method) ?? []
+      list.push(err)
+      errorQueue.set(method, list)
+    },
+  }
+}
+
+const stubLog: Logger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+}
+
+function defaultOpts(clock: FakeClock): RateLimitOptions {
+  return {
+    perChatRefillPerSec: 1,
+    perChatBurstCapacity: 3,
+    globalRefillPerSec: 25,
+    globalBurstCapacity: 25,
+    maxRetries: 3,
+    jitterMaxMs: 0, // deterministic
+    now: clock.now,
+    sleep: clock.sleep,
+  }
+}
+
+describe('createRateLimitedTelegramApi — per-chat token bucket', () => {
+  test('single send passes through immediately', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
+    const result = await api.sendMessage('100', 'hi', {})
+    expect(result.message_id).toBe(1)
+    expect(stub.calls.length).toBe(1)
+    expect(stub.calls[0]?.ts).toBe(0)
+  })
+
+  test('first 3 sends to same chat consume burst capacity without waiting', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
+    await Promise.all([
+      api.sendMessage('100', 'a', {}),
+      api.sendMessage('100', 'b', {}),
+      api.sendMessage('100', 'c', {}),
+    ])
+    expect(stub.calls.map((c) => c.text)).toEqual(['a', 'b', 'c'])
+    expect(stub.calls.every((c) => c.ts === 0)).toBe(true)
+  })
+
+  test('4th send to same chat waits for refill (1s)', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
+    // Drain the burst.
+    await api.sendMessage('100', 'a', {})
+    await api.sendMessage('100', 'b', {})
+    await api.sendMessage('100', 'c', {})
+    expect(stub.calls.length).toBe(3)
+    // Fourth send must wait ~1000ms for refill.
+    const p = api.sendMessage('100', 'd', {})
+    await flushMicrotasks()
+    expect(stub.calls.length).toBe(3) // still queued
+    await clock.tick(999)
+    expect(stub.calls.length).toBe(3)
+    await clock.tick(1)
+    await p
+    expect(stub.calls.length).toBe(4)
+    expect(stub.calls[3]?.text).toBe('d')
+  })
+
+  test('sends to different chats run in parallel up to global cap', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
+    // 5 different chats — global cap is 25, per-chat each gets a fresh
+    // bucket, so all 5 should fire at t=0.
+    await Promise.all([
+      api.sendMessage('100', 'a', {}),
+      api.sendMessage('200', 'b', {}),
+      api.sendMessage('300', 'c', {}),
+      api.sendMessage('400', 'd', {}),
+      api.sendMessage('500', 'e', {}),
+    ])
+    expect(stub.calls.length).toBe(5)
+    expect(stub.calls.every((c) => c.ts === 0)).toBe(true)
+  })
+
+  test('FIFO order preserved within a single chat under concurrency', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
+    // Fire 5 sends concurrently — first 3 burst through, 4th waits 1s, 5th waits 2s.
+    const p = Promise.all([
+      api.sendMessage('100', '1', {}),
+      api.sendMessage('100', '2', {}),
+      api.sendMessage('100', '3', {}),
+      api.sendMessage('100', '4', {}),
+      api.sendMessage('100', '5', {}),
+    ])
+    await flushMicrotasks()
+    expect(stub.calls.length).toBe(3)
+    await clock.tick(1000)
+    expect(stub.calls.length).toBe(4)
+    await clock.tick(1000)
+    await p
+    expect(stub.calls.length).toBe(5)
+    expect(stub.calls.map((c) => c.text)).toEqual(['1', '2', '3', '4', '5'])
+  })
+})
+
+describe('createRateLimitedTelegramApi — global token bucket', () => {
+  test('global cap caps parallel sends across chats', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const opts = defaultOpts(clock)
+    opts.globalBurstCapacity = 2
+    opts.globalRefillPerSec = 1
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, opts)
+    // 3 different chats, each chat has fresh per-chat bucket. Global cap=2
+    // means only 2 fire at t=0; the third waits 1s for global refill.
+    const p = Promise.all([
+      api.sendMessage('100', 'a', {}),
+      api.sendMessage('200', 'b', {}),
+      api.sendMessage('300', 'c', {}),
+    ])
+    await flushMicrotasks()
+    expect(stub.calls.length).toBe(2)
+    await clock.tick(1000)
+    await p
+    expect(stub.calls.length).toBe(3)
+  })
+})
+
+describe('createRateLimitedTelegramApi — 429 retry-after', () => {
+  test('429 with retry_after triggers single backoff and retries', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
+    stub.queueError('sendMessage', make429Error(2))
+    const p = api.sendMessage('100', 'hi', {})
+    await flushMicrotasks()
+    // First call threw 429 — no recorded call yet (error path skips push).
+    expect(stub.calls.length).toBe(0)
+    // Advance < retry_after — still waiting.
+    await clock.tick(1999)
+    expect(stub.calls.length).toBe(0)
+    await clock.tick(1)
+    const r = await p
+    expect(stub.calls.length).toBe(1)
+    expect(r.message_id).toBe(1)
+  })
+
+  test('429 without retry_after falls back to 1s', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
+    stub.queueError('sendMessage', make429Error(undefined))
+    const p = api.sendMessage('100', 'hi', {})
+    await flushMicrotasks()
+    await clock.tick(999)
+    expect(stub.calls.length).toBe(0)
+    await clock.tick(1)
+    await p
+    expect(stub.calls.length).toBe(1)
+  })
+
+  test('two consecutive 429s succeed on the third attempt', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
+    stub.queueError('sendMessage', make429Error(1))
+    stub.queueError('sendMessage', make429Error(2))
+    const p = api.sendMessage('100', 'hi', {})
+    await flushMicrotasks()
+    await clock.tick(1000) // first retry-after
+    await flushMicrotasks()
+    await clock.tick(2000) // second retry-after
+    await p
+    expect(stub.calls.length).toBe(1)
+  })
+
+  test('after maxRetries 429s, error propagates', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const opts = defaultOpts(clock)
+    opts.maxRetries = 2
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, opts)
+    stub.queueError('sendMessage', make429Error(1))
+    stub.queueError('sendMessage', make429Error(1))
+    const p = api.sendMessage('100', 'hi', {}).catch((e: unknown) => e)
+    await flushMicrotasks()
+    await clock.tick(1000)
+    await flushMicrotasks()
+    const result = await p
+    expect(result).toBeInstanceOf(Error)
+    expect((result as { error_code?: number }).error_code).toBe(429)
+    expect(stub.calls.length).toBe(0)
+  })
+
+  test('non-429 errors propagate immediately without retry', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
+    const err = new Error('boom') as Error & { error_code?: number }
+    err.error_code = 400
+    stub.queueError('sendMessage', err)
+    await expect(api.sendMessage('100', 'hi', {})).rejects.toMatchObject({ message: 'boom' })
+    expect(stub.calls.length).toBe(0)
+  })
+
+  test('429 on editMessageText also retries (lighter bucket)', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
+    stub.queueError('editMessageText', make429Error(1))
+    const p = api.editMessageText('100', 42, 'edited', {})
+    await flushMicrotasks()
+    await clock.tick(1000)
+    await p
+    expect(stub.calls.length).toBe(1)
+  })
+})
+
+describe('createRateLimitedTelegramApi — retry_after clamp & edge values', () => {
+  test('retry_after over 60s is clamped to 60s', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
+    stub.queueError('sendMessage', make429Error(300))
+    const p = api.sendMessage('100', 'hi', {})
+    await flushMicrotasks()
+    // Even though Telegram said 300s, we should retry after 60s.
+    await clock.tick(60_000)
+    await p
+    expect(stub.calls.length).toBe(1)
+  })
+
+  test('retry_after = 0 is treated as 1s fallback', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
+    stub.queueError('sendMessage', make429Error(0))
+    const p = api.sendMessage('100', 'hi', {})
+    await flushMicrotasks()
+    await clock.tick(1000)
+    await p
+    expect(stub.calls.length).toBe(1)
+  })
+
+  test('FIFO: second send waits for first retry to finish, then runs in order', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
+    // First call gets a 429 (retry_after=1), then succeeds.
+    stub.queueError('sendMessage', make429Error(1))
+    const p = Promise.all([
+      api.sendMessage('100', 'first', {}),
+      api.sendMessage('100', 'second', {}),
+    ])
+    await flushMicrotasks()
+    // First call threw 429; second is still waiting on the chat tail.
+    expect(stub.calls.length).toBe(0)
+    await clock.tick(1000)
+    await p
+    expect(stub.calls.map((c) => c.text)).toEqual(['first', 'second'])
+  })
+})
+
+describe('createRateLimitedTelegramApi — pass-through methods', () => {
+  test('downloadFile is not rate-limited', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
+    // 10 parallel downloads should all fire at t=0.
+    await Promise.all(
+      Array.from({ length: 10 }, () => api.downloadFile('f', '/tmp')),
+    )
+    expect(stub.calls.length).toBe(10)
+    expect(stub.calls.every((c) => c.ts === 0)).toBe(true)
+  })
+
+  test('editMessageText does not consume the per-chat send bucket', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const opts = defaultOpts(clock)
+    opts.perChatBurstCapacity = 1
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, opts)
+    // Use up the per-chat send bucket.
+    await api.sendMessage('100', 'a', {})
+    // Now do many edits — they must not be throttled by the send bucket.
+    await Promise.all(
+      Array.from({ length: 5 }, () => api.editMessageText('100', 42, 'edit', {})),
+    )
+    expect(stub.calls.filter((c) => c.method === 'editMessageText').length).toBe(5)
+  })
+
+  test('setMessageReaction is not gated by send bucket', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const opts = defaultOpts(clock)
+    opts.perChatBurstCapacity = 1
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, opts)
+    await api.sendMessage('100', 'a', {})
+    await Promise.all(
+      Array.from({ length: 5 }, () => api.setMessageReaction('100', 42, 'eyes')),
+    )
+    expect(stub.calls.filter((c) => c.method === 'setMessageReaction').length).toBe(5)
+  })
+
+  test('sendDocument and sendPhoto share the per-chat send bucket', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const opts = defaultOpts(clock)
+    opts.perChatBurstCapacity = 2
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, opts)
+    // Fire send + document + photo — third must wait since burst=2.
+    const p = Promise.all([
+      api.sendMessage('100', 'a', {}),
+      api.sendDocument('100', '/tmp/d.pdf', {}),
+      api.sendPhoto('100', '/tmp/p.jpg', {}),
+    ])
+    await flushMicrotasks()
+    expect(stub.calls.length).toBe(2)
+    await clock.tick(1000)
+    await p
+    expect(stub.calls.length).toBe(3)
+  })
+})


### PR DESCRIPTION
## Проблема

Burst отправок (например, многочастный отчёт) Telegram воспринимает как rate-limit violation и возвращает 429 с `retry_after` 300+ секунд. Канал ложится на 5+ минут, агент видит ошибку, но не может programmatically её обработать. Прямой триггер — security audit отчёт сегодня: 3 длинных сообщения подряд → 429 → 5 минут тишины.

## Решение

Новый wrapper `createRateLimitedTelegramApi` между `rawTelegramApi` и `createSafeTelegramApi` в `server.ts`. Делает rate limit ПОЛНОСТЬЮ невидимым для агента.

### Слои защиты

- **Per-chat token bucket** (`1 msg/sec sustained, burst 3`)
- **Global bucket** (`25 msg/sec, burst 25`, под Telegram 30/sec)
- **Per-chat FIFO ordering** через `tail: Promise<void>` chain
- **429 retry**: парсит grammY shape, sleep + retry, `maxRetries=3` total
- **retry_after clamp** `[1, 60s]`: worst-case per-chat stall = `3 × 60s = 3 min`

### Композиция

```
caller -> safeTelegramApi (sanitize) -> rateLimitedTelegramApi (queue + 429) -> rawTelegramApi (grammY)
```

`editMessageText`, реакции, `sendChatAction`, `deleteMessage` НЕ потребляют send-bucket (более лояльные лимиты Telegram), но всё равно проходят через 429 retry.

## Тесты

19 тестов в `tests/safety/rate-limited-telegram-api.test.ts`. Все зелёные.

- Per-chat bucket: single/burst/FIFO ordering
- Global cap: cross-chat throttle
- 429: single retry, double retry, `maxRetries` exhaustion, clamp, edge values
- 429 + FIFO: retry первой op не ломает порядок второй
- Pass-through: `downloadFile`, `editMessageText`, `setMessageReaction`

Test seams: `opts.now` + `opts.sleep` — virtual time, мгновенные deterministic тесты.

## Double review

Codex GPT-5.5 review applied:
- MEDIUM: `retry_after` clamp до 60s — fixed
- LOW (docs): FIFO HOL blocking — задокументировано в JSDoc
- Не делал в этом PR (scope): TTL cleanup `chatState` Map, monotonic clock

## Backwards compatibility

`TelegramApi` interface не меняется. Без feature flag — лимитер всегда активен.

## Test plan

- [x] `bun test tests/safety/rate-limited-telegram-api.test.ts` — 19 pass
- [x] `bun test tests/safety/` — 98 pass (no regression)
- [x] `bun run typecheck` — my files clean
- [ ] Smoke test после merge: burst из 5 reply без 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)