### PR TITLE
fix(tests): привёл тест-фикстуры к сигнатурам после PR #9/#28

### DIFF
--- a/plugin/tests/channel/permissions.test.ts
+++ b/plugin/tests/channel/permissions.test.ts
@@ -45,6 +45,7 @@ function mkStatePaths(): StatePaths {
       telegram: join(root, 'logs', 'telegram.log'),
       permissions: join(root, 'logs', 'permissions.jsonl'),
       webhook: join(root, 'logs', 'webhook.log'),
+      ask_user_question: join(root, 'logs', 'ask-user-question.jsonl'),
     },
   }
 }
@@ -86,6 +87,9 @@ function mkConfig(allowedIds: number[] = [164795011]): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
+    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    multichat: { enabled: false },
+    ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
   }
 }
 

--- a/plugin/tests/channel/tools.test.ts
+++ b/plugin/tests/channel/tools.test.ts
@@ -82,6 +82,9 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
+    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    multichat: { enabled: false },
+    ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     ...overrides,
   }
 }
@@ -105,6 +108,7 @@ function makeStatePaths(): StatePaths {
       telegram: join(root, 'logs', 'telegram.log'),
       permissions: join(root, 'logs', 'permissions.jsonl'),
       webhook: join(root, 'logs', 'webhook.log'),
+      ask_user_question: join(root, 'logs', 'ask-user-question.jsonl'),
     },
   }
 }

--- a/plugin/tests/commands/oob.test.ts
+++ b/plugin/tests/commands/oob.test.ts
@@ -50,6 +50,9 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
+    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    multichat: { enabled: false },
+    ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     ...overrides,
   }
 }

--- a/plugin/tests/config.test.ts
+++ b/plugin/tests/config.test.ts
@@ -424,7 +424,7 @@ describe('loadConfig', () => {
     const cfg = loadConfig(env())
     expect(cfg.ask_user_question.allowed_user_ids).toBeUndefined()
 
-    const calls: Array<{ msg: string; fields?: Record<string, unknown> }> = []
+    const calls: Array<{ msg: string; fields: Record<string, unknown> | undefined }> = []
     const logger = { info: (msg: string, fields?: Record<string, unknown>) => calls.push({ msg, fields }) }
     const resolved = resolveAskUserQuestionAllowedUserIds(cfg, logger)
     expect(resolved).toEqual(cfg.permission_relay.allowed_user_ids)
@@ -440,7 +440,7 @@ describe('loadConfig', () => {
     const cfg = loadConfig(env())
     expect(cfg.ask_user_question.allowed_user_ids).toEqual([555, 666])
 
-    const calls: Array<{ msg: string; fields?: Record<string, unknown> }> = []
+    const calls: Array<{ msg: string; fields: Record<string, unknown> | undefined }> = []
     const logger = { info: (msg: string, fields?: Record<string, unknown>) => calls.push({ msg, fields }) }
     const resolved = resolveAskUserQuestionAllowedUserIds(cfg, logger)
     expect(resolved).toEqual([555, 666])

--- a/plugin/tests/prompt/media-prompt.test.ts
+++ b/plugin/tests/prompt/media-prompt.test.ts
@@ -58,6 +58,9 @@ const voiceConfig: AppConfig = {
     debounce_ms: 10_000,
     busy_threshold_ms: 30_000,
   },
+  tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+  multichat: { enabled: false },
+  ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/plugin/tests/security/paths.test.ts
+++ b/plugin/tests/security/paths.test.ts
@@ -54,6 +54,26 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       buffer_ttl_ms: 5 * 60 * 1000,
       buffer_max_entries: 100,
     },
+    progress: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      recent_buffer: 10,
+      session_ttl_ms: 600000,
+    },
+    task_mirror: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      session_ttl_ms: 600000,
+      collapse_completed_after: 5,
+    },
+    watcher: {
+      enabled: true,
+      debounce_ms: 10_000,
+      busy_threshold_ms: 30_000,
+    },
+    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    multichat: { enabled: false },
+    ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     ...overrides,
   }
 }

--- a/plugin/tests/status/progress-reporter.test.ts
+++ b/plugin/tests/status/progress-reporter.test.ts
@@ -83,6 +83,9 @@ function makeConfig(overrides: Partial<AppConfig['progress']> = {}): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
+    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    multichat: { enabled: false },
+    ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
   }
 }
 

--- a/plugin/tests/status/status-manager.multichat.test.ts
+++ b/plugin/tests/status/status-manager.multichat.test.ts
@@ -111,6 +111,9 @@ function makeConfig(): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
+    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    multichat: { enabled: false },
+    ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
   }
 }
 

--- a/plugin/tests/status/status-manager.test.ts
+++ b/plugin/tests/status/status-manager.test.ts
@@ -60,6 +60,9 @@ function makeConfig(overrides: Partial<AppConfig['status']> = {}): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
+    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    multichat: { enabled: false },
+    ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
   }
 }
 

--- a/plugin/tests/status/task-mirror.test.ts
+++ b/plugin/tests/status/task-mirror.test.ts
@@ -71,6 +71,9 @@ function makeConfig(overrides: Partial<AppConfig['task_mirror']> = {}): AppConfi
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
+    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    multichat: { enabled: false },
+    ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
   }
 }
 

--- a/plugin/tests/telegram/gate.test.ts
+++ b/plugin/tests/telegram/gate.test.ts
@@ -47,6 +47,9 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
+    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    multichat: { enabled: false },
+    ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     ...overrides,
   }
 }

--- a/plugin/tests/telegram/handlers.addressing.test.ts
+++ b/plugin/tests/telegram/handlers.addressing.test.ts
@@ -112,6 +112,7 @@ function makeStatePaths(): StatePaths {
       telegram: join(root, 'logs', 'telegram.log'),
       permissions: join(root, 'logs', 'permissions.jsonl'),
       webhook: join(root, 'logs', 'webhook.log'),
+      ask_user_question: join(root, 'logs', 'ask-user-question.jsonl'),
     },
   }
 }

--- a/plugin/tests/telegram/handlers.album.test.ts
+++ b/plugin/tests/telegram/handlers.album.test.ts
@@ -130,6 +130,7 @@ function makeStatePaths(): StatePaths {
       telegram: join(root, 'logs', 'telegram.log'),
       permissions: join(root, 'logs', 'permissions.jsonl'),
       webhook: join(root, 'logs', 'webhook.log'),
+      ask_user_question: join(root, 'logs', 'ask-user-question.jsonl'),
     },
   }
 }

--- a/plugin/tests/telegram/handlers.test.ts
+++ b/plugin/tests/telegram/handlers.test.ts
@@ -75,6 +75,9 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
+    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    multichat: { enabled: false },
+    ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     ...overrides,
   }
 }
@@ -98,6 +101,7 @@ function makeStatePaths(): StatePaths {
       telegram: join(root, 'logs', 'telegram.log'),
       permissions: join(root, 'logs', 'permissions.jsonl'),
       webhook: join(root, 'logs', 'webhook.log'),
+      ask_user_question: join(root, 'logs', 'ask-user-question.jsonl'),
     },
   }
 }

--- a/plugin/tests/telegram/watcher.test.ts
+++ b/plugin/tests/telegram/watcher.test.ts
@@ -54,6 +54,9 @@ function makeConfig(overrides: Partial<AppConfig['watcher']> = {}): AppConfig {
       busy_threshold_ms: 30_000,
       ...overrides,
     },
+    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    multichat: { enabled: false },
+    ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
   }
 }
 

--- a/plugin/tests/webhook/ask-user-question-routes.test.ts
+++ b/plugin/tests/webhook/ask-user-question-routes.test.ts
@@ -62,10 +62,10 @@ beforeEach(() => {
     TELEGRAM_BOT_TOKEN: FAKE_TOKEN,
     TELEGRAM_STATE_DIR: stateDir,
   })
-  // ensureStateDirs is a stub today (state/store.ts); the audit writer
-  // creates its parent dir on demand via mkdirSync(recursive: true), so
-  // we don't need a pre-pass.
-  ensureStateDirs()
+  // ensureStateDirs now creates the state directory tree (state/store.ts).
+  // The audit writer also creates its parent dir on demand via
+  // mkdirSync(recursive: true), so either path is safe.
+  ensureStateDirs(paths)
   handle = null
 })
 


### PR DESCRIPTION
## Что

После мержа #9 (реальный `store.ts`) и #28 (3 новых config-поля) тест-фикстуры остались под старый стаб — main падал: `bun run typecheck` 20 ошибок, тесты красные. Этот PR чинит ТОЛЬКО тесты (src/ не тронут, кастов нет).

- `makeConfig` в 12 файлах: добавлены недостающие `tmux_mirror` / `multichat` / `ask_user_question` реальными значениями.
- `StatePaths.logs` в 5 файлах: добавлен путь `ask_user_question`.
- `ask-user-question-routes.test.ts`: `ensureStateDirs()` → `ensureStateDirs(paths)` (реальная сигнатура из #9).
- `config.test.ts`: `calls[].fields` → `Record|undefined` под `exactOptionalPropertyTypes`.
- `security/paths.test.ts`: дозаполнены required `progress`/`task_mirror`/`watcher`.

## Проверка

- `bun run typecheck` → **0 ошибок** (было 20)
- `bun test` → **1113 pass / 0 fail**
- diff: только `plugin/tests/`, без `as any`/`as unknown`

Закрывает хвост от мержа #9/#10 — main снова зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)