### PR TITLE
fix(channel): детерминистская реакция-прочтение 👀 (eyes-on-read)

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -42,6 +42,42 @@ bash plugin/scripts/install-hooks.sh \
 
 Идемпотентно. Marker-based replacement — повторный запуск не дублирует записи. Чистит legacy markerless entries указывающие на наш `post-hook.ts`.
 
+## Read receipts (реакция 👀)
+
+**Зачем.** Реакция `👀` на входящем сообщении — это сигнал «агент это **прочитал**». Главная её ценность в том, что вождь видит, какие сообщения уже дошли до агента и обработаны, а какие ещё нет — особенно для голосовых, файлов и фото, где иначе непонятно, «увидел» ли их агент вообще. Поэтому момент постановки реакции критичен: `👀` должна означать «прочитано агентом», а не «бот принял апдейт».
+
+**Как это работает (детерминистски).** Реакция ставится НЕ в момент приёма апдейта ботом. Если так делать, при занятой сессии сообщение стоит в очереди, а глаза уже горят — сигнал врёт. Вместо этого:
+
+1. Сообщение доходит до сессии Claude (через MCP-нотификацию в личке вождя или через per-chat сессию в мультичате) и попадает в её ход как блок `<channel source="telegram" ... chat_id="X" message_id="Y">`.
+2. По событию `Stop` (конец хода) хук `scripts/read-receipt-hook.ts` читает транскрипт сессии, находит telegram-блоки, которые ход реально прочитал, и POST'ит их в роут плагина `POST /hooks/react`.
+3. Роут (loopback + bearer + chat-allowlist) ставит `👀` единственным ботом.
+
+Так `👀` = «прочитано агентом» одинаково для текста, голоса, фото — и в личке, и в мультичате (каждая per-chat сессия гоняет тот же Stop-хук против своего транскрипта). Хук берёт сообщения именно текущего хода (идёт по транскрипту с конца, пропуская хвост из ответа+тулов — длинный ход с кучей tool-вызовов не «теряет» входящее). Пер-сессионный дедуп-лог (`<state>/read-receipts/<session_id>.log`) гарантирует ровно одну реакцию на сообщение и исключает гонку между параллельными сессиями.
+
+**Почему через env-файл (важно для мультичата).** Per-chat сессии стартуют под `env -i` со строгим allowlist (`src/router/tmux-session-pool.ts`), который вырезает ВСЕ `TELEGRAM_*`. Поэтому хук НЕ читает webhook-конфиг из `process.env` — он берёт `TELEGRAM_WEBHOOK_PORT/HOST/TOKEN` и `TELEGRAM_STATE_DIR` (для дедуп-лога) из env-файла, путь до которого вписан прямо в команду хука (shell-присваивание перед `bun` переживает `env -i`). Токен в `settings.json` НЕ пишется — только путь до файла. В per-chat сессии дедуп дополнительно умеет падать на `MULTICHAT_STATE_DIR` (он в allowlist).
+
+**Регистрация хука** (в дополнение к `install-hooks.sh` выше) — добавь в `Stop` своего `settings.json` команду с путём до env-файла плагина:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "marker": "dashi-channel-read-receipt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "TELEGRAM_CHANNEL_ENV_FILE='/abs/path/to/channel.env' bun '/abs/path/to/plugin/scripts/read-receipt-hook.ts'"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Хук всегда exit 0 и не пишет в stdout — read receipt никогда не блокирует и не загрязняет контекст модели. Если роут недоступен (или реакция не вписана в деплой) — хук тихо ничего не делает.
+
 ## Environment variables
 
 Полный список — `plugin/src/config.ts` (`RuntimeEnvSchema`). Минимум:
@@ -55,6 +91,9 @@ bash plugin/scripts/install-hooks.sh \
 | `TELEGRAM_ALLOWED_USER_IDS` | CSV — кто имеет право писать боту (legacy DM-режим). |
 | `TELEGRAM_WORKSPACE_ROOT` | Корень agent workspace (где CLAUDE.md). |
 | `TELEGRAM_WEBHOOK_HOST` / `TELEGRAM_WEBHOOK_PORT` / `TELEGRAM_WEBHOOK_TOKEN` | Bind для webhook-сервера хуков. |
+| `TELEGRAM_CHANNEL_ENV_FILE` | Путь до env-файла плагина — read-receipt хук (`Stop`) берёт из него `WEBHOOK_PORT/HOST/TOKEN`, чтобы ставить `👀` даже из per-chat сессии с очищенным env. См. секцию «Read receipts». |
+| `TELEGRAM_READ_RECEIPT_URL` | Явный URL роута `/hooks/react` (альтернатива выводу из `HOST`+`PORT`). |
+| `TELEGRAM_READ_RECEIPT_STATE` | Явный путь до дедуп-лога (single-writer). По умолчанию — пер-сессионный `<state>/read-receipts/<session_id>.log` в `TELEGRAM_STATE_DIR` (или `MULTICHAT_STATE_DIR`). |
 | `TELEGRAM_MEMORY_*` | Memory hook config (см. секцию ниже). |
 | `TELEGRAM_MULTICHAT_*` | Multichat router config (см. секцию ниже). |
 | `GROQ_API_KEY` | Whisper transcription для голосовых (опционально). |

--- a/plugin/scripts/read-receipt-hook.ts
+++ b/plugin/scripts/read-receipt-hook.ts
@@ -1,0 +1,386 @@
+#!/usr/bin/env bun
+// read-receipt-hook.ts — Claude Code Stop hook → deterministic 👀 receipt.
+//
+// fix/eyes-on-read (2026-05-28). The 👀 reaction used to be set the instant
+// the bot RECEIVED a Telegram update (src/telegram/handlers.ts). That made
+// the eyes mean "the bot saw it", not "the agent read it" — if the session
+// was busy, the message queued while the eyes already showed, so the signal
+// lied. This hook moves the receipt to the truthful moment: it runs on the
+// Stop event (once per turn the agent completes), scans the session
+// transcript for the inbound `<channel source="telegram" ...>` block(s) the
+// turn actually read, and posts them to the plugin's `/hooks/react` route so
+// the single bot sets 👀. Because EVERY session (the warchief DM + each
+// per-chat multichat session) runs the same Stop hook against its own
+// transcript, the receipt works uniformly across the DM and group chats.
+//
+// Hard invariants (mirrors post-hook.ts):
+//   * Exit code 0 in ALL paths. A non-zero hook blocks the model; a read
+//     receipt must never gate the agent.
+//   * Stdout stays EMPTY. Stop-hook stdout is treated as model context.
+//   * Stderr lines are short and secret-free (no token, no transcript body).
+//
+// Configuration (env), in priority order:
+//   TELEGRAM_READ_RECEIPT_URL    full route URL, e.g. http://127.0.0.1:8089/hooks/react
+//   TELEGRAM_WEBHOOK_TOKEN       bearer token for the route
+//   — or, when those are absent —
+//   TELEGRAM_CHANNEL_ENV_FILE    path to the plugin env file; HOST/PORT/TOKEN
+//                                are read from it so per-chat sessions with a
+//                                sanitised env still resolve the route.
+//   TELEGRAM_STATE_DIR           dir for the dedup log (default: cwd-less → skip persist)
+//   TELEGRAM_READ_RECEIPT_STATE  explicit dedup-log path (overrides STATE_DIR)
+
+import { readFileSync, appendFileSync, writeFileSync, mkdirSync } from 'fs'
+import { dirname, join } from 'path'
+
+// ─────────────────────────────────────────────────────────────────────
+// Channel-block parsing. Tolerant of BOTH the JSON-escaped form found in a
+// transcript line (`message_id=\"28045\"`) and the raw form. Only telegram
+// blocks are matched — orgrimmar-inbox events carry no Telegram message_id.
+// ─────────────────────────────────────────────────────────────────────
+
+export interface ReadReceiptRef {
+  readonly chat_id: string
+  readonly message_id: number
+}
+
+export function refKey(ref: ReadReceiptRef): string {
+  return `${ref.chat_id}:${ref.message_id}`
+}
+
+const CHANNEL_TAG_RE = /<channel\b([^>]*)>/g
+
+/** Extract telegram (chat_id, message_id) pairs from one chunk of text. */
+export function parseChannelRefs(text: string): ReadReceiptRef[] {
+  const refs: ReadReceiptRef[] = []
+  CHANNEL_TAG_RE.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = CHANNEL_TAG_RE.exec(text)) !== null) {
+    const attrs = match[1] ?? ''
+    // Only Telegram blocks get a read receipt. The inbound format carries
+    // both `source="dashi-channel"` and `source="telegram"`, so a substring
+    // test is enough.
+    if (!/source\s*=\s*\\?"telegram\\?"/.test(attrs)) continue
+    // chat_id is negative for groups/supergroups (multichat), so allow `-`.
+    const chat = attrs.match(/chat_id\s*=\s*\\?"(-?\d+)\\?"/)
+    const msg = attrs.match(/message_id\s*=\s*\\?"(\d+)\\?"/)
+    if (!chat || !msg) continue
+    const messageId = Number(msg[1])
+    if (!Number.isInteger(messageId) || messageId <= 0) continue
+    refs.push({ chat_id: chat[1] as string, message_id: messageId })
+  }
+  return refs
+}
+
+/**
+ * Extract the telegram refs of the CURRENT turn's inbound message(s).
+ *
+ * We must NOT use a fixed line-count tail: a tool-heavy turn writes many
+ * assistant/tool lines AFTER the inbound `<channel>` line, which would push
+ * it out of any fixed window and the receipt would never fire (Codex HIGH).
+ * Instead we walk the transcript backward and:
+ *   - skip trailing lines that carry no telegram block (the turn's assistant
+ *     reply + tool I/O), then
+ *   - collect the CONTIGUOUS run of telegram-bearing lines (a batched
+ *     multi-message turn), stopping at the first non-telegram line above it.
+ *
+ * This finds exactly the inbound block of the most recent turn regardless of
+ * how much tool output followed it, and never replays the whole history
+ * (only the latest turn). The per-session dedup log then guarantees one
+ * receipt per message across repeated Stop events. Returns refs in
+ * transcript (top-to-bottom) order.
+ */
+export function extractCurrentTurnRefs(transcript: string): ReadReceiptRef[] {
+  const lines = transcript.split('\n').filter((l) => l.trim().length > 0)
+  const seen = new Set<string>()
+  const collected: ReadReceiptRef[] = []
+  let started = false
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const refs = parseChannelRefs(lines[i] as string)
+    if (refs.length === 0) {
+      if (started) break // passed above the contiguous inbound block
+      continue // still in the trailing assistant/tool output
+    }
+    started = true
+    for (const ref of refs) {
+      const key = refKey(ref)
+      if (seen.has(key)) continue
+      seen.add(key)
+      collected.push(ref)
+    }
+  }
+  return collected.reverse()
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Route config resolution.
+// ─────────────────────────────────────────────────────────────────────
+
+export interface ReactConfig {
+  readonly url: string
+  readonly token: string
+}
+export interface ReactConfigError {
+  readonly kind: 'error'
+  readonly reason: string
+}
+export type ReactConfigResult = ReactConfig | ReactConfigError
+
+/** Minimal KEY=VALUE env-file parser (no shell expansion, strips quotes). */
+export function parseEnvFile(content: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+    const eq = line.indexOf('=')
+    if (eq <= 0) continue
+    const key = line.slice(0, eq).trim()
+    let value = line.slice(eq + 1).trim()
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+    out[key] = value
+  }
+  return out
+}
+
+/**
+ * Load the plugin env file named by TELEGRAM_CHANNEL_ENV_FILE, if any.
+ * Returns {} when no path is set; throws nothing — an unreadable file just
+ * yields {} so the caller degrades to whatever is in the process env.
+ *
+ * This is the linchpin for multichat: per-chat sessions are spawned with
+ * `env -i` + a strict allowlist (src/router/tmux-session-pool.ts) that wipes
+ * EVERY `TELEGRAM_*` var, so the hook's process.env carries none of the
+ * webhook config. The env-file PATH is injected inline in the Stop-hook
+ * command string (a shell assignment prefix survives `env -i`), and the
+ * secret webhook token + port are read from the file here — never from the
+ * sanitised process env.
+ */
+export function loadChannelEnvFile(
+  env: Readonly<Record<string, string | undefined>>,
+  readFile: (path: string) => string = (p) => readFileSync(p, 'utf8'),
+): Record<string, string> {
+  const path = env.TELEGRAM_CHANNEL_ENV_FILE
+  if (!path) return {}
+  try {
+    return parseEnvFile(readFile(path))
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Resolve the /hooks/react route URL + bearer token from an ALREADY-MERGED
+ * env (process env overlaid on the env-file vars — see main()). Pure: no I/O.
+ */
+export function resolveReactConfig(
+  env: Readonly<Record<string, string | undefined>>,
+): ReactConfigResult {
+  const token = env.TELEGRAM_WEBHOOK_TOKEN
+  if (!token) return { kind: 'error', reason: 'missing TELEGRAM_WEBHOOK_TOKEN' }
+
+  if (env.TELEGRAM_READ_RECEIPT_URL) return { url: env.TELEGRAM_READ_RECEIPT_URL, token }
+
+  const host = env.TELEGRAM_WEBHOOK_HOST ?? '127.0.0.1'
+  const port = env.TELEGRAM_WEBHOOK_PORT
+  if (!port) return { kind: 'error', reason: 'missing TELEGRAM_WEBHOOK_PORT' }
+  return { url: `http://${host}:${port}/hooks/react`, token }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Dedup log. One `chat_id:message_id` per line. We re-read it each run
+// (Set) and append only the keys we successfully handled, capping the file
+// so it can't grow unbounded over a long-lived session.
+// ─────────────────────────────────────────────────────────────────────
+
+const STATE_CAP_LINES = 5000
+
+/** Filename-safe form of a session id (defends against odd ids in a path). */
+function safeSessionId(sessionId: string): string {
+  const cleaned = sessionId.replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 128)
+  return cleaned.length > 0 ? cleaned : 'session'
+}
+
+/**
+ * Per-SESSION dedup-log path. Keyed by session id so each session (the DM and
+ * every per-chat multichat session) writes ONLY its own file — no shared file,
+ * hence no cross-session append/trim race. An explicit
+ * TELEGRAM_READ_RECEIPT_STATE overrides with a literal path (tests / single
+ * writer). Base dir falls back through TELEGRAM_STATE_DIR →
+ * MULTICHAT_STATE_DIR (the latter survives the per-chat `env -i` allowlist).
+ */
+export function resolveStatePath(
+  env: Readonly<Record<string, string | undefined>>,
+  sessionId?: string,
+): string | undefined {
+  if (env.TELEGRAM_READ_RECEIPT_STATE) return env.TELEGRAM_READ_RECEIPT_STATE
+  const base = env.TELEGRAM_STATE_DIR ?? env.MULTICHAT_STATE_DIR
+  if (!base) return undefined
+  const file = sessionId ? `${safeSessionId(sessionId)}.log` : 'read-receipts.log'
+  return join(base, 'read-receipts', file)
+}
+
+export function loadSeen(path: string, readFile: (p: string) => string = (p) => readFileSync(p, 'utf8')): Set<string> {
+  try {
+    const content = readFile(path)
+    return new Set(content.split('\n').map((l) => l.trim()).filter(Boolean))
+  } catch {
+    // Missing file on first run is expected.
+    return new Set<string>()
+  }
+}
+
+function persistSeen(path: string, existing: Set<string>, added: string[]): void {
+  if (added.length === 0) return
+  try {
+    mkdirSync(dirname(path), { recursive: true })
+    const combined = [...existing, ...added]
+    // Cap: keep the most recent entries. Re-reacting an evicted-then-seen
+    // message is harmless (Telegram is idempotent for an unchanged reaction).
+    if (combined.length <= STATE_CAP_LINES) {
+      appendFileSync(path, added.map((k) => `${k}\n`).join(''), { mode: 0o600 })
+    } else {
+      // Rewrite (not append) when trimming so the file stays bounded.
+      const trimmed = combined.slice(combined.length - STATE_CAP_LINES)
+      writeFileSync(path, trimmed.map((k) => `${k}\n`).join(''), { mode: 0o600 })
+    }
+  } catch {
+    /* persistence is best-effort; a re-react next turn is harmless */
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// HTTP + stdin plumbing (mirrors post-hook.ts).
+// ─────────────────────────────────────────────────────────────────────
+
+interface BunGlobal {
+  readonly stdin?: { readonly text?: () => Promise<string> }
+}
+
+async function readStdin(): Promise<string> {
+  try {
+    const bun = (globalThis as { Bun?: BunGlobal }).Bun
+    const fn = bun?.stdin?.text
+    if (typeof fn === 'function') return await fn.call(bun?.stdin)
+  } catch {
+    /* fall through */
+  }
+  return await new Promise<string>((resolve) => {
+    const chunks: Buffer[] = []
+    process.stdin.on('data', (chunk: Buffer) => chunks.push(chunk))
+    process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')))
+    process.stdin.on('error', () => resolve(''))
+  })
+}
+
+function warn(reason: string): void {
+  const safe = reason.length > 80 ? `${reason.slice(0, 77)}...` : reason
+  process.stderr.write(`read-receipt-hook: ${safe}\n`)
+}
+
+const FETCH_TIMEOUT_MS = 5000
+
+/** POST one receipt. Returns true when the route handled it (200 family). */
+async function postReceipt(config: ReactConfig, ref: ReadReceiptRef): Promise<boolean> {
+  try {
+    const response = await fetch(config.url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${config.token}`,
+      },
+      body: JSON.stringify({ chat_id: ref.chat_id, message_id: ref.message_id }),
+      // Bound the wait: the route awaits a rate-limited setMessageReaction
+      // whose 429 backoff can otherwise hold the connection open for minutes,
+      // and a Stop hook must not linger and delay session teardown.
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    })
+    // The route returns 200 for both a successful reaction AND a terminal
+    // Telegram failure (e.g. 429/400 after retries → {status:'react_failed'}):
+    // both are recorded as handled so we don't retry-storm a message that
+    // can't be reacted to. A 4xx/5xx (auth, route down) or a network/timeout
+    // error returns false → left unrecorded so the next turn retries.
+    return response.ok
+  } catch {
+    // AbortError (timeout) or network failure — retry on a later turn.
+    return false
+  }
+}
+
+async function main(): Promise<void> {
+  let raw = ''
+  try {
+    raw = await readStdin()
+  } catch {
+    warn('stdin read failed')
+    return
+  }
+  if (raw.trim().length === 0) return
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    warn('stdin not valid JSON')
+    return
+  }
+  if (typeof parsed !== 'object' || parsed === null) return
+  const fields = parsed as Record<string, unknown>
+  const transcriptPath = fields.transcript_path
+  if (typeof transcriptPath !== 'string' || transcriptPath.length === 0) return
+  const sessionId = typeof fields.session_id === 'string' ? fields.session_id : undefined
+
+  let transcript = ''
+  try {
+    transcript = readFileSync(transcriptPath, 'utf8')
+  } catch {
+    // No transcript yet (e.g. a SessionStart Stop with nothing read).
+    return
+  }
+
+  const refs = extractCurrentTurnRefs(transcript)
+  if (refs.length === 0) return
+
+  // Merge the env file UNDER the process env: a per-chat session's sanitised
+  // process.env carries no TELEGRAM_* (so the file supplies token/port/state),
+  // while the main session's real env wins where both define a key.
+  const fileVars = loadChannelEnvFile(process.env)
+  const env: Record<string, string | undefined> = { ...fileVars, ...process.env }
+
+  const config = resolveReactConfig(env)
+  if ('kind' in config && config.kind === 'error') {
+    warn(config.reason)
+    return
+  }
+
+  const statePath = resolveStatePath(env, sessionId)
+  const seen = statePath ? loadSeen(statePath) : new Set<string>()
+  const fresh = refs.filter((r) => !seen.has(refKey(r)))
+  if (fresh.length === 0) return
+
+  const handled: string[] = []
+  for (const ref of fresh) {
+    const ok = await postReceipt(config as ReactConfig, ref)
+    if (ok) handled.push(refKey(ref))
+  }
+
+  if (statePath && handled.length > 0) persistSeen(statePath, seen, handled)
+}
+
+const isMainModule = (() => {
+  try {
+    const arg = process.argv[1] ?? ''
+    return arg.endsWith('read-receipt-hook.ts') || arg.endsWith('read-receipt-hook.js')
+  } catch {
+    return false
+  }
+})()
+
+if (isMainModule) {
+  await main().catch((err) => {
+    warn(err instanceof Error ? err.message : 'unknown error')
+  })
+}

--- a/plugin/src/schemas.ts
+++ b/plugin/src/schemas.ts
@@ -34,6 +34,20 @@ export const ReactArgsSchema = z.object({
 })
 export type ReactArgs = z.infer<typeof ReactArgsSchema>
 
+// Webhook route body - POST /hooks/react (read-receipt hook → plugin).
+// The read-receipt Stop hook posts here once per inbound message it has
+// actually read in a turn, so `👀` deterministically means "the agent read
+// this through the plugin" rather than "the bot received it". message_id is
+// coerced from a numeric string because hook payloads carry it as text.
+// emoji defaults to 👀 so the common read-receipt call body is just
+// {chat_id, message_id}.
+export const ReactRouteRequestSchema = z.object({
+  chat_id: z.string().min(1),
+  message_id: z.coerce.number().int().positive(),
+  emoji: z.string().min(1).default('👀'),
+})
+export type ReactRouteRequest = z.infer<typeof ReactRouteRequestSchema>
+
 // Tool args - download_attachment. chat_id is required so the tool can
 // gate the download through the chat allowlist — without it, Claude could
 // be tricked into fetching an arbitrary file_id (e.g. one leaked into a

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -982,6 +982,11 @@ try {
     // at runtime via env without a restart.
     askRelay: askUserQuestionRelay,
     askUi: askUserQuestionUi,
+    // fix/eyes-on-read (2026-05-28): read-receipt route capability. Uses
+    // the same safe-wrapped, rate-limited telegramApi every other outbound
+    // call goes through, so 👀 reactions share the per-chat rate budget.
+    reactToMessage: (chatId, messageId, emoji) =>
+      telegramApi.setMessageReaction(chatId, messageId, emoji),
   })
 } catch (err) {
   log.error('webhook server failed to start', {

--- a/plugin/src/telegram/handlers.ts
+++ b/plugin/src/telegram/handlers.ts
@@ -1003,31 +1003,15 @@ export async function sendAlbumNotification(
 export async function handleInboundText(ctx: Context, deps: HandlerDeps): Promise<void> {
   const text = ctx.message?.text ?? ''
 
-  // Auto-react 👀 on inbound — prince visibility signal, replaces typing indicator.
-  // ONLY for messages that pass BOTH the allowlist gate AND the addressing
-  // check (DM, @mention from a mention_allowlist sender, or reply to bot).
-  //
-  // Bug #4 (TASK-4): historically reaction ran before the allowlist gate,
-  // so an unallowed DM sender, or a group sender whose mention WAS allowed
-  // by mention_allowlist but whose chat/user was NOT in the gate
-  // allowlist, could force visible bot activity (and burn 429 budget on
-  // setMessageReaction). Gating on `gateTelegramMessage` + addressing
-  // pulls reactions back behind the same fence reply/notify already sit
-  // behind.
-  const reactionInput = gateInputFromContext(ctx)
-  const reactionDecision = gateTelegramMessage(reactionInput, deps.config, deps.policy)
-  if (
-    reactionDecision.kind === 'allow'
-    && isAddressedToBot(ctx, deps.policy?.mention_allowlist)
-  ) {
-    try {
-      const _chatId = ctx.chat?.id
-      const _msgId = ctx.message?.message_id
-      if (_chatId !== undefined && _msgId !== undefined) {
-        await deps.telegramApi.setMessageReaction(String(_chatId), _msgId, '👀')
-      }
-    } catch (_e) { /* react best-effort */ }
-  }
+  // fix/eyes-on-read (2026-05-28): the 👀 read receipt is NO LONGER set
+  // here. Setting it at bot-receive time made 👀 mean "the bot saw the
+  // update", not "Thrall read it" — if a turn was busy, the message queued
+  // while the eyes already showed, so the signal lied. The reaction now
+  // fires deterministically from the Stop hook (scripts/read-receipt-hook.ts
+  // → POST /hooks/react) once the message has actually entered and been read
+  // in a session turn. This covers every message type (text, voice, photo,
+  // document) and both the DM and per-chat multichat sessions uniformly,
+  // because all of them run the same Stop hook against their transcript.
 
   // FIX-T1 F3 (PRX-1 Phase 5, 2026-05-27): permission verdicts ALWAYS take
   // priority over the AskUserQuestion «Other» text consumer. Previously the

--- a/plugin/src/webhook/server.ts
+++ b/plugin/src/webhook/server.ts
@@ -26,6 +26,7 @@ import { writeDeadLetter } from '../state/store.js'
 import {
   AskUserQuestionAnswerSchema,
   AskUserQuestionRequestSchema,
+  ReactRouteRequestSchema,
   WebhookPayloadSchema,
   type AskUserQuestionAnswer,
   type AskUserQuestionRequest,
@@ -50,6 +51,9 @@ const BODY_LIMIT_BYTES = 256 * 1024
 // 4 questions × 4 options × ~1 KB preview ≈ 16 KB worst case, leaving
 // headroom for header/description text + question prose.
 const ASK_BODY_LIMIT_BYTES = 64 * 1024
+// Read-receipt bodies are tiny ({chat_id, message_id, emoji}); 4 KB is
+// generous and keeps the route cheap to abuse-proof.
+const REACT_BODY_LIMIT_BYTES = 4 * 1024
 const DEFAULT_AGENT_ID = 'dashi-channel'
 
 // Margin added on top of the configured AskUserQuestion timeout to set
@@ -158,6 +162,14 @@ export interface WebhookDeps {
   // "wired but disabled" from "wrong route".)
   askRelay?: AskUserQuestionRelay
   askUi?: AskUserQuestionUi
+  // fix/eyes-on-read (2026-05-28): read-receipt route. The Stop hook posts
+  // {chat_id, message_id} here once it has confirmed the agent actually read
+  // an inbound message in a turn (parsed from the session transcript). We set
+  // the 👀 reaction at THAT point — not when the bot first received the update
+  // — so the reaction deterministically means "Thrall read it through the
+  // plugin". Optional so tests/legacy paths can omit; when absent the route
+  // answers 503 and the hook degrades to a no-op (no read receipt, no crash).
+  reactToMessage?: (chatId: string, messageId: number, emoji: string) => Promise<void>
 }
 
 export interface WebhookServerHandle {
@@ -313,6 +325,14 @@ async function handleRequest(
   }
   if (method === 'POST' && path === '/hooks/ask-user-question/answer') {
     await handleAskAnswer(req, res, deps, webhookToken)
+    return
+  }
+
+  // fix/eyes-on-read (2026-05-28): read-receipt route. Wired before
+  // /hooks/agent so the more-specific path takes priority. Loopback +
+  // bearer + chat allowlist, then sets 👀 via deps.reactToMessage.
+  if (method === 'POST' && path === '/hooks/react') {
+    await handleReact(req, res, deps, webhookToken)
     return
   }
 
@@ -713,6 +733,66 @@ function authGate(
     return false
   }
   return true
+}
+
+// fix/eyes-on-read (2026-05-28): POST /hooks/react — set the 👀 read
+// receipt on an inbound message the agent has actually read in a turn.
+// Auth: loopback origin + bearer (same fence as the AskUserQuestion
+// routes). Defence in depth: chatId must be in the allowlist, so a leaked
+// token still can't make the bot react in an arbitrary chat.
+async function handleReact(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: WebhookDeps,
+  webhookToken: string | undefined,
+): Promise<void> {
+  const { config, log, reactToMessage } = deps
+
+  if (!authGate(req, res, webhookToken)) return
+
+  // Feature wiring gate: when no reaction capability was injected we answer
+  // 503 (not 404) so an operator can tell "wired but disabled" from "wrong
+  // route", and the hook degrades to a no-op without retry storms.
+  if (!reactToMessage) {
+    reply(res, 503, { status: 'reactions_unavailable' })
+    return
+  }
+
+  const parsed = await readJsonBody(
+    req,
+    res,
+    log,
+    REACT_BODY_LIMIT_BYTES,
+    ReactRouteRequestSchema,
+    'react',
+  )
+  if (!parsed.ok) return
+  const payload = parsed.value
+  const emoji = payload.emoji ?? '👀'
+
+  if (!chatIdAllowed(config, payload.chat_id)) {
+    log.warn('react chatId not in allowlist', { chat_id: payload.chat_id })
+    reply(res, 403, { error: 'chatId not in allowlist' })
+    return
+  }
+
+  try {
+    await reactToMessage(payload.chat_id, payload.message_id, emoji)
+  } catch (err) {
+    // A failed reaction must never wedge the hook. Telegram returns 400 for
+    // reactions on messages too old to react to (and 429 under burst); we
+    // log and answer 200 so the hook records the message as handled and
+    // moves on rather than retrying forever.
+    log.warn('react setMessageReaction failed', {
+      chat_id: payload.chat_id,
+      message_id: payload.message_id,
+      error: err instanceof Error ? redactToken(err.message) : String(err),
+    })
+    reply(res, 200, { status: 'react_failed' })
+    return
+  }
+
+  reply(res, 200, { status: 'reacted' })
 }
 
 async function handleAskRequest(

--- a/plugin/tests/hooks/read-receipt-hook.test.ts
+++ b/plugin/tests/hooks/read-receipt-hook.test.ts
@@ -1,0 +1,237 @@
+// fix/eyes-on-read (2026-05-28) — unit tests for the read-receipt Stop hook.
+// Pure functions only: no real network, no real session. Exercises channel
+// parsing (escaped + raw forms), tail extraction + dedup, env-file fallback
+// config resolution, and the dedup state log round-trip.
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  parseChannelRefs,
+  extractCurrentTurnRefs,
+  resolveReactConfig,
+  resolveStatePath,
+  loadChannelEnvFile,
+  parseEnvFile,
+  loadSeen,
+  refKey,
+} from '../../scripts/read-receipt-hook.js'
+
+describe('parseChannelRefs', () => {
+  test('extracts telegram chat_id + message_id from raw form', () => {
+    const text =
+      '<channel source="dashi-channel" source="telegram" chat_id="164795011" user_id="164795011" ts="x" message_id="28045">hi</channel>'
+    expect(parseChannelRefs(text)).toEqual([{ chat_id: '164795011', message_id: 28045 }])
+  })
+
+  test('extracts from JSON-escaped transcript form', () => {
+    const line =
+      '{"type":"user","message":{"content":"<channel source=\\"dashi-channel\\" source=\\"telegram\\" chat_id=\\"164795011\\" message_id=\\"28049\\">voice</channel>"}}'
+    expect(parseChannelRefs(line)).toEqual([{ chat_id: '164795011', message_id: 28049 }])
+  })
+
+  test('supports negative chat_id (multichat group / supergroup)', () => {
+    const text = '<channel source="telegram" chat_id="-1003784643974" message_id="42">grp</channel>'
+    expect(parseChannelRefs(text)).toEqual([{ chat_id: '-1003784643974', message_id: 42 }])
+  })
+
+  test('ignores non-telegram channel blocks (orgrimmar-inbox)', () => {
+    const text = '<channel source="orgrimmar-inbox" from="sa-silvana" type="task">body</channel>'
+    expect(parseChannelRefs(text)).toEqual([])
+  })
+
+  test('skips a block missing message_id', () => {
+    const text = '<channel source="telegram" chat_id="164795011">no id</channel>'
+    expect(parseChannelRefs(text)).toEqual([])
+  })
+
+  test('extracts multiple blocks in one chunk', () => {
+    const text =
+      '<channel source="telegram" chat_id="1" message_id="10">a</channel>' +
+      '<channel source="telegram" chat_id="2" message_id="20">b</channel>'
+    expect(parseChannelRefs(text)).toEqual([
+      { chat_id: '1', message_id: 10 },
+      { chat_id: '2', message_id: 20 },
+    ])
+  })
+})
+
+describe('extractCurrentTurnRefs', () => {
+  test('finds the inbound block even behind a long trailing tool/assistant output (Codex HIGH)', () => {
+    const inbound = '<channel source="telegram" chat_id="1" message_id="99">read me</channel>'
+    // Simulate a tool-heavy turn: 200 assistant/tool lines AFTER the inbound.
+    const trailing = Array.from({ length: 200 }, (_, i) => `{"type":"assistant","i":${i}}`)
+    const transcript = [inbound, ...trailing].join('\n')
+    expect(extractCurrentTurnRefs(transcript)).toEqual([{ chat_id: '1', message_id: 99 }])
+  })
+
+  test('collects a contiguous batched multi-message turn, in order', () => {
+    const transcript = [
+      '{"type":"assistant","prev":"reply"}',
+      '<channel source="telegram" chat_id="1" message_id="10">a</channel>',
+      '<channel source="telegram" chat_id="1" message_id="11">b</channel>',
+      '{"type":"assistant","cur":"reply"}',
+    ].join('\n')
+    expect(extractCurrentTurnRefs(transcript)).toEqual([
+      { chat_id: '1', message_id: 10 },
+      { chat_id: '1', message_id: 11 },
+    ])
+  })
+
+  test('does NOT reach a previous turn behind a non-telegram line', () => {
+    const transcript = [
+      '<channel source="telegram" chat_id="1" message_id="1">old turn</channel>',
+      '{"type":"assistant","reply":"to old"}',
+      '<channel source="telegram" chat_id="1" message_id="2">current turn</channel>',
+      '{"type":"assistant","reply":"to current"}',
+    ].join('\n')
+    expect(extractCurrentTurnRefs(transcript)).toEqual([{ chat_id: '1', message_id: 2 }])
+  })
+
+  test('dedups a repeated id within the inbound block', () => {
+    const transcript = [
+      '<channel source="telegram" chat_id="1" message_id="10">a</channel>',
+      '<channel source="telegram" chat_id="1" message_id="10">a-dup</channel>',
+    ].join('\n')
+    expect(extractCurrentTurnRefs(transcript)).toEqual([{ chat_id: '1', message_id: 10 }])
+  })
+
+  test('empty transcript → no refs', () => {
+    expect(extractCurrentTurnRefs('')).toEqual([])
+  })
+})
+
+describe('resolveReactConfig (pure, env already merged)', () => {
+  test('explicit url + token wins', () => {
+    const cfg = resolveReactConfig({
+      TELEGRAM_READ_RECEIPT_URL: 'http://127.0.0.1:8089/hooks/react',
+      TELEGRAM_WEBHOOK_TOKEN: 'tok',
+    })
+    expect(cfg).toEqual({ url: 'http://127.0.0.1:8089/hooks/react', token: 'tok' })
+  })
+
+  test('builds url from host+port', () => {
+    const cfg = resolveReactConfig({
+      TELEGRAM_WEBHOOK_HOST: '127.0.0.1',
+      TELEGRAM_WEBHOOK_PORT: '8093',
+      TELEGRAM_WEBHOOK_TOKEN: 'filetok',
+    })
+    expect(cfg).toEqual({ url: 'http://127.0.0.1:8093/hooks/react', token: 'filetok' })
+  })
+
+  test('defaults host to 127.0.0.1 when only port present', () => {
+    const cfg = resolveReactConfig({ TELEGRAM_WEBHOOK_PORT: '9001', TELEGRAM_WEBHOOK_TOKEN: 'e' })
+    expect(cfg).toEqual({ url: 'http://127.0.0.1:9001/hooks/react', token: 'e' })
+  })
+
+  test('errors when token cannot be resolved', () => {
+    const cfg = resolveReactConfig({})
+    expect('kind' in cfg && cfg.kind === 'error').toBe(true)
+  })
+
+  test('errors when port missing and no explicit url', () => {
+    const cfg = resolveReactConfig({ TELEGRAM_WEBHOOK_TOKEN: 'tok' })
+    expect('kind' in cfg && cfg.kind === 'error').toBe(true)
+  })
+})
+
+describe('loadChannelEnvFile (multichat env-i fallback)', () => {
+  test('parses the named env file into vars', () => {
+    const fakeFile =
+      'TELEGRAM_WEBHOOK_HOST=127.0.0.1\nTELEGRAM_WEBHOOK_PORT=8093\nTELEGRAM_WEBHOOK_TOKEN=filetok\n'
+    const vars = loadChannelEnvFile({ TELEGRAM_CHANNEL_ENV_FILE: '/fake/channel.env' }, () => fakeFile)
+    expect(vars.TELEGRAM_WEBHOOK_PORT).toBe('8093')
+    expect(vars.TELEGRAM_WEBHOOK_TOKEN).toBe('filetok')
+  })
+
+  test('no path set → empty (degrade to process env)', () => {
+    expect(loadChannelEnvFile({})).toEqual({})
+  })
+
+  test('unreadable file → empty, never throws', () => {
+    expect(
+      loadChannelEnvFile({ TELEGRAM_CHANNEL_ENV_FILE: '/nope' }, () => {
+        throw new Error('ENOENT')
+      }),
+    ).toEqual({})
+  })
+
+  test('merged env (file under process env) resolves config in a per-chat session', () => {
+    // Simulates env -i: process env has no TELEGRAM_*, only the env-file path.
+    const fileVars = loadChannelEnvFile(
+      { TELEGRAM_CHANNEL_ENV_FILE: '/fake' },
+      () => 'TELEGRAM_WEBHOOK_PORT=8093\nTELEGRAM_WEBHOOK_TOKEN=filetok\n',
+    )
+    const merged = { ...fileVars, MULTICHAT_STATE_DIR: '/mc/state' }
+    expect(resolveReactConfig(merged)).toEqual({
+      url: 'http://127.0.0.1:8093/hooks/react',
+      token: 'filetok',
+    })
+  })
+})
+
+describe('parseEnvFile', () => {
+  test('parses KEY=VALUE, strips quotes, skips comments/blanks', () => {
+    const parsed = parseEnvFile('# comment\nA=1\nB="two"\nC=\'three\'\n\nD=has=eq\n')
+    expect(parsed).toEqual({ A: '1', B: 'two', C: 'three', D: 'has=eq' })
+  })
+})
+
+describe('resolveStatePath (per-session)', () => {
+  test('explicit state path wins over state dir', () => {
+    expect(
+      resolveStatePath({ TELEGRAM_READ_RECEIPT_STATE: '/x/y.log', TELEGRAM_STATE_DIR: '/d' }, 's1'),
+    ).toBe('/x/y.log')
+  })
+  test('derives a per-session file from state dir', () => {
+    expect(resolveStatePath({ TELEGRAM_STATE_DIR: '/d' }, 'sess-1')).toBe(
+      '/d/read-receipts/sess-1.log',
+    )
+  })
+  test('falls back to MULTICHAT_STATE_DIR (per-chat env -i survivor)', () => {
+    expect(resolveStatePath({ MULTICHAT_STATE_DIR: '/mc' }, 'abc')).toBe(
+      '/mc/read-receipts/abc.log',
+    )
+  })
+  test('TELEGRAM_STATE_DIR wins over MULTICHAT_STATE_DIR', () => {
+    expect(resolveStatePath({ TELEGRAM_STATE_DIR: '/t', MULTICHAT_STATE_DIR: '/mc' }, 's')).toBe(
+      '/t/read-receipts/s.log',
+    )
+  })
+  test('sanitises a hostile session id', () => {
+    expect(resolveStatePath({ TELEGRAM_STATE_DIR: '/d' }, '../../etc/passwd')).toBe(
+      '/d/read-receipts/.._.._etc_passwd.log',
+    )
+  })
+  test('no session id → shared fallback filename', () => {
+    expect(resolveStatePath({ TELEGRAM_STATE_DIR: '/d' })).toBe('/d/read-receipts/read-receipts.log')
+  })
+  test('undefined when no base dir', () => {
+    expect(resolveStatePath({}, 's1')).toBeUndefined()
+  })
+})
+
+describe('loadSeen dedup log', () => {
+  let dir: string
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  })
+  test('missing file → empty set', () => {
+    dir = mkdtempSync(join(tmpdir(), 'rr-'))
+    expect(loadSeen(join(dir, 'nope.log')).size).toBe(0)
+  })
+  test('reads keys, trims blanks', () => {
+    const seen = loadSeen('/whatever', () => '1:10\n\n-1:20\n')
+    expect(seen.has('1:10')).toBe(true)
+    expect(seen.has('-1:20')).toBe(true)
+    expect(seen.size).toBe(2)
+  })
+})
+
+describe('refKey', () => {
+  test('stable composite key', () => {
+    expect(refKey({ chat_id: '-1003784643974', message_id: 7 })).toBe('-1003784643974:7')
+  })
+})

--- a/plugin/tests/telegram/handlers.addressing.test.ts
+++ b/plugin/tests/telegram/handlers.addressing.test.ts
@@ -3,11 +3,12 @@
 // Covers:
 //   * watcher does not fire for a group message without @mention / reply
 //   * tmux-mirror bump does not fire for a non-addressed group message
-//   * setMessageReaction does NOT run when the allowlist gate would
-//     drop the sender (unallowed sender, or allowed sender in a chat
-//     not in the gate's allowlist)
-//   * setMessageReaction DOES fire for an allowed DM sender and for
-//     an allowed group sender that @mentions the bot
+//   * setMessageReaction never runs at bot-receive time at all
+//     (fix/eyes-on-read 2026-05-28): the 👀 read receipt moved to the
+//     Stop hook so it means "Thrall read it", not "the bot saw it".
+//     These tests now assert NO receive-time reaction for any sender —
+//     allowed or dropped. The receipt path is covered by
+//     tests/hooks/read-receipt-hook.test.ts + tests/webhook/react-route.test.ts.
 //
 // Permitted-side effects in legacy mode (no policy) are exercised in
 // handlers.test.ts; this file focuses on the multichat-aware paths
@@ -418,7 +419,7 @@ describe('handleInboundText — addressing gate on side effects (Bug #3)', () =>
 // Bug #4 — reaction must require gate.allow before firing
 // ─────────────────────────────────────────────────────────────────────
 
-describe('handleInboundText — reaction guard (Bug #4)', () => {
+describe('handleInboundText — no receive-time reaction (fix/eyes-on-read)', () => {
   test('unallowed DM sender does NOT receive reaction', async () => {
     const tg = makeTelegramApi()
     const { deps, statePaths } = makeDeps({ telegramApi: tg.api })
@@ -434,7 +435,11 @@ describe('handleInboundText — reaction guard (Bug #4)', () => {
     rmSync(statePaths.root, { recursive: true, force: true })
   })
 
-  test('allowed DM sender DOES receive reaction', async () => {
+  // fix/eyes-on-read (2026-05-28): the 👀 receipt no longer fires at
+  // bot-receive time — it moved to the Stop hook so it means "Thrall read
+  // it", not "the bot saw it". An allowed DM message must therefore produce
+  // NO reaction inside handleInboundText.
+  test('allowed DM sender gets NO receive-time reaction (moved to Stop hook)', async () => {
     const tg = makeTelegramApi()
     const { deps, statePaths } = makeDeps({ telegramApi: tg.api })
     const ctx = makeDmCtx({
@@ -443,12 +448,11 @@ describe('handleInboundText — reaction guard (Bug #4)', () => {
       fromId: WARCHIEF_USER_ID,
     })
     await handleInboundText(ctx, deps)
-    expect(tg.reactions.length).toBe(1)
-    expect(tg.reactions[0]!.emoji).toBe('👀')
+    expect(tg.reactions.length).toBe(0)
     rmSync(statePaths.root, { recursive: true, force: true })
   })
 
-  test('allowed sender in group + mention → reaction fires after gate', async () => {
+  test('allowed group + mention gets NO receive-time reaction (moved to Stop hook)', async () => {
     const policy = makePolicy()
     const tg = makeTelegramApi()
     const { deps, statePaths } = makeDeps({ policy, telegramApi: tg.api })
@@ -459,8 +463,7 @@ describe('handleInboundText — reaction guard (Bug #4)', () => {
       mentionBot: true,
     })
     await handleInboundText(ctx, deps)
-    expect(tg.reactions.length).toBe(1)
-    expect(tg.reactions[0]!.chatId).toBe(String(ALLOWED_GROUP_CHAT_ID))
+    expect(tg.reactions.length).toBe(0)
     rmSync(statePaths.root, { recursive: true, force: true })
   })
 

--- a/plugin/tests/webhook/react-route.test.ts
+++ b/plugin/tests/webhook/react-route.test.ts
@@ -1,0 +1,176 @@
+// fix/eyes-on-read (2026-05-28) — webhook route tests for POST /hooks/react.
+// Exercises the read-receipt route end-to-end via fetch() with a stub
+// reactToMessage so no live TG bot is needed.
+//
+// Taxonomy: happy path (DM + negative group chat_id), emoji default,
+// reactToMessage failure → 200 react_failed, 503 when capability unwired,
+// 403 chat not in allowlist, 401 missing bearer, 400 malformed body.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { getStatePaths, loadConfig, type AppConfig, type StatePaths } from '../../src/config.js'
+import { createLogger } from '../../src/log.js'
+import { ensureStateDirs } from '../../src/state/store.js'
+import { startWebhookServer, type WebhookDeps, type WebhookServerHandle } from '../../src/webhook/server.js'
+
+const FAKE_TOKEN = '123456789:AAH-fake_test_token_with_at_least_thirty_chars'
+const WEBHOOK_TOKEN = 'wh_test_token_32_chars__________'
+const WARCHIEF_ID = '164795011'
+const GROUP_ID = '-1003784643974'
+
+let stateDir: string
+let paths: StatePaths
+let baseConfig: AppConfig
+let handle: WebhookServerHandle | null
+
+interface StubMcp {
+  server: { notification: () => Promise<void> }
+}
+function makeMcpStub(): StubMcp {
+  return { server: { notification: async () => { /* noop */ } } }
+}
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), 'dashi-channel-react-'))
+  delete process.env.TELEGRAM_WEBHOOK_TOKEN
+  const env = {
+    TELEGRAM_BOT_TOKEN: FAKE_TOKEN,
+    TELEGRAM_STATE_DIR: stateDir,
+    TELEGRAM_ALLOWED_CHAT_IDS: `${WARCHIEF_ID},${GROUP_ID}`,
+  }
+  baseConfig = loadConfig(env)
+  paths = getStatePaths(baseConfig, { TELEGRAM_BOT_TOKEN: FAKE_TOKEN, TELEGRAM_STATE_DIR: stateDir })
+  ensureStateDirs(paths)
+  handle = null
+})
+
+afterEach(async () => {
+  if (handle) {
+    await handle.close()
+    handle = null
+  }
+  delete process.env.TELEGRAM_WEBHOOK_TOKEN
+  rmSync(stateDir, { recursive: true, force: true })
+})
+
+interface ReactCall {
+  chatId: string
+  messageId: number
+  emoji: string
+}
+
+async function start(
+  opts: {
+    omitReact?: boolean
+    reactToMessage?: WebhookDeps['reactToMessage']
+  } = {},
+): Promise<{ h: WebhookServerHandle; calls: ReactCall[] }> {
+  const calls: ReactCall[] = []
+  const config: AppConfig = { ...baseConfig, webhook: { enabled: true, host: '127.0.0.1', port: 0 } }
+  const reactToMessage =
+    opts.reactToMessage ??
+    (async (chatId: string, messageId: number, emoji: string) => {
+      calls.push({ chatId, messageId, emoji })
+    })
+  const deps: WebhookDeps = {
+    mcpServer: makeMcpStub().server as never,
+    config,
+    statePaths: paths,
+    log: createLogger('test-react'),
+    // 503 path: leave the capability unwired entirely.
+    ...(opts.omitReact ? {} : { reactToMessage }),
+  }
+  const h = await startWebhookServer(config, deps)
+  if (!h) throw new Error('expected handle')
+  handle = h
+  return { h, calls }
+}
+
+function url(h: WebhookServerHandle, path: string): string {
+  return `http://${h.host}:${h.port}${path}`
+}
+
+function post(h: WebhookServerHandle, body: unknown, token: string | null = WEBHOOK_TOKEN): Promise<Response> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (token) headers.Authorization = `Bearer ${token}`
+  return fetch(url(h, '/hooks/react'), { method: 'POST', headers, body: JSON.stringify(body) })
+}
+
+describe('POST /hooks/react', () => {
+  test('happy path sets 👀 for a DM message_id', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { h, calls } = await start()
+    const resp = await post(h, { chat_id: WARCHIEF_ID, message_id: 28045 })
+    expect(resp.status).toBe(200)
+    expect(await resp.json()).toEqual({ status: 'reacted' })
+    expect(calls).toEqual([{ chatId: WARCHIEF_ID, messageId: 28045, emoji: '👀' }])
+  })
+
+  test('coerces numeric-string message_id and supports negative group chat_id', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { h, calls } = await start()
+    const resp = await post(h, { chat_id: GROUP_ID, message_id: '42' })
+    expect(resp.status).toBe(200)
+    expect(calls).toEqual([{ chatId: GROUP_ID, messageId: 42, emoji: '👀' }])
+  })
+
+  test('honours an explicit emoji override', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { h, calls } = await start()
+    await post(h, { chat_id: WARCHIEF_ID, message_id: 1, emoji: '🔥' })
+    expect(calls[0]?.emoji).toBe('🔥')
+  })
+
+  test('reactToMessage throw → 200 react_failed, never wedges the hook', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { h } = await start({
+      reactToMessage: async () => {
+        throw new Error('429 Too Many Requests')
+      },
+    })
+    const resp = await post(h, { chat_id: WARCHIEF_ID, message_id: 5 })
+    expect(resp.status).toBe(200)
+    expect(await resp.json()).toEqual({ status: 'react_failed' })
+  })
+
+  test('503 when reaction capability is not wired', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { h } = await start({ omitReact: true })
+    const resp = await post(h, { chat_id: WARCHIEF_ID, message_id: 5 })
+    expect(resp.status).toBe(503)
+    expect(await resp.json()).toEqual({ status: 'reactions_unavailable' })
+  })
+
+  test('403 when chat_id not in allowlist', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { h, calls } = await start()
+    const resp = await post(h, { chat_id: '999999', message_id: 5 })
+    expect(resp.status).toBe(403)
+    expect(calls).toEqual([])
+  })
+
+  test('401 without bearer', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { h, calls } = await start()
+    const resp = await post(h, { chat_id: WARCHIEF_ID, message_id: 5 }, null)
+    expect(resp.status).toBe(401)
+    expect(calls).toEqual([])
+  })
+
+  test('400 on malformed body (missing message_id)', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { h } = await start()
+    const resp = await post(h, { chat_id: WARCHIEF_ID })
+    expect(resp.status).toBe(400)
+  })
+
+  test('400 on non-positive message_id', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { h } = await start()
+    const resp = await post(h, { chat_id: WARCHIEF_ID, message_id: 0 })
+    expect(resp.status).toBe(400)
+  })
+})


### PR DESCRIPTION
## Проблема

Реакция `👀` ставилась в момент приёма апдейта ботом (`handleInboundText`) — это означало «бот увидел», а не «агент прочитал». При занятой сессии сообщение стояло в очереди, а глаза уже горели — сигнал врал. На голосовые/фото реакция не ставилась вообще (была только в текстовом хендлере).

## Решение

`👀` ставится детерминистски по событию `Stop`, когда сообщение реально прочитано в ходе сессии.

- **`scripts/read-receipt-hook.ts`** — Stop-хук читает транскрипт, берёт входящие telegram-блоки **текущего хода** (идёт с конца, пропуская хвост из ответа и тул-вызовов — длинный tool-ход не теряет входящее), POST'ит их в роут плагина.
- **`src/webhook/server.ts`** — роут `POST /hooks/react`: loopback + constant-time bearer + chat-allowlist, ставит реакцию единственным ботом.
- **`src/telegram/handlers.ts`** — убрана реакция на приёме бота.
- **Личка + мультичат, все типы** (текст/голос/фото). Per-chat сессии под `env -i` не имеют `TELEGRAM_*`, поэтому хук берёт webhook-конфиг + state-dir из env-файла (путь вписан inline в команду хука — shell-присваивание переживает `env -i`); дедуп падает на `MULTICHAT_STATE_DIR`.
- Пер-сессионный дедуп-лог `<state>/read-receipts/<session_id>.log` — ровно одна реакция на сообщение, без гонки между сессиями.
- `fetch` с таймаутом 5с — 429-backoff роута не вешает Stop-хук.
- Exit 0 на всех путях, пустой stdout (Stop-хук дисциплина).

## Двойное ревью (Opus + Codex GPT-5.5)

Закрыты до коммита:
- **CRITICAL** (Opus): мультичат под `env -i` не резолвил конфиг → читаем из env-файла.
- **HIGH** (Codex): фикс-окно из N строк теряло сообщение за хвостом транскрипта → парсим именно текущий ход.
- дедуп-гонка между сессиями → пер-сессионный лог.
- таймаут fetch.

Известный LOW (отложено): пользователь в allowed-группе может вписать поддельный `<channel>`-блок и вызвать `👀` на произвольный message_id в той же группе (косметика, gated allowlist'ом).

## Проверки

- `tsc --noEmit` чисто
- **1186** тестов зелёные (+43 новых: роут, парсер хода, env-файл, дедуп, sanitize session_id)

## Активация (после мёржа)

Регистрация Stop-хука в `settings.json` + рестарт `channel-thrall` (делегируется — агент не рестартит свой gateway сам). См. раздел «Read receipts» в README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)