### PR TITLE
feat(mirror): latest_inbound_only режим + max_lines cap + input_box + Tip footer

### DIFF
--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -143,8 +143,13 @@ export const AppConfigSchema = z.object({
     line_count: z.number().int().min(5).max(500).default(50),
     // Segments to drop from the rendered mirror. Default hides the boot
     // banner (Claude Code splash + email + path), the inbound-injection
-    // warning, and the footer hints (bypass-perms reminder, auto-update
-    // failure, tmux focus-events note). Pass an empty list to mirror
+    // warning, the footer hints (bypass-perms, auto-update, focus-events,
+    // /btw Tip line) AND the input box (the bordered prompt area —
+    // ── separators + ❯/> cursor). `inbound_preview` stays visible by
+    // default because `latest_inbound_only` mode anchors on it; hiding
+    // it would silently turn the mode into a no-op (filter applies mode
+    // BEFORE hide, but only `latest_inbound_only` survives that order —
+    // see tmux-pane-filter.filterPane). Pass an empty list to mirror
     // raw pane content. Validated against the SegmentType enum to keep
     // typos out of production — bad values fail config load loud.
     hide_segments: z
@@ -155,9 +160,36 @@ export const AppConfigSchema = z.object({
           'channel_status',
           'conversation',
           'footer_hints',
+          'input_box',
+          'inbound_preview',
         ]),
       )
-      .default(['boot_banner', 'inbound_warning', 'footer_hints']),
+      .default(['boot_banner', 'inbound_warning', 'footer_hints', 'input_box']),
+    // Anchor mode for the rolling mirror. `latest_inbound_only` (default,
+    // 2026-05-22) drops every pane segment up to and including the last
+    // `← <channel>: …` preview Claude Code emitted — only what the agent
+    // is doing AFTER the warchief's most recent message remains. Falls
+    // back to `full_pane` automatically when no preview exists in the
+    // current capture (fresh session). Set to `full_pane` to mirror the
+    // whole pane (pre-2026-05-22 behaviour).
+    mode: z.enum(['full_pane', 'latest_inbound_only']).default('latest_inbound_only'),
+    // Max lines kept in the rendered mirror, post-filter. Default 14 —
+    // empirically that fits one iPhone-screen worth of Telegram <pre>
+    // content (the warchief asked for ≤70% screen height on 2026-05-22).
+    // Truncation removes from the TOP (oldest), preserving the live
+    // tail, and prepends a `… +N lines` marker that counts toward the
+    // cap. Set to 0 to disable (uncapped, only the 4096-char body cap
+    // in renderBody still applies). Codex review 2026-05-22 [medium]
+    // tightened the allowed range to `0` or `4..100` — values 1..3
+    // render only the marker plus 0..2 lines, which is degenerate and
+    // not useful in production.
+    max_lines: z
+      .number()
+      .int()
+      .refine((n) => n === 0 || (n >= 4 && n <= 100), {
+        message: 'max_lines must be 0 (disabled) or an integer in 4..100',
+      })
+      .default(14),
   }).default({}),
 })
 export type AppConfig = z.infer<typeof AppConfigSchema>

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -302,6 +302,8 @@ if (config.tmux_mirror.enabled) {
       pollIntervalMs: config.tmux_mirror.poll_interval_ms,
       lineCount: config.tmux_mirror.line_count,
       hideSegments: config.tmux_mirror.hide_segments,
+      mode: config.tmux_mirror.mode,
+      maxLines: config.tmux_mirror.max_lines,
       redact: (text) => redactSecrets(text, apiSecrets),
     })
     void tmuxMirror.start().catch((err: unknown) => {

--- a/plugin/src/status/tmux-mirror.ts
+++ b/plugin/src/status/tmux-mirror.ts
@@ -37,7 +37,9 @@ import type { Logger } from '../log.js'
 import type { TelegramApi } from '../channel/tools.js'
 import {
   filterPane,
+  capLines,
   DEFAULT_HIDDEN_SEGMENTS,
+  type RenderMode,
   type SegmentType,
 } from './tmux-pane-filter.js'
 
@@ -76,10 +78,21 @@ export interface TmuxMirrorOptions {
   maxBodyChars?: number
   // Optional: segment types to hide from the rendered mirror. When
   // omitted, `DEFAULT_HIDDEN_SEGMENTS` from tmux-pane-filter is used —
-  // boot banner, inbound-injection warning, and footer hints — so the
-  // rolling message only carries semantically useful pane content. Pass
-  // an empty array to disable filtering entirely (raw pane mirror).
+  // boot banner, inbound-injection warning, footer hints, AND the input
+  // box — so the rolling message only carries semantically useful pane
+  // content. Pass an empty array to disable filtering entirely (raw
+  // pane mirror).
   hideSegments?: ReadonlyArray<SegmentType>
+  // Optional: anchor mode for the mirror (see `RenderMode`). Default
+  // `latest_inbound_only` — show only the activity that came AFTER the
+  // warchief's last inbound message. Use `full_pane` for the legacy
+  // whole-pane mirror (debugging or wide-terminal screenshots).
+  mode?: RenderMode
+  // Optional: cap on the number of lines surfaced into the rendered
+  // body. Default 14 (≈70% of an iPhone Telegram screen at the moment).
+  // Set to 0 to disable. Trimming removes from the top (oldest content)
+  // and prepends a `… +N lines` marker; see `capLines`.
+  maxLines?: number
 }
 
 export interface TmuxMirrorStatus {
@@ -196,6 +209,8 @@ export class TmuxMirror {
   private readonly now: () => number
   private readonly maxBodyChars: number
   private readonly hideSegments: ReadonlyArray<SegmentType>
+  private readonly mode: RenderMode
+  private readonly maxLines: number
 
   private timer: ReturnType<typeof setInterval> | null = null
   private enabled = false
@@ -221,6 +236,8 @@ export class TmuxMirror {
     this.now = opts.now ?? ((): number => Date.now())
     this.maxBodyChars = opts.maxBodyChars ?? 4096
     this.hideSegments = opts.hideSegments ?? DEFAULT_HIDDEN_SEGMENTS
+    this.mode = opts.mode ?? 'latest_inbound_only'
+    this.maxLines = opts.maxLines ?? 14
   }
 
   // Pure rendering: turn a tmux exec result into the final body. Side
@@ -234,20 +251,30 @@ export class TmuxMirror {
       return renderBody('(no output)', errMsg, this.maxBodyChars)
     }
     const cleaned = stripAnsi(result.stdout)
-    // Drop boot banner / inbound warning / footer hints BEFORE redaction
-    // — the filter's anchors look at the raw textual structure (box
-    // corners, specific phrases) and must not be perturbed by replaced
-    // tokens. An empty hideSegments list short-circuits to the raw
-    // cleaned text so the mirror can be rendered unfiltered when needed.
-    let filtered =
-      this.hideSegments.length === 0
-        ? cleaned
-        : filterPane(cleaned, { hide: this.hideSegments })
+    // Drop banner / warning / footer / input-box BEFORE redaction — the
+    // filter's anchors look at the raw textual structure (box corners,
+    // specific phrases, U+2500 separators) and must not be perturbed by
+    // token replacement. We also need the `latest_inbound_only` mode to
+    // see the verbatim `← <channel>:` pivot line. Empty hide list +
+    // `full_pane` mode short-circuits to raw cleaned text (raw mirror
+    // debug path).
+    const needsFilter = this.hideSegments.length > 0 || this.mode !== 'full_pane'
+    let filtered = needsFilter
+      ? filterPane(cleaned, { hide: this.hideSegments, mode: this.mode })
+      : cleaned
+    // Line cap runs AFTER the segment filter so the warchief's iPhone
+    // sees a tidy ~14-line tail of the post-filter content, not a
+    // 14-line slice of raw tmux output that includes hidden segments.
+    // `capLines(_, 0)` is a no-op — keeps the existing 4096-char body
+    // cap as the only safety net for callers that opt out.
+    if (this.maxLines > 0) {
+      filtered = capLines(filtered, this.maxLines)
+    }
     // Telegram rejects `<pre></pre>` with no inner text as "message
-    // text is empty" (400). If the filter consumed everything (idle
-    // tmux pane that only renders banner + footer right now), render
-    // a placeholder so the rolling message stays visible and the
-    // self-heal path can still fire on next poll.
+    // text is empty" (400). If the filter (or line cap, or mode pivot)
+    // consumed everything (idle pane / fresh session / over-aggressive
+    // hide list), render a placeholder so the rolling message stays
+    // visible and the self-heal path can still fire on next poll.
     if (filtered.trim() === '') {
       filtered = '(no visible output)'
     }

--- a/plugin/src/status/tmux-pane-filter.ts
+++ b/plugin/src/status/tmux-pane-filter.ts
@@ -27,6 +27,17 @@ export type SegmentType =
   | 'channel_status'
   | 'conversation'
   | 'footer_hints'
+  | 'input_box'
+  | 'inbound_preview'
+
+// Render mode: `full_pane` keeps all non-hidden segments as today.
+// `latest_inbound_only` (introduced 2026-05-22 for the iPhone mirror)
+// anchors on the last inbound preview line that Claude Code emits when
+// the dashi-channel MCP pushes a notification (`← <channel>: …`). All
+// segments before AND the anchor itself are dropped — only what came
+// AFTER the warchief's last message remains. If no preview is present
+// (fresh session) the mode degrades to `full_pane`.
+export type RenderMode = 'full_pane' | 'latest_inbound_only'
 
 export interface PaneSegment {
   type: SegmentType
@@ -37,17 +48,25 @@ export interface FilterOptions {
   // Segments to drop from the rendered output. Order does not matter; an
   // empty list disables filtering.
   hide?: ReadonlyArray<SegmentType> | ReadonlySet<SegmentType>
+  // Anchor mode (see `RenderMode`). Default `full_pane` so existing
+  // callers / tests keep their behaviour. The Telegram mirror passes
+  // `latest_inbound_only` explicitly.
+  mode?: RenderMode
 }
 
-// Default hide-list. Mirrors the warchief's spec on 2026-05-20: hide the
-// boot banner (splash + email + path), hide the inbound-injection
-// warning, hide the footer hints (bypass-perms reminder, auto-update
-// failure, tmux focus-events note). Keep channel_status + conversation
-// (which includes the input prompt by design).
+// Default hide-list. Mirrors the warchief's spec on 2026-05-20 + 05-22:
+// boot banner (splash + email + path), inbound-injection warning,
+// footer hints (bypass-perms reminder, auto-update failure, tmux
+// focus-events note, /btw tip) AND the input box (the bordered prompt
+// area at the bottom of the pane — long ─ separators + ❯/> cursor).
+// `inbound_preview` is intentionally kept visible by default: it is the
+// anchor for `latest_inbound_only` mode and must survive the segmentize
+// pass even when callers drop it from the rendered output later.
 export const DEFAULT_HIDDEN_SEGMENTS: readonly SegmentType[] = [
   'boot_banner',
   'inbound_warning',
   'footer_hints',
+  'input_box',
 ]
 
 // ─── Line-level anchors ──────────────────────────────────────────────
@@ -95,13 +114,66 @@ const CHANNEL_STATUS_FOLLOW_RE = /^\s*server:\S/
 
 // Footer-hint phrases. Picked because each is a complete, specific
 // sentence — short tokens like «doctor» or «Auto-update» on their own
-// would cause false positives in conversation text. All three patterns
+// would cause false positives in conversation text. All patterns
 // must remain word-anchored.
+//
+// 2026-05-22: added the «Tip: Use /…» footer line. Claude Code v2.1.144
+// renders rotating tips below the input box (e.g. «Tip: Use /btw to ask
+// a quick side question without interrupting Claude's current work»);
+// they slipped past the previous footer set because the original three
+// phrases were specific to the bypass-permissions / auto-update /
+// focus-events lines. The Tip pattern is line-start anchored and
+// requires `Use /` literally — a conversation phrase like «Tip: try X»
+// or «Tip: use indexes» will NOT match.
 const FOOTER_LINE_RES: readonly RegExp[] = [
   /bypass permissions on\s*\(shift\+tab to cycle\)/i,
   /Auto-update failed\s*[·•]\s*Try claude doctor/i,
   /tmux focus-events off\s*[·•]\s*add /i,
+  /^\s*Tip:\s+Use\s*\//i,
 ]
+
+// ─── Input box + inbound-preview anchors ────────────────────────────
+
+// Inbound preview: Claude Code emits one such line when an MCP channel
+// (e.g. dashi-channel) pushes a notification mid-session — `← <name>:
+// <preview>`. The arrow is U+2190; the channel name is a kebab-case
+// identifier in our world (`dashi-channel`, `orgrimmar-inbox`, etc.).
+//
+// Codex review 2026-05-22 flagged the earlier `\S+:` form as too loose
+// — a tool that prints «← github: issue title» at column zero would
+// hijack the `latest_inbound_only` pivot and hide everything before
+// it. We now require:
+//   • leading `← ` (U+2190 + space) at column zero (no indent / diff)
+//   • channel name starts with a lowercase ASCII letter
+//   • channel name is lowercase letters / digits / `-_` only
+//   • terminated by a literal `:`
+// This matches every real MCP channel id we emit and rules out
+// «← Some Channel: …», «← Foo Bar:» and other free-text imposters.
+const INBOUND_PREVIEW_RE = /^← [a-z][a-z0-9_-]*:/
+
+// Input separator. Claude Code v2 renders the bottom input area as a
+// pair of long U+2500 ── horizontals bracketing a `❯` (U+276F) or `>`
+// cursor line. We require at least 20 separator glyphs on a line so a
+// short ── used inline (e.g. «section ──» in a tool output) does not
+// accidentally open an input box.
+const INPUT_SEPARATOR_RE = /^─{20,}\s*$/
+
+// Cursor line inside the input box. Accepts both `❯` (current Claude
+// Code v2.1.144 cursor glyph) and the legacy `>` ASCII fallback.
+// Critically, the line must be EMPTY after the cursor: matching just
+// `>` or `❯` would false-positive on conversation text like
+// «> Что у нас по EdgeLab?» (a quoted reply). Trailing whitespace is
+// fine — the cursor pads with spaces to the column count.
+const INPUT_PROMPT_RE = /^\s*[>❯]\s*$/
+
+// Cap on input box accumulation. Real boxes are 3 lines (sep + prompt
+// + sep), sometimes padded with one or two blanks. Ten lines INCLUDING
+// the opener gives generous headroom for future multi-line input UI
+// without letting a stray separator swallow the rest of the pane.
+// (Codex review 2026-05-22 flagged the earlier "10 after the opener"
+// off-by-one: the opener was pushed before the counter started, so the
+// effective cap was 11. The scanner now counts the opener too.)
+const INPUT_BOX_LINE_CAP = 10
 
 function isFooterLine(line: string): boolean {
   return FOOTER_LINE_RES.some((re) => re.test(line))
@@ -115,7 +187,9 @@ function isBoundaryLine(line: string): boolean {
     BANNER_OPEN_RE.test(line) ||
     INBOUND_OPEN_RE.test(line) ||
     CHANNEL_STATUS_OPEN_RE.test(line) ||
-    isFooterLine(line)
+    isFooterLine(line) ||
+    INBOUND_PREVIEW_RE.test(line) ||
+    INPUT_SEPARATOR_RE.test(line)
   )
 }
 
@@ -271,7 +345,55 @@ export function segmentizePane(text: string): PaneSegment[] {
       continue
     }
 
-    // 5) Conversation (default). Accumulate until we hit a boundary or
+    // 5) Inbound preview — single-line segment. Emitted by Claude Code
+    //    when an MCP channel pushes a notification. Kept as its own
+    //    segment type so `latest_inbound_only` mode can pivot on it
+    //    without re-scanning the text downstream.
+    if (INBOUND_PREVIEW_RE.test(line)) {
+      out.push({ type: 'inbound_preview', text: line })
+      i += 1
+      continue
+    }
+
+    // 6) Input box — separator-anchored. Opens on a long ── line, then
+    //    greedily collects separators, blank lines, and cursor lines
+    //    (`>` or `❯` followed only by whitespace). Closes on the first
+    //    non-matching line so a stray separator inside tool output can
+    //    only consume the matching tail, not the rest of the pane.
+    //    Capped at INPUT_BOX_LINE_CAP (counting the opener) for the
+    //    same safety reason as BANNER_LINE_CAP / INBOUND_LINE_CAP.
+    //
+    //    Codex review 2026-05-22 [high]: a STANDALONE long ── line in
+    //    tool output (a markdown divider, a separator in a help dump)
+    //    must not be hidden as an input box. We now require at least
+    //    one cursor line in the collected block — without that
+    //    confirmation we emit the lines as a conversation segment
+    //    instead, so legitimate dividers remain visible.
+    if (INPUT_SEPARATOR_RE.test(line)) {
+      const box: string[] = [line]
+      i += 1
+      let consumed = 1 // opener already counted
+      let hasCursor = false
+      while (i < lines.length && consumed < INPUT_BOX_LINE_CAP) {
+        const inner = lines[i]!
+        const isSep = INPUT_SEPARATOR_RE.test(inner)
+        const isPrompt = INPUT_PROMPT_RE.test(inner)
+        const isBlank = inner.trim() === ''
+        if (!isSep && !isPrompt && !isBlank) break
+        if (isPrompt) hasCursor = true
+        box.push(inner)
+        i += 1
+        consumed += 1
+      }
+      // Reclassify when the block lacks a cursor — almost certainly a
+      // standalone divider in tool output rather than a real prompt.
+      const type: SegmentType = hasCursor ? 'input_box' : 'conversation'
+      const seg = joinSegment(type, box)
+      if (seg !== null) out.push(seg)
+      continue
+    }
+
+    // 7) Conversation (default). Accumulate until we hit a boundary or
     //    the end of input.
     const conv: string[] = []
     while (i < lines.length) {
@@ -299,11 +421,56 @@ function asSet(
 
 export function filterPane(text: string, opts?: FilterOptions): string {
   const hide = asSet(opts?.hide)
-  const segs = segmentizePane(text)
+  const mode: RenderMode = opts?.mode ?? 'full_pane'
+  let segs = segmentizePane(text)
+  // Mode is applied BEFORE the hide list. If hide were applied first,
+  // an aggressive config that hides `inbound_preview` would erase the
+  // anchor and turn `latest_inbound_only` into a silent no-op. Order
+  // matters: pivot first, then drop.
+  if (mode === 'latest_inbound_only') {
+    let lastIdx = -1
+    for (let k = segs.length - 1; k >= 0; k -= 1) {
+      if (segs[k]!.type === 'inbound_preview') {
+        lastIdx = k
+        break
+      }
+    }
+    // Fresh session with no preview line at all → degrade to full_pane.
+    if (lastIdx >= 0) {
+      // Drop the anchor itself AND every segment before it. The mirror
+      // wants only what happened AFTER the warchief's last message, so
+      // the preview (which echoes that message) is not part of "after".
+      segs = segs.slice(lastIdx + 1)
+    }
+  }
   const kept = segs.filter((s) => !hide.has(s.type))
   if (kept.length === 0) return ''
   // Join with a blank line between segments to keep them visually
   // separated in the Telegram `<pre>` block. Each segment body is
   // already inner-trimmed.
   return kept.map((s) => s.text).join('\n\n')
+}
+
+// ─── Line cap ───────────────────────────────────────────────────────
+
+// capLines — keep at most `maxLines` lines, truncating from the TOP
+// (oldest content) so the rendered tail stays visible. When the input
+// is taller than the cap, the first kept line is replaced with a
+// `… +N lines` marker; the marker counts toward `maxLines`, so the
+// returned string has at most `maxLines` lines on any input.
+//
+// `maxLines === 0` disables capping (caller wants full filtered text).
+// `maxLines === 1` is degenerate but well-defined: returns only the
+// marker, no tail.
+export function capLines(text: string, maxLines: number): string {
+  if (maxLines <= 0) return text
+  if (text.length === 0) return text
+  const lines = text.split('\n')
+  if (lines.length <= maxLines) return text
+  // Reserve 1 line for the marker; the rest goes to the tail.
+  const keep = Math.max(0, maxLines - 1)
+  const dropped = lines.length - keep
+  const tail = lines.slice(lines.length - keep)
+  const marker = `… +${dropped} lines`
+  return [marker, ...tail].join('\n')
 }

--- a/plugin/tests/config.test.ts
+++ b/plugin/tests/config.test.ts
@@ -231,4 +231,47 @@ describe('loadConfig', () => {
       expect(cfg.memory.enabled).toBe(false)
     }
   })
+
+  // ─── tmux_mirror schema (added 2026-05-22) ─────────────────────────
+
+  test('tmux_mirror defaults: mode=latest_inbound_only, max_lines=14, hide_segments includes input_box', () => {
+    const cfg = loadConfig(env())
+    expect(cfg.tmux_mirror.mode).toBe('latest_inbound_only')
+    expect(cfg.tmux_mirror.max_lines).toBe(14)
+    expect(cfg.tmux_mirror.hide_segments).toContain('input_box')
+    expect(cfg.tmux_mirror.hide_segments).toContain('boot_banner')
+    expect(cfg.tmux_mirror.hide_segments).toContain('inbound_warning')
+    expect(cfg.tmux_mirror.hide_segments).toContain('footer_hints')
+  })
+
+  test('tmux_mirror.max_lines rejects degenerate values 1..3 (Codex 2026-05-22 [medium])', () => {
+    // Spec: 0 = disabled, otherwise 4..100. Smaller values render only
+    // the marker plus a handful of lines — not useful.
+    for (const bad of [1, 2, 3, -1, 101]) {
+      writeFileSync(join(stateDir, 'config.json'), JSON.stringify({
+        tmux_mirror: { max_lines: bad },
+      }))
+      expect(() => loadConfig(env())).toThrow(/max_lines must be 0 \(disabled\) or an integer in 4..100/)
+    }
+  })
+
+  test('tmux_mirror.max_lines accepts 0 (disabled) and 4..100', () => {
+    for (const good of [0, 4, 14, 50, 100]) {
+      writeFileSync(join(stateDir, 'config.json'), JSON.stringify({
+        tmux_mirror: { max_lines: good },
+      }))
+      const cfg = loadConfig(env())
+      expect(cfg.tmux_mirror.max_lines).toBe(good)
+    }
+  })
+
+  test('tmux_mirror.mode accepts both full_pane and latest_inbound_only', () => {
+    for (const mode of ['full_pane', 'latest_inbound_only'] as const) {
+      writeFileSync(join(stateDir, 'config.json'), JSON.stringify({
+        tmux_mirror: { mode },
+      }))
+      const cfg = loadConfig(env())
+      expect(cfg.tmux_mirror.mode).toBe(mode)
+    }
+  })
 })

--- a/plugin/tests/status/tmux-mirror.test.ts
+++ b/plugin/tests/status/tmux-mirror.test.ts
@@ -320,7 +320,7 @@ describe('TmuxMirror — tmux unavailable', () => {
 })
 
 describe('TmuxMirror — length cap', () => {
-  test('large pane is truncated to fit Telegram body cap', async () => {
+  test('large pane is line-capped (default maxLines=14) then char-capped to fit Telegram body', async () => {
     const stub = makeStubApi()
     // Generate 5000 chars of text (over 4096 cap).
     const bigLine = 'X'.repeat(120)
@@ -334,13 +334,155 @@ describe('TmuxMirror — length cap', () => {
       pollIntervalMs: 1000,
       lineCount: 50,
       exec,
+      // No maxLines override → default 14 from constructor applies and
+      // capLines shrinks 50 lines → 14 with a `… +N lines` marker BEFORE
+      // renderBody char-truncation has anything left to do.
     })
     await mirror.start()
     const sent = stub.ops.find((o) => o.method === 'sendMessage')
     expect(sent).toBeDefined()
     expect(sent!.text!.length).toBeLessThanOrEqual(4096)
-    // Truncation must keep the END (newest output) and mark the head.
+    // Line cap marker (matches `… +N lines`). Char-cap `[truncated]`
+    // header is only emitted when the body STILL exceeds 4096 after the
+    // line cap — with the default cap that path is unreachable here.
+    expect(sent!.text).toMatch(/… \+\d+ lines/)
+    // Tail of the original blob survives.
+    expect(sent!.text).toContain('49:')
+    await mirror.stop()
+  })
+
+  test('maxLines=0 disables the line cap; renderBody char truncation kicks in instead', async () => {
+    const stub = makeStubApi()
+    const bigLine = 'X'.repeat(120)
+    const blob = Array.from({ length: 50 }, (_, i) => `${i}: ${bigLine}`).join('\n')
+    const exec = makeExec([ok(blob)])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+      maxLines: 0,
+    })
+    await mirror.start()
+    const sent = stub.ops.find((o) => o.method === 'sendMessage')
+    expect(sent).toBeDefined()
+    expect(sent!.text!.length).toBeLessThanOrEqual(4096)
     expect(sent!.text).toContain('truncated')
+    await mirror.stop()
+  })
+})
+
+describe('TmuxMirror — latest_inbound_only (default)', () => {
+  test('default mode pivots on the last `← <channel>:` preview and drops earlier history', async () => {
+    const stub = makeStubApi()
+    const pane = [
+      '● Old turn from yesterday',
+      '← dashi-channel: stale-voice-1',
+      '● Reply to stale voice 1',
+      '← dashi-channel: latest-voice',
+      '● Live agent activity after the warchief\'s last message',
+    ].join('\n')
+    const exec = makeExec([ok(pane)])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+    })
+    await mirror.start()
+    const sent = stub.ops.find((o) => o.method === 'sendMessage')
+    expect(sent).toBeDefined()
+    // Pre-pivot content must not leak into the iPhone view.
+    expect(sent!.text).not.toContain('Old turn from yesterday')
+    expect(sent!.text).not.toContain('stale-voice-1')
+    expect(sent!.text).not.toContain('latest-voice')
+    // Tail survives.
+    expect(sent!.text).toContain('Live agent activity')
+    await mirror.stop()
+  })
+
+  test('explicit mode=full_pane preserves the entire pane (legacy behaviour)', async () => {
+    const stub = makeStubApi()
+    const pane = [
+      '● Old turn',
+      '← dashi-channel: preview',
+      '● New turn',
+    ].join('\n')
+    const exec = makeExec([ok(pane)])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+      mode: 'full_pane',
+    })
+    await mirror.start()
+    const sent = stub.ops.find((o) => o.method === 'sendMessage')
+    expect(sent).toBeDefined()
+    expect(sent!.text).toContain('Old turn')
+    expect(sent!.text).toContain('preview')
+    expect(sent!.text).toContain('New turn')
+    await mirror.stop()
+  })
+
+  test('fresh session with no preview line falls back to full_pane and stays visible', async () => {
+    const stub = makeStubApi()
+    const pane = '● First turn of a fresh session, nothing inbound yet'
+    const exec = makeExec([ok(pane)])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+      // default mode = latest_inbound_only
+    })
+    await mirror.start()
+    const sent = stub.ops.find((o) => o.method === 'sendMessage')
+    expect(sent).toBeDefined()
+    expect(sent!.text).toContain('First turn')
+    expect(sent!.text).not.toContain('no visible output')
+    await mirror.stop()
+  })
+
+  test('input box (── + ❯ + ──) and Tip footer are hidden by default', async () => {
+    const stub = makeStubApi()
+    const pane = [
+      '● Live agent line',
+      '────────────────────────────────────────',
+      '❯                                       ',
+      '────────────────────────────────────────',
+      'Tip: Use /btw to ask a quick side question',
+    ].join('\n')
+    const exec = makeExec([ok(pane)])
+    const mirror = new TmuxMirror({
+      api: stub.api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec,
+      mode: 'full_pane', // disable pivot so we test ONLY the hide list
+    })
+    await mirror.start()
+    const sent = stub.ops.find((o) => o.method === 'sendMessage')
+    expect(sent).toBeDefined()
+    expect(sent!.text).toContain('Live agent line')
+    expect(sent!.text).not.toContain('────')
+    expect(sent!.text).not.toContain('❯')
+    expect(sent!.text).not.toContain('Tip: Use /btw')
     await mirror.stop()
   })
 })

--- a/plugin/tests/status/tmux-pane-filter.test.ts
+++ b/plugin/tests/status/tmux-pane-filter.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, test } from 'bun:test'
 import {
   segmentizePane,
   filterPane,
+  capLines,
   DEFAULT_HIDDEN_SEGMENTS,
   type SegmentType,
 } from '../../src/status/tmux-pane-filter.js'
@@ -132,11 +133,14 @@ describe('segmentizePane — classification', () => {
   test('full pane: types appear in the canonical order', () => {
     const types = typesOf(FULL_PANE)
     // The exact list (no extraneous segments, no swapped order).
+    // `input_box` was promoted from "lives inside conversation" to its
+    // own segment on 2026-05-22 — see scanner branch 6 in the filter.
     expect(types).toEqual([
       'boot_banner',
       'channel_status',
       'inbound_warning',
       'conversation',
+      'input_box',
       'footer_hints',
     ])
   })
@@ -153,11 +157,13 @@ describe('segmentizePane — classification', () => {
     expect(segs[0]?.type).toBe('conversation')
   })
 
-  test('input prompt box (─ line + > line + ─ line) stays inside conversation segment', () => {
-    // Input prompt is NOT a separate type in v1 — it lives inside the
-    // surrounding conversation. The mirror should keep it visible.
+  test('input prompt box (─ line + > line + ─ line) classifies as input_box', () => {
+    // 2026-05-22: input box was promoted to its own segment so the
+    // warchief's mirror can hide it. A conversation line that follows
+    // («> hello», not all-whitespace after >) breaks out of the box.
     const segs = segmentizePane(INPUT_PROMPT_BOX + '\n> hello\n')
     const types = segs.map((s) => s.type)
+    expect(types).toContain('input_box')
     expect(types).toContain('conversation')
     expect(types).not.toContain('footer_hints')
   })
@@ -184,9 +190,16 @@ describe('filterPane — applies hide-list', () => {
     expect(out).toContain('Сделано. Порядок восстановлен.')
   })
 
-  test('DEFAULT_HIDDEN_SEGMENTS lists exactly the three groups we hide by default', () => {
+  test('DEFAULT_HIDDEN_SEGMENTS lists the four groups we hide by default', () => {
+    // 2026-05-22: `input_box` joined the default hide list — the
+    // warchief's iPhone mirror should not surface the prompt area.
     expect(new Set(DEFAULT_HIDDEN_SEGMENTS)).toEqual(
-      new Set<SegmentType>(['boot_banner', 'inbound_warning', 'footer_hints']),
+      new Set<SegmentType>([
+        'boot_banner',
+        'inbound_warning',
+        'footer_hints',
+        'input_box',
+      ]),
     )
   })
 
@@ -205,6 +218,8 @@ describe('filterPane — applies hide-list', () => {
         'channel_status',
         'conversation',
         'footer_hints',
+        'input_box',
+        'inbound_preview',
       ],
     })
     expect(out.trim()).toBe('')
@@ -346,5 +361,291 @@ describe('segmentizePane — robustness', () => {
     const dt = Date.now() - t0
     expect(out.length).toBeGreaterThan(0)
     expect(dt).toBeLessThan(2000)
+  })
+})
+
+// ─── input_box segment (added 2026-05-22) ────────────────────────────
+
+describe('segmentizePane — input_box', () => {
+  test('separator + > cursor + separator classifies as one input_box segment', () => {
+    const segs = segmentizePane(INPUT_PROMPT_BOX)
+    expect(segs.length).toBe(1)
+    expect(segs[0]?.type).toBe('input_box')
+    expect(segs[0]?.text).toContain('─')
+  })
+
+  test('separator + ❯ (U+276F) + separator classifies as input_box', () => {
+    // Claude Code v2.1.144 emits U+276F as the cursor glyph; the legacy
+    // ASCII `>` and the new ❯ must both classify as cursor lines.
+    const box = [
+      '────────────────────────────────────────',
+      '❯                                       ',
+      '────────────────────────────────────────',
+    ].join('\n')
+    const segs = segmentizePane(box)
+    expect(segs.length).toBe(1)
+    expect(segs[0]?.type).toBe('input_box')
+  })
+
+  test('input_box absorbs interleaved blank lines between separators and cursor', () => {
+    const box = [
+      '────────────────────────────────────────',
+      '',
+      '❯                                       ',
+      '',
+      '────────────────────────────────────────',
+    ].join('\n')
+    const segs = segmentizePane(box)
+    expect(segs.length).toBe(1)
+    expect(segs[0]?.type).toBe('input_box')
+  })
+
+  test('input_box closes on the first non-matching line; later conversation survives', () => {
+    const text = [
+      INPUT_PROMPT_BOX,
+      '',
+      '● Conversation line that must NOT be eaten by the box',
+    ].join('\n')
+    const types = segmentizePane(text).map((s) => s.type)
+    expect(types).toEqual(['input_box', 'conversation'])
+  })
+
+  test('short ── inline (under 20 chars) is NOT an input_box', () => {
+    // A diff line or a heading like «section ──» must stay in
+    // conversation; the 20-glyph threshold rules that out.
+    const text = [
+      '+ section ──── short separator',
+      '● another bullet',
+    ].join('\n')
+    const types = segmentizePane(text).map((s) => s.type)
+    expect(types).toEqual(['conversation'])
+  })
+
+  test('conversation line «> Что у нас по EdgeLab?» is NOT a cursor (text after >)', () => {
+    // The cursor anchor is `^\s*[>❯]\s*$` — line must be empty after
+    // the cursor glyph. A quoted reply like `> Что у нас` has content
+    // after `>` and stays in conversation. The lone separator above it
+    // lacks a cursor confirmation (Codex 2026-05-22 [high] fix), so it
+    // reclassifies as conversation rather than a fake input_box.
+    const text = [
+      '────────────────────────────────────────',
+      '> Что у нас по EdgeLab?',
+    ].join('\n')
+    const segs = segmentizePane(text)
+    const types = segs.map((s) => s.type)
+    expect(types).not.toContain('input_box')
+    expect(types).toContain('conversation')
+    const conv = segs.find((s) => s.type === 'conversation' && s.text.includes('Что у нас'))
+    expect(conv).toBeDefined()
+  })
+
+  test('standalone long ── line without cursor is NOT an input_box (markdown divider)', () => {
+    // Codex review 2026-05-22 [high]: a long ── separator in tool
+    // output (a markdown divider, a help-dump rule) must not vanish
+    // from the mirror. Reclassified as conversation when the block
+    // contains no cursor line.
+    const text = [
+      '● Some tool output',
+      '────────────────────────────────────────',
+      '● Continued output below the divider',
+    ].join('\n')
+    const types = segmentizePane(text).map((s) => s.type)
+    expect(types).not.toContain('input_box')
+    expect(types.every((t) => t === 'conversation')).toBe(true)
+  })
+
+  test('input_box stops at the 10-line cap (including opener) so a stray real box does not swallow scrollback', () => {
+    // 8 separators + cursor + 20 more separators — the cap fires
+    // before the trailing run is absorbed. Cursor is present so the
+    // block IS classified as input_box. After the cap, remaining
+    // separators end up reclassified individually (no cursor) as
+    // conversation.
+    const lines: string[] = []
+    for (let k = 0; k < 8; k += 1) lines.push('────────────────────────────────────────')
+    lines.push('❯                                       ')
+    for (let k = 0; k < 20; k += 1) lines.push('────────────────────────────────────────')
+    lines.push('● later content')
+    const segs = segmentizePane(lines.join('\n'))
+    const boxSegs = segs.filter((s) => s.type === 'input_box')
+    expect(boxSegs.length).toBeGreaterThanOrEqual(1)
+    // Cap is inclusive of opener — at most 10 lines per input_box.
+    const firstBox = boxSegs[0]!.text.split('\n')
+    expect(firstBox.length).toBeLessThanOrEqual(10)
+    expect(segs.some((s) => s.type === 'conversation' && s.text.includes('later content'))).toBe(true)
+  })
+})
+
+// ─── inbound_preview segment (added 2026-05-22) ──────────────────────
+
+describe('segmentizePane — inbound_preview', () => {
+  test('«← dashi-channel: …» line is a single-line inbound_preview segment', () => {
+    const text = '← dashi-channel: <media kind="voice" file_id="AwAC***SpDA"'
+    const segs = segmentizePane(text)
+    expect(segs.length).toBe(1)
+    expect(segs[0]?.type).toBe('inbound_preview')
+    expect(segs[0]?.text).toContain('dashi-channel')
+  })
+
+  test('indented or quoted «← …» does NOT classify as inbound_preview', () => {
+    // Anchor requires `^← ` at column zero — a quoted line with
+    // leading whitespace stays in conversation. Same for diff lines.
+    const text = [
+      '  ← github: oops quoted in conversation',
+      '+ ← diff: added by patch',
+    ].join('\n')
+    const segs = segmentizePane(text)
+    const types = segs.map((s) => s.type)
+    expect(types).not.toContain('inbound_preview')
+    expect(types).toEqual(['conversation'])
+  })
+
+  test('uppercase / mixed-case channel name does NOT classify as inbound_preview', () => {
+    // Codex review 2026-05-22 [medium]: the original `\S+:` form was
+    // too loose — a tool printing «← GitHub: …» or «← Some Channel: …»
+    // would hijack the latest_inbound_only pivot. Channel names must
+    // now start with a lowercase ASCII letter and contain only
+    // [a-z0-9_-].
+    const text = [
+      '← GitHub: issue title',
+      '← Some Channel: free text label',
+      '← 1bad: starts with digit',
+    ].join('\n')
+    const types = segmentizePane(text).map((s) => s.type)
+    expect(types).not.toContain('inbound_preview')
+  })
+
+  test('multiple inbound previews in a row each get their own segment', () => {
+    const text = [
+      '← dashi-channel: msg one',
+      '← dashi-channel: msg two',
+      '● conversation between two messages',
+      '← dashi-channel: msg three',
+    ].join('\n')
+    const types = segmentizePane(text).map((s) => s.type)
+    expect(types).toEqual([
+      'inbound_preview',
+      'inbound_preview',
+      'conversation',
+      'inbound_preview',
+    ])
+  })
+})
+
+// ─── Tip footer line (added 2026-05-22) ──────────────────────────────
+
+describe('segmentizePane — Tip footer', () => {
+  test('«Tip: Use /btw …» is hidden as a footer_hints segment', () => {
+    const text = 'Tip: Use /btw to ask a quick side question without interrupting Claude\'s current work'
+    const segs = segmentizePane(text)
+    expect(segs.length).toBe(1)
+    expect(segs[0]?.type).toBe('footer_hints')
+  })
+
+  test('conversation phrase «Tip: try X» is NOT classified as footer', () => {
+    // Anchor requires `Use /` literal — generic «Tip:» without `/`
+    // command suffix must stay in conversation.
+    const text = 'Tip: try indexing before that join, it cut p99 by 4x.'
+    const segs = segmentizePane(text)
+    expect(segs.length).toBe(1)
+    expect(segs[0]?.type).toBe('conversation')
+  })
+})
+
+// ─── filterPane mode='latest_inbound_only' ───────────────────────────
+
+describe('filterPane — mode latest_inbound_only', () => {
+  test('drops every segment up to AND INCLUDING the last inbound preview', () => {
+    const text = [
+      '● Earlier conversation about EdgeLab',
+      '← dashi-channel: first voice from warchief',
+      '● Reply to first voice',
+      '← dashi-channel: second voice from warchief',
+      '● Reply still in progress',
+    ].join('\n')
+    const out = filterPane(text, { hide: [], mode: 'latest_inbound_only' })
+    // Nothing from before the second preview should leak.
+    expect(out).not.toContain('Earlier conversation')
+    expect(out).not.toContain('first voice')
+    expect(out).not.toContain('Reply to first voice')
+    expect(out).not.toContain('second voice') // anchor itself dropped
+    // Only the activity AFTER the last preview remains.
+    expect(out).toContain('Reply still in progress')
+  })
+
+  test('falls back to full_pane when no inbound preview is present', () => {
+    const text = [
+      '● Conversation without any inbound preview',
+      '● Another line',
+    ].join('\n')
+    const out = filterPane(text, { hide: [], mode: 'latest_inbound_only' })
+    expect(out).toContain('Conversation without any inbound preview')
+    expect(out).toContain('Another line')
+  })
+
+  test('mode applies BEFORE hide list so hide cannot erase the anchor', () => {
+    // Even if a misconfigured caller tries to hide inbound_preview,
+    // the pivot still finds it (mode runs first), then hide drops it.
+    const text = [
+      '● Old turn',
+      '← dashi-channel: PIVOT_LINE',
+      '● New turn',
+    ].join('\n')
+    const out = filterPane(text, {
+      hide: ['inbound_preview'],
+      mode: 'latest_inbound_only',
+    })
+    expect(out).not.toContain('Old turn')
+    expect(out).not.toContain('PIVOT_LINE')
+    expect(out).toContain('New turn')
+  })
+
+  test('default mode is full_pane (backwards-compatible with existing callers)', () => {
+    // No `mode` arg → existing behaviour preserved.
+    const text = [
+      '● Earlier turn',
+      '← dashi-channel: preview',
+      '● Later turn',
+    ].join('\n')
+    const out = filterPane(text, { hide: [] })
+    expect(out).toContain('Earlier turn')
+    expect(out).toContain('preview')
+    expect(out).toContain('Later turn')
+  })
+})
+
+// ─── capLines (added 2026-05-22) ─────────────────────────────────────
+
+describe('capLines', () => {
+  test('returns input unchanged when line count ≤ maxLines', () => {
+    const text = ['a', 'b', 'c'].join('\n')
+    expect(capLines(text, 3)).toBe(text)
+    expect(capLines(text, 10)).toBe(text)
+  })
+
+  test('truncates from the TOP and prepends `… +N lines` marker', () => {
+    const text = ['l1', 'l2', 'l3', 'l4', 'l5'].join('\n')
+    const out = capLines(text, 3)
+    const lines = out.split('\n')
+    expect(lines.length).toBe(3)
+    expect(lines[0]).toMatch(/^… \+\d+ lines$/)
+    // Tail preserved: last `maxLines - 1` lines from input.
+    expect(lines[1]).toBe('l4')
+    expect(lines[2]).toBe('l5')
+    // Dropped count is `inputLen - (maxLines - 1)` = 5 - 2 = 3.
+    expect(lines[0]).toBe('… +3 lines')
+  })
+
+  test('maxLines = 0 disables capping', () => {
+    const text = ['l1', 'l2', 'l3', 'l4', 'l5'].join('\n')
+    expect(capLines(text, 0)).toBe(text)
+  })
+
+  test('empty input returns empty', () => {
+    expect(capLines('', 5)).toBe('')
+  })
+
+  test('negative maxLines is a no-op (defensive)', () => {
+    const text = 'a\nb\nc'
+    expect(capLines(text, -1)).toBe(text)
   })
 })


### PR DESCRIPTION
## Summary

Вождь (2026-05-22) через Telegram попросил три вещи:
1. Видеть в зеркале только активность ПОСЛЕ его последнего сообщения, не всю историю pane.
2. Помещаться в ~70% iPhone-экрана (≈14 строк) без листания.
3. Скрыть «полосы» — рамку input box Claude Code (── separators + ❯ cursor).

Плюс из fallout PR #19: `Tip: Use /btw...` просочилась через footer-фильтр.

## Changes

### `src/status/tmux-pane-filter.ts`
- +SegmentType: `input_box`, `inbound_preview`
- +RenderMode: `full_pane` | `latest_inbound_only`
- `INBOUND_PREVIEW_RE = /^← [a-z][a-z0-9_-]*:/` — kebab-case only (Codex review)
- `INPUT_SEPARATOR_RE = /^─{20,}\s*$/` — ≥20 box-drawing
- `INPUT_PROMPT_RE = /^\s*[>❯]\s*$/` — line empty after cursor
- Scanner branch 6 (input_box): require ≥1 cursor line for confirmation; else reclassify as conversation (защищает markdown dividers)
- `filterPane()` теперь принимает `mode` — применяется ДО hide
- +`capLines(text, maxLines)` — truncate from TOP с маркером `… +N lines`
- Tip footer pattern: `/^\s*Tip:\s+Use\s*\//i`
- DEFAULT_HIDDEN_SEGMENTS включает `input_box`

### `src/status/tmux-mirror.ts`
- +TmuxMirrorOptions: `mode` (default `latest_inbound_only`), `maxLines` (default 14, 0 disables)
- buildRendered: stripAnsi → filterPane(hide+mode) → capLines → redact → renderBody

### `src/config.ts`
- `tmux_mirror.mode`, `tmux_mirror.max_lines` (0 ИЛИ 4..100, Codex review reject degenerate 1..3)
- `tmux_mirror.hide_segments` enum расширен

### `src/server.ts`
- Wires mode + max_lines в TmuxMirror

## Test plan

- [x] 99 локальных тестов (pane-filter + mirror + config) — все проходят
- [x] Полный bun test: 667/683 pass; 16 fail — pre-existing (verified via git stash)
- [x] Double review: Codex GPT-5.5 + Opus self-review
- [x] Все 4 finding'а Codex review адресованы (1 high, 2 medium, 1 low)

### Adversarial cases included
- Tip false-positive
- mode pivot когда inbound_preview hidden
- input_box без cursor → conversation
- 30-separator stream cap
- max_lines=1..3 reject
- mixed-case `← GitHub:` rejected
- diff line `+ ← x:` rejected

## Activation

После merge — рестарт Claude Code сессии `channel-thrall` чтобы перезапустить MCP stdio-сервер с новым кодом.

🤖 Generated with [Claude Code](https://claude.com/claude-code)