### PR TITLE
fix(safety): pace editMessageText/setMessageReaction through the per-chat bucket

### DIFF
--- a/plugin/src/safety/rate-limited-telegram-api.ts
+++ b/plugin/src/safety/rate-limited-telegram-api.ts
@@ -15,12 +15,16 @@
 //      throughput across all chats under Telegram's 30/sec bot-wide limit.
 //   3. 429 retry: on a grammY-shaped 429 (`error_code: 429`, optional
 //      `parameters.retry_after`), sleep the requested seconds + a small
-//      jitter and retry the SAME call. Bounded by `maxRetries` (default 3).
+//      jitter and retry the SAME call. Bounded by `maxRetries` (default 2).
 //
-// Methods that don't consume the send-bucket: editMessageText (Telegram's
-// edit limits are far more lenient), setMessageReaction, sendChatAction,
-// deleteMessage, downloadFile. They still get the 429 retry wrapper so a
-// stray 429 on an edit can recover without the caller seeing it.
+// Every Telegram-bound text / edit / reaction / delete call runs through the
+// per-chat bucket + FIFO queue — including editMessageText and
+// setMessageReaction. Leaving edits unpaced let a busy session's status
+// bubbles + reactions trip Telegram's per-chat flood limit on their own.
+// sendChatAction is the one exception: a "typing…" pulse is worthless once
+// stale, so it is best-effort — dropped when the chat has no token, never
+// queued or retried (queuing chat actions is pure flood pressure).
+// downloadFile is inbound and untouched.
 //
 // Test seams: `opts.now` and `opts.sleep` replace the real clock and
 // setTimeout-based sleep, so tests can run instantly with deterministic
@@ -104,13 +108,16 @@ interface Grammy429 {
   parameters?: { retry_after?: number }
 }
 
-// Cap retry_after so one giant value from Telegram (or a hostile-shaped
-// error) can't lock a chat's FIFO queue for minutes on end. The per-chat
-// tail-promise chain blocks all subsequent sends to the same chat until the
-// in-flight op finishes, so worst-case stall = maxRetries × MAX_RETRY_AFTER_S.
-// With defaults (3 × 60s) that's a 3-minute ceiling; if Telegram really
-// needs longer, the bounded retries exhaust and the caller sees the 429.
-const MAX_RETRY_AFTER_S = 60
+// Cap retry_after so a giant or hostile-shaped value can't pin a chat's
+// FIFO queue indefinitely. The cap must still be large enough to honour a
+// real Telegram flood-wait (135s and 503s observed in prod): retrying
+// BEFORE the window elapses is counted as continued flooding and extends
+// the ban. The per-chat tail-promise chain blocks subsequent sends to the
+// same chat until the in-flight op finishes, so worst-case stall =
+// maxRetries × MAX_RETRY_AFTER_S. With defaults (2 × 900s) that is a
+// 30-minute ceiling — reached only if Telegram re-bans on the retry, which
+// the pacing above is designed to prevent.
+const MAX_RETRY_AFTER_S = 900
 
 function parse429(err: unknown): { retryAfter: number } | null {
   if (typeof err !== 'object' || err === null) return null
@@ -135,7 +142,7 @@ export function createRateLimitedTelegramApi(
     perChatBurstCapacity: opts.perChatBurstCapacity ?? 3,
     globalRefillPerSec: opts.globalRefillPerSec ?? 25,
     globalBurstCapacity: opts.globalBurstCapacity ?? 25,
-    maxRetries: opts.maxRetries ?? 3,
+    maxRetries: opts.maxRetries ?? 2,
     jitterMaxMs: opts.jitterMaxMs ?? 150,
   }
   const now = opts.now ?? ((): number => Date.now())
@@ -183,7 +190,7 @@ export function createRateLimitedTelegramApi(
 
   // `maxRetries` is the MAX NUMBER OF ATTEMPTS including the initial call.
   // Semantically: budget of how many times we hit Telegram for this op.
-  // maxRetries=3 → up to 3 attempts (2 retries after the first failure).
+  // maxRetries=2 → up to 2 attempts (1 retry after the first failure).
   async function withRetry<T>(method: string, op: () => Promise<T>): Promise<T> {
     let attempt = 0
     let lastErr: unknown
@@ -244,7 +251,9 @@ export function createRateLimitedTelegramApi(
       text: string,
       editOpts: EditOpts,
     ): Promise<void> {
-      return withRetry('editMessageText', () =>
+      // Paced through the per-chat bucket: status-bubble edits fire every
+      // few seconds during a turn and used to bypass the limiter entirely.
+      return enqueueSend(chatId, () =>
         raw.editMessageText(chatId, messageId, text, editOpts),
       )
     },
@@ -254,13 +263,26 @@ export function createRateLimitedTelegramApi(
       messageId: number,
       emoji: string,
     ): Promise<void> {
-      return withRetry('setMessageReaction', () =>
+      return enqueueSend(chatId, () =>
         raw.setMessageReaction(chatId, messageId, emoji),
       )
     },
 
     async sendChatAction(chatId: string, action: ChatAction): Promise<void> {
-      return withRetry('sendChatAction', () => raw.sendChatAction(chatId, action))
+      // Best-effort, fire-and-forget. A "typing…" pulse is worthless once
+      // stale, so it is never queued or retried — queuing/retrying chat
+      // actions is pure flood pressure. Drop it when either bucket is out
+      // of tokens; swallow any error (a missed indicator is cosmetic).
+      const state = getChatState(chatId)
+      const t = now()
+      if (waitMs(state.bucket, t) > 0 || waitMs(globalBucket, t) > 0) return
+      consume(state.bucket)
+      consume(globalBucket)
+      try {
+        await raw.sendChatAction(chatId, action)
+      } catch {
+        /* cosmetic — ignore (incl. 429) */
+      }
     },
 
     async sendDocument(

--- a/plugin/tests/safety/rate-limited-telegram-api.test.ts
+++ b/plugin/tests/safety/rate-limited-telegram-api.test.ts
@@ -357,7 +357,7 @@ describe('createRateLimitedTelegramApi — 429 retry-after', () => {
     expect(stub.calls.length).toBe(0)
   })
 
-  test('429 on editMessageText also retries (lighter bucket)', async () => {
+  test('429 on editMessageText retries after backoff', async () => {
     const clock = new FakeClock()
     const stub = makeStubApi(clock)
     const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
@@ -371,15 +371,17 @@ describe('createRateLimitedTelegramApi — 429 retry-after', () => {
 })
 
 describe('createRateLimitedTelegramApi — retry_after clamp & edge values', () => {
-  test('retry_after over 60s is clamped to 60s', async () => {
+  test('retry_after over 900s is clamped to 900s', async () => {
     const clock = new FakeClock()
     const stub = makeStubApi(clock)
     const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
-    stub.queueError('sendMessage', make429Error(300))
+    stub.queueError('sendMessage', make429Error(1200))
     const p = api.sendMessage('100', 'hi', {})
     await flushMicrotasks()
-    // Even though Telegram said 300s, we should retry after 60s.
-    await clock.tick(60_000)
+    // Telegram said 1200s; we clamp to the 900s ceiling. Retrying before the
+    // real window elapses is counted as continued flooding and extends the
+    // ban, so the cap only guards against absurd / hostile-shaped values.
+    await clock.tick(900_000)
     await p
     expect(stub.calls.length).toBe(1)
   })
@@ -415,7 +417,7 @@ describe('createRateLimitedTelegramApi — retry_after clamp & edge values', () 
   })
 })
 
-describe('createRateLimitedTelegramApi — pass-through methods', () => {
+describe('createRateLimitedTelegramApi — per-method bucketing', () => {
   test('downloadFile is not rate-limited', async () => {
     const clock = new FakeClock()
     const stub = makeStubApi(clock)
@@ -428,32 +430,70 @@ describe('createRateLimitedTelegramApi — pass-through methods', () => {
     expect(stub.calls.every((c) => c.ts === 0)).toBe(true)
   })
 
-  test('editMessageText does not consume the per-chat send bucket', async () => {
+  test('editMessageText is paced through the per-chat bucket', async () => {
     const clock = new FakeClock()
     const stub = makeStubApi(clock)
     const opts = defaultOpts(clock)
     opts.perChatBurstCapacity = 1
     const api = createRateLimitedTelegramApi(stub.api, stubLog, opts)
-    // Use up the per-chat send bucket.
-    await api.sendMessage('100', 'a', {})
-    // Now do many edits — they must not be throttled by the send bucket.
-    await Promise.all(
-      Array.from({ length: 5 }, () => api.editMessageText('100', 42, 'edit', {})),
+    // Status-bubble edits fire every few seconds during a turn; leaving them
+    // unpaced let them trip Telegram's per-chat flood limit on their own.
+    // Burst 1: the first edit fires at t=0, the rest wait for refill.
+    const p = Promise.all(
+      Array.from({ length: 3 }, (_, i) => api.editMessageText('100', 42, `e${i}`, {})),
     )
-    expect(stub.calls.filter((c) => c.method === 'editMessageText').length).toBe(5)
+    await flushMicrotasks()
+    expect(stub.calls.length).toBe(1)
+    await clock.tick(1000)
+    expect(stub.calls.length).toBe(2)
+    await clock.tick(1000)
+    await p
+    expect(stub.calls.length).toBe(3)
   })
 
-  test('setMessageReaction is not gated by send bucket', async () => {
+  test('setMessageReaction is paced through the per-chat bucket', async () => {
     const clock = new FakeClock()
     const stub = makeStubApi(clock)
     const opts = defaultOpts(clock)
     opts.perChatBurstCapacity = 1
     const api = createRateLimitedTelegramApi(stub.api, stubLog, opts)
-    await api.sendMessage('100', 'a', {})
-    await Promise.all(
-      Array.from({ length: 5 }, () => api.setMessageReaction('100', 42, 'eyes')),
+    const p = Promise.all(
+      Array.from({ length: 3 }, () => api.setMessageReaction('100', 42, 'eyes')),
     )
-    expect(stub.calls.filter((c) => c.method === 'setMessageReaction').length).toBe(5)
+    await flushMicrotasks()
+    expect(stub.calls.length).toBe(1)
+    await clock.tick(1000)
+    expect(stub.calls.length).toBe(2)
+    await clock.tick(1000)
+    await p
+    expect(stub.calls.length).toBe(3)
+  })
+
+  test('sendChatAction is best-effort: dropped when the bucket is empty', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const opts = defaultOpts(clock)
+    opts.perChatBurstCapacity = 1
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, opts)
+    // Spend the one token on a real send.
+    await api.sendMessage('100', 'a', {})
+    // Bucket empty → the chat action is dropped, never queued or retried.
+    await api.sendChatAction('100', 'typing')
+    expect(stub.calls.filter((c) => c.method === 'sendChatAction').length).toBe(0)
+    // After refill there is a token → it goes through.
+    await clock.tick(1000)
+    await api.sendChatAction('100', 'typing')
+    expect(stub.calls.filter((c) => c.method === 'sendChatAction').length).toBe(1)
+  })
+
+  test('sendChatAction swallows a 429 instead of throwing', async () => {
+    const clock = new FakeClock()
+    const stub = makeStubApi(clock)
+    const api = createRateLimitedTelegramApi(stub.api, stubLog, defaultOpts(clock))
+    stub.queueError('sendChatAction', make429Error(5))
+    // Must resolve, not reject — a missed typing indicator is cosmetic.
+    await api.sendChatAction('100', 'typing')
+    expect(stub.calls.filter((c) => c.method === 'sendChatAction').length).toBe(0)
   })
 
   test('sendDocument and sendPhoto share the per-chat send bucket', async () => {


### PR DESCRIPTION
## Проблема

`rate-limited-telegram-api.ts` пропускает `editMessageText`,
`setMessageReaction` и `sendChatAction` **мимо** per-chat token-bucket —
через `enqueueSend` идут только `sendMessage` / `sendDocument` /
`sendPhoto`.

Активная сессия правит статус-бабл каждые несколько секунд и ставит
реакции. Без ограничения эти вызовы сами пробивают per-chat флуд-лимит
Telegram. Дальше лимитер повторяет 429 **внутри ещё активного
флуд-окна** (`MAX_RETRY_AFTER_S` обрезал ожидание до 60с), а каждый
преждевременный повтор Telegram засчитывает как продолжение флуда и
продлевает бан. В проде наблюдали эскалацию 135с → 503с — бот замолкал
на минуты.

## Решение

- `editMessageText` / `setMessageReaction` теперь идут через
  `enqueueSend` (per-chat FIFO + token-bucket), тем же путём, что и
  `sendMessage`;
- `sendChatAction` — best-effort: дропается при пустом per-chat или
  global бакете, не очередится и не ретраится, глотает 429. Протухший
  «печатает…» бесполезен, а очередь chat-action'ов — чистое флуд-давление;
- `MAX_RETRY_AFTER_S` 60 → 900: реальный Telegram'овский flood-wait
  соблюдается целиком; повтор до конца окна продлевает бан;
- `maxRetries` по умолчанию 3 → 2 (один повтор после первого падения);
- тесты обновлены под новую тарификацию, добавлены 2 теста на
  best-effort `sendChatAction`.

## Проверка

`bun test tests/safety/rate-limited-telegram-api.test.ts` — **21/21 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)