### PR TITLE
fix(status): suppress «Печатает.» bubble — лениво создаём при первом не-typing событии

### DIFF
--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -50,6 +50,12 @@ export const AppConfigSchema = z.object({
     interval_ms: z.number().int().positive().default(700),
     ttl_ms: z.number().int().positive().default(300_000),
     delete_on_complete: z.boolean().default(true),
+    // Warchief request 2026-05-27: the bare «Печатает...» bubble is visual
+    // noise on top of the TmuxMirror status card. When true, StatusManager
+    // skips the initial sendMessage while state is `typing` — the bubble is
+    // created lazily on the first thinking/tool/activity transition. Native
+    // sendChatAction (header animation) is unaffected.
+    suppress_typing_bubble: z.boolean().default(true),
   }).default({}),
   album: z.object({
     flush_ms: z.number().int().positive().default(2000),

--- a/plugin/src/status/status-manager.ts
+++ b/plugin/src/status/status-manager.ts
@@ -132,8 +132,17 @@ export interface StatusManagerDeps {
   streamingEnabled?: boolean
 }
 
+// Internal mirror of StatusHandle without the `readonly` modifiers — we
+// mutate messageId lazily when the bubble is created after a typing-only
+// start. The public StatusHandle (returned to callers) stays readonly.
+interface MutableHandle {
+  chatId: string
+  messageId: number
+  startedAt: number
+}
+
 interface InternalEntry {
-  handle: StatusHandle
+  handle: MutableHandle
   state: StatusState
   // Cycle index used to advance the dot animation on each tick.
   tick: number
@@ -142,6 +151,14 @@ interface InternalEntry {
   ttlHandle: NodeJS.Timeout | null
   // Separate cadence from the message edit ticker — see CHAT_ACTION_PULSE_MS.
   chatActionHandle: NodeJS.Timeout | null
+  // Original reply target captured from start(). Re-used when the bubble is
+  // created lazily on the first non-typing transition so it threads under
+  // the same inbound message the user originally sent.
+  replyToMessageId: number | undefined
+  // True when sendMessage has not been called yet because state is still
+  // typing and suppress_typing_bubble is on. Lazy-create path flips this on
+  // first non-typing transition.
+  bubbleSuppressed: boolean
   // Rolling activity state — kept on the entry even while state.kind!=
   // 'activity' so a Stop after a non-tool reasoning phase still has the
   // recorded history. Last-tool-render timestamp throttles non-Agent edits.
@@ -249,39 +266,48 @@ export class StatusManager {
       await this.cancel(chatId, 'superseded')
     }
 
+    const suppressBubble =
+      this.config.status.suppress_typing_bubble && initialState.kind === 'typing'
+
     const text = renderState(initialState, 0, this.now())
-    const sendOpts: { parse_mode: 'HTML'; reply_to_message_id?: number } = {
-      parse_mode: 'HTML',
-    }
-    if (replyToMessageId !== undefined) sendOpts.reply_to_message_id = replyToMessageId
+    let messageId = 0
+    if (!suppressBubble) {
+      const sendOpts: { parse_mode: 'HTML'; reply_to_message_id?: number } = {
+        parse_mode: 'HTML',
+      }
+      if (replyToMessageId !== undefined) sendOpts.reply_to_message_id = replyToMessageId
 
-    let sent: { message_id: number }
-    try {
-      sent = await this.telegramApi.sendMessage(chatId, text, sendOpts)
-    } catch (err) {
-      // If we can't even send the initial status, log and rethrow — caller
-      // can decide whether to proceed without status. (handlers.ts treats
-      // status as best-effort and will catch this.)
-      this.log.warn('status start failed', {
-        chat_id: chatId,
-        error: err instanceof Error ? err.message : String(err),
-      })
-      throw err
+      let sent: { message_id: number }
+      try {
+        sent = await this.telegramApi.sendMessage(chatId, text, sendOpts)
+      } catch (err) {
+        // If we can't even send the initial status, log and rethrow — caller
+        // can decide whether to proceed without status. (handlers.ts treats
+        // status as best-effort and will catch this.)
+        this.log.warn('status start failed', {
+          chat_id: chatId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+        throw err
+      }
+      messageId = sent.message_id
     }
 
-    const handle: StatusHandle = {
+    const handle: MutableHandle = {
       chatId,
-      messageId: sent.message_id,
+      messageId,
       startedAt: this.now(),
     }
     const entry: InternalEntry = {
       handle,
       state: initialState,
       tick: 0,
-      lastText: text,
+      lastText: suppressBubble ? '' : text,
       intervalHandle: null,
       ttlHandle: null,
       chatActionHandle: null,
+      replyToMessageId,
+      bubbleSuppressed: suppressBubble,
       activityCalls: [],
       activityPhase: 'reasoning',
       activityStartedAt: this.now(),
@@ -293,48 +319,102 @@ export class StatusManager {
     this.entries.set(chatId, entry)
 
     // Fire-and-forget initial chat action so the Telegram header shows
-    // `typing…` immediately, not on the first pulse 4 s in.
+    // `typing…` immediately, not on the first pulse 4 s in. Keeps firing
+    // even when the message bubble is suppressed — the native indicator
+    // is what the warchief still wants to see.
     void this.pulseChatAction(entry)
     entry.chatActionHandle = this.setTimer(
-      () => this.chatActionTick(chatId, handle.messageId),
+      () => this.chatActionTick(chatId),
       CHAT_ACTION_PULSE_MS,
     )
 
     // Periodic tick — re-edit with advanced ellipsis (typing/thinking only)
     // or keep the same text for tool/stopped/error states. Same-text edits
     // collapse via the "message is not modified" swallow path below.
+    //
+    // While the bubble is suppressed we still advance the tick counter so
+    // animation timing stays continuous when the bubble eventually appears,
+    // but `editSafely` short-circuits because messageId is 0.
     const tick = (): void => {
       const live = this.entries.get(chatId)
-      if (!live || live.handle.messageId !== handle.messageId) return
+      if (!live) return
       live.tick += 1
-      const next = renderState(live.state, live.tick, this.now())
-      void this.editSafely(live, next)
+      if (!live.bubbleSuppressed) {
+        const next = renderState(live.state, live.tick, this.now())
+        void this.editSafely(live, next)
+      }
       // Re-arm next tick.
       live.intervalHandle = this.setTimer(tick, this.config.status.interval_ms)
     }
     entry.intervalHandle = this.setTimer(tick, this.config.status.interval_ms)
 
     // TTL guard. On expiry we cancel with reason='ttl' so the message turns
-    // into "Остановлено: ttl" rather than vanishing silently.
+    // into "Остановлено: ttl" rather than vanishing silently. When the
+    // bubble was suppressed end-to-end (pure typing session that timed
+    // out) cancel() turns into a quiet cleanup with no Telegram edit.
     entry.ttlHandle = this.setTimer(() => {
       const live = this.entries.get(chatId)
-      if (!live || live.handle.messageId !== handle.messageId) return
+      if (!live) return
       void this.cancel(chatId, 'ttl')
     }, this.config.status.ttl_ms)
 
-    return handle
+    return {
+      chatId: handle.chatId,
+      messageId: handle.messageId,
+      startedAt: handle.startedAt,
+    }
+  }
+
+  // Lazy-create the Telegram message bubble when state advances from typing
+  // to anything else (thinking/tool/activity/stopped/error). No-op when the
+  // bubble already exists. Used by update() and recordActivityByChatId().
+  private async ensureBubble(entry: InternalEntry, state: StatusState): Promise<void> {
+    if (!entry.bubbleSuppressed) return
+    if (state.kind === 'typing') return
+    const text = renderState(state, 0, this.now())
+    const sendOpts: { parse_mode: 'HTML'; reply_to_message_id?: number } = {
+      parse_mode: 'HTML',
+    }
+    if (entry.replyToMessageId !== undefined) {
+      sendOpts.reply_to_message_id = entry.replyToMessageId
+    }
+    try {
+      const sent = await this.telegramApi.sendMessage(entry.handle.chatId, text, sendOpts)
+      entry.handle.messageId = sent.message_id
+      entry.lastText = text
+      entry.bubbleSuppressed = false
+    } catch (err) {
+      // Best-effort — log and leave bubble suppressed. Next non-typing
+      // event will retry the send.
+      this.log.warn('status lazy-send failed (ignored)', {
+        chat_id: entry.handle.chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
   }
 
   async update(handle: StatusHandle, state: StatusState): Promise<void> {
     const entry = this.entries.get(handle.chatId)
-    if (!entry || entry.handle.messageId !== handle.messageId) {
+    if (!entry) return
+    // Staleness check is messageId-based, but a still-suppressed entry has
+    // messageId 0 in both the caller's handle (returned from start) and the
+    // internal entry, so the comparison still passes. Once the bubble has
+    // been created lazily, callers using the original 0-handle drift into
+    // staleness — by then they should be using updateByChatId, which is the
+    // documented path for late edits.
+    if (entry.handle.messageId !== handle.messageId && !entry.bubbleSuppressed) {
       // Stale handle — caller is editing something already completed.
-      // Drop silently; the original status is gone.
       return
     }
     entry.state = state
     // Reset tick on state change so the ellipsis animation restarts at 1.
     entry.tick = 0
+    if (entry.bubbleSuppressed) {
+      await this.ensureBubble(entry, state)
+      // ensureBubble already wrote the rendered text for non-typing states
+      // and flipped bubbleSuppressed off. Nothing else to edit on this turn.
+      return
+    }
     const text = renderState(state, 0, this.now())
     await this.editSafely(entry, text)
   }
@@ -486,6 +566,12 @@ export class StatusManager {
     )
     entry.state = { kind: 'activity', snapshot }
     entry.tick = 0
+    if (entry.bubbleSuppressed) {
+      // First non-typing event creates the bubble with the activity render
+      // directly — no «Печатает.» preamble.
+      await this.ensureBubble(entry, entry.state)
+      return
+    }
     const text = renderState(entry.state, 0, now)
     await this.editSafely(entry, text)
   }
@@ -508,6 +594,8 @@ export class StatusManager {
     if (!entry) return
     this.stopTimers(entry)
     this.entries.delete(chatId)
+    // Suppressed bubble = never sent a Telegram message, nothing to delete.
+    if (entry.bubbleSuppressed) return
     if (this.config.status.delete_on_complete && this.telegramApi.deleteMessage) {
       try {
         await this.telegramApi.deleteMessage(chatId, entry.handle.messageId)
@@ -527,6 +615,9 @@ export class StatusManager {
     if (!entry) return
     this.stopTimers(entry)
     this.entries.delete(chatId)
+    // Pure typing session that ended without ever transitioning — no bubble
+    // exists on Telegram, so there is nothing to mark as «Остановлено».
+    if (entry.bubbleSuppressed) return
     const text = renderState({ kind: 'stopped', reason }, 0, this.now())
     try {
       await this.telegramApi.editMessageText(
@@ -549,6 +640,10 @@ export class StatusManager {
   // ───── internals ─────
 
   private async editSafely(entry: InternalEntry, text: string): Promise<void> {
+    // Bubble suppressed — no Telegram message to edit. Caller is expected to
+    // go through ensureBubble() instead. Guard defends timer-driven ticks
+    // that fire before the first non-typing transition.
+    if (entry.bubbleSuppressed || entry.handle.messageId === 0) return
     if (text === entry.lastText) {
       // Skip the network roundtrip; Telegram would respond with "message is
       // not modified" anyway and we'd swallow it.
@@ -609,12 +704,12 @@ export class StatusManager {
     }
   }
 
-  private chatActionTick(chatId: string, messageId: number): void {
+  private chatActionTick(chatId: string): void {
     const live = this.entries.get(chatId)
-    if (!live || live.handle.messageId !== messageId) return
+    if (!live) return
     void this.pulseChatAction(live)
     live.chatActionHandle = this.setTimer(
-      () => this.chatActionTick(chatId, messageId),
+      () => this.chatActionTick(chatId),
       CHAT_ACTION_PULSE_MS,
     )
   }

--- a/plugin/tests/channel/permissions.test.ts
+++ b/plugin/tests/channel/permissions.test.ts
@@ -55,7 +55,7 @@ function mkConfig(allowedIds: number[] = [164795011]): AppConfig {
     dm_only: true,
     allowed_user_ids: [164795011],
     allowed_chat_ids: [164795011],
-    status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true },
+    status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true, suppress_typing_bubble: false },
     album: { flush_ms: 2000 },
     voice: { provider: 'groq', language: 'ru', model: 'whisper-large-v3-turbo' },
     webhook: { enabled: false, host: '127.0.0.1', port: 0 },

--- a/plugin/tests/channel/tools.test.ts
+++ b/plugin/tests/channel/tools.test.ts
@@ -51,7 +51,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     dm_only: true,
     allowed_user_ids: [164795011],
     allowed_chat_ids: [164795011],
-    status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true },
+    status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true, suppress_typing_bubble: false },
     album: { flush_ms: 2000 },
     voice: { provider: 'groq', language: 'ru', model: 'whisper-large-v3-turbo' },
     webhook: { enabled: false, host: '127.0.0.1', port: 0 },

--- a/plugin/tests/commands/oob.test.ts
+++ b/plugin/tests/commands/oob.test.ts
@@ -15,7 +15,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     dm_only: true,
     allowed_user_ids: [164795011],
     allowed_chat_ids: [164795011],
-    status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true },
+    status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true, suppress_typing_bubble: false },
     album: { flush_ms: 2000 },
     voice: { provider: 'groq', language: 'ru', model: 'whisper-large-v3-turbo' },
     webhook: { enabled: false, host: '127.0.0.1', port: 0 },

--- a/plugin/tests/prompt/media-prompt.test.ts
+++ b/plugin/tests/prompt/media-prompt.test.ts
@@ -27,7 +27,7 @@ const voiceConfig: AppConfig = {
   dm_only: true,
   allowed_user_ids: [1],
   allowed_chat_ids: [1],
-  status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true },
+  status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true, suppress_typing_bubble: false },
   album: { flush_ms: 2000 },
   voice: { provider: 'groq', language: 'ru', model: 'whisper-large-v3-turbo' },
   webhook: { enabled: false, host: '127.0.0.1', port: 0 },

--- a/plugin/tests/security/paths.test.ts
+++ b/plugin/tests/security/paths.test.ts
@@ -40,7 +40,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     dm_only: true,
     allowed_user_ids: [164795011],
     allowed_chat_ids: [164795011],
-    status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true },
+    status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true, suppress_typing_bubble: false },
     album: { flush_ms: 2000 },
     voice: { provider: 'groq', language: 'ru', model: 'whisper-large-v3-turbo' },
     webhook: { enabled: false, host: '127.0.0.1', port: 0 },

--- a/plugin/tests/status/progress-reporter.test.ts
+++ b/plugin/tests/status/progress-reporter.test.ts
@@ -50,6 +50,7 @@ function makeConfig(overrides: Partial<AppConfig['progress']> = {}): AppConfig {
       interval_ms: 700,
       ttl_ms: 300_000,
       delete_on_complete: true,
+      suppress_typing_bubble: false,
     },
     album: { flush_ms: 2000 },
     voice: { provider: 'groq', language: 'ru', model: 'whisper-large-v3-turbo' },

--- a/plugin/tests/status/status-manager.test.ts
+++ b/plugin/tests/status/status-manager.test.ts
@@ -24,6 +24,10 @@ function makeConfig(overrides: Partial<AppConfig['status']> = {}): AppConfig {
       interval_ms: 700,
       ttl_ms: 300_000,
       delete_on_complete: true,
+      // Keep legacy behaviour (eager «Печатает...» bubble) so the existing
+      // suite covers the non-suppressed path. Dedicated tests below opt in
+      // by passing { suppress_typing_bubble: true } via overrides.
+      suppress_typing_bubble: false,
       ...overrides,
     },
     album: { flush_ms: 2000 },
@@ -698,5 +702,119 @@ describe('StatusManager.recordActivityByChatId', () => {
     expect(last.text).not.toContain('cmd-00')
     expect(last.text).not.toContain('cmd-01')
     expect(last.text).not.toContain('cmd-06')
+  })
+})
+
+describe('StatusManager.suppress_typing_bubble', () => {
+  // Warchief request 2026-05-27: the «Печатает...» bubble is visual noise
+  // on top of TmuxMirror. When suppress_typing_bubble=true (production
+  // default), the bubble must NOT exist until state advances past typing.
+  // Native sendChatAction (header animation) and TTL guard still run.
+
+  test('skips initial sendMessage while state is typing', async () => {
+    const { mgr, api } = makeManager({
+      config: makeConfig({ suppress_typing_bubble: true }),
+    })
+    const handle = await mgr.start('164795011', undefined)
+    expect(handle.messageId).toBe(0)
+    // No send for the bubble. sendChatAction still fires immediately so the
+    // Telegram header animation is unchanged.
+    expect(api.calls.filter((c) => c.kind === 'send').length).toBe(0)
+    expect(api.calls.filter((c) => c.kind === 'chat_action').length).toBe(1)
+    expect(mgr.isActive('164795011')).toBe(true)
+  })
+
+  test('does not edit while state stays in typing across ticks', async () => {
+    const { mgr, api, clock } = makeManager({
+      config: makeConfig({ suppress_typing_bubble: true }),
+    })
+    await mgr.start('164795011', undefined)
+    clock.advance(5000)
+    expect(api.calls.filter((c) => c.kind === 'edit').length).toBe(0)
+    expect(api.calls.filter((c) => c.kind === 'send').length).toBe(0)
+  })
+
+  test('lazy-creates bubble on first non-typing update', async () => {
+    const { mgr, api } = makeManager({
+      config: makeConfig({ suppress_typing_bubble: true }),
+    })
+    await mgr.start('164795011', 4242)
+    await mgr.updateByChatId('164795011', { kind: 'tool', toolName: 'Bash' })
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(1)
+    expect(sends[0]!.text).toContain('Bash')
+    // Lazy create preserves the original reply target captured at start.
+    const opts = sends[0]!.opts as { reply_to_message_id?: number }
+    expect(opts.reply_to_message_id).toBe(4242)
+  })
+
+  test('lazy-creates bubble on first activity event', async () => {
+    const { mgr, api } = makeManager({
+      config: makeConfig({ suppress_typing_bubble: true }),
+    })
+    await mgr.start('164795011', undefined)
+    await mgr.recordActivityByChatId('164795011', { kind: 'reasoning' })
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(1)
+    // First render is the activity block, not «Печатает...».
+    expect(sends[0]!.text).not.toContain('Печатает')
+  })
+
+  test('cancel on a pure-typing session is a quiet no-op (no edit, no leak)', async () => {
+    const { mgr, api } = makeManager({
+      config: makeConfig({ suppress_typing_bubble: true }),
+    })
+    await mgr.start('164795011', undefined)
+    await mgr.cancel('164795011', 'user stop')
+    expect(api.calls.filter((c) => c.kind === 'send').length).toBe(0)
+    expect(api.calls.filter((c) => c.kind === 'edit').length).toBe(0)
+    expect(mgr.isActive('164795011')).toBe(false)
+  })
+
+  test('complete on a pure-typing session does not call deleteMessage', async () => {
+    const { mgr, api } = makeManager({
+      config: makeConfig({ suppress_typing_bubble: true }),
+    })
+    await mgr.start('164795011', undefined)
+    await mgr.complete('164795011')
+    expect(api.calls.filter((c) => c.kind === 'delete').length).toBe(0)
+    expect(mgr.isActive('164795011')).toBe(false)
+  })
+
+  test('TTL on a pure-typing session expires silently without «Остановлено» bubble', async () => {
+    const { mgr, api, clock, config } = makeManager({
+      config: makeConfig({ suppress_typing_bubble: true }),
+    })
+    await mgr.start('164795011', undefined)
+    clock.advance(config.status.ttl_ms + 1)
+    expect(api.calls.filter((c) => c.kind === 'send').length).toBe(0)
+    expect(api.calls.filter((c) => c.kind === 'edit').length).toBe(0)
+    expect(mgr.isActive('164795011')).toBe(false)
+  })
+
+  test('chat_action still pulses on the 4s timer while bubble is suppressed', async () => {
+    const { mgr, api, clock } = makeManager({
+      config: makeConfig({ suppress_typing_bubble: true }),
+    })
+    await mgr.start('164795011', undefined)
+    expect(api.calls.filter((c) => c.kind === 'chat_action').length).toBe(1)
+    clock.advance(4000)
+    expect(api.calls.filter((c) => c.kind === 'chat_action').length).toBe(2)
+    clock.advance(4000)
+    expect(api.calls.filter((c) => c.kind === 'chat_action').length).toBe(3)
+  })
+
+  test('subsequent edits after lazy-create go through editMessageText', async () => {
+    const { mgr, api } = makeManager({
+      config: makeConfig({ suppress_typing_bubble: true }),
+    })
+    await mgr.start('164795011', undefined)
+    await mgr.updateByChatId('164795011', { kind: 'thinking' })
+    await mgr.updateByChatId('164795011', { kind: 'tool', toolName: 'Read' })
+    // First non-typing transition sends; second edits the same message.
+    expect(api.calls.filter((c) => c.kind === 'send').length).toBe(1)
+    expect(api.calls.filter((c) => c.kind === 'edit').length).toBeGreaterThanOrEqual(1)
+    const lastEdit = api.calls.filter((c) => c.kind === 'edit').pop()!
+    expect(lastEdit.text).toContain('Read')
   })
 })

--- a/plugin/tests/status/task-mirror.test.ts
+++ b/plugin/tests/status/task-mirror.test.ts
@@ -39,7 +39,7 @@ function makeConfig(overrides: Partial<AppConfig['task_mirror']> = {}): AppConfi
     dm_only: true,
     allowed_user_ids: [164795011],
     allowed_chat_ids: [164795011],
-    status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true },
+    status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true, suppress_typing_bubble: false },
     album: { flush_ms: 2000 },
     voice: { provider: 'groq', language: 'ru', model: 'whisper-large-v3-turbo' },
     webhook: { enabled: false, host: '127.0.0.1', port: 0 },

--- a/plugin/tests/telegram/gate.test.ts
+++ b/plugin/tests/telegram/gate.test.ts
@@ -16,7 +16,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     dm_only: true,
     allowed_user_ids: [164795011],
     allowed_chat_ids: [164795011],
-    status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true },
+    status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true, suppress_typing_bubble: false },
     album: { flush_ms: 2000 },
     voice: { provider: 'groq', language: 'ru', model: 'whisper-large-v3-turbo' },
     webhook: { enabled: false, host: '127.0.0.1', port: 0 },

--- a/plugin/tests/telegram/handlers.test.ts
+++ b/plugin/tests/telegram/handlers.test.ts
@@ -44,7 +44,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     dm_only: true,
     allowed_user_ids: [164795011],
     allowed_chat_ids: [164795011],
-    status: { enabled: false, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true },
+    status: { enabled: false, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true, suppress_typing_bubble: false },
     album: { flush_ms: 2000 },
     voice: { provider: 'groq', language: 'ru', model: 'whisper-large-v3-turbo' },
     webhook: { enabled: false, host: '127.0.0.1', port: 0 },

--- a/plugin/tests/telegram/watcher.test.ts
+++ b/plugin/tests/telegram/watcher.test.ts
@@ -22,7 +22,7 @@ function makeConfig(overrides: Partial<AppConfig['watcher']> = {}): AppConfig {
     dm_only: true,
     allowed_user_ids: [164795011],
     allowed_chat_ids: [164795011],
-    status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true },
+    status: { enabled: true, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true, suppress_typing_bubble: false },
     album: { flush_ms: 2000 },
     voice: { provider: 'groq', language: 'ru', model: 'whisper-large-v3-turbo' },
     webhook: { enabled: false, host: '127.0.0.1', port: 0 },


### PR DESCRIPTION
## Проблема

Вождь скриншотил: в DM поверх rolling TmuxMirror status card отдельным сообщением висит «Печатает.» bubble. Это визуальный шум — TmuxMirror уже показывает thinking/activity, а StatusManager добавляет дубль.

Просьба вождя (voice 2026-05-27):
> «Давай этот текст печатает уберем, а тот который в статусе пусть будет. Важно typing telegram не трогать, в сообщении не писать печатает …»

Scope (подтверждён вождём): только typing-bubble — остальное (🔧 tool, activity-блок, «Остановлено: ...») остаётся.

## Решение

Новое поле `status.suppress_typing_bubble` (default=true). При initial state=typing плагин:
- НЕ шлёт `sendMessage` — bubble не создаётся.
- Продолжает пульсировать `sendChatAction('typing')` каждые 4 с — Telegram-нативный typing-индикатор в шапке («... печатает») остаётся.
- TTL guard и tick-таймер крутятся, но editSafely no-op'ит пока messageId=0.

Bubble лениво создаётся методом `ensureBubble()` при первом не-typing событии — `update()` (thinking/tool) или `recordActivityByChatId()` (reasoning/tool_start). Использует сохранённый `reply_to_message_id` из исходного `start()`, так что нить под сообщение вождя сохраняется.

## Test plan

- [x] `tests/status/status-manager.test.ts` — 43 теста зелёные (34 legacy + 9 новых suppress-режим)
- [x] 334 теста в смежных модулях зелёные (status, channel, commands, telegram handlers/gate/watcher, security)
- [x] Сборка typecheck чистая для затронутых файлов (pre-existing failures на ветке — tmux_mirror/multichat в test fixtures + state.test.ts API drift — не вызваны этим PR)
- [ ] Smoke на staging-плагине: вождь шлёт voice → видит только TmuxMirror card, без «Печатает.» bubble
- [ ] Smoke на staging: при первом tool-вызове появляется bubble с 🔧 ToolName
- [ ] Header-индикатор «... печатает» продолжает мигать в шапке чата

## Активация

Деплой требует рестарт channel-thrall (мой собственный плагин). Согласно core/rules.md — рестарт ТОЛЬКО с явного OK вождя через Сильвану или Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)