### PR TITLE
feat(poller): in-process auto-reconnect 1→60с экспоненциально (task #17)

### DIFF
--- a/plugin/src/telegram/poller.ts
+++ b/plugin/src/telegram/poller.ts
@@ -83,6 +83,17 @@ const LONG_POLL_TIMEOUT_SEC = 25
 const MAX_409_ATTEMPTS = 8
 const MAX_401_ATTEMPTS = 3
 const BACKOFF_CAP_MS = 15_000
+// Reconnect backoff for transient errors (network drops, 5xx, 429 without
+// retry_after). Exponential 1s → 2s → 4s → ... capped at 60s, plus jitter to
+// avoid retry-synchronization across replicas. Reset to attempt=1 on every
+// successful getUpdates round (see loop()).
+const EXPONENTIAL_BACKOFF_BASE_MS = 1_000
+const RECONNECT_BACKOFF_CAP_MS = 60_000
+const RECONNECT_JITTER_MIN_MS = 100
+const RECONNECT_JITTER_MAX_MS = 1_000
+// Hard upper bound on the exponent so `2 ** exp` never overflows even if a
+// pathological stuck-transient run reaches very high attempt counters.
+const RECONNECT_MAX_EXPONENT = 30
 // Cap honour-retry_after at 10 minutes. If Telegram asks for longer the
 // answer is "operator action" rather than "sleep for hours".
 const FLOOD_BACKOFF_CAP_MS = 600_000
@@ -310,22 +321,58 @@ function classifyError(err: unknown): ErrorClass {
   return { kind: 'fatal', message: String(err), retriable: false }
 }
 
+// Exponential reconnect backoff used by the `transient` and (since
+// task #17) `flood`-without-retry_after paths.
+//
+// Sequence for attempt = 1, 2, 3, …: 1s, 2s, 4s, 8s, 16s, 32s, 60s, 60s, …
+// with [100..1000)ms jitter added to each step, hard-capped at
+// RECONNECT_BACKOFF_CAP_MS (inclusive of jitter).
+//
+// `attempt` is 1-based — the loop increments before calling this. We clamp
+// the exponent to RECONNECT_MAX_EXPONENT so that a stuck-transient run with
+// attempt counters running into the thousands never produces `Infinity` or
+// `NaN`. The rng parameter is injectable so unit tests can pin the jitter.
+export function reconnectSleepMs(
+  attempt: number,
+  rng: () => number = Math.random,
+): number {
+  // Coerce attempt at the API boundary: NaN/Infinity/fractional inputs from
+  // a hostile caller (or future drift in the counter type) collapse to a
+  // safe integer in [0, RECONNECT_MAX_EXPONENT].
+  const safeAttempt = Number.isFinite(attempt) ? Math.floor(attempt) : 0
+  const exp = Math.min(Math.max(0, safeAttempt - 1), RECONNECT_MAX_EXPONENT)
+  const base = Math.min(
+    EXPONENTIAL_BACKOFF_BASE_MS * 2 ** exp,
+    RECONNECT_BACKOFF_CAP_MS,
+  )
+  // Clamp the rng roll into [0, 1) so a hostile rng returning negative /
+  // NaN / >= 1 can't push the jitter below RECONNECT_JITTER_MIN_MS or
+  // produce NaN. Math.random's contract is already [0, 1); this is purely
+  // defensive for the exported helper signature.
+  const raw = rng()
+  const roll = Number.isFinite(raw) ? Math.min(Math.max(raw, 0), 0.999_999) : 0
+  const jitterRange = RECONNECT_JITTER_MAX_MS - RECONNECT_JITTER_MIN_MS
+  const jitter = RECONNECT_JITTER_MIN_MS + Math.floor(roll * jitterRange)
+  return Math.min(base + jitter, RECONNECT_BACKOFF_CAP_MS)
+}
+
 // Compute the actual sleep duration for a 429 response. Adds 100..500ms
 // jitter so concurrent retries don't dogpile, caps at FLOOD_BACKOFF_CAP_MS.
 // When `retryAfterSec` is undefined (Telegram omitted the hint), falls back
-// to the existing linear backoff so behaviour is purely additive.
+// to the exponential reconnect backoff (task #17 — was linear cap 15s
+// before, which under-handled real flood-control bursts).
 function floodSleepMs(
   retryAfterSec: number | undefined,
   attempt: number,
   rng: () => number = Math.random,
 ): number {
-  const jitter =
-    FLOOD_JITTER_MIN_MS + Math.floor(rng() * (FLOOD_JITTER_MAX_MS - FLOOD_JITTER_MIN_MS))
   if (retryAfterSec !== undefined) {
+    const jitter =
+      FLOOD_JITTER_MIN_MS + Math.floor(rng() * (FLOOD_JITTER_MAX_MS - FLOOD_JITTER_MIN_MS))
     const base = Math.max(0, retryAfterSec) * 1000
     return Math.min(base + jitter, FLOOD_BACKOFF_CAP_MS)
   }
-  return Math.min(1000 * Math.max(1, attempt), BACKOFF_CAP_MS)
+  return reconnectSleepMs(attempt, rng)
 }
 
 /**
@@ -677,8 +724,10 @@ export class TelegramPoller {
           return
         }
 
-        // Transient network / Telegram 5xx: backoff and retry forever.
-        const delay = Math.min(1000 * attempt, BACKOFF_CAP_MS)
+        // Transient network / Telegram 5xx: exponential reconnect backoff,
+        // retry forever (task #17). Counter resets on any successful round
+        // above, so a single good poll brings us back to the 1s step.
+        const delay = reconnectSleepMs(attempt)
         log.warn('transient poller error, retrying', {
           attempt,
           delay_ms: delay,

--- a/plugin/tests/telegram/poller.retry.test.ts
+++ b/plugin/tests/telegram/poller.retry.test.ts
@@ -16,7 +16,7 @@ import type { Update } from 'grammy/types'
 import { getStatePaths, loadConfig, type AppConfig, type StatePaths } from '../../src/config.js'
 import { createLogger } from '../../src/log.js'
 import { ensureStateDirs } from '../../src/state/store.js'
-import { TelegramPoller } from '../../src/telegram/poller.js'
+import { TelegramPoller, reconnectSleepMs } from '../../src/telegram/poller.js'
 
 const FAKE_TOKEN = '123456789:AAH-fake_test_token_with_at_least_thirty_chars'
 
@@ -67,6 +67,48 @@ function flood(retryAfter: number | undefined): GrammyError {
   )
 }
 
+describe('reconnectSleepMs() — exponential backoff helper (task #17)', () => {
+  test('exponential growth at attempts 1..8 with rng=0 (lower jitter bound)', () => {
+    const rng = (): number => 0
+    expect(reconnectSleepMs(1, rng)).toBe(1_100) // 1000 + 100 min jitter
+    expect(reconnectSleepMs(2, rng)).toBe(2_100)
+    expect(reconnectSleepMs(3, rng)).toBe(4_100)
+    expect(reconnectSleepMs(4, rng)).toBe(8_100)
+    expect(reconnectSleepMs(5, rng)).toBe(16_100)
+    expect(reconnectSleepMs(6, rng)).toBe(32_100)
+    // attempt=7 → base 64_000, capped to 60_000 before + jitter then re-capped.
+    expect(reconnectSleepMs(7, rng)).toBe(60_000)
+    expect(reconnectSleepMs(8, rng)).toBe(60_000)
+  })
+
+  test('upper jitter bound saturates at the cap, never exceeds it', () => {
+    const rng = (): number => 0.999
+    // Within range: base + max jitter (999 rounded down)
+    expect(reconnectSleepMs(1, rng)).toBe(1_000 + 999) // 1999
+    expect(reconnectSleepMs(2, rng)).toBe(2_000 + 999) // 2999
+    // Cap path: base reached cap, jitter added then re-capped at 60_000.
+    expect(reconnectSleepMs(10, rng)).toBe(60_000)
+    expect(reconnectSleepMs(100, rng)).toBe(60_000)
+  })
+
+  test('overflow safety: very large attempt values do not produce Infinity/NaN', () => {
+    const rng = (): number => 0
+    const v1 = reconnectSleepMs(1_000, rng)
+    const v2 = reconnectSleepMs(Number.MAX_SAFE_INTEGER, rng)
+    for (const v of [v1, v2]) {
+      expect(Number.isFinite(v)).toBe(true)
+      expect(v).toBeGreaterThan(0)
+      expect(v).toBeLessThanOrEqual(60_000)
+    }
+  })
+
+  test('attempt=0 or negative collapses to the base step (not zero-sleep, not NaN)', () => {
+    const rng = (): number => 0
+    expect(reconnectSleepMs(0, rng)).toBe(1_000 + 100)
+    expect(reconnectSleepMs(-5, rng)).toBe(1_000 + 100)
+  })
+})
+
 describe('TelegramPoller 429 handling (TASK-7 bug B)', () => {
   test('429 with retry_after=10 sleeps ~10s + jitter (100..500ms), then retries', async () => {
     const { bot } = makeBotStub()
@@ -112,7 +154,7 @@ describe('TelegramPoller 429 handling (TASK-7 bug B)', () => {
     expect(delay).toBeLessThan(10_500)
   })
 
-  test('429 without retry_after falls back to linear backoff (no infinite/wrong sleep)', async () => {
+  test('429 without retry_after falls back to exponential reconnect backoff (task #17)', async () => {
     const { bot } = makeBotStub()
     const sleepCalls: number[] = []
     let call = 0
@@ -145,9 +187,12 @@ describe('TelegramPoller 429 handling (TASK-7 bug B)', () => {
     await poller.stop()
     await run
     expect(sleepCalls.length).toBeGreaterThanOrEqual(1)
-    // Fallback: floodCounter starts at 1, so 1000*1 = 1000 ms, < BACKOFF_CAP_MS.
+    // Task #17: floodCounter=1 → reconnectSleepMs(1) = base 1000ms +
+    // [100..1000)ms jitter, capped at 60_000. Was strict `=== 1000` before
+    // the unification with the transient backoff path.
     const delay = sleepCalls[0]!
-    expect(delay).toBe(1000)
+    expect(delay).toBeGreaterThanOrEqual(1_100)
+    expect(delay).toBeLessThan(2_000)
   })
 
   test('429 retry_after caps at 600s even if Telegram asks for more', async () => {
@@ -224,9 +269,110 @@ describe('TelegramPoller 429 handling (TASK-7 bug B)', () => {
     expect(calls).toBeGreaterThanOrEqual(3)
   })
 
+  test('transient errors follow exponential reconnect 1→60s (task #17)', async () => {
+    const { bot } = makeBotStub()
+    const sleepCalls: number[] = []
+    const transientErr = (): Error => {
+      const e = new Error('ETIMEDOUT')
+      ;(e as NodeJS.ErrnoException).code = 'ETIMEDOUT'
+      return e
+    }
+    const poller = new TelegramPoller(
+      {
+        bot,
+        config,
+        statePaths: paths,
+        log: createLogger('test'),
+        onUpdate: async () => undefined,
+      },
+      {
+        getUpdates: async () => {
+          throw transientErr()
+        },
+        sleep: async (ms) => {
+          sleepCalls.push(ms)
+          await new Promise((r) => setTimeout(r, 0))
+        },
+      },
+    )
+    const run = poller.start()
+    // Yield enough times for the loop to throw, sleep, retry, sleep, ...
+    // The Promise-microtask loop without real delay produces many iterations.
+    await new Promise((r) => setTimeout(r, 50))
+    await poller.stop()
+    await run
+
+    expect(sleepCalls.length).toBeGreaterThanOrEqual(6)
+    // Expected base sequence: 1000, 2000, 4000, 8000, 16000, 32000, 60000, 60000, ...
+    // With jitter [100, 1000), each step is in [base+100, base+1000).
+    const expectedBases = [1_000, 2_000, 4_000, 8_000, 16_000, 32_000]
+    for (let i = 0; i < expectedBases.length; i++) {
+      const base = expectedBases[i]!
+      const observed = sleepCalls[i]!
+      expect(observed).toBeGreaterThanOrEqual(base + 100)
+      expect(observed).toBeLessThan(base + 1_000)
+    }
+    // Past the 60s cap: hard-capped at exactly RECONNECT_BACKOFF_CAP_MS
+    // (cap is `Math.min(base + jitter, 60_000)`; once base hits the cap,
+    // adding jitter and re-capping always lands on 60_000 exactly).
+    const capped = sleepCalls.slice(6)
+    for (const ms of capped) {
+      expect(ms).toBe(60_000)
+    }
+  })
+
+  test('transient counter resets after a successful getUpdates round (task #17)', async () => {
+    const { bot } = makeBotStub()
+    const sleepCalls: number[] = []
+    let call = 0
+    const transientErr = (): Error => new Error('ECONNRESET')
+    const poller = new TelegramPoller(
+      {
+        bot,
+        config,
+        statePaths: paths,
+        log: createLogger('test'),
+        onUpdate: async () => undefined,
+      },
+      {
+        getUpdates: async () => {
+          call++
+          // Throw twice, then succeed, then throw again.
+          if (call === 1 || call === 2) throw transientErr()
+          if (call === 3) return []
+          if (call === 4) throw transientErr()
+          await new Promise((r) => setTimeout(r, 5))
+          return []
+        },
+        sleep: async (ms) => {
+          sleepCalls.push(ms)
+          await new Promise((r) => setTimeout(r, 0))
+        },
+      },
+    )
+    const run = poller.start()
+    await new Promise((r) => setTimeout(r, 50))
+    await poller.stop()
+    await run
+
+    // We expect at least three sleeps recorded — two before success, one after.
+    expect(sleepCalls.length).toBeGreaterThanOrEqual(3)
+    const [d1, d2, d3] = sleepCalls
+    // First failure → attempt=1, base 1000 + jitter.
+    expect(d1!).toBeGreaterThanOrEqual(1_100)
+    expect(d1!).toBeLessThan(2_000)
+    // Second failure → attempt=2, base 2000 + jitter.
+    expect(d2!).toBeGreaterThanOrEqual(2_100)
+    expect(d2!).toBeLessThan(3_000)
+    // After the successful round, attempt resets → first failure is back at base 1000.
+    expect(d3!).toBeGreaterThanOrEqual(1_100)
+    expect(d3!).toBeLessThan(2_000)
+  })
+
   test('existing 409 fatal-after-8 still works (regression check)', async () => {
     const { bot } = makeBotStub()
     let calls = 0
+    const sleepCalls: number[] = []
     const poller = new TelegramPoller(
       {
         bot,
@@ -245,7 +391,9 @@ describe('TelegramPoller 429 handling (TASK-7 bug B)', () => {
             {},
           )
         },
-        sleep: async () => undefined,
+        sleep: async (ms) => {
+          sleepCalls.push(ms)
+        },
       },
     )
     let caught: unknown
@@ -256,5 +404,9 @@ describe('TelegramPoller 429 handling (TASK-7 bug B)', () => {
     }
     expect((caught as Error).name).toBe('PollerFatalError')
     expect(calls).toBeGreaterThanOrEqual(8)
+    // Task #17 regression assertion: 409 path stays LINEAR (1000*attempt,
+    // cap 15s) — exponential reconnect must not apply to token-ownership
+    // contention.
+    expect(sleepCalls.slice(0, 7)).toEqual([1_000, 2_000, 3_000, 4_000, 5_000, 6_000, 7_000])
   })
 })


### PR DESCRIPTION
## Контекст — incident 2026-05-24
Память Thrall была забита (5.3/7.8 GB used + 2.8 GB swap), channel-thrall peak 1.8 GB RSS. Под нагрузкой Telegram long-poll умер, плагин не переподключился, Сильвана сделала `systemctl restart channel-thrall` — Claude сессия Тралла потеряла **402k токенов** thinking-контекста (1ч 41мин Cogitated).

## Что меняется
Линейный backoff `1000 * attempt` cap 15с заменён на экспоненциальный 1→60с + jitter [100..1000)мс на тех ветках, что обслуживают сетевые сбои:
- **transient** — HttpError, GrammyError 5xx, generic network Error (ETIMEDOUT/ECONNRESET/ENOTFOUND/EAI_AGAIN)
- **flood-fallback** — 429 БЕЗ retry_after (когда Telegram забыл hint)

## Что НЕ тронуто (regression-safe)
| Path | Поведение |
|------|-----------|
| 409 conflict | Линейный backoff cap 15с, MAX_409_ATTEMPTS=8 (token-ownership contention) |
| 401 unauthorized | Линейный, MAX_401_ATTEMPTS=3 (credential failure не должен прятаться за длинными sleep'ами) |
| 429 с retry_after | Honor Telegram hint, jitter, cap 10мин |
| fatal | exit poller |
| offset persistence / dead-letter / handler error | unchanged |
| multichat router / webhook handler / token lock | untouched |

## Пересмотренный scope
Изначальное описание task #17 покрывало P0+P0.5+P0.7+P1+P2+P3. Phase 1 Research показал:
- **(b) MCP hot-reload не существует** в Claude Code v2.1.80+
- **(c) systemd MemoryMax без MCP hot-reload не сохраняет сессию** — при SIGKILL плагина handle MCP-сервера в Claude обрывается, нужен restart Claude в любом случае
- **Acceptance критерий P0.7 «(1) Claude session жива при SIGKILL» физически невыполним** без core-изменений Claude Code

Вождь одобрил сокращение до ТОЛЬКО **(a) — auto-reconnect**. Это полностью покрывает 24 мая incident: плагин не умирает от network blip, переподнимает long-poll сам, Claude сессия живёт.

P0.5 (enrichment) уже закрыт PR #29.

Отложено: (b), (c), (d), P1 healthcheck, P2 file-logs, P3 memory budget. Откроем отдельные PR-ы если потребуются.

## Реализация
**plugin/src/telegram/poller.ts** (+61 / -10):
- 5 новых констант: `EXPONENTIAL_BACKOFF_BASE_MS=1000`, `RECONNECT_BACKOFF_CAP_MS=60000`, `RECONNECT_JITTER_MIN_MS=100`, `RECONNECT_JITTER_MAX_MS=1000`, `RECONNECT_MAX_EXPONENT=30`
- Новый export `reconnectSleepMs(attempt, rng=Math.random)` — pure helper, defensively coerces NaN/Infinity/негативный attempt + clamp rng в [0, 0.999999]
- `floodSleepMs()` fallback (когда `retry_after` undef) переключён на `reconnectSleepMs`
- transient ветка `loop()` переключена с линейного на `reconnectSleepMs`

## Тесты (+162 / -1)
**plugin/tests/telegram/poller.retry.test.ts**:
- Новый describe `reconnectSleepMs() — exponential backoff helper`: 4 unit-теста (экспоненциальный рост attempts 1..8 с rng=0, верхняя граница jitter с rng=0.999, overflow safety при `Number.MAX_SAFE_INTEGER`, clamp attempt=0/negative)
- Новый loop-level integration test `transient errors follow exponential reconnect 1→60s` — проверяет первые 6 ступеней + точный cap=60000 после
- Новый loop-level integration test `transient counter resets after a successful getUpdates round`
- Обновлён существующий `429 без retry_after` — ожидает range `[1100, 2000)` вместо строгого `===1000` (новое поведение, теперь fallback тоже exponential)
- Добавлена regression-assertion в существующий `409 fatal-after-8` — `sleepCalls.slice(0,7).toEqual([1000,2000,...,7000])` чтобы заблокировать любой случайный sweep 409 на exponential

## Test result
- `bun test tests/telegram/poller.retry.test.ts` → **11/11 pass**
- `bun test` (full) → **1073 pass / 16 fail** — 16 failures pre-existing baseline (state-store / dead-letter / pollOnce setup), не задело

## Double review
Phase 4 review проведён параллельно Opus code-reviewer + Codex GPT-5.5. Оба — **SHIP, no blocking issues**.

Закрытые в fix-loop iter 1 nit-finding'и:
1. Defensive `rng()` clamp при hostile input — обе ревью flagged
2. Coercion `attempt` через `Math.floor + Number.isFinite` на exported API (Codex)
3. Tighten cap-band `>= 60_000 - 1` → exact `=== 60_000` (Opus)
4. 409 regression test — добавил `sleepCalls.slice(0,7).toEqual([1000,...,7000])` чтобы зафиксировать linear shape (Opus)

## Artifacts
Run-dir: `~/.claude-lab/thrall/.claude/loop-coding-runs/2026-05-27-jarvis-channel-resilience/`
{RESEARCH,PLAN,REVIEW,FIX-LOG}.md

## Acceptance
- [x] `bun test plugin/tests/telegram/poller*.test.ts` зелёный
- [x] Recorded transient delays следуют экспоненциальной последовательности и cap-ятся на ≤60с
- [x] После одного успешного getUpdates round, следующий transient использует first backoff bucket
- [x] 401/409 продолжают throw PollerFatalError на существующих thresholds
- [x] 429 retry_after path не задет (existing test проходит без изменений)
- [x] Full bun test baseline 1073/16 без регрессов

## Test plan для production
- [ ] После merge синхронизировать listener.py поведение на проде Thrall (если нужно)
- [ ] **Production deploy на Thrall (systemctl restart channel-thrall) — ТОЛЬКО с явным OK вождя** (это смена backoff поведения live плагина)
- [ ] Smoke: имитировать network drop (block Telegram API на 30с) и убедиться что reconnect ≤60с без рестарта Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)