### PR TITLE
feat(multichat): typing-индикатор + reply-on-mention в группах (M7)

### DIFF
--- a/plugin/src/router/inbox-bridge.ts
+++ b/plugin/src/router/inbox-bridge.ts
@@ -66,6 +66,12 @@ export type InboundMessage = {
   reply_context?: string
   media_paths?: string[]
   timestamp: string
+  // Telegram message_id (stringified) of the triggering message — the one
+  // that summoned the bot (an @mention or reply-to-bot in a group). The
+  // router stores it per chat and, for public chats, threads the outbound
+  // reply as a quote-reply to it (reply_to_message_id). Omitted for legacy
+  // writers / messages where no id was available.
+  message_id?: string
 }
 
 // Outbound DTO — what the tmux session emits back to the plugin.

--- a/plugin/src/router/multichat-router.ts
+++ b/plugin/src/router/multichat-router.ts
@@ -47,11 +47,13 @@ import {
 } from './inbox-bridge.js'
 import type { TmuxSessionPool } from './tmux-session-pool.js'
 
-// Telegram surface the router actually touches. We only need sendMessage —
-// editMessageText is owned by StatusManager / TmuxMirror, not the outbox
-// path. Keep the type narrow so unit tests can stub a minimal surface.
+// Telegram surface the router actually touches: sendMessage for outbox
+// replies and sendChatAction for the group typing indicator (M7).
+// editMessageText is owned by StatusManager / TmuxMirror, not this path.
+// Keep the type narrow so unit tests can stub a minimal surface.
 export interface MultichatTelegramApi {
   sendMessage: TelegramApi['sendMessage']
+  sendChatAction: TelegramApi['sendChatAction']
 }
 
 export interface RouterDeps {
@@ -73,6 +75,25 @@ export interface RouterDeps {
 // for replies without hammering the disk (one readdir per chat).
 // Matches PLAN.md section 2 ("setInterval(200ms)").
 const DEFAULT_OUTBOX_POLL_INTERVAL_MS = 200
+// M7 typing indicator. Telegram clears a chat action ~5s after it is sent, so
+// re-send every 4s to keep the "typing…" status alive while the per-chat
+// session works. TYPING_MAX_TICKS caps the loop (~2 min) so a session that
+// never produces an outbox reply cannot leave the indicator spinning forever.
+const TYPING_INTERVAL_MS = 4000
+const TYPING_MAX_TICKS = 30
+
+/**
+ * Parse a Telegram message_id string into a positive, safe-integer number.
+ * Stricter than parseInt (Codex review 2026-05-28 [low]): requires all
+ * digits so partial garbage like "123abc" is rejected, and rejects values
+ * outside the JS safe-integer range. Returns undefined when invalid.
+ */
+function parseMessageId(raw: string): number | undefined {
+  if (!/^\d+$/.test(raw)) return undefined
+  const n = Number(raw)
+  if (!Number.isSafeInteger(n) || n <= 0) return undefined
+  return n
+}
 
 // Per-chat outbox loop bookkeeping. fs.watch is intentionally NOT used
 // today — Node's watcher behaviour differs across platforms (linux
@@ -126,6 +147,20 @@ export class MultichatRouter {
   // to wait on inbound writes for the same chat — unnecessary
   // latency.
   private readonly dispatchLocks = new Map<string, Promise<void>>()
+  // M7 (2026-05-28): per-chat quote-reply target. On dispatch we record the
+  // triggering message_id (the @mention / reply-to-bot that summoned us in a
+  // public group); deliverClaim consumes it ONCE to thread the first outbound
+  // reply as reply_to_message_id, then deletes it so a later un-prompted
+  // outbox message is not mis-threaded.
+  private readonly pendingReplyTo = new Map<string, string>()
+  // M7: per-chat typing-indicator loop. Presence means "typing is being shown
+  // for this chat". sendChatAction('typing') is re-sent every ~4s (Telegram
+  // clears the status after 5s); stopped when the reply is delivered or after
+  // an idle cap so a session that never replies cannot leave it spinning.
+  private readonly typingTimers = new Map<
+    string,
+    ReturnType<typeof setInterval>
+  >()
   private started = false
 
   constructor(deps: RouterDeps) {
@@ -174,6 +209,12 @@ export class MultichatRouter {
     for (const chatId of Array.from(this.outboxLoops.keys())) {
       this.stopOutboxLoop(chatId)
     }
+    // M7: tear down any live typing-indicator loops so timers don't leak
+    // across stop()/start() cycles (and the process can exit cleanly).
+    for (const chatId of Array.from(this.typingTimers.keys())) {
+      this.stopTypingLoop(chatId)
+    }
+    this.pendingReplyTo.clear()
     this.pool.stopWatchdog()
     // FIX-E M3: clear any lingering dispatch chain heads. The values
     // are promise chains — Node will GC them once their owning
@@ -401,6 +442,18 @@ export class MultichatRouter {
     // 7. Arm outbox poll if missing. Idempotent.
     this.startOutboxLoop(input.chat_id)
 
+    // 8. M7 — group liveness. Only public (group) chats: in a DM the
+    //    in-process StatusManager already drives the typing bubble, and
+    //    reply-to-mention is meaningless. A message only reaches dispatch
+    //    for a public chat if it was addressed (mention / reply-to-bot per
+    //    handlers' gate), so threading the reply to it == reply-on-mention.
+    if (chatPolicy.mode === 'public') {
+      if (input.message_id !== undefined) {
+        this.pendingReplyTo.set(input.chat_id, input.message_id)
+      }
+      this.startTypingLoop(input.chat_id)
+    }
+
     this.logger.debug?.('router.dispatch.ok', {
       chat_id: input.chat_id,
       user_id: input.user_id,
@@ -485,6 +538,54 @@ export class MultichatRouter {
    * id is logged and silently skipped (the chat was already denied at
    * dispatch, so a poll loop here is a programmer error in start()).
    */
+  /**
+   * M7: start (or no-op if already running) the group typing indicator for a
+   * chat. Sends `sendChatAction('typing')` immediately, then every
+   * `TYPING_INTERVAL_MS` until {@link stopTypingLoop} is called (reply
+   * delivered) or `TYPING_MAX_TICKS` is reached (session never replied).
+   * Send errors are swallowed — a failed chat action must never affect
+   * delivery or crash the interval. The timer is `unref`'d so it never keeps
+   * the process alive on its own.
+   */
+  private startTypingLoop(chatId: string): void {
+    if (this.typingTimers.has(chatId)) return
+    const send = (): void => {
+      void Promise.resolve(this.telegramApi.sendChatAction(chatId, 'typing')).catch(
+        (err: unknown) => {
+          this.logger.debug?.('router.typing.send_failed', {
+            chat_id: chatId,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        },
+      )
+    }
+    send()
+    let ticks = 0
+    const timer = setInterval(() => {
+      ticks += 1
+      if (ticks >= TYPING_MAX_TICKS) {
+        this.logger.debug?.('router.typing.capped', { chat_id: chatId })
+        this.stopTypingLoop(chatId)
+        // Codex review [medium]: the session never produced a reply this
+        // turn — drop the stale pending reply target too, so it cannot
+        // mis-thread a much-later un-prompted outbox message.
+        this.pendingReplyTo.delete(chatId)
+        return
+      }
+      send()
+    }, TYPING_INTERVAL_MS)
+    timer.unref?.()
+    this.typingTimers.set(chatId, timer)
+  }
+
+  /** M7: stop the typing indicator for a chat. No-op when none is running. */
+  private stopTypingLoop(chatId: string): void {
+    const timer = this.typingTimers.get(chatId)
+    if (timer === undefined) return
+    clearInterval(timer)
+    this.typingTimers.delete(chatId)
+  }
+
   private startOutboxLoop(chatId: string): void {
     // TASK-5 bug 4 (2026-05-27): assertValidChatId at the outbox-loop
     // entry point. start() iterates `policy.allowlist.chats`, which
@@ -650,7 +751,32 @@ export class MultichatRouter {
           reply_to: message.reply_to,
         })
       }
+    } else {
+      // M7: the session did not set an explicit reply_to. Thread the FIRST
+      // outbound reply to the mention that summoned us (only ever populated
+      // for public chats — see dispatch step 8). Consume it so a follow-up
+      // un-prompted outbox message is not mis-threaded.
+      //
+      // Semantics are per-chat "latest mention" (Codex review 2026-05-28
+      // [high]): if a second addressed message arrives before the first
+      // reply drains, its id overwrites the pending one, so the reply
+      // threads to the most recent question. Precise per-turn threading
+      // would require piping message_id through the tmux session/outbox;
+      // for a quote-reply UX nicety the latest-mention behaviour is the
+      // accepted trade-off. max_queue_depth=1 keeps one turn in flight in
+      // the common case.
+      const pending = this.pendingReplyTo.get(chatId)
+      if (pending !== undefined) {
+        this.pendingReplyTo.delete(chatId)
+        const id = parseMessageId(pending)
+        if (id !== undefined) {
+          opts.reply_to_message_id = id
+        }
+      }
     }
+
+    // M7: a reply is leaving for this chat — the agent is no longer "typing".
+    this.stopTypingLoop(chatId)
     // FIX-F (2026-05-27, Opus router #14): map OutboxMessage.format to
     // the Telegram parse_mode. The Zod schema in inbox-bridge.ts
     // populates `format` with the default 'html' when the writer omits

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -775,10 +775,13 @@ if (
       workspaceDir: multichatWorkspaceDir,
       telegramApi: {
         // Adapt the safe-wrapped API surface to the narrow contract the
-        // router asks for. `sendMessage` is the only method touched on
-        // the outbox path; the router never edits or deletes messages.
+        // router asks for. `sendMessage` carries outbox replies;
+        // `sendChatAction` drives the group typing indicator (M7). The
+        // router never edits or deletes messages.
         sendMessage: (chatId, text, opts) =>
           telegramApi.sendMessage(chatId, text, opts),
+        sendChatAction: (chatId, action) =>
+          telegramApi.sendChatAction(chatId, action),
       },
       logger: log,
     })

--- a/plugin/src/telegram/handlers.ts
+++ b/plugin/src/telegram/handlers.ts
@@ -502,6 +502,9 @@ async function gateAndNotify(
       timestamp: new Date().toISOString(),
       ...(replyContext !== undefined ? { reply_context: replyContext } : {}),
       ...(mediaPaths.length > 0 ? { media_paths: mediaPaths } : {}),
+      ...(ctx.message?.message_id !== undefined
+        ? { message_id: String(ctx.message.message_id) }
+        : {}),
     }
 
     deps.log.info('inbound dispatched to router', { kind, chat_id: decision.chatId })
@@ -926,6 +929,11 @@ export async function sendAlbumNotification(
     const replyContext = reply
       ? buildChannelContent({ text: '', bot: deps.bot, reply })
       : undefined
+    // First available message_id in the album — Telegram attaches the
+    // @mention to one fragment; any fragment's id anchors the quote-reply.
+    const albumMessageId = album.messages.find(
+      (m) => m.messageId !== undefined,
+    )?.messageId
     const inboundMsg: InboundMessage = {
       text: mergedText,
       chat_id: ids.chatId,
@@ -934,6 +942,7 @@ export async function sendAlbumNotification(
       timestamp: new Date().toISOString(),
       ...(replyContext !== undefined ? { reply_context: replyContext } : {}),
       ...(combinedMediaPaths.length > 0 ? { media_paths: combinedMediaPaths } : {}),
+      ...(albumMessageId !== undefined ? { message_id: String(albumMessageId) } : {}),
     }
     deps.log.info('album dispatched to router', {
       kind: ids.kind,

--- a/plugin/tests/router/fix-e.test.ts
+++ b/plugin/tests/router/fix-e.test.ts
@@ -530,6 +530,7 @@ describe('FIX-E M3 — dispatch concurrent + max_queue_depth', () => {
         ({ ok: true, result: { message_id: 1 } }) as unknown as Awaited<
           ReturnType<MultichatTelegramApi['sendMessage']>
         >,
+      sendChatAction: async () => {},
     }
   }
 

--- a/plugin/tests/router/fix-f.test.ts
+++ b/plugin/tests/router/fix-f.test.ts
@@ -174,6 +174,7 @@ function spyTelegramApi(): {
         ReturnType<MultichatTelegramApi['sendMessage']>
       >
     },
+    sendChatAction: async () => {},
   }
   return { api, calls }
 }

--- a/plugin/tests/router/m7-typing-reply.test.ts
+++ b/plugin/tests/router/m7-typing-reply.test.ts
@@ -1,0 +1,286 @@
+// M7 tests (2026-05-28) — group typing indicator + reply-on-mention.
+//
+// Feature: in PUBLIC (group) chats the router
+//   1. threads the FIRST outbound reply of a turn as a quote-reply to the
+//      message that summoned the bot (reply_to_message_id), consuming the
+//      stored id once; and
+//   2. shows a `sendChatAction('typing')` indicator from dispatch until the
+//      reply is delivered.
+// Neither applies to PRIVATE (DM) chats — there the in-process StatusManager
+// already drives the typing bubble and reply-to-mention is meaningless.
+//
+// Covered:
+//   * public dispatch with message_id → outbox send carries reply_to_message_id
+//   * the stored reply target is consumed ONCE (second outbox reply has none)
+//   * an explicit OutboxMessage.reply_to is preserved (not overwritten)
+//   * private chat → no reply_to_message_id and no typing
+//   * public dispatch → at least one sendChatAction('typing') is sent
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { Logger } from '../../src/log.js'
+import type { ChatPolicy, MultichatPolicy } from '../../src/chats/policy-loader.js'
+import {
+  MultichatRouter,
+  type MultichatTelegramApi,
+} from '../../src/router/multichat-router.js'
+import type {
+  SessionHandle,
+  TmuxSessionPool,
+} from '../../src/router/tmux-session-pool.js'
+import type { InboundMessage } from '../../src/router/inbox-bridge.js'
+
+const GROUP = '-1001234567890'
+const USER = '164795011'
+
+function silentLogger(): Logger {
+  const noop = (): void => {}
+  return { debug: noop, info: noop, warn: noop, error: noop } as unknown as Logger
+}
+
+function makeChatPolicy(overrides: Partial<ChatPolicy> = {}): ChatPolicy {
+  return {
+    mode: 'private',
+    streaming: 'progress',
+    tmux_mirror: false,
+    edit_message_progress: false,
+    delivery: 'streamed',
+    persona_file: 'persona.md',
+    handoff_file: 'handoff.md',
+    system_reminder: '',
+    idle_ttl_ms: 1_800_000,
+    max_queue_depth: 1,
+    ...overrides,
+  }
+}
+
+function makePolicy(chats: Record<string, ChatPolicy>): MultichatPolicy {
+  return {
+    version: 1,
+    allowlist: { chats: Object.keys(chats), users: [USER] },
+    mention_allowlist: [USER],
+    chats,
+  }
+}
+
+class FakePool {
+  async loadSessions(): Promise<void> {}
+  startWatchdog(): void {}
+  stopWatchdog(): void {}
+  async getOrSpawn(chatId: string): Promise<SessionHandle> {
+    return {
+      chatId,
+      sessionName: `claude-${chatId}`,
+      spawnedAt: Date.now(),
+      lastMessageAt: Date.now(),
+    }
+  }
+  touch(): void {}
+  async kill(): Promise<void> {}
+}
+
+function spy(): {
+  api: MultichatTelegramApi
+  sends: Array<{ chatId: string; text: string; opts: Record<string, unknown> }>
+  actions: Array<{ chatId: string; action: string }>
+} {
+  const sends: Array<{ chatId: string; text: string; opts: Record<string, unknown> }> = []
+  const actions: Array<{ chatId: string; action: string }> = []
+  const api: MultichatTelegramApi = {
+    sendMessage: async (chatId, text, opts) => {
+      sends.push({ chatId, text, opts: opts as Record<string, unknown> })
+      return { ok: true, result: { message_id: sends.length } } as unknown as Awaited<
+        ReturnType<MultichatTelegramApi['sendMessage']>
+      >
+    },
+    sendChatAction: async (chatId, action) => {
+      actions.push({ chatId, action: action as unknown as string })
+    },
+  }
+  return { api, sends, actions }
+}
+
+function inbound(overrides: Partial<InboundMessage> = {}): InboundMessage {
+  return {
+    text: 'привет',
+    chat_id: GROUP,
+    user_id: USER,
+    user: 'dashieshiev',
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+async function seedOutbox(
+  stateDir: string,
+  chatId: string,
+  filename: string,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const outboxDir = join(stateDir, 'chats', chatId, 'outbox')
+  await mkdir(join(outboxDir, 'processing'), { recursive: true })
+  await mkdir(join(outboxDir, 'dead-letter'), { recursive: true })
+  await writeFile(join(outboxDir, filename), JSON.stringify(payload))
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+interface Fx {
+  tmpDir: string
+  stateDir: string
+  telegram: ReturnType<typeof spy>
+}
+
+let fx: Fx
+
+beforeEach(() => {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'm7-test-'))
+  fx = { tmpDir, stateDir: join(tmpDir, 'state'), telegram: spy() }
+})
+afterEach(() => {
+  try {
+    rmSync(fx.tmpDir, { recursive: true, force: true })
+  } catch {
+    /* best effort */
+  }
+})
+
+function makeRouter(policy: MultichatPolicy): MultichatRouter {
+  return new MultichatRouter({
+    policy,
+    pool: new FakePool() as unknown as TmuxSessionPool,
+    stateDir: fx.stateDir,
+    workspaceDir: join(fx.tmpDir, 'workspace'),
+    telegramApi: fx.telegram.api,
+    logger: silentLogger(),
+  })
+}
+
+describe('M7 — reply-on-mention (public chats)', () => {
+  test('public dispatch with message_id → outbox reply carries reply_to_message_id', async () => {
+    const router = makeRouter(makePolicy({ [GROUP]: makeChatPolicy({ mode: 'public' }) }))
+    await router.start()
+    await router.dispatch(inbound({ message_id: '555' }))
+    await seedOutbox(fx.stateDir, GROUP, `${Date.now()}-aaaa.json`, {
+      text: 'ответ',
+      chat_id: GROUP,
+      timestamp: '2026-05-28T00:00:00Z',
+      format: 'text',
+    })
+    await sleep(600)
+    await router.stop()
+
+    expect(fx.telegram.sends.length).toBe(1)
+    expect(fx.telegram.sends[0]?.opts.reply_to_message_id).toBe(555)
+  }, 5_000)
+
+  test('the stored reply target is consumed ONCE (second reply has none)', async () => {
+    const router = makeRouter(makePolicy({ [GROUP]: makeChatPolicy({ mode: 'public' }) }))
+    await router.start()
+    await router.dispatch(inbound({ message_id: '555' }))
+    await seedOutbox(fx.stateDir, GROUP, `1000000000000-aaaa.json`, {
+      text: 'первый', chat_id: GROUP, timestamp: '2026-05-28T00:00:00Z', format: 'text',
+    })
+    await seedOutbox(fx.stateDir, GROUP, `1000000000001-bbbb.json`, {
+      text: 'второй', chat_id: GROUP, timestamp: '2026-05-28T00:00:01Z', format: 'text',
+    })
+    await sleep(900)
+    await router.stop()
+
+    expect(fx.telegram.sends.length).toBe(2)
+    const byText = Object.fromEntries(fx.telegram.sends.map((s) => [s.text, s.opts]))
+    expect(byText['первый']?.reply_to_message_id).toBe(555)
+    expect('reply_to_message_id' in (byText['второй'] ?? {})).toBe(false)
+  }, 5_000)
+
+  test('an explicit OutboxMessage.reply_to is preserved, not overwritten', async () => {
+    const router = makeRouter(makePolicy({ [GROUP]: makeChatPolicy({ mode: 'public' }) }))
+    await router.start()
+    await router.dispatch(inbound({ message_id: '555' }))
+    await seedOutbox(fx.stateDir, GROUP, `${Date.now()}-cccc.json`, {
+      text: 'ответ',
+      chat_id: GROUP,
+      reply_to: '999',
+      timestamp: '2026-05-28T00:00:00Z',
+      format: 'text',
+    })
+    await sleep(600)
+    await router.stop()
+
+    expect(fx.telegram.sends[0]?.opts.reply_to_message_id).toBe(999)
+  }, 5_000)
+
+  test('a non-numeric message_id is rejected (no reply_to)', async () => {
+    const router = makeRouter(makePolicy({ [GROUP]: makeChatPolicy({ mode: 'public' }) }))
+    await router.start()
+    await router.dispatch(inbound({ message_id: '123abc' }))
+    await seedOutbox(fx.stateDir, GROUP, `${Date.now()}-eeee.json`, {
+      text: 'ответ',
+      chat_id: GROUP,
+      timestamp: '2026-05-28T00:00:00Z',
+      format: 'text',
+    })
+    await sleep(600)
+    await router.stop()
+
+    expect(fx.telegram.sends.length).toBe(1)
+    expect('reply_to_message_id' in fx.telegram.sends[0]!.opts).toBe(false)
+  }, 5_000)
+
+  test('private chat → no reply_to_message_id', async () => {
+    const router = makeRouter(makePolicy({ [USER]: makeChatPolicy({ mode: 'private' }) }))
+    await router.start()
+    await router.dispatch(inbound({ chat_id: USER, message_id: '555' }))
+    await seedOutbox(fx.stateDir, USER, `${Date.now()}-dddd.json`, {
+      text: 'ответ',
+      chat_id: USER,
+      timestamp: '2026-05-28T00:00:00Z',
+      format: 'text',
+    })
+    await sleep(600)
+    await router.stop()
+
+    expect(fx.telegram.sends.length).toBe(1)
+    expect('reply_to_message_id' in fx.telegram.sends[0]!.opts).toBe(false)
+  }, 5_000)
+})
+
+describe('M7 — typing indicator', () => {
+  test('public dispatch sends sendChatAction("typing")', async () => {
+    const router = makeRouter(makePolicy({ [GROUP]: makeChatPolicy({ mode: 'public' }) }))
+    await router.start()
+    await router.dispatch(inbound({ message_id: '555' }))
+    await sleep(50)
+    await router.stop()
+
+    const typing = fx.telegram.actions.filter(
+      (a) => a.chatId === GROUP && a.action === 'typing',
+    )
+    expect(typing.length).toBeGreaterThanOrEqual(1)
+  }, 5_000)
+
+  test('private dispatch sends NO typing action', async () => {
+    const router = makeRouter(makePolicy({ [USER]: makeChatPolicy({ mode: 'private' }) }))
+    await router.start()
+    await router.dispatch(inbound({ chat_id: USER, message_id: '555' }))
+    await sleep(50)
+    await router.stop()
+
+    expect(fx.telegram.actions.length).toBe(0)
+  }, 5_000)
+
+  test('stop() clears the typing loop (no actions after stop)', async () => {
+    const router = makeRouter(makePolicy({ [GROUP]: makeChatPolicy({ mode: 'public' }) }))
+    await router.start()
+    await router.dispatch(inbound({ message_id: '555' }))
+    await sleep(50)
+    await router.stop()
+    const countAfterStop = fx.telegram.actions.length
+    await sleep(300)
+    expect(fx.telegram.actions.length).toBe(countAfterStop)
+  }, 5_000)
+})

--- a/plugin/tests/router/multichat-router.gate.test.ts
+++ b/plugin/tests/router/multichat-router.gate.test.ts
@@ -167,6 +167,7 @@ function spyTelegramApi(): {
         ReturnType<MultichatTelegramApi['sendMessage']>
       >
     },
+    sendChatAction: async () => {},
   }
   return {
     api,


### PR DESCRIPTION
## Что (M7)

Делает поведение бота в групповых чатах живее и адреснее (запрос вождя из чата интенсива):

1. **Typing-индикатор** — в публичных (групповых) чатах router шлёт `sendChatAction('typing')` от момента dispatch до доставки ответа (немедленно + каждые 4с, Telegram сбрасывает статус через 5с). Cap 30 тиков (~2 мин) на случай, если сессия не ответит.
2. **Reply-on-mention** — первый исходящий ответ турна привязывается через `reply_to_message_id` к сообщению, которое вызвало бота (@mention / reply-to-bot). Сообщение доходит до dispatch в группе только если прошло addressing-гейт, поэтому это и есть reply-on-mention.

В личных DM не применяется — там `StatusManager` уже ведёт typing-bubble.

## Как
- `InboundMessage.message_id` (опц.) — handlers заполняют из `ctx.message.message_id` (альбом — id первого фрагмента).
- Router: `pendingReplyTo: Map<chatId,string>` ставится в dispatch (только public + есть message_id), потребляется ОДИН раз в `deliverClaim`; явный `OutboxMessage.reply_to` не перетирается.
- `startTypingLoop/stopTypingLoop`, `unref`'нутый таймер; `stop()` сносит все таймеры + `pendingReplyTo`.

## Double review (Opus + Codex GPT-5.5)
- **[low]** строгая валидация message_id — `parseMessageId`: только цифры + `Number.isSafeInteger`.
- **[medium]** при cap typing-лупа чистим stale `pendingReplyTo` (не мис-тредит поздний un-prompted ответ).
- **[high]** семантика per-chat «последний mention» (если два mention пришли до первого ответа, тредится к последнему) — задокументирована как осознанный trade-off. Точный per-turn threading потребовал бы проброса id через tmux-сессию/outbox; для UX-нички reply это приемлемо, `max_queue_depth=1` держит один турн в полёте в обычном случае.

## Тесты
- `tests/router/m7-typing-reply.test.ts` — 8/0 (reply_to threading, consume-once, explicit-preserved, private-excluded, строгий message_id, typing fired/not-fired, stop() без утечки)
- router suite 66/0, полный suite **1127/0**, typecheck 0

## Деплой
Router — plugin-side, вступит в силу при рестарте плагина (через Сильвану, в связке с M5a hook + STOP_OUTBOX_DEBUG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)