### PR TITLE
feat(reply): default format='html' для markdown-рендера в Telegram

### DIFF
--- a/plugin/src/channel/tools.ts
+++ b/plugin/src/channel/tools.ts
@@ -221,8 +221,9 @@ const TOOL_DEFINITIONS: ToolDefinition[] = [
         format: {
           type: 'string',
           enum: ['text', 'markdownv2', 'html'],
+          default: 'html',
           description:
-            "Rendering mode. 'html' converts markdown (**bold**, *italic*, `code`, ```fenced```, [text](url), tables, headings) to Telegram's HTML subset and auto-chunks at 4000 chars. 'markdownv2' passes raw — caller escapes per Telegram rules. Default: 'text' (plain).",
+            "Rendering mode. Default: 'html' — markdown (**bold**, *italic*, `code`, ```fenced```, [text](url), tables, # headings) is auto-converted to Telegram's HTML subset and auto-chunked at 4000 chars. Plain `<`, `>`, `&` in regular text are safe — they get auto-escaped before sending. On parse error the chunk re-sends as plain text so the reply still ships. Use 'text' only to bypass markdown conversion entirely (e.g. sending pre-built Telegram entity strings verbatim). 'markdownv2' passes raw — caller escapes per Telegram rules.",
         },
       },
       required: ['chat_id', 'text'],

--- a/plugin/src/schemas.ts
+++ b/plugin/src/schemas.ts
@@ -17,7 +17,12 @@ export const ReplyArgsSchema = z.object({
   text: z.string().min(1),
   reply_to: z.string().optional(),
   files: z.array(z.string()).optional(),
-  format: z.enum(['text', 'markdownv2', 'html']).optional(),
+  // Default 'html' — markdown (**bold**, headings, tables, ```code```) is
+  // converted to Telegram's HTML subset via markdownToTelegramHtml. Plain
+  // text without markdown markers passes through unchanged. Pass 'text'
+  // explicitly only when the caller needs a literal `<` / `>` / `&` in
+  // the body (rare). Inspired by openclaw/extensions/telegram (MIT).
+  format: z.enum(['text', 'markdownv2', 'html']).default('html'),
 })
 export type ReplyArgs = z.infer<typeof ReplyArgsSchema>
 

--- a/plugin/tests/channel/tools.test.ts
+++ b/plugin/tests/channel/tools.test.ts
@@ -374,6 +374,58 @@ describe('callTool', () => {
     rmSync(deps.statePaths.root, { recursive: true, force: true })
   })
 
+  test('reply without explicit format defaults to html (markdown auto-converts)', async () => {
+    // Regression: when the caller omits `format`, the schema defaults to
+    // 'html'. The body should be markdown-converted and sent with
+    // parse_mode='HTML'. Before this change, the default was 'text' and
+    // markdown leaked through to the user as literal `**bold**`.
+    const captured: Array<{ text: string; opts: SendMessageOpts }> = []
+    const api = makeStubApi({
+      sendMessage: async (_chatId, text, opts) => {
+        captured.push({ text, opts })
+        return { message_id: 600 + captured.length }
+      },
+    })
+    const deps = makeDeps({ telegramApi: api })
+    const result = await callTool(
+      callReq('reply', { chat_id: '164795011', text: 'Hello **bold** world' }),
+      deps,
+    )
+    expect(result.isError).toBeUndefined()
+    expect(captured.length).toBe(1)
+    expect(captured[0]!.opts.parse_mode).toBe('HTML')
+    expect(captured[0]!.text).toContain('<b>bold</b>')
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('reply default html auto-escapes raw &, <, > in plain text', async () => {
+    // Regression: with default='html', callers who send literal &/</> in
+    // ordinary text (URLs with query strings, code snippets in plain prose)
+    // must not break Telegram's HTML parser. markdownToTelegramHtml escapes
+    // them on the way out (& → &amp;, < → &lt;, > → &gt;) so the message
+    // remains valid HTML and ships with parse_mode='HTML'.
+    const captured: Array<{ text: string; opts: SendMessageOpts }> = []
+    const api = makeStubApi({
+      sendMessage: async (_chatId, text, opts) => {
+        captured.push({ text, opts })
+        return { message_id: 700 + captured.length }
+      },
+    })
+    const deps = makeDeps({ telegramApi: api })
+    const result = await callTool(
+      callReq('reply', { chat_id: '164795011', text: 'curl https://x.com?a=1&b=2 < y > z' }),
+      deps,
+    )
+    expect(result.isError).toBeUndefined()
+    expect(captured.length).toBe(1)
+    expect(captured[0]!.opts.parse_mode).toBe('HTML')
+    expect(captured[0]!.text).toContain('a=1&amp;b=2')
+    expect(captured[0]!.text).toContain('&lt; y &gt; z')
+    // No raw ampersand survives outside an entity.
+    expect(captured[0]!.text).not.toMatch(/&(?!amp;|lt;|gt;|quot;|#)/)
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
   // Fix 5 — long replies must chunk under all formats (not only html).
   test('reply text format chunks long messages under 4096 cap', async () => {
     const captured: Array<{ text: string; opts: SendMessageOpts }> = []


### PR DESCRIPTION
## Summary

Вождь (2026-05-22) видел в Telegram литералы `===`, `**`, бэктики и pipe-таблицы вместо рендеренного markdown. Корень: я (агент) забывал передавать `format='html'` в reply tool — дефолт был `'text'`, markdown шёл сырым.

Полноценный `markdownToTelegramHtml` уже работает (PR #8) с поддержкой bold/italic/code/headings/tables/links + safe-telegram-api wrapper с redact + validateHtml + auto-downgrade на parse error. Нужно просто сделать его дефолтом.

## Changes

- `src/schemas.ts`: `ReplyArgsSchema.format` `.optional()` → `.default('html')` с 5-строчным комментарием
- `src/channel/tools.ts`: JSON Schema получил `default: 'html'` (sync с Zod); tool description обновлён
- `tests/channel/tools.test.ts`: два regression-теста (markdown auto-converts + raw &/</> auto-escapes)

## Inspired by

`openclaw/extensions/telegram/src/format.ts` (MIT). У openclaw тот же default-html подход. Полный port whitelist tags — следующим PR.

## Test plan

- [x] `bun test tests/channel/tools.test.ts` — 21/21 pass
- [x] Полный `bun test` — 668 pass / 16 fail (все 16 pre-existing)
- [x] Double review: Opus + Codex GPT-5.5, все замечания применены
- [ ] После merge — restart channel-thrall.service, smoke conversation report у вождя

🤖 Generated with [Claude Code](https://claude.com/claude-code)