### PR TITLE
feat(status): TmuxMirror — rolling terminal view в Telegram

### DIFF
--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -127,6 +127,21 @@ export const AppConfigSchema = z.object({
     debounce_ms: z.number().int().nonnegative().default(10_000),
     busy_threshold_ms: z.number().int().positive().default(30_000),
   }).default({}),
+  // TmuxMirror (2026-05-20) — read-only view of the agent's terminal pane
+  // mirrored into one rolling Telegram message via editMessageText. Pulls
+  // `tmux capture-pane` on a timer, dedups by hash, and self-heals when
+  // the message is deleted (re-sends on next poll).
+  //
+  // Default-OFF: pane content can include unexpected secrets, and the
+  // warchief should opt in explicitly. Enable via config.json or env.
+  // pane_target follows the `session:window.pane` syntax — empty string
+  // means «use the session in $TMUX env at startup».
+  tmux_mirror: z.object({
+    enabled: z.boolean().default(false),
+    pane_target: z.string().default(''),
+    poll_interval_ms: z.number().int().min(500).default(5000),
+    line_count: z.number().int().min(5).max(500).default(50),
+  }).default({}),
 })
 export type AppConfig = z.infer<typeof AppConfigSchema>
 

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -41,6 +41,7 @@ import { redactSecrets } from './safety/redact.js'
 import { StatusManager } from './status/status-manager.js'
 import { ProgressReporter } from './status/progress-reporter.js'
 import { TaskMirror } from './status/task-mirror.js'
+import { TmuxMirror } from './status/tmux-mirror.js'
 import { InboundWatcher } from './telegram/watcher.js'
 import { MemoryWriter, type MemoryConfig } from './memory/writer.js'
 import { dirname as pathDirname } from 'path'
@@ -279,6 +280,44 @@ const progressReporter = new ProgressReporter({ telegramApi, config, log })
 // above; uses the same safe-wrapped telegramApi so every text/edit goes
 // through redact + HTML validation before leaving the process.
 const taskMirror = new TaskMirror({ telegramApi, config, log })
+
+// TmuxMirror (2026-05-20) — read-only mirror of the agent's terminal pane
+// into ONE rolling Telegram message. Default-OFF in config; the warchief
+// opts in explicitly. When enabled without an explicit pane_target we
+// fall back to `channel-thrall:0.0` — the canonical session for this
+// plugin on Thrall VPS.
+let tmuxMirror: TmuxMirror | null = null
+if (config.tmux_mirror.enabled) {
+  const target = config.tmux_mirror.pane_target || 'channel-thrall:0.0'
+  const mirrorChatId = String(config.allowed_chat_ids[0] ?? '')
+  if (mirrorChatId === '') {
+    log.warn('tmux mirror enabled but no allowed_chat_ids configured — skipping')
+  } else {
+    tmuxMirror = new TmuxMirror({
+      api: telegramApi,
+      log,
+      chatId: mirrorChatId,
+      paneTarget: target,
+      pollIntervalMs: config.tmux_mirror.poll_interval_ms,
+      lineCount: config.tmux_mirror.line_count,
+      redact: (text) => redactSecrets(text, apiSecrets),
+    })
+    void tmuxMirror.start().catch((err: unknown) => {
+      log.warn('tmux mirror start failed', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    })
+    // Best-effort cleanup on process exit: delete the rolling message so
+    // a stale «terminal mirror» card doesn't sit in the chat forever.
+    const shutdownMirror = (): void => {
+      tmuxMirror?.stop().catch(() => {
+        /* already logged inside stop() */
+      })
+    }
+    process.once('SIGINT', shutdownMirror)
+    process.once('SIGTERM', shutdownMirror)
+  }
+}
 
 // InboundWatcher (PR-A3, 2026-05-20) — auto-reply «Тралл занят» when the
 // warchief sends plain text while ProgressReporter says the session is

--- a/plugin/src/status/tmux-mirror.ts
+++ b/plugin/src/status/tmux-mirror.ts
@@ -1,0 +1,371 @@
+// TmuxMirror — read-only «what is the agent doing right now» surface.
+//
+// Polls `tmux capture-pane` for a configured pane, strips ANSI/control
+// sequences, runs the bytes through the same secret redactor used for
+// Telegram-bound text, then re-renders the result into ONE rolling
+// Telegram message via editMessageText. Identical poll output (same hash)
+// is a no-op: we never spam Telegram when the pane is idle.
+//
+// Lifecycle:
+//   start() — sets enabled=true, captures the pane, sends the initial
+//     message, arms the internal interval.
+//   onPoll() — public for tests; the interval also calls this. Captures,
+//     diffs against the last hash, and either edits or skips.
+//   stop()  — clears the interval, attempts to deleteMessage (best effort),
+//     forgets the messageId so a future start() begins clean.
+//
+// Failure modes:
+//   tmux exec fails (session gone, binary missing) → render an «unavailable»
+//     state into the rolling message and keep polling. Self-heals on the
+//     next successful capture.
+//   editMessageText returns 4xx «message not found» → forget messageId so
+//     the next poll re-sends. (Tests cover error_code 400.)
+//   safe-telegram-api already applies a redactor on the outbound path, but
+//     we run our own pass first so the queued payload is already redacted
+//     by the time it sits in the rate-limit queue.
+//
+// What this module DOES NOT do (deliberate out-of-scope):
+//   • Telegram → tmux keystroke injection (control surface, future PR).
+//   • Voice transcription / screenshots.
+//   • Multiple panes per session.
+
+import { execFile } from 'child_process'
+import { createHash } from 'crypto'
+import { promisify } from 'util'
+
+import type { Logger } from '../log.js'
+import type { TelegramApi } from '../channel/tools.js'
+
+export interface TmuxExecResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+// Test seam: the production wrapper calls `tmux capture-pane`; tests
+// inject a deterministic stub. Args are exactly the argv after the binary.
+export type TmuxExec = (args: readonly string[]) => Promise<TmuxExecResult>
+
+export interface TmuxMirrorOptions {
+  api: TelegramApi
+  log: Logger
+  chatId: string
+  // tmux target spec, e.g. `channel-thrall:0.0` (session:window.pane).
+  paneTarget: string
+  // Polling cadence. Tests usually drive `onPoll()` directly and pass a
+  // long interval so the interval never fires within the test window.
+  pollIntervalMs: number
+  // -S argument to capture-pane: N most recent lines.
+  lineCount: number
+  // Optional: replace the default child-process driver. Default uses
+  // execFile + promisify. Tests inject a function returning canned output.
+  exec?: TmuxExec
+  // Optional: replace redactSecrets pipeline. Default = identity (the
+  // safe-telegram-api wrapper still redacts on the send path, so this
+  // second pass is defence-in-depth). Wiring callers (server.ts) pass
+  // the same redactor that the safe-telegram-api uses.
+  redact?: (text: string) => string
+  // Optional: clock override for status timestamps. Default Date.now.
+  now?: () => number
+  // Telegram body cap. Defaults to 4096 — the hard limit on sendMessage.
+  maxBodyChars?: number
+}
+
+export interface TmuxMirrorStatus {
+  enabled: boolean
+  messageId?: number
+  lastHash?: string
+  lastError?: string
+  lastPollAt?: number
+}
+
+// Telegram HTML parse mode keeps `<pre>` formatting intact.
+const HTML_OPTS = { parse_mode: 'HTML' as const }
+
+// Strip ANSI / vt control sequences and bare control characters. Keep
+// newlines + tabs. Patterns:
+//   • CSI:  ESC [ ... terminator-letter
+//   • OSC:  ESC ] ... BEL  OR  ESC ] ... ST (ESC \)
+//   • DCS/PM/APC/SOS: ESC (P|^|_|X) ... ST
+//   • two-byte: ESC + single char in @-Z, \, -, _
+// Stripping happens BEFORE htmlEscape so leftover characters can't blow up
+// Telegram's HTML parser. ST is `ESC \`; we accept both BEL and ST as
+// terminators for OSC since real terminals emit either.
+const ANSI_RE =
+  // eslint-disable-next-line no-control-regex
+  /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][\s\S]*?(?:\x07|\x1b\\)|[P^_X][\s\S]*?\x1b\\|[@-Z\\\-_])/g
+// eslint-disable-next-line no-control-regex
+const CTRL_RE = /[\x00-\x08\x0B-\x0C\x0E-\x1F\x7F]/g
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, '').replace(CTRL_RE, '')
+}
+
+function htmlEscape(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+function hash(text: string): string {
+  return createHash('sha256').update(text).digest('hex').slice(0, 16)
+}
+
+// Default exec: spawn tmux and capture stdout/stderr. We never throw on
+// non-zero exit so the caller can render the failure state instead of
+// crashing the polling loop.
+const execFileAsync = promisify(execFile)
+async function defaultTmuxExec(args: readonly string[]): Promise<TmuxExecResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync('tmux', args as string[], {
+      maxBuffer: 4 * 1024 * 1024,
+      encoding: 'utf8',
+      timeout: 5000,
+    })
+    return { stdout, stderr, exitCode: 0 }
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; code?: number; message?: string }
+    return {
+      stdout: e.stdout ?? '',
+      stderr: e.stderr ?? e.message ?? 'tmux exec failed',
+      exitCode: typeof e.code === 'number' ? e.code : 1,
+    }
+  }
+}
+
+// Render the body. Wraps content in a `<pre>` block, prepends a small
+// header so it's clear what is being mirrored, and enforces the body cap
+// by trimming from the TOP (oldest lines) — the warchief almost always
+// cares about the most recent output.
+function renderBody(rawPane: string, errorMsg: string | undefined, maxChars: number): string {
+  const header = errorMsg
+    ? `<b>terminal mirror</b> — <i>${htmlEscape(errorMsg)}</i>\n`
+    : `<b>terminal mirror</b>\n`
+  const footer = '' // reserved for future state lines
+  const overhead = '<pre></pre>'.length
+  const reserved = header.length + footer.length + overhead + 32 // safety
+  const budget = Math.max(256, maxChars - reserved)
+
+  let payload = htmlEscape(rawPane)
+  let truncated = false
+  if (payload.length > budget) {
+    payload = payload.slice(payload.length - budget)
+    // Try to break on the next newline so we don't slice mid-line.
+    const nl = payload.indexOf('\n')
+    if (nl >= 0 && nl < 200) {
+      payload = payload.slice(nl + 1)
+    }
+    truncated = true
+  }
+  const prefix = truncated ? '… [truncated]\n' : ''
+  return `${header}<pre>${prefix}${payload}</pre>${footer}`
+}
+
+export class TmuxMirror {
+  private readonly api: TelegramApi
+  private readonly log: Logger
+  private readonly chatId: string
+  private readonly paneTarget: string
+  private readonly pollIntervalMs: number
+  private readonly lineCount: number
+  private readonly exec: TmuxExec
+  private readonly redact: (text: string) => string
+  private readonly now: () => number
+  private readonly maxBodyChars: number
+
+  private timer: ReturnType<typeof setInterval> | null = null
+  private enabled = false
+  private messageId: number | undefined
+  private lastHash: string | undefined
+  private lastError: string | undefined
+  private lastPollAt: number | undefined
+  // In-flight guard: while a poll is processing (capture + send/edit),
+  // overlapping calls return early. Combined with hash-dedup this keeps
+  // Telegram traffic O(1) per pane change rather than O(N) per poll.
+  private inFlight = false
+
+  constructor(opts: TmuxMirrorOptions) {
+    this.api = opts.api
+    this.log = opts.log
+    this.chatId = opts.chatId
+    this.paneTarget = opts.paneTarget
+    this.pollIntervalMs = opts.pollIntervalMs
+    this.lineCount = opts.lineCount
+    this.exec = opts.exec ?? defaultTmuxExec
+    this.redact = opts.redact ?? ((s) => s)
+    this.now = opts.now ?? ((): number => Date.now())
+    this.maxBodyChars = opts.maxBodyChars ?? 4096
+  }
+
+  // Pure rendering: turn a tmux exec result into the final body. Side
+  // effects are confined to `this.lastError` so the caller can surface the
+  // last failure reason via status() without re-parsing. Never throws —
+  // a failing redact callback is caught and rendered as an error state.
+  private buildRendered(result: TmuxExecResult): string {
+    if (result.exitCode !== 0) {
+      this.lastError = result.stderr.trim() || `tmux exited ${result.exitCode}`
+      const errMsg = `tmux unavailable: ${this.lastError.slice(0, 200)}`
+      return renderBody('(no output)', errMsg, this.maxBodyChars)
+    }
+    const cleaned = stripAnsi(result.stdout)
+    let redacted: string
+    try {
+      redacted = this.redact(cleaned)
+    } catch (err) {
+      this.lastError = err instanceof Error ? err.message : String(err)
+      this.log.warn('tmux mirror redact threw (rendered as error)', {
+        error: this.lastError,
+      })
+      const errMsg = `redactor failed: ${this.lastError.slice(0, 200)}`
+      return renderBody('(redacted suppressed)', errMsg, this.maxBodyChars)
+    }
+    this.lastError = undefined
+    return renderBody(redacted, undefined, this.maxBodyChars)
+  }
+
+  status(): TmuxMirrorStatus {
+    // Use conditional spread to honour `exactOptionalPropertyTypes: true`:
+    // optional fields must be omitted when unset rather than explicitly
+    // undefined.
+    const out: TmuxMirrorStatus = { enabled: this.enabled }
+    if (this.messageId !== undefined) out.messageId = this.messageId
+    if (this.lastHash !== undefined) out.lastHash = this.lastHash
+    if (this.lastError !== undefined) out.lastError = this.lastError
+    if (this.lastPollAt !== undefined) out.lastPollAt = this.lastPollAt
+    return out
+  }
+
+  async start(): Promise<void> {
+    if (this.enabled) return
+    this.enabled = true
+    // First poll runs synchronously inside start() so the caller can
+    // observe the initial message_id (and tests can assert on it without
+    // waiting on the interval).
+    await this.onPoll()
+    // stop() could have been called while the first poll was awaiting.
+    // Don't arm the interval in that case — it would just spin forever
+    // bailing out at the enabled-check inside onPoll.
+    if (!this.enabled) return
+    this.timer = setInterval(() => {
+      this.onPoll().catch((err: unknown) => {
+        // Should never reach here — onPoll catches everything internally —
+        // but guard the interval callback anyway so a bug here can't crash
+        // the host process.
+        this.log.warn('tmux mirror onPoll uncaught', {
+          error: err instanceof Error ? err.message : String(err),
+        })
+      })
+    }, this.pollIntervalMs)
+  }
+
+  async stop(): Promise<void> {
+    this.enabled = false
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+    if (this.messageId !== undefined) {
+      try {
+        await this.api.deleteMessage(this.chatId, this.messageId)
+      } catch (err) {
+        // Best-effort; deletion is cosmetic.
+        this.log.warn('tmux mirror delete failed (ignored)', {
+          chat_id: this.chatId,
+          message_id: this.messageId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+      this.messageId = undefined
+    }
+    this.lastHash = undefined
+  }
+
+  async onPoll(): Promise<void> {
+    if (!this.enabled) return
+    if (this.inFlight) return
+    this.inFlight = true
+    try {
+      this.lastPollAt = this.now()
+      const result = await this.exec([
+        'capture-pane',
+        '-p',
+        '-t',
+        this.paneTarget,
+        '-S',
+        `-${this.lineCount}`,
+      ])
+      // stop() may have flipped `enabled` while exec was awaiting. If so,
+      // bail before producing any side effect (send / edit / state change).
+      // Without this, a poll that started moments before stop() would
+      // resurrect `messageId` and leave a ghost message in the chat.
+      if (!this.enabled) return
+
+      const rendered = this.buildRendered(result)
+      const h = hash(rendered)
+      if (h === this.lastHash) {
+        // Identical body — skip the Telegram round-trip entirely.
+        return
+      }
+
+      if (this.messageId === undefined) {
+        try {
+          const sent = await this.api.sendMessage(this.chatId, rendered, HTML_OPTS)
+          // Late gate: stop() between the await and now would otherwise
+          // leave us with a fresh messageId on a disabled mirror. Delete
+          // the freshly-sent message to keep the contract.
+          if (!this.enabled) {
+            try {
+              await this.api.deleteMessage(this.chatId, sent.message_id)
+            } catch {
+              /* best effort */
+            }
+            return
+          }
+          this.messageId = sent.message_id
+          this.lastHash = h
+        } catch (err) {
+          this.log.warn('tmux mirror sendMessage failed (ignored)', {
+            chat_id: this.chatId,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
+        return
+      }
+
+      try {
+        await this.api.editMessageText(this.chatId, this.messageId, rendered, HTML_OPTS)
+        this.lastHash = h
+      } catch (err) {
+        // Recreate only when Telegram says "message to edit not found",
+        // not on every 4xx. 400 + that description means the message
+        // is gone; auth (401), forbidden (403), payload-too-large (413)
+        // etc. must NOT trigger recreate — that would cause an infinite
+        // resend storm on a permanent failure.
+        const e = err as { error_code?: number; description?: string }
+        const desc = (e.description ?? '').toLowerCase()
+        const isMessageGone =
+          (e.error_code === 400 || e.error_code === 404) &&
+          (desc.includes('message to edit not found') ||
+            desc.includes('message not found') ||
+            desc.includes('message_id_invalid'))
+        if (isMessageGone) {
+          this.messageId = undefined
+          this.lastHash = undefined
+          this.log.info('tmux mirror message gone, will resend next poll', {
+            chat_id: this.chatId,
+            error_code: e.error_code,
+          })
+        } else {
+          this.log.warn('tmux mirror editMessageText failed (ignored)', {
+            chat_id: this.chatId,
+            error_code: e.error_code,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
+      }
+    } finally {
+      this.inFlight = false
+    }
+  }
+}

--- a/plugin/tests/status/tmux-mirror.test.ts
+++ b/plugin/tests/status/tmux-mirror.test.ts
@@ -1,0 +1,468 @@
+// Tests for TmuxMirror — the rolling Telegram message that polls
+// `tmux capture-pane` and re-renders the last N lines into one
+// chat message. We exercise the lifecycle (start / stop), the hash-dedup
+// skip, the recreate-on-404 path, ANSI strip + redaction, length cap, and
+// tmux-unavailable behaviour.
+//
+// The mirror is wall-clock + child-process driven, so the test injects
+// fake `exec` and `now` seams to keep tests deterministic and fast.
+
+import { describe, expect, test } from 'bun:test'
+import type {
+  ChatAction,
+  DownloadResult,
+  EditOpts,
+  SendDocumentOpts,
+  SendMessageOpts,
+  TelegramApi,
+} from '../../src/channel/tools.js'
+import type { Logger } from '../../src/log.js'
+import {
+  TmuxMirror,
+  type TmuxExec,
+  type TmuxExecResult,
+} from '../../src/status/tmux-mirror.js'
+
+interface SentOp {
+  method: 'sendMessage' | 'editMessageText' | 'deleteMessage'
+  chatId: string
+  messageId?: number
+  text?: string
+}
+
+function makeStubApi(initialMessageId = 100): {
+  api: TelegramApi
+  ops: SentOp[]
+  queueEditError(err: { error_code: number; description?: string }): void
+  reset(): void
+} {
+  const ops: SentOp[] = []
+  let nextMessageId = initialMessageId
+  let editErrorQueue: Array<{ error_code: number; description?: string }> = []
+  const api: TelegramApi = {
+    async sendMessage(chatId, text, _opts: SendMessageOpts) {
+      ops.push({ method: 'sendMessage', chatId, text })
+      const id = nextMessageId++
+      return { message_id: id }
+    },
+    async editMessageText(chatId, messageId, text, _opts: EditOpts) {
+      if (editErrorQueue.length > 0) {
+        const err = editErrorQueue.shift()
+        if (err) {
+          const e = new Error(`telegram error ${err.error_code}`) as Error & {
+            error_code: number
+            description?: string
+          }
+          e.error_code = err.error_code
+          if (err.description !== undefined) e.description = err.description
+          throw e
+        }
+      }
+      ops.push({ method: 'editMessageText', chatId, messageId, text })
+    },
+    async deleteMessage(chatId, messageId) {
+      ops.push({ method: 'deleteMessage', chatId, messageId })
+    },
+    async setMessageReaction() {},
+    async sendChatAction(_chatId, _action: ChatAction) {},
+    async sendDocument(_chatId, _filePath, _opts: SendDocumentOpts) {
+      return { message_id: 0 }
+    },
+    async sendPhoto(_chatId, _filePath, _opts: SendDocumentOpts) {
+      return { message_id: 0 }
+    },
+    async downloadFile(_id, _dir): Promise<DownloadResult> {
+      return { path: '/tmp/x', size: 0 }
+    },
+  }
+  return {
+    api,
+    ops,
+    queueEditError(err) {
+      editErrorQueue.push(err)
+    },
+    reset() {
+      ops.length = 0
+      editErrorQueue = []
+    },
+  }
+}
+
+const stubLog: Logger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+}
+
+function makeExec(scenarios: TmuxExecResult[]): TmuxExec {
+  let i = 0
+  return async () => {
+    const r = scenarios[Math.min(i, scenarios.length - 1)] ?? { stdout: '', stderr: '', exitCode: 0 }
+    i += 1
+    return r
+  }
+}
+
+function ok(stdout: string): TmuxExecResult {
+  return { stdout, stderr: '', exitCode: 0 }
+}
+
+function fail(stderr: string, exitCode = 1): TmuxExecResult {
+  return { stdout: '', stderr, exitCode }
+}
+
+describe('TmuxMirror — lifecycle', () => {
+  test('start sends initial message; subsequent identical poll is skipped', async () => {
+    const stub = makeStubApi()
+    const exec = makeExec([ok('hello world'), ok('hello world'), ok('hello world')])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+    })
+    await mirror.start()
+    await mirror.onPoll()
+    await mirror.onPoll()
+    const sends = stub.ops.filter((o) => o.method === 'sendMessage')
+    const edits = stub.ops.filter((o) => o.method === 'editMessageText')
+    expect(sends.length).toBe(1)
+    expect(edits.length).toBe(0) // identical content, no edits
+    expect(mirror.status().enabled).toBe(true)
+    await mirror.stop()
+  })
+
+  test('changed pane content triggers editMessageText', async () => {
+    const stub = makeStubApi()
+    const exec = makeExec([ok('one'), ok('two'), ok('three')])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+    })
+    await mirror.start()
+    await mirror.onPoll()
+    await mirror.onPoll()
+    expect(stub.ops.filter((o) => o.method === 'sendMessage').length).toBe(1)
+    expect(stub.ops.filter((o) => o.method === 'editMessageText').length).toBe(2)
+    await mirror.stop()
+  })
+
+  test('stop deletes the rolling message and clears messageId', async () => {
+    const stub = makeStubApi()
+    const exec = makeExec([ok('hello')])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+    })
+    await mirror.start()
+    await mirror.stop()
+    const deletes = stub.ops.filter((o) => o.method === 'deleteMessage')
+    expect(deletes.length).toBe(1)
+    expect(mirror.status().messageId).toBeUndefined()
+    expect(mirror.status().enabled).toBe(false)
+  })
+
+  test('start is idempotent — second start does not double-send', async () => {
+    const stub = makeStubApi()
+    const exec = makeExec([ok('hello'), ok('hello')])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+    })
+    await mirror.start()
+    await mirror.start()
+    expect(stub.ops.filter((o) => o.method === 'sendMessage').length).toBe(1)
+    await mirror.stop()
+  })
+})
+
+describe('TmuxMirror — recreate on Telegram 400 (message not found)', () => {
+  test('edit returning "message to edit not found" clears messageId and next poll resends', async () => {
+    const stub = makeStubApi()
+    const exec = makeExec([ok('first'), ok('second'), ok('third')])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+    })
+    await mirror.start()
+    stub.queueEditError({
+      error_code: 400,
+      description: 'Bad Request: message to edit not found',
+    })
+    await mirror.onPoll() // tries edit, gets 400, clears messageId
+    await mirror.onPoll() // sends fresh message
+    const sends = stub.ops.filter((o) => o.method === 'sendMessage')
+    expect(sends.length).toBe(2)
+    await mirror.stop()
+  })
+
+  test('edit returning unrelated 4xx (e.g. 403 Forbidden) does NOT trigger resend', async () => {
+    const stub = makeStubApi()
+    const exec = makeExec([ok('first'), ok('second'), ok('third')])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+    })
+    await mirror.start()
+    stub.queueEditError({
+      error_code: 403,
+      description: 'Forbidden: bot was blocked by the user',
+    })
+    await mirror.onPoll() // tries edit, gets 403, logs warn — must NOT clear messageId
+    await mirror.onPoll() // tries edit again with same messageId — no resend
+    const sends = stub.ops.filter((o) => o.method === 'sendMessage')
+    // Only the initial send from start(). No recreate on permanent failure.
+    expect(sends.length).toBe(1)
+    await mirror.stop()
+  })
+})
+
+describe('TmuxMirror — ANSI strip & secret redaction', () => {
+  test('ANSI escape sequences are stripped before rendering', async () => {
+    const stub = makeStubApi()
+    const ansi = '\x1b[31mERROR\x1b[0m okay'
+    const exec = makeExec([ok(ansi)])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+    })
+    await mirror.start()
+    const sent = stub.ops.find((o) => o.method === 'sendMessage')
+    expect(sent).toBeDefined()
+    expect(sent?.text).not.toContain('\x1b[')
+    expect(sent?.text).toContain('ERROR okay')
+    await mirror.stop()
+  })
+
+  test('redactor is applied to pane content before send', async () => {
+    const stub = makeStubApi()
+    const redactor = (s: string): string => s.replace(/SECRET-[A-Z0-9]+/g, '[REDACTED]')
+    const exec = makeExec([ok('token: SECRET-ABC123 visible')])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+      redact: redactor,
+    })
+    await mirror.start()
+    const sent = stub.ops.find((o) => o.method === 'sendMessage')
+    expect(sent?.text).toContain('[REDACTED]')
+    expect(sent?.text).not.toContain('SECRET-ABC123')
+    await mirror.stop()
+  })
+})
+
+describe('TmuxMirror — tmux unavailable', () => {
+  test('failed tmux exec renders error state and keeps polling', async () => {
+    const stub = makeStubApi()
+    const exec = makeExec([
+      fail("can't find session: channel-thrall", 1),
+      ok('alive now'),
+    ])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+    })
+    await mirror.start()
+    // First poll surfaced an error state.
+    const first = stub.ops.find((o) => o.method === 'sendMessage')
+    expect(first?.text).toContain('tmux')
+    // Next poll succeeds — mirror should self-heal and edit to the new content.
+    await mirror.onPoll()
+    const editsAfter = stub.ops.filter((o) => o.method === 'editMessageText')
+    expect(editsAfter.length).toBeGreaterThan(0)
+    expect(mirror.status().enabled).toBe(true) // still enabled
+    await mirror.stop()
+  })
+})
+
+describe('TmuxMirror — length cap', () => {
+  test('large pane is truncated to fit Telegram body cap', async () => {
+    const stub = makeStubApi()
+    // Generate 5000 chars of text (over 4096 cap).
+    const bigLine = 'X'.repeat(120)
+    const blob = Array.from({ length: 50 }, (_, i) => `${i}: ${bigLine}`).join('\n')
+    const exec = makeExec([ok(blob)])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+    })
+    await mirror.start()
+    const sent = stub.ops.find((o) => o.method === 'sendMessage')
+    expect(sent).toBeDefined()
+    expect(sent!.text!.length).toBeLessThanOrEqual(4096)
+    // Truncation must keep the END (newest output) and mark the head.
+    expect(sent!.text).toContain('truncated')
+    await mirror.stop()
+  })
+})
+
+describe('TmuxMirror — concurrency', () => {
+  test('overlapping polls do not double-edit', async () => {
+    const stub = makeStubApi()
+    let resolveFirst!: (v: TmuxExecResult) => void
+    const exec: TmuxExec = (() => {
+      let call = 0
+      return async () => {
+        call += 1
+        if (call === 1) return ok('first')
+        if (call === 2) {
+          // Block until releaseExec is called.
+          return await new Promise<TmuxExecResult>((r) => {
+            resolveFirst = r
+          })
+        }
+        return ok('third')
+      }
+    })()
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+    })
+    await mirror.start()
+    // Fire two onPolls concurrently — the second must skip while the first runs.
+    const p1 = mirror.onPoll()
+    const p2 = mirror.onPoll()
+    // Release the first poll's tmux exec.
+    resolveFirst(ok('second'))
+    await Promise.all([p1, p2])
+    // We expect exactly one edit (from p1's content); p2 should have been
+    // skipped (in-flight guard).
+    expect(stub.ops.filter((o) => o.method === 'editMessageText').length).toBe(1)
+    await mirror.stop()
+  })
+})
+
+describe('TmuxMirror — stop()-during-poll race', () => {
+  test('stop() while first onPoll() is in flight does not leave a ghost message', async () => {
+    const stub = makeStubApi()
+    let resolveExec!: (v: TmuxExecResult) => void
+    const slowExec: TmuxExec = () =>
+      new Promise<TmuxExecResult>((r) => {
+        resolveExec = r
+      })
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec: slowExec,
+    })
+    // start() is awaiting onPoll → exec → hanging on slowExec.
+    const startPromise = mirror.start()
+    // Now stop() while exec hasn't resolved yet.
+    const stopPromise = mirror.stop()
+    // Release the exec → onPoll proceeds, but enabled is now false.
+    resolveExec(ok('would have been published'))
+    await startPromise
+    await stopPromise
+    // No send and no orphan messageId.
+    expect(stub.ops.filter((o) => o.method === 'sendMessage').length).toBe(0)
+    expect(mirror.status().messageId).toBeUndefined()
+    expect(mirror.status().enabled).toBe(false)
+  })
+
+  test('redact callback throw renders error state, mirror keeps polling', async () => {
+    const stub = makeStubApi()
+    const throwingRedactor = (): string => {
+      throw new Error('redactor exploded')
+    }
+    const exec = makeExec([ok('secret pane'), ok('still alive')])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+      redact: throwingRedactor,
+    })
+    await mirror.start()
+    // First send must be the error-state body, NOT the raw pane text.
+    const sent = stub.ops.find((o) => o.method === 'sendMessage')
+    expect(sent?.text).toContain('redactor failed')
+    expect(sent?.text).not.toContain('secret pane')
+    expect(mirror.status().lastError).toContain('redactor exploded')
+    await mirror.stop()
+  })
+})
+
+describe('TmuxMirror — status accessor', () => {
+  test('status reflects last poll outcome', async () => {
+    const stub = makeStubApi()
+    const exec = makeExec([ok('hello')])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+      now: () => 1000,
+    })
+    await mirror.start()
+    const s = mirror.status()
+    expect(s.enabled).toBe(true)
+    expect(s.messageId).toBeDefined()
+    expect(s.lastPollAt).toBe(1000)
+    expect(s.lastError).toBeUndefined()
+    await mirror.stop()
+  })
+})


### PR DESCRIPTION
## Проблема

Warchief не видит, что агент делает в bash между ответами Claude. Channel-thrall сейчас мирорит только Claude hook events (через ProgressReporter, TaskMirror), а raw terminal output остаётся скрыт. Прямая жалоба: «не вижу твои баши, не могу понять что происходит».

## Решение

`TmuxMirror` — read-only, polled mirror of the agent's tmux pane into ONE rolling Telegram message via `editMessageText`. Поведение похоже на ProgressReporter, но источник — `tmux capture-pane`, а не Claude hook events.

### Lifecycle
- `start()` — первый capture + send + arm `setInterval`
- `onPoll()` — exec → ANSI strip → redact → render → hash-dedup → edit
- `stop()` — clearInterval + deleteMessage + reset state

### Слои защиты
- ANSI/CSI/OSC/DCS/PM/APC/SOS stripped before HTML escape
- `redact()` через try/catch — error state вместо leak
- in-flight guard защищает от overlapping polls
- `enabled` gate после каждого `await`: `stop()` не оставляет ghost message
- 4xx recreate сужен ТОЛЬКО для "message to edit not found" (не на 401/403/413)
- Truncation с маркером "[truncated]" + length cap 4096

### Config (default-OFF)
```jsonc
{
  "tmux_mirror": {
    "enabled": false,
    "pane_target": "channel-thrall:0.0",
    "poll_interval_ms": 5000,
    "line_count": 50
  }
}
```

## Тесты

14 тестов. Все зелёные.

- Lifecycle: start sends initial, identical polls skip, changed → edit, stop deletes, start idempotent
- Recreate: edit "message to edit not found" → resend; edit 403 Forbidden → NO resend (avoid storm)
- ANSI strip + redact pipeline
- tmux unavailable: error state rendered + keeps polling
- Length cap > 4096 → truncated с маркером
- Concurrency: overlapping polls do not double-edit
- Race: `stop()` while first onPoll() in flight → no ghost message
- redact callback throws → error state, no leak

Test seams: `exec` (TmuxExec function), `redact`, `now` — deterministic instant tests.

## Double Review

- **Plan**: Codex GPT-5.5 (модуль layout, контракт API, алгоритм, риски)
- **Implementation**: Opus (TDD)
- **Review**: Codex + Opus параллельно. Все HIGH/MEDIUM findings закрыты:
  - HIGH race stop()-during-poll → enabled gates после await
  - HIGH 4xx too broad → narrow на specific description match
  - MEDIUM ANSI regex incomplete → +DCS/PM/APC/SOS/OSC-ST
  - MEDIUM redact throws → try/catch + error state
- LOW findings out-of-scope (см. ниже)

## Wiring

`src/server.ts` после TaskMirror:
- Default-OFF — warchief opts in via config
- SIGINT/SIGTERM handler для best-effort delete on shutdown
- `redact` callback использует `apiSecrets` (тот же что в safe-telegram-api)

## Smoke test (after merge)

1. `config.tmux_mirror.enabled = true`, рестарт channel-thrall MCP.
2. В TG появится сообщение «terminal mirror» с последними 50 строками pane.
3. Сделать что-то в bash — сообщение должно обновиться в течение 5 сек.
4. Повторить identical вывод — edit не должен сработать (hash dedup).
5. Вручную удалить сообщение в TG — на следующем изменении pane должно появиться новое.
6. SIGTERM → сообщение удаляется из чата, interval остановлен.

## Out of scope этого PR

- `/mirror on|off|status` OOB command (touchpoint на oob.ts — отдельный PR)
- TG → tmux send-keys (control surface — большая фича)
- Voice transcription, screenshots
- paneTarget regex валидация в config schema (используем execFile — shell injection невозможна; ошибка пользователя видна как «tmux unavailable»)

## Backwards compatibility

Module default-disabled. Никакого влияния на текущее поведение если warchief не включит.

🤖 Generated with [Claude Code](https://claude.com/claude-code)