### PR TITLE
fix(multichat): гибридный роутинг — личка в channel-thrall, группы в per-chat

### DIFF
--- a/plugin/src/telegram/handlers.ts
+++ b/plugin/src/telegram/handlers.ts
@@ -440,12 +440,16 @@ async function gateAndNotify(
   const descriptors = buildMedia ? await buildMedia() : []
   const renderedMedia = descriptors.map(renderMediaDescriptor)
 
-  // Router path: when wired, dispatch to the per-chat tmux session via
-  // file-based inbox instead of MCP-notifying the master session. The
-  // router takes full ownership — no fallback to sendChannelNotification
-  // so the master Claude session never sees traffic that belongs to a
-  // different chat (defence in depth, persona isolation).
-  if (deps.router && deps.policy) {
+  // Router path: route GROUP/supergroup chats to their per-chat tmux
+  // session via the file-based inbox. Private DMs deliberately fall
+  // through to the legacy sendChannelNotification path below so they
+  // land in the master (channel-thrall) session — the warchief's main
+  // Telegram channel lives there, not in a spawned per-chat session
+  // (explicit requirement 2026-05-28; matches the long-standing comments
+  // that "DMs use the legacy notify path even in multichat builds").
+  // For groups the router still takes full ownership — no fallback — so
+  // the master session never sees traffic belonging to a different chat.
+  if (deps.router && deps.policy && isGroup) {
     // Open a status before dispatch — symmetric with the legacy path so
     // the user sees "Печатает..." within a tick. Streaming is per-chat
     // gated inside StatusManager.start via shouldStreamForChat(policy,
@@ -905,11 +909,16 @@ export async function sendAlbumNotification(
   // user replied with the first photo of the album we forward that context.
   const reply = album.messages.find((m) => m.reply !== undefined)?.reply
 
-  // Router path: synthesise one InboundMessage that carries the merged
-  // caption + every downloaded media path. Symmetric with the single-
-  // message router branch in gateAndNotify so the tmux side sees a
-  // consistent DTO shape regardless of album vs solo arrival.
-  if (deps.router && deps.policy) {
+  // Router path: GROUP albums go to the per-chat session (merged caption
+  // + every downloaded media path). Private-DM albums fall through to the
+  // legacy notify path below, landing in the master (channel-thrall)
+  // session — symmetric with the single-message branch in gateAndNotify.
+  // Reuse the `isGroup` local set above (isGroupChatId(ids.chatId)) — it
+  // is the only group signal here since the original Context/chatType is
+  // gone by album flush time. Channel-type posts never reach this path
+  // (gate.ts drops chatType==='channel' before buffering), so the
+  // negative-id check cannot misclassify a channel as a group here.
+  if (deps.router && deps.policy && isGroup) {
     const combinedMediaPaths: string[] = []
     for (const m of album.messages) {
       for (const p of m.mediaPaths) combinedMediaPaths.push(p)

--- a/plugin/tests/telegram/handlers.addressing.test.ts
+++ b/plugin/tests/telegram/handlers.addressing.test.ts
@@ -36,6 +36,8 @@ import { createLogger } from '../../src/log.js'
 import type { TelegramApi } from '../../src/channel/tools.js'
 import type { BotIdentity } from '../../src/prompt/build.js'
 import type { TmuxMirrorControl } from '../../src/commands/oob.js'
+import type { MultichatRouter } from '../../src/router/multichat-router.js'
+import type { InboundMessage } from '../../src/router/inbox-bridge.js'
 
 const silentLog = createLogger('test', {
   stream: { write: () => true } as unknown as NodeJS.WritableStream,
@@ -592,6 +594,92 @@ describe('FIX-D M1 — text handler policy/router XOR check', () => {
 
     // DM notify fires through legacy path.
     expect(notifyCalls.length).toBe(1)
+    rmSync(statePaths.root, { recursive: true, force: true })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// Hybrid routing (2026-05-28): even with router AND policy wired, a
+// private DM lands in the master (channel-thrall) session via legacy
+// notify — NOT a per-chat tmux session. Only group/supergroup chats are
+// dispatched to the router. This is the warchief's explicit topology:
+// "main Telegram → channel-thrall, group chats → multichat".
+// ─────────────────────────────────────────────────────────────────────
+
+describe('hybrid routing — DM to master, groups to per-chat (router wired)', () => {
+  function makeRouterSpy(): { router: MultichatRouter; calls: InboundMessage[] } {
+    const calls: InboundMessage[] = []
+    const router = {
+      dispatch: async (msg: InboundMessage) => {
+        calls.push(msg)
+      },
+    } as unknown as MultichatRouter
+    return { router, calls }
+  }
+
+  function makeDepsWithRouter(
+    router: MultichatRouter,
+    policy: MultichatPolicy,
+    notifyCalls: Array<{ method: string; params: unknown }>,
+  ): { deps: HandlerDeps; statePaths: StatePaths } {
+    const statePaths = makeStatePaths()
+    const bot: BotIdentity = { id: 8507713167, username: 'canarybot' }
+    const deps: HandlerDeps = {
+      server: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        notification: async (msg: any) => {
+          notifyCalls.push({ method: msg.method, params: msg.params })
+        },
+      } as any,
+      config: makeConfig(),
+      statePaths,
+      telegramApi: makeTelegramApi().api,
+      log: silentLog,
+      bot,
+      botApi: { api: {} } as unknown as HandlerDeps['botApi'],
+      botToken: 'fake-token',
+      env: {},
+      policy,
+      router,
+    }
+    return { deps, statePaths }
+  }
+
+  test('DM + policy + router PRESENT → legacy notify, NO router dispatch', async () => {
+    const { router, calls } = makeRouterSpy()
+    const notifyCalls: Array<{ method: string; params: unknown }> = []
+    const { deps, statePaths } = makeDepsWithRouter(router, makePolicy(), notifyCalls)
+
+    const ctx = makeDmCtx({
+      text: 'привет',
+      chatId: WARCHIEF_USER_ID,
+      fromId: WARCHIEF_USER_ID,
+    })
+    await handleInboundText(ctx, deps)
+
+    // DM stays on the master session — router is NOT used.
+    expect(calls.length).toBe(0)
+    expect(notifyCalls.length).toBe(1)
+    rmSync(statePaths.root, { recursive: true, force: true })
+  })
+
+  test('group + policy + router PRESENT → router dispatch, NO legacy notify', async () => {
+    const { router, calls } = makeRouterSpy()
+    const notifyCalls: Array<{ method: string; params: unknown }> = []
+    const { deps, statePaths } = makeDepsWithRouter(router, makePolicy(), notifyCalls)
+
+    const ctx = makeGroupCtx({
+      text: 'эй',
+      chatId: ALLOWED_GROUP_CHAT_ID,
+      fromId: WARCHIEF_USER_ID,
+      mentionBot: true,
+    })
+    await handleInboundText(ctx, deps)
+
+    // Group goes to its per-chat session via the router, not the master.
+    expect(calls.length).toBe(1)
+    expect(calls[0]?.chat_id).toBe(String(ALLOWED_GROUP_CHAT_ID))
+    expect(notifyCalls.length).toBe(0)
     rmSync(statePaths.root, { recursive: true, force: true })
   })
 })

--- a/plugin/tests/telegram/handlers.album.test.ts
+++ b/plugin/tests/telegram/handlers.album.test.ts
@@ -1024,6 +1024,60 @@ describe('FIX-D B1 — group album aggregate addressing', () => {
     rmSync(statePaths.root, { recursive: true, force: true })
   })
 
+  test('DM album + router wired → legacy notify to master, NO router dispatch', async () => {
+    // Hybrid routing (2026-05-28): even with the router wired, a private
+    // DM album must land in the master (channel-thrall) session via legacy
+    // notify, NOT a per-chat session. Mirrors the single-message DM test
+    // in handlers.addressing.test.ts, for the album flush path.
+    const clock = makeClock()
+    const buffer = makeBuffer(50, clock)
+    const serverSpy = makeServerSpy()
+    const policy = makeAlbumPolicy()
+    const routerCalls: InboundMessage[] = []
+    const router: MultichatRouter = {
+      dispatch: async (msg: InboundMessage) => {
+        routerCalls.push(msg)
+      },
+    } as unknown as MultichatRouter
+    const { deps, statePaths } = makeDeps({
+      albumBuffer: buffer,
+      server: serverSpy.server,
+      policy,
+      router,
+    })
+
+    // DM album (positive chat id = private). No @mention needed — DMs are
+    // addressed unconditionally.
+    const ctx1 = makeAlbumCtx({
+      chatId: ADDR_WARCHIEF,
+      fromId: ADDR_WARCHIEF,
+      messageId: 1,
+      mediaGroupId: 'dm-mgid',
+      fileId: 'dm-doc-1',
+      caption: 'личный альбом',
+    })
+    const ctx2 = makeAlbumCtx({
+      chatId: ADDR_WARCHIEF,
+      fromId: ADDR_WARCHIEF,
+      messageId: 2,
+      mediaGroupId: 'dm-mgid',
+      fileId: 'dm-doc-2',
+    })
+
+    await handleInboundDocument(ctx1, deps)
+    await handleInboundDocument(ctx2, deps)
+
+    await clock.tick(60)
+    for (let i = 0; i < 10; i++) await new Promise((r) => setTimeout(r, 5))
+
+    // DM album stays on the master session — router NOT used.
+    expect(routerCalls.length).toBe(0)
+    expect(serverSpy.calls.length).toBe(1)
+    expect(JSON.stringify(serverSpy.calls[0]!.params)).toContain('личный альбом')
+
+    rmSync(statePaths.root, { recursive: true, force: true })
+  })
+
   test('3 fragments NONE addressed in group → silent drop, no dispatch, dir cleaned', async () => {
     const clock = makeClock()
     const buffer = makeBuffer(50, clock)


### PR DESCRIPTION
## Требование вождя

Основной канал (`channel-thrall`) должен ВСЕГДА обслуживать личный Telegram вождя (его главный канал связи), а групповые чаты — идти в отдельные multichat per-chat сессии.

## Проблема

При включённом multichat (`router && policy` подключены) код в `handlers.ts` диспатчил в per-chat сессию ВСЁ, включая личку (строки 448 и 912 — без исключения для приватных чатов). Личка вождя уходила в спавнящуюся per-chat сессию вместо мастер-сессии. Это и противоречит требованию, и совпадает по симптомам с тем, что давние комментарии в этом же файле утверждают обратное («DMs use the legacy notify path even in multichat builds») — то есть intent был верный, но в коде не реализован.

## Фикс

Добавлено условие группы в обе ветки `router.dispatch`:
- `gateAndNotify` (одиночные сообщения): `&& isGroup` (`chatType === 'group' || 'supergroup'`, уже вычислялся рядом для XOR-guard).
- `sendAlbumNotification` (flush альбома): `&& isGroup` — переиспользован локальный `isGroup = isGroupChatId(ids.chatId)` (на flush оригинальный Context/chatType недоступен).

Приватная личка теперь падает на legacy `sendChannelNotification` → мастер-сессия `channel-thrall`. Группы по-прежнему идут в per-chat.

## Тесты

3 регрессионных:
- DM + policy + router → legacy notify, БЕЗ router.dispatch
- group + policy + router → router.dispatch, БЕЗ notify
- DM-альбом + router → legacy notify (симметрично, для flush-пути)

Полный набор: **1077 pass / 16 fail** — те же 16 пред-существующих падений, что и на main (дрейф конфиг-фикстур в несвязанных файлах). Регрессий ноль. Typecheck `src/` чист.

## Ревью

Двойное (Opus + Codex) — APPROVE. Применены правки по ревью: переиспользован локал `isGroup`, добавлен комментарий про channel-дроп в gate.ts, добавлен album-тест.

## Известные follow-up (вне scope, пред-существующие — нашёл Codex)

- `edited_message` в `ALLOWED_UPDATES` поллера, но нет `bot.on('edited_message:*')` хендлера → редактирования молча игнорируются.
- AlbumBuffer не скоупится по chat_id — теоретическая коллизия `media_group_id` между чатами.
- Исходящий мост per-chat сессий (Stop-хук → outbox) не дописан — группы принимают, но не отвечают в Telegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)