### PR TITLE
Замкнул исходящий путь multichat: Stop-хук пишет ответ в outbox

### DIFF
--- a/plugin/src/chats/hooks/stop-to-outbox.py
+++ b/plugin/src/chats/hooks/stop-to-outbox.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Claude Code Stop hook for multichat-thrall — bridge transcript → outbox.
+
+Role:
+    In headless mode the router captures the SDK ``result`` event and writes
+    the agent's final text to the per-chat outbox. In *interactive* (tmux)
+    mode there is no ``result`` event — the per-chat ``claude`` session only
+    prints to its transcript JSONL, so nothing ever lands in
+    ``{MULTICHAT_STATE_DIR}/chats/{CHAT_ID}/outbox/`` and the router has
+    nothing to drain to Telegram. This Stop hook is the interactive-mode
+    analog of capturing the headless ``result`` event: on every turn-end it
+    extracts the latest assistant text from the transcript and writes an
+    ``OutboxMessage`` JSON the router already knows how to send.
+
+Extraction algorithm:
+    Based on ``readLastAssistantText`` in ``src/memory/transcript-reader.ts``
+    — tail-read the trailing ``TAIL_BYTES`` of the transcript and drop the
+    first (possibly truncated) line when not starting at byte 0. It then walks
+    lines backward to the MOST RECENT assistant message and returns its
+    ``{"type": "text", "text": ...}`` blocks joined with newlines.
+
+    Divergence from the memory reader (deliberate): if that most-recent
+    assistant message is tool-use-only (no text blocks), we return ``None``
+    rather than continuing back to an OLDER text message. For outbox delivery
+    we must send only the reply of the turn that just ended — resurfacing an
+    older answer would re-deliver a stale reply to Telegram after a tool-only
+    turn, a resume, or a clear (the memory reader wants the last text ever,
+    which is the opposite requirement).
+
+Safety:
+    Fail-safe everywhere — every error path exits 0 so the hook never blocks
+    or crashes the session. ``chat_id`` is taken strictly from the ``CHAT_ID``
+    environment variable, never from the transcript. Nothing is shelled out,
+    so transcript content can never be shell-interpolated. Errors are logged
+    to stderr only; stdout is kept clean.
+
+Dedupe:
+    Stop can fire repeatedly for the same turn. A state file records the last
+    delivered ``(session_id, transcript_path, dedupe_token)``; an identical
+    triple short-circuits with no write, preventing duplicate Telegram sends.
+    ``dedupe_token`` is the assistant transcript line's ``uuid`` when present
+    (falling back to the text hash), so two DIFFERENT turns that happen to
+    reply with identical text (e.g. "Готово." twice) are NOT suppressed —
+    only the same turn re-firing is.
+    This assumes Claude Code serialises Stop invocations for a session (it
+    does): two truly-concurrent fires could each read the pre-write state and
+    both write. The atomic state rename prevents corruption, not that race —
+    acceptable since a rare duplicate send beats a lost reply.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import secrets
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+TAIL_BYTES = 256 * 1024
+
+# Telegram chat ids are integers (groups are negative). CHAT_ID is used as a
+# filesystem path segment, so we reject anything else to block path-traversal
+# / wrong-chat writes from a malformed env value.
+_CHAT_ID_RE = re.compile(r"-?\d+")
+
+logging.basicConfig(stream=sys.stderr, level=logging.INFO)
+logger = logging.getLogger("stop-to-outbox")
+
+
+def read_last_assistant_text(transcript_path: Path) -> tuple[str, str | None] | None:
+    """Tail-read the latest assistant text from a Claude transcript JSONL.
+
+    Based on ``readLastAssistantText`` (transcript-reader.ts): reads at most
+    the trailing ``TAIL_BYTES`` bytes, drops the first possibly-truncated
+    line when the read did not start at byte 0, then walks lines backward to
+    the MOST RECENT assistant message and returns its
+    ``{"type": "text", "text": str}`` blocks joined with newlines, together
+    with that transcript line's ``uuid`` (when present) for dedupe.
+
+    Args:
+        transcript_path: Absolute path to the session transcript ``.jsonl``.
+
+    Returns:
+        ``(text, uuid)`` for the most recent assistant message — ``uuid`` is
+        the transcript line's ``uuid`` field or ``None`` if absent. Returns
+        ``None`` if the file is missing/empty/unreadable, there is no
+        assistant message, or the most recent assistant message is
+        tool-use-only (no text).
+    """
+    try:
+        with transcript_path.open("rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            if size == 0:
+                return None
+            length = min(size, TAIL_BYTES)
+            start = size - length
+            fh.seek(start, os.SEEK_SET)
+            buf = fh.read(length)
+    except OSError as exc:
+        logger.error("transcript read failed: %s", exc)
+        return None
+
+    # errors="replace" guarantees decode never raises.
+    text = buf.decode("utf-8", errors="replace")
+
+    split = text.split("\n")
+    lines = (split[1:] if start > 0 else split)
+    lines = [line for line in lines if line]
+
+    for line in reversed(lines):
+        try:
+            obj: Any = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(obj, dict):
+            continue
+        message = obj.get("message")
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") != "assistant":
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "text" and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+        # This is the MOST RECENT assistant message. Return its text if any;
+        # otherwise it is a tool-use-only final turn — return None rather than
+        # resurfacing an older (already-delivered / stale) answer.
+        if not parts:
+            return None
+        uuid = obj.get("uuid")
+        return "\n".join(parts), (uuid if isinstance(uuid, str) and uuid else None)
+    return None
+
+
+def build_filename() -> str:
+    """Build an outbox filename matching the router's ``buildFilename`` scheme.
+
+    Returns:
+        ``{epoch_ms}-{rand}.json`` where ``epoch_ms`` is millisecond unix time
+        and ``rand`` is 4 hex chars (2 random bytes).
+    """
+    epoch_ms = int(time.time() * 1000)
+    rand = secrets.token_hex(2)
+    return f"{epoch_ms}-{rand}.json"
+
+
+def atomic_write_json(target: Path, payload: dict[str, Any]) -> None:
+    """Write ``payload`` as JSON to ``target`` atomically (tmp + fsync + rename).
+
+    The router only consumes ``*.json`` files, so the intermediate ``.tmp``
+    file is invisible to it mid-write.
+
+    Args:
+        target: Final destination path (must end in ``.json`` for the outbox).
+        payload: JSON-serialisable mapping to write.
+    """
+    tmp = target.with_name(target.name + ".tmp")
+    try:
+        with tmp.open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh, ensure_ascii=False)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.rename(tmp, target)
+    except OSError:
+        # Never leave an orphan .tmp behind. The router ignores non-.json
+        # files, but a crash between open and rename would otherwise leak
+        # tmp files into the outbox dir forever.
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def main() -> int:
+    """Read the Stop payload, extract assistant text, write an OutboxMessage.
+
+    Returns:
+        Always ``0`` — every error path is fail-safe so the hook never
+        blocks the session.
+    """
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw)
+    except (ValueError, TypeError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+
+    chat_id = os.environ.get("CHAT_ID", "")
+    state_dir = os.environ.get("MULTICHAT_STATE_DIR", "")
+    if not chat_id or not state_dir:
+        return 0
+    if not _CHAT_ID_RE.fullmatch(chat_id):
+        logger.error("invalid CHAT_ID shape; refusing to write")
+        return 0
+
+    transcript_path_raw = payload.get("transcript_path")
+    if not isinstance(transcript_path_raw, str) or not transcript_path_raw:
+        return 0
+    session_id_raw = payload.get("session_id")
+    session_id = session_id_raw if isinstance(session_id_raw, str) else ""
+
+    extracted = read_last_assistant_text(Path(transcript_path_raw))
+    if extracted is None:
+        return 0
+    assistant_text, assistant_uuid = extracted
+    if not assistant_text.strip():
+        return 0
+
+    assistant_hash = hashlib.sha256(assistant_text.encode("utf-8")).hexdigest()
+    # Dedupe discriminator: the transcript line's uuid uniquely identifies the
+    # turn, so two DIFFERENT turns with identical text (e.g. "Готово." twice)
+    # are NOT suppressed. Fall back to the text hash only when the transcript
+    # carries no uuid.
+    dedupe_token = assistant_uuid or assistant_hash
+
+    chat_root = Path(state_dir) / "chats" / chat_id
+    hook_state_dir = chat_root / ".hook-state"
+    state_file = hook_state_dir / "last-stop-outbox.json"
+    outbox_dir = chat_root / "outbox"
+
+    # Dedupe: skip if this exact turn was already delivered.
+    try:
+        prior = json.loads(state_file.read_text(encoding="utf-8"))
+        if (
+            isinstance(prior, dict)
+            and prior.get("session_id") == session_id
+            and prior.get("transcript_path") == transcript_path_raw
+            and prior.get("dedupe_token") == dedupe_token
+        ):
+            return 0
+    except (OSError, ValueError, TypeError):
+        pass  # No prior state / unreadable — proceed with write.
+
+    try:
+        outbox_dir.mkdir(parents=True, exist_ok=True)
+        hook_state_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        logger.error("mkdir failed: %s", exc)
+        return 0
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    message: dict[str, Any] = {
+        "text": assistant_text,
+        "chat_id": chat_id,  # strictly from env, never from transcript
+        "timestamp": now_iso,
+        "format": "text",
+    }
+
+    final_path = outbox_dir / build_filename()
+    try:
+        atomic_write_json(final_path, message)
+    except OSError as exc:
+        logger.error("outbox write failed: %s", exc)
+        return 0
+
+    # Update dedupe state only after a successful outbox write.
+    try:
+        atomic_write_json(
+            state_file,
+            {
+                "session_id": session_id,
+                "transcript_path": transcript_path_raw,
+                "dedupe_token": dedupe_token,
+                "assistant_hash": assistant_hash,
+                "sent_at": now_iso,
+            },
+        )
+    except OSError as exc:
+        logger.error("state write failed: %s", exc)
+        # Outbox write already succeeded — fail-safe, don't undo it.
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugin/tests/chats/stop-to-outbox.test.ts
+++ b/plugin/tests/chats/stop-to-outbox.test.ts
@@ -1,0 +1,427 @@
+// End-to-end tests for the multichat Stop → outbox bridge hook
+// (src/chats/hooks/stop-to-outbox.py).
+//
+// The hook is the interactive-mode analog of capturing the headless
+// `result` event: on turn-end it extracts the latest assistant text from
+// the per-chat `claude` session transcript and writes an OutboxMessage
+// JSON the router drains to Telegram. We exercise the real python3 hook
+// by spawning it with a fixture transcript and a temp MULTICHAT_STATE_DIR,
+// then assert on the file(s) that land in the router's outbox path
+// `{MULTICHAT_STATE_DIR}/chats/{CHAT_ID}/outbox/`.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { spawnSync } from 'child_process'
+import {
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const HOOK = join(
+  import.meta.dir,
+  '..',
+  '..',
+  'src',
+  'chats',
+  'hooks',
+  'stop-to-outbox.py',
+)
+
+const CHAT_ID = '164795011'
+
+interface RunResult {
+  code: number
+  stdout: string
+  stderr: string
+}
+
+let stateDir: string
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), 'stop-to-outbox-'))
+})
+
+afterEach(() => {
+  rmSync(stateDir, { recursive: true, force: true })
+})
+
+// Build a JSONL transcript line for an assistant message with the given
+// content blocks.
+function assistantLine(blocks: Array<Record<string, unknown>>): string {
+  return JSON.stringify({ message: { role: 'assistant', content: blocks } })
+}
+
+function userLine(text: string): string {
+  return JSON.stringify({
+    message: { role: 'user', content: [{ type: 'text', text }] },
+  })
+}
+
+function writeTranscript(lines: string[]): string {
+  const p = join(stateDir, 'transcript.jsonl')
+  writeFileSync(p, lines.join('\n') + '\n', 'utf8')
+  return p
+}
+
+function run(
+  env: Record<string, string>,
+  stdinPayload: Record<string, unknown>,
+): RunResult {
+  const r = spawnSync('python3', [HOOK], {
+    input: JSON.stringify(stdinPayload),
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ...env,
+    },
+  })
+  return {
+    code: r.status ?? -1,
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+  }
+}
+
+function outboxDir(): string {
+  return join(stateDir, 'chats', CHAT_ID, 'outbox')
+}
+
+// List only the `.json` outbox files the router would consume (ignore
+// processing/ etc. subdirs and any .tmp).
+function listOutboxJson(): string[] {
+  try {
+    return readdirSync(outboxDir()).filter((f) => f.endsWith('.json'))
+  } catch {
+    return []
+  }
+}
+
+function readOutboxPayload(name: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(outboxDir(), name), 'utf8'))
+}
+
+describe('stop-to-outbox.py — extraction', () => {
+  test('extracts latest assistant text and writes one outbox .json', () => {
+    const transcript = writeTranscript([
+      userLine('привет'),
+      assistantLine([{ type: 'text', text: 'old answer' }]),
+      userLine('второй вопрос'),
+      assistantLine([{ type: 'text', text: 'final answer' }]),
+    ])
+    const r = run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    expect(r.code).toBe(0)
+    const files = listOutboxJson()
+    expect(files.length).toBe(1)
+    const payload = readOutboxPayload(files[0]!)
+    expect(payload.text).toBe('final answer')
+    expect(payload.chat_id).toBe(CHAT_ID)
+    expect(payload.format).toBe('text')
+    expect(typeof payload.timestamp).toBe('string')
+    expect((payload.timestamp as string).length).toBeGreaterThan(0)
+  })
+
+  test('joins multiple text blocks in one assistant message with newline', () => {
+    const transcript = writeTranscript([
+      assistantLine([
+        { type: 'text', text: 'line one' },
+        { type: 'text', text: 'line two' },
+      ]),
+    ])
+    const r = run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    expect(r.code).toBe(0)
+    const files = listOutboxJson()
+    expect(files.length).toBe(1)
+    expect(readOutboxPayload(files[0]!).text).toBe('line one\nline two')
+  })
+
+  test('tool-only MOST-RECENT assistant turn -> no delivery (no stale resend)', () => {
+    // The latest assistant message is tool-use-only. We must NOT resurface
+    // the older "the real answer" text — that would re-deliver a stale reply
+    // after a tool-only turn / resume / clear.
+    const transcript = writeTranscript([
+      assistantLine([{ type: 'text', text: 'the real answer' }]),
+      assistantLine([
+        { type: 'tool_use', id: 'tu1', name: 'Bash', input: { command: 'ls' } },
+      ]),
+    ])
+    const r = run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    expect(r.code).toBe(0)
+    expect(listOutboxJson().length).toBe(0)
+  })
+
+  test('delivers the final text that FOLLOWS a tool_use within the turn', () => {
+    // tool_use earlier in the turn, then the final text reply — the most
+    // recent assistant message has text, so it is delivered.
+    const transcript = writeTranscript([
+      assistantLine([
+        { type: 'tool_use', id: 'tu1', name: 'Bash', input: { command: 'ls' } },
+      ]),
+      JSON.stringify({
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'tu1', content: 'ok' }],
+        },
+      }),
+      assistantLine([{ type: 'text', text: 'final answer' }]),
+    ])
+    const r = run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    expect(r.code).toBe(0)
+    const files = listOutboxJson()
+    expect(files.length).toBe(1)
+    expect(readOutboxPayload(files[0]!).text).toBe('final answer')
+  })
+
+  test('tail-reads past 256KB: drops truncated leading line, still extracts', () => {
+    // A >256KB leading assistant line forces the tail read to start mid-file
+    // (start > 0), so its first in-window line is a truncated JSON fragment
+    // that must be dropped without aborting extraction of the final line.
+    const huge = 'x'.repeat(300 * 1024)
+    const transcript = writeTranscript([
+      assistantLine([{ type: 'text', text: huge }]),
+      assistantLine([{ type: 'text', text: 'tail answer' }]),
+    ])
+    const r = run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    expect(r.code).toBe(0)
+    const files = listOutboxJson()
+    expect(files.length).toBe(1)
+    expect(readOutboxPayload(files[0]!).text).toBe('tail answer')
+  })
+
+  test('ignores invalid JSON lines and still extracts valid assistant text', () => {
+    const transcript = writeTranscript([
+      'this is not json',
+      assistantLine([{ type: 'text', text: 'good answer' }]),
+      '{ broken json',
+    ])
+    const r = run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    expect(r.code).toBe(0)
+    const files = listOutboxJson()
+    expect(files.length).toBe(1)
+    expect(readOutboxPayload(files[0]!).text).toBe('good answer')
+  })
+
+  test('chat_id comes from env, NOT from a chat_id field in the transcript', () => {
+    const transcript = writeTranscript([
+      JSON.stringify({
+        chat_id: '-999999999',
+        message: {
+          role: 'assistant',
+          chat_id: '-999999999',
+          content: [{ type: 'text', text: 'answer', chat_id: '-999999999' }],
+        },
+      }),
+    ])
+    const r = run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    expect(r.code).toBe(0)
+    const files = listOutboxJson()
+    expect(files.length).toBe(1)
+    expect(readOutboxPayload(files[0]!).chat_id).toBe(CHAT_ID)
+  })
+
+  test('only a .json file lands in outbox (no leftover .tmp)', () => {
+    const transcript = writeTranscript([
+      assistantLine([{ type: 'text', text: 'answer' }]),
+    ])
+    run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    const all = readdirSync(outboxDir())
+    expect(all.every((f) => f.endsWith('.json'))).toBe(true)
+    expect(all.some((f) => f.endsWith('.tmp'))).toBe(false)
+    expect(all.filter((f) => f.endsWith('.json')).length).toBe(1)
+  })
+})
+
+describe('stop-to-outbox.py — no-write paths (fail-safe, exit 0)', () => {
+  test('blank/whitespace-only assistant text -> no outbox file', () => {
+    const transcript = writeTranscript([
+      assistantLine([{ type: 'text', text: '   \n\t  ' }]),
+    ])
+    const r = run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    expect(r.code).toBe(0)
+    expect(listOutboxJson().length).toBe(0)
+  })
+
+  test('missing transcript file -> no file, exit 0', () => {
+    const r = run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir },
+      { transcript_path: join(stateDir, 'does-not-exist.jsonl'), session_id: 's1' },
+    )
+    expect(r.code).toBe(0)
+    expect(listOutboxJson().length).toBe(0)
+  })
+
+  test('missing/empty transcript_path in payload -> no file, exit 0', () => {
+    const rMissing = run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir },
+      { session_id: 's1' },
+    )
+    expect(rMissing.code).toBe(0)
+    expect(listOutboxJson().length).toBe(0)
+
+    const rEmpty = run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir },
+      { transcript_path: '', session_id: 's1' },
+    )
+    expect(rEmpty.code).toBe(0)
+    expect(listOutboxJson().length).toBe(0)
+  })
+
+  test('missing CHAT_ID -> no file, exit 0', () => {
+    const transcript = writeTranscript([
+      assistantLine([{ type: 'text', text: 'answer' }]),
+    ])
+    const r = run(
+      { MULTICHAT_STATE_DIR: stateDir },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    expect(r.code).toBe(0)
+    // CHAT_ID unset => no chat dir created at all.
+    expect(listOutboxJson().length).toBe(0)
+  })
+
+  test('missing MULTICHAT_STATE_DIR -> no file, exit 0', () => {
+    const transcript = writeTranscript([
+      assistantLine([{ type: 'text', text: 'answer' }]),
+    ])
+    // Strip any inherited MULTICHAT_STATE_DIR so the env var is truly absent.
+    const r = run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: '' },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    expect(r.code).toBe(0)
+    expect(listOutboxJson().length).toBe(0)
+  })
+
+  test('malformed CHAT_ID (path traversal) -> no write, exit 0', () => {
+    const transcript = writeTranscript([
+      assistantLine([{ type: 'text', text: 'answer' }]),
+    ])
+    for (const bad of ['../../etc', 'abc', '12/34', '..']) {
+      const r = run(
+        { CHAT_ID: bad, MULTICHAT_STATE_DIR: stateDir },
+        { transcript_path: transcript, session_id: 's1' },
+      )
+      expect(r.code).toBe(0)
+    }
+    // No chat dir for the legit CHAT_ID, and no traversal artifacts.
+    expect(listOutboxJson().length).toBe(0)
+  })
+})
+
+describe('stop-to-outbox.py — dedupe on repeated Stop', () => {
+  // A transcript line carrying a uuid (Claude Code emits one per entry).
+  function assistantLineWithUuid(
+    uuid: string,
+    blocks: Array<Record<string, unknown>>,
+  ): string {
+    return JSON.stringify({ uuid, message: { role: 'assistant', content: blocks } })
+  }
+
+  test('identical text in two DIFFERENT turns (distinct uuid) -> both delivered', () => {
+    // Regression guard: dedupe must key on the turn (uuid), not the text —
+    // otherwise a legitimate repeated "Готово." would be silently dropped.
+    const transcriptPath = join(stateDir, 'transcript.jsonl')
+    writeFileSync(
+      transcriptPath,
+      assistantLineWithUuid('u1', [{ type: 'text', text: 'Готово.' }]) + '\n',
+      'utf8',
+    )
+    const payload = { transcript_path: transcriptPath, session_id: 's1' }
+
+    const r1 = run({ CHAT_ID, MULTICHAT_STATE_DIR: stateDir }, payload)
+    expect(r1.code).toBe(0)
+    expect(listOutboxJson().length).toBe(1)
+
+    // New turn, SAME text, DIFFERENT uuid -> must deliver again.
+    writeFileSync(
+      transcriptPath,
+      assistantLineWithUuid('u1', [{ type: 'text', text: 'Готово.' }]) +
+        '\n' +
+        assistantLineWithUuid('u2', [{ type: 'text', text: 'Готово.' }]) +
+        '\n',
+      'utf8',
+    )
+    const r2 = run({ CHAT_ID, MULTICHAT_STATE_DIR: stateDir }, payload)
+    expect(r2.code).toBe(0)
+    expect(listOutboxJson().length).toBe(2)
+  })
+
+  test('same turn (same uuid) re-fires -> deduped to one file', () => {
+    const transcriptPath = join(stateDir, 'transcript.jsonl')
+    writeFileSync(
+      transcriptPath,
+      assistantLineWithUuid('u1', [{ type: 'text', text: 'answer' }]) + '\n',
+      'utf8',
+    )
+    const payload = { transcript_path: transcriptPath, session_id: 's1' }
+    run({ CHAT_ID, MULTICHAT_STATE_DIR: stateDir }, payload)
+    run({ CHAT_ID, MULTICHAT_STATE_DIR: stateDir }, payload)
+    expect(listOutboxJson().length).toBe(1)
+  })
+
+  test('identical payload twice -> exactly one file; changed text -> a second', () => {
+    const transcriptPath = join(stateDir, 'transcript.jsonl')
+    writeFileSync(
+      transcriptPath,
+      assistantLine([{ type: 'text', text: 'first answer' }]) + '\n',
+      'utf8',
+    )
+    const payload = { transcript_path: transcriptPath, session_id: 's1' }
+
+    const r1 = run({ CHAT_ID, MULTICHAT_STATE_DIR: stateDir }, payload)
+    expect(r1.code).toBe(0)
+    expect(listOutboxJson().length).toBe(1)
+
+    // Second identical Stop fire: deduped, still one file.
+    const r2 = run({ CHAT_ID, MULTICHAT_STATE_DIR: stateDir }, payload)
+    expect(r2.code).toBe(0)
+    expect(listOutboxJson().length).toBe(1)
+
+    // Append a newer assistant turn; same session/transcript path but the
+    // extracted final text changed -> hash differs -> a second file appears.
+    writeFileSync(
+      transcriptPath,
+      assistantLine([{ type: 'text', text: 'first answer' }]) +
+        '\n' +
+        assistantLine([{ type: 'text', text: 'second answer' }]) +
+        '\n',
+      'utf8',
+    )
+    const r3 = run({ CHAT_ID, MULTICHAT_STATE_DIR: stateDir }, payload)
+    expect(r3.code).toBe(0)
+    const files = listOutboxJson()
+    expect(files.length).toBe(2)
+    const texts = files.map((f) => readOutboxPayload(f).text).sort()
+    expect(texts).toEqual(['first answer', 'second answer'])
+  })
+})


### PR DESCRIPTION
## Проблема
Группа-чаты маршрутизируются в per-chat tmux-сессию с интерактивным `claude`. Входящий путь работал (router -> inbox -> watcher -> send-keys), но **исходящего не было**: claude отвечал только в свой транскрипт, router'у было нечего слать в Telegram. У лички ответ идёт через MCP reply-тул; у группы аналога не существовало -> ответы бота в группе не доходили.

## Решение
`src/chats/hooks/stop-to-outbox.py` -- Stop-хук, интерактивный аналог захвата headless-события `result` (как в gateway Сильваны). На завершении хода читает транскрипт, берёт текст последнего сообщения ассистента и атомарно пишет `OutboxMessage` JSON в `outbox/`. Router (уже рабочий, дренит каждые 200мс) доставляет в Telegram.

## Что учтено (двойное ревью)
- **Codex HIGH** -- семантика доставки: если последний ход tool-only, возвращаем None, не воскрешаем старый (уже доставленный) ответ
- **Codex MEDIUM** -- `chat_id` строго из `$CHAT_ID` + валидация `-?\d+` против path-traversal
- **Codex MEDIUM** -- дедуп повторных Stop по `uuid` строки транскрипта (fallback на hash): одинаковый текст в разных ходах («Готово.» дважды) не глушится
- `format=text` (HTML раньше ломался), fail-safe `exit 0` на всех путях, без shell-out
- 17 тестов (bun): извлечение, fail-safe, дедуп, атомарность, traversal

## Ревью
- Opus code-reviewer: 0 Critical/High
- Codex GPT-5.5: SHIP, no blockers

## Активация (отдельно, не в этом PR)
Хук становится активным после регистрации `Stop` в `chats/.claude/settings.json` живого workspace + рестарт per-chat сессий. Делегируется Сильване.

🤖 Generated with [Claude Code](https://claude.com/claude-code)