### PR TITLE
fix(multichat): проброс TMUX_PANE через env -i — восстановлена маршрутизация по сессиям

### DIFF
--- a/plugin/scripts/spawn-chat-shell.sh
+++ b/plugin/scripts/spawn-chat-shell.sh
@@ -49,11 +49,36 @@ shift
 # Optional (hook bookkeeping, set when policy-loader / persona pipeline
 # wants them; absent in MVP):
 #   POLICY_PATH, PERSONA_PATH
+#
+# FIX (2026-05-28): forward TMUX and TMUX_PANE through the env -i wipe.
+# tmux sets these on the new-session command's environment (verified:
+# this wrapper, run as that command, sees TMUX_PANE=%N before we exec).
+# The consumer is the deployed per-chat entrypoint hook (in the agent
+# workspace at chats/hooks/multichat-entrypoint.sh — NOT shipped in this
+# repo; wired via TmuxSessionPool.entrypointScript). Its background
+# inbox-watcher reads $TMUX_PANE to know which pane to `tmux send-keys`
+# inbound messages into. Without it the watcher self-disables
+# ("TMUX_PANE not set, watcher disabled") and the per-chat session never
+# consumes its inbox — the whole chat_id->session routing silently dies.
+# This regressed on 2026-05-27 when FIX-A B2 (env -i) and FIX-A B3
+# (removal of the bare `-e TMUX_PANE` arg) landed together: B3's premise
+# that "tmux populates TMUX_PANE regardless" is false once B2 wipes it.
+#
+# Why BOTH, not just TMUX_PANE: send-keys by pane id alone works only
+# when the server is on tmux's DEFAULT socket; forwarding TMUX keeps the
+# watcher correct under a custom socket (`tmux -L`) too. Forwarding TMUX
+# does not widen the trust boundary — a same-UID process already reaches
+# the default socket, and TMUX_PANE alone is enough to target any pane
+# on it. (Cross-pane isolation between chats is a separate concern, not
+# something this env wipe ever provided.) Neither value is a credential:
+# TMUX is a socket path, TMUX_PANE a pane id — token isolation intact.
 
 exec env -i \
   CHAT_ID="${CHAT_ID:-}" \
   MULTICHAT_STATE_DIR="${MULTICHAT_STATE_DIR:-}" \
   CLAUDE_WORKSPACE_DIR="${CLAUDE_WORKSPACE_DIR:-}" \
+  TMUX="${TMUX:-}" \
+  TMUX_PANE="${TMUX_PANE:-}" \
   PATH="${PATH:-/usr/local/bin:/usr/bin:/bin}" \
   HOME="${HOME:-}" \
   USER="${USER:-}" \

--- a/plugin/tests/router/tmux-session-pool.env.test.ts
+++ b/plugin/tests/router/tmux-session-pool.env.test.ts
@@ -542,8 +542,11 @@ describe('TmuxSessionPool end-to-end env sanitization', () => {
         )
       }
     }
-    // Sanity: there should be no `TMUX_PANE=` either (we deliberately
-    // do not forward it; tmux populates it inside each pane).
+    // Sanity: the POOL must not forward TMUX_PANE via a tmux `-e` flag —
+    // it has no valid pane id at spawn time. The pane id is recovered
+    // inside the pane by spawn-chat-shell.sh, which reads $TMUX_PANE
+    // (set by tmux on the new-session command) and forwards it across
+    // its `env -i` wipe. See the standalone wrapper test below.
     expect(readFileSync(fixture.argvLog, 'utf8')).not.toContain('TMUX_PANE=')
   })
 
@@ -663,6 +666,39 @@ describe('spawn-chat-shell.sh standalone leak closure (FIX-A B2)', () => {
     expect(childEnv).toMatch(/^CHAT_ID=12345$/m)
     expect(childEnv).toMatch(/^MULTICHAT_STATE_DIR=\/tmp\/state$/m)
     expect(childEnv).toMatch(/^CLAUDE_WORKSPACE_DIR=\/tmp\/ws$/m)
+  })
+
+  test('TMUX and TMUX_PANE ARE forwarded across `env -i` (watcher routing fix, 2026-05-28)', () => {
+    // Regression guard: multichat-entrypoint.sh's inbox-watcher reads
+    // $TMUX_PANE to target its pane with `tmux send-keys`. tmux sets
+    // TMUX_PANE on the new-session command; the wrapper's `env -i` must
+    // forward it (and TMUX) or the watcher self-disables and the
+    // chat_id→session routing silently dies. Neither value is a
+    // credential, so forwarding them does not weaken FIX-A B2 isolation.
+    const result = spawnSync(SPAWN_WRAPPER, ['/usr/bin/env'], {
+      env: {
+        PATH: '/usr/local/bin:/usr/bin:/bin',
+        HOME: '/home/test',
+        CHAT_ID: '12345',
+        MULTICHAT_STATE_DIR: '/tmp/state',
+        CLAUDE_WORKSPACE_DIR: '/tmp/ws',
+        // Values tmux would have set on the pane process.
+        TMUX: '/tmp/tmux-1000/default,4242,7',
+        TMUX_PANE: '%7',
+        // A leaked credential in the same env must STILL be dropped —
+        // forwarding the pane locators must not widen the allowlist.
+        TELEGRAM_BOT_TOKEN: 'leaked-token-DO-NOT-PROPAGATE',
+      },
+      encoding: 'utf8',
+    })
+
+    expect(result.status).toBe(0)
+    const childEnv = result.stdout
+    expect(childEnv).toMatch(/^TMUX_PANE=%7$/m)
+    expect(childEnv).toMatch(/^TMUX=\/tmp\/tmux-1000\/default,4242,7$/m)
+    // Isolation guarantee unchanged: the credential is still gone.
+    expect(childEnv).not.toContain('leaked-token-DO-NOT-PROPAGATE')
+    expect(childEnv).not.toMatch(/^TELEGRAM_BOT_TOKEN=/m)
   })
 
   test('wrapper exits non-zero if no CLAUDE_BIN argument given', () => {


### PR DESCRIPTION
## Проблема

При включённом multichat каждый Telegram-чат маршрутизируется в свою per-chat tmux-сессию `claude` через file-based inbox-bridge. Per-chat сессии **перестали читать свой inbox** — сообщения вождя копились непрочитанными, штатный обработчик молчал.

## Корень

Обёртка `plugin/scripts/spawn-chat-shell.sh` запускает сессию через `env -i` (стирает всё окружение ради изоляции токенов, затем возвращает белый список). Фоновый inbox-watcher в `chats/hooks/multichat-entrypoint.sh` читает `$TMUX_PANE`, чтобы знать, в какую панель слать `tmux send-keys`. `env -i` затирал `TMUX_PANE`, обратно его не возвращали → watcher на старте писал `TMUX_PANE not set, watcher disabled` и выходил. Маршрутизация по `chat_id` молча умирала.

Регрессия от 2026-05-27: **FIX-A B2** (`env -i`) и **FIX-A B3** (удаление bare `-e TMUX_PANE`) приземлились вместе. Премиса B3 «tmux выставит TMUX_PANE сам» ложна после того, как B2 стирает окружение.

## Фикс

Вернул `TMUX` и `TMUX_PANE` в белый список `env -i` обёртки. tmux выставляет их на команде `new-session` (проверено эмпирически: команда видит `TMUX_PANE=%N` до `env -i`), форвард сохраняет pane id. Ни то, ни другое не секрет (`TMUX` — путь сокета, `TMUX_PANE` — id панели) — token-изоляция FIX-A B2 не ослаблена.

## Почему оба, а не только TMUX_PANE

`send-keys` по pane id без `TMUX` работает только на дефолтном сокете; форвард `TMUX` сохраняет корректность и на кастомном (`tmux -L`). Это не расширяет границу доверия — процесс того же UID и так достаёт дефолтный сокет.

## Тесты

- Новый регрессионный тест: `TMUX`/`TMUX_PANE` переживают `env -i`, при этом утёкший `TELEGRAM_BOT_TOKEN` всё равно отбрасывается.
- Полный прогон: 1074 pass / 16 fail — те же 16 пред-существующих падений, что и на main (дрейф конфиг-фикстур в несвязанных файлах). Регрессий ноль.

## Ревью

Двойное: Opus (code-reviewer) + Codex (adversarial) — оба APPROVE, без CRITICAL/HIGH/MEDIUM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)