### PR TITLE
fix(multichat): Stop-хук доставляет текст турна, завершившегося вызовом инструмента

### DIFF
--- a/plugin/src/chats/hooks/stop-to-outbox.py
+++ b/plugin/src/chats/hooks/stop-to-outbox.py
@@ -19,13 +19,17 @@ Extraction algorithm:
     lines backward to the MOST RECENT assistant message and returns its
     ``{"type": "text", "text": ...}`` blocks joined with newlines.
 
-    Divergence from the memory reader (deliberate): if that most-recent
-    assistant message is tool-use-only (no text blocks), we return ``None``
-    rather than continuing back to an OLDER text message. For outbox delivery
-    we must send only the reply of the turn that just ended — resurfacing an
-    older answer would re-deliver a stale reply to Telegram after a tool-only
-    turn, a resume, or a clear (the memory reader wants the last text ever,
-    which is the opposite requirement).
+    Divergence from the memory reader (deliberate): we return the most recent
+    assistant text of the CURRENT TURN — i.e. we walk backward across
+    tool-use-only assistant messages and tool_result lines, but STOP at the
+    last genuine user prompt. This fixes the 2026-05-28 production drop where
+    a turn answered with text and then ended on a tool call (Write / gbrain /
+    Bash): the old "most recent message must itself be text, else None" rule
+    silently discarded the reply the turn had already produced, so group chats
+    received nothing. We must NOT cross the user-prompt boundary, because text
+    from a PREVIOUS (already-delivered) turn would be a stale resend after a
+    tool-only turn, a resume, or a clear. Dedupe (below) is the second guard
+    against re-delivering the same turn.
 
 Safety:
     Fail-safe everywhere — every error path exits 0 so the hook never blocks
@@ -62,7 +66,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-TAIL_BYTES = 256 * 1024
+# Tail window for the backward walk. Sized so a whole interactive turn —
+# including large tool_result blocks (file reads, command output) — almost
+# always fits, keeping the current turn's user-prompt boundary inside the
+# window. If a single turn ever exceeds this, the boundary can fall outside
+# the window and the walk could reach a previous turn's text; dedupe is the
+# secondary guard against re-delivering it (Codex review 2026-05-28 [high]).
+TAIL_BYTES = 1024 * 1024
 
 # Telegram chat ids are integers (groups are negative). CHAT_ID is used as a
 # filesystem path segment, so we reject anything else to block path-traversal
@@ -79,7 +89,10 @@ def read_last_assistant_text(transcript_path: Path) -> tuple[str, str | None] | 
     Based on ``readLastAssistantText`` (transcript-reader.ts): reads at most
     the trailing ``TAIL_BYTES`` bytes, drops the first possibly-truncated
     line when the read did not start at byte 0, then walks lines backward to
-    the MOST RECENT assistant message and returns its
+    the most recent assistant message that carries text WITHIN THE CURRENT
+    TURN. The walk skips tool-use-only assistant messages and ``tool_result``
+    lines, but stops at the last genuine user prompt (so older, already-
+    delivered turns are never resurfaced). Returns that message's
     ``{"type": "text", "text": str}`` blocks joined with newlines, together
     with that transcript line's ``uuid`` (when present) for dedupe.
 
@@ -87,11 +100,11 @@ def read_last_assistant_text(transcript_path: Path) -> tuple[str, str | None] | 
         transcript_path: Absolute path to the session transcript ``.jsonl``.
 
     Returns:
-        ``(text, uuid)`` for the most recent assistant message — ``uuid`` is
-        the transcript line's ``uuid`` field or ``None`` if absent. Returns
-        ``None`` if the file is missing/empty/unreadable, there is no
-        assistant message, or the most recent assistant message is
-        tool-use-only (no text).
+        ``(text, uuid)`` for the most recent text-bearing assistant message of
+        the current turn — ``uuid`` is that transcript line's ``uuid`` field
+        or ``None`` if absent. Returns ``None`` if the file is
+        missing/empty/unreadable, or the current turn produced no assistant
+        text (pure tool-use turn).
     """
     try:
         with transcript_path.open("rb") as fh:
@@ -124,9 +137,21 @@ def read_last_assistant_text(transcript_path: Path) -> tuple[str, str | None] | 
         message = obj.get("message")
         if not isinstance(message, dict):
             continue
-        if message.get("role") != "assistant":
-            continue
+        role = message.get("role")
         content = message.get("content")
+
+        if role == "user":
+            # A genuine user prompt marks the start of the current turn: stop
+            # the backward walk so we never resurface text from an older,
+            # already-delivered turn. A user line whose content is ONLY
+            # tool_result(s) is part of the current turn (the SDK echoes tool
+            # output as a user-role message) — skip past it, do not stop.
+            if _is_user_prompt(content):
+                return None
+            continue
+
+        if role != "assistant":
+            continue
         if not isinstance(content, list):
             continue
         parts: list[str] = []
@@ -135,14 +160,52 @@ def read_last_assistant_text(transcript_path: Path) -> tuple[str, str | None] | 
                 continue
             if block.get("type") == "text" and isinstance(block.get("text"), str):
                 parts.append(block["text"])
-        # This is the MOST RECENT assistant message. Return its text if any;
-        # otherwise it is a tool-use-only final turn — return None rather than
-        # resurfacing an older (already-delivered / stale) answer.
         if not parts:
-            return None
+            # Tool-use-only assistant message — keep walking back within the
+            # current turn to the text the turn already produced (the reply
+            # must not be dropped just because the turn ended on a tool call).
+            continue
         uuid = obj.get("uuid")
         return "\n".join(parts), (uuid if isinstance(uuid, str) and uuid else None)
     return None
+
+
+def _is_user_prompt(content: Any) -> bool:
+    """True when a user-role message is a genuine prompt, not tool_result echo.
+
+    The per-chat router injects the inbound message as a user prompt whose
+    ``content`` is a plain string or a list of content blocks (text, image,
+    document, ...). The Claude SDK also writes tool outputs as user-role
+    messages, but those carry ONLY ``{"type": "tool_result", ...}`` blocks —
+    they belong to the current turn and must NOT end the backward walk.
+
+    Classification is deliberately conservative for stale-resend safety: a
+    user-role message is treated as a genuine prompt UNLESS it is confidently a
+    tool_result-only echo. So a media-only prompt, or an unknown future block
+    shape, still counts as a turn boundary (stops the walk) rather than being
+    walked through into a previous, already-delivered turn (Codex review
+    2026-05-28 [medium]).
+
+    Args:
+        content: The ``message.content`` value of a user-role transcript line.
+
+    Returns:
+        ``True`` if this is a real user prompt (turn boundary); ``False`` only
+        for a confident tool_result-only echo or an empty/blank shape.
+    """
+    if isinstance(content, str):
+        return bool(content.strip())
+    if isinstance(content, list):
+        if not content:
+            return False
+        # Prompt unless EVERY block is a tool_result. Any other block type
+        # (text, image, document, or an unrecognised future shape) marks a
+        # genuine user turn boundary.
+        return any(
+            not (isinstance(block, dict) and block.get("type") == "tool_result")
+            for block in content
+        )
+    return False
 
 
 def build_filename() -> str:
@@ -185,6 +248,44 @@ def atomic_write_json(target: Path, payload: dict[str, Any]) -> None:
         raise
 
 
+_DEBUG_LOG_CAP_BYTES = 512 * 1024
+
+
+def _debug_log(hook_state_dir: Path, decision: str, **fields: Any) -> None:
+    """Append a one-line JSON diagnostic record — opt-in, fail-safe, capped.
+
+    Enabled only when the ``STOP_OUTBOX_DEBUG`` environment variable is set, so
+    production sessions write nothing. Records every Stop invocation and its
+    decision (``fired`` / ``no_text`` / ``deduped`` / ``written`` / ``error``)
+    to ``{hook_state_dir}/stop-outbox-debug.log``. This is the only way to tell,
+    after the fact, whether Claude Code fired the Stop hook for a given turn —
+    the symptom we cannot observe otherwise. Truncated when it exceeds
+    ``_DEBUG_LOG_CAP_BYTES`` so it can never grow unbounded. All errors are
+    swallowed; logging must never affect delivery.
+
+    Args:
+        hook_state_dir: Per-chat ``.hook-state`` directory (log lives here).
+        decision: Short decision tag for this invocation.
+        **fields: Extra JSON-serialisable context (session_id, reason, ...).
+    """
+    if not os.environ.get("STOP_OUTBOX_DEBUG"):
+        return
+    try:
+        hook_state_dir.mkdir(parents=True, exist_ok=True)
+        log_path = hook_state_dir / "stop-outbox-debug.log"
+        try:
+            if log_path.stat().st_size > _DEBUG_LOG_CAP_BYTES:
+                log_path.unlink()
+        except OSError:
+            pass
+        record = {"ts": datetime.now(timezone.utc).isoformat(), "decision": decision}
+        record.update(fields)
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except (OSError, ValueError, TypeError):
+        pass
+
+
 def main() -> int:
     """Read the Stop payload, extract assistant text, write an OutboxMessage.
 
@@ -208,17 +309,28 @@ def main() -> int:
         logger.error("invalid CHAT_ID shape; refusing to write")
         return 0
 
+    chat_root = Path(state_dir) / "chats" / chat_id
+    hook_state_dir = chat_root / ".hook-state"
+    state_file = hook_state_dir / "last-stop-outbox.json"
+    outbox_dir = chat_root / "outbox"
+
     transcript_path_raw = payload.get("transcript_path")
     if not isinstance(transcript_path_raw, str) or not transcript_path_raw:
         return 0
     session_id_raw = payload.get("session_id")
     session_id = session_id_raw if isinstance(session_id_raw, str) else ""
 
+    # Records that the Stop hook fired at all — the symptom we otherwise cannot
+    # observe (opt-in via STOP_OUTBOX_DEBUG; no-op in production).
+    _debug_log(hook_state_dir, "fired", session_id=session_id)
+
     extracted = read_last_assistant_text(Path(transcript_path_raw))
     if extracted is None:
+        _debug_log(hook_state_dir, "no_text", session_id=session_id, reason="tool_only_turn")
         return 0
     assistant_text, assistant_uuid = extracted
     if not assistant_text.strip():
+        _debug_log(hook_state_dir, "no_text", session_id=session_id, reason="blank")
         return 0
 
     assistant_hash = hashlib.sha256(assistant_text.encode("utf-8")).hexdigest()
@@ -227,11 +339,6 @@ def main() -> int:
     # are NOT suppressed. Fall back to the text hash only when the transcript
     # carries no uuid.
     dedupe_token = assistant_uuid or assistant_hash
-
-    chat_root = Path(state_dir) / "chats" / chat_id
-    hook_state_dir = chat_root / ".hook-state"
-    state_file = hook_state_dir / "last-stop-outbox.json"
-    outbox_dir = chat_root / "outbox"
 
     # Dedupe: skip if this exact turn was already delivered.
     try:
@@ -242,6 +349,7 @@ def main() -> int:
             and prior.get("transcript_path") == transcript_path_raw
             and prior.get("dedupe_token") == dedupe_token
         ):
+            _debug_log(hook_state_dir, "deduped", session_id=session_id)
             return 0
     except (OSError, ValueError, TypeError):
         pass  # No prior state / unreadable — proceed with write.
@@ -266,7 +374,12 @@ def main() -> int:
         atomic_write_json(final_path, message)
     except OSError as exc:
         logger.error("outbox write failed: %s", exc)
+        _debug_log(hook_state_dir, "error", session_id=session_id, reason="outbox_write_failed")
         return 0
+
+    _debug_log(
+        hook_state_dir, "written", session_id=session_id, chars=len(assistant_text)
+    )
 
     # Update dedupe state only after a successful outbox write.
     try:

--- a/plugin/tests/chats/stop-to-outbox.test.ts
+++ b/plugin/tests/chats/stop-to-outbox.test.ts
@@ -144,12 +144,87 @@ describe('stop-to-outbox.py — extraction', () => {
     expect(readOutboxPayload(files[0]!).text).toBe('line one\nline two')
   })
 
-  test('tool-only MOST-RECENT assistant turn -> no delivery (no stale resend)', () => {
-    // The latest assistant message is tool-use-only. We must NOT resurface
-    // the older "the real answer" text — that would re-deliver a stale reply
-    // after a tool-only turn / resume / clear.
+  test('delivers current-turn text even when the turn ENDS on a tool_use', () => {
+    // Production bug (2026-05-28): the agent answered with text, then ran a
+    // tool (Write/gbrain/Bash) as the LAST action of the same turn. The old
+    // "most-recent message is tool-only -> None" rule dropped the answer the
+    // turn already produced, so the group chat never received the reply.
+    // The reply text belongs to the current turn (after the last real user
+    // prompt) so it MUST be delivered regardless of a trailing tool_use.
     const transcript = writeTranscript([
-      assistantLine([{ type: 'text', text: 'the real answer' }]),
+      userLine('упакуй задачу в md'),
+      assistantLine([{ type: 'text', text: 'Файл готов, держи.' }]),
+      assistantLine([
+        { type: 'tool_use', id: 'tu1', name: 'Write', input: { file_path: '/tmp/x.md' } },
+      ]),
+      JSON.stringify({
+        message: {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'tu1', content: 'ok' }],
+        },
+      }),
+      assistantLine([
+        { type: 'tool_use', id: 'tu2', name: 'Bash', input: { command: 'ls' } },
+      ]),
+    ])
+    const r = run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    expect(r.code).toBe(0)
+    const files = listOutboxJson()
+    expect(files.length).toBe(1)
+    expect(readOutboxPayload(files[0]!).text).toBe('Файл готов, держи.')
+  })
+
+  test('does NOT resurface text from BEFORE the current user prompt', () => {
+    // Stale-resend guard (the original concern): text answered in a previous
+    // turn must not leak into the current turn's delivery. The current turn
+    // (after "новый вопрос") is tool-only, so nothing is delivered.
+    const transcript = writeTranscript([
+      userLine('старый вопрос'),
+      assistantLine([{ type: 'text', text: 'старый ответ' }]),
+      userLine('новый вопрос'),
+      assistantLine([
+        { type: 'tool_use', id: 'tu1', name: 'Bash', input: { command: 'ls' } },
+      ]),
+    ])
+    const r = run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    expect(r.code).toBe(0)
+    expect(listOutboxJson().length).toBe(0)
+  })
+
+  test('a media-only user prompt is a turn boundary (no stale resend)', () => {
+    // Codex review [medium]: a prompt whose content is media-only (no text
+    // block) must still stop the backward walk, so a previous turn's answer is
+    // never resurfaced when the current (media-prompt) turn is tool-only.
+    const transcript = writeTranscript([
+      userLine('старый вопрос'),
+      assistantLine([{ type: 'text', text: 'старый ответ' }]),
+      JSON.stringify({
+        message: {
+          role: 'user',
+          content: [{ type: 'image', source: { type: 'base64', data: 'AAAA' } }],
+        },
+      }),
+      assistantLine([
+        { type: 'tool_use', id: 'tu1', name: 'Bash', input: { command: 'ls' } },
+      ]),
+    ])
+    const r = run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    expect(r.code).toBe(0)
+    expect(listOutboxJson().length).toBe(0)
+  })
+
+  test('pure tool-only turn with no text -> no delivery', () => {
+    const transcript = writeTranscript([
+      userLine('запусти ls'),
       assistantLine([
         { type: 'tool_use', id: 'tu1', name: 'Bash', input: { command: 'ls' } },
       ]),
@@ -187,11 +262,12 @@ describe('stop-to-outbox.py — extraction', () => {
     expect(readOutboxPayload(files[0]!).text).toBe('final answer')
   })
 
-  test('tail-reads past 256KB: drops truncated leading line, still extracts', () => {
-    // A >256KB leading assistant line forces the tail read to start mid-file
-    // (start > 0), so its first in-window line is a truncated JSON fragment
-    // that must be dropped without aborting extraction of the final line.
-    const huge = 'x'.repeat(300 * 1024)
+  test('tail-reads past the window: drops truncated leading line, still extracts', () => {
+    // A leading assistant line larger than TAIL_BYTES (1 MiB) forces the tail
+    // read to start mid-file (start > 0), so its first in-window line is a
+    // truncated JSON fragment that must be dropped without aborting extraction
+    // of the final line.
+    const huge = 'x'.repeat(1200 * 1024)
     const transcript = writeTranscript([
       assistantLine([{ type: 'text', text: huge }]),
       assistantLine([{ type: 'text', text: 'tail answer' }]),
@@ -255,6 +331,57 @@ describe('stop-to-outbox.py — extraction', () => {
     expect(all.every((f) => f.endsWith('.json'))).toBe(true)
     expect(all.some((f) => f.endsWith('.tmp'))).toBe(false)
     expect(all.filter((f) => f.endsWith('.json')).length).toBe(1)
+  })
+})
+
+describe('stop-to-outbox.py — diagnostic log (STOP_OUTBOX_DEBUG)', () => {
+  function debugLogPath(): string {
+    return join(stateDir, 'chats', CHAT_ID, '.hook-state', 'stop-outbox-debug.log')
+  }
+
+  test('off by default: no debug log written', () => {
+    const transcript = writeTranscript([
+      userLine('вопрос'),
+      assistantLine([{ type: 'text', text: 'ответ' }]),
+    ])
+    run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    expect(() => readFileSync(debugLogPath(), 'utf8')).toThrow()
+  })
+
+  test('on: records fired + written for a delivered turn', () => {
+    const transcript = writeTranscript([
+      userLine('вопрос'),
+      assistantLine([{ type: 'text', text: 'ответ' }]),
+    ])
+    run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir, STOP_OUTBOX_DEBUG: '1' },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    const lines = readFileSync(debugLogPath(), 'utf8').trim().split('\n').map((l) => JSON.parse(l))
+    const decisions = lines.map((l) => l.decision)
+    expect(decisions).toContain('fired')
+    expect(decisions).toContain('written')
+  })
+
+  test('on: records no_text for a tool-only turn', () => {
+    const transcript = writeTranscript([
+      userLine('запусти ls'),
+      assistantLine([
+        { type: 'tool_use', id: 'tu1', name: 'Bash', input: { command: 'ls' } },
+      ]),
+    ])
+    run(
+      { CHAT_ID, MULTICHAT_STATE_DIR: stateDir, STOP_OUTBOX_DEBUG: '1' },
+      { transcript_path: transcript, session_id: 's1' },
+    )
+    const decisions = readFileSync(debugLogPath(), 'utf8')
+      .trim().split('\n').map((l) => JSON.parse(l).decision)
+    expect(decisions).toContain('fired')
+    expect(decisions).toContain('no_text')
+    expect(listOutboxJson().length).toBe(0)
   })
 })
 


### PR DESCRIPTION
## Проблема (M5a)

В интерактивном multichat у каждой per-chat `claude` tmux-сессии есть Stop-хук `stop-to-outbox.py`, который читает транскрипт и пишет ответ агента в outbox (router сливает его в Telegram). Старое извлечение брало текст **только последнего** assistant-сообщения турна. Если турн отвечал текстом, а затем завершался вызовом инструмента (Write / gbrain / Bash) — последнее сообщение было tool-use-only → хук возвращал `None` → **ответ молча терялся**, группа не получала ничего.

Подтверждено чтением live-транскрипта + падающим тестом.

## Фикс

- `read_last_assistant_text`: идём назад через tool-use-only assistant-сообщения и `tool_result`-строки до последнего **текстового** assistant-сообщения текущего турна, останавливаясь на реальном user-промпте (чтобы не воскрешать уже доставленный прошлый турн). Дедуп (uuid/hash) без изменений — второй барьер.
- `_is_user_prompt`: user-сообщение считается границей турна, кроме уверенно `tool_result`-only эха. Media-only и неизвестные блоки тоже граница — защита от stale-resend (**Codex review [medium]**).
- `TAIL_BYTES` 256 KB → 1 MiB: турн с крупными `tool_result` влезает в окно, граница не выпадает наружу → меньше риск пересечь в прошлый турн (**Codex review [high]**).
- Опциональный `STOP_OUTBOX_DEBUG` лог (capped 512 KB, fail-safe, без контента) — чтобы после рестарта видеть, фа́йрит ли Stop и какое решение принял.

## Проверка

- Двойной ревью: **Opus + Codex GPT-5.5** (High/Medium из ревью устранены)
- `bun test tests/chats/stop-to-outbox.test.ts` → 23/0
- Полный suite → **1119 pass / 0 fail**, `typecheck` → 0

## Важно (не входит в этот PR)

1. **Деплой:** live-копия хука — отдельный файл `~/.claude-lab/thrall/.claude/chats/hooks/stop-to-outbox.py`. Нужно редеплоить + рестарт per-chat сессии (через Сильвану), чтобы фикс вступил в силу.
2. **M5b (открыто):** конкретный пропавший ответ вождя завершался ТЕКСТОМ, т.е. этот фикс его не объясняет — там live Stop-хук не отработал по неизвестной причине. `STOP_OUTBOX_DEBUG` после рестарта даст диагностику.

🤖 Generated with [Claude Code](https://claude.com/claude-code)