### PR TITLE
docs: dark minimalist SVG diagrams in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,7 @@
 
 It replaces the deprecated `claude -p` gateway pattern (a Python daemon that spawned a fresh headless session for every message). Cutover deadline — **2026-06-15** (Anthropic is splitting billing; details in section [13](#13-why-migrate--the-2026-06-15-deadline)).
 
-```
-[ Telegram ]
-     │
-     ▼  getUpdates (long polling)
-[ plugin (Bun + TypeScript) ]──── push channel message ───▶ [ Claude Code session ]
-     ▲                                                              │
-     │  reply / status / reactions / media                          │  thinking + tools + final answer
-     └──────────────────────────────────────────────────────────────┘
-```
+![Architecture — Telegram ↔ plugin ↔ Claude Code session](docs/assets/architecture-hero.svg)
 
 One plugin process = one Telegram bot = one agent. By default it serves **a single DM chat** (legacy single-session mode). With `multichat.enabled` turned on, the same bot fans incoming messages out across several per-chat tmux sessions of one identity — see section [3](#3-multichat--how-it-works-and-why).
 
@@ -107,6 +99,8 @@ The parser (`src/config.ts`) validates every value as a positive integer and fai
 
 ## 3. Multichat — how it works and why
 
+![Multichat — one bot fans out across several per-chat tmux sessions](docs/assets/multichat.svg)
+
 ### Why
 
 Sometimes you need to run several chats in parallel under the same identity: the operator's personal DM + a work group + a sandbox. One bot, one personality, different "rooms" with different rights and different privacy levels.
@@ -169,6 +163,8 @@ chats:
 ## 4. Plugin hooks
 
 Progress in Telegram (`ProgressReporter`, `TaskMirror`, `StatusManager`) is fed by Claude Code hooks. Without installing the hooks these surfaces stay silent — you only get the final reply.
+
+![Hooks — Claude Code event flows through post-hook and the webhook server to the progress surfaces](docs/assets/hooks.svg)
 
 ### Installation
 
@@ -373,6 +369,8 @@ The `reply` default is `format='html'` (PR #22): markdown is auto-converted, aut
 ## 10. Security — so data never leaks
 
 Defence is layered — several independent barriers:
+
+![Security — layered defence-in-depth from inbound message to processed safely](docs/assets/security.svg)
 
 **Allowlist gate (the first barrier).** Every incoming message is checked *before* processing (`src/telegram/gate.ts`): in a DM — sender_id ∈ `allowed_user_ids` (+ a defensive chat_id check); in groups (multichat) — chat ∈ `policy.allowlist.chats` AND sender ∈ `policy.allowlist.users`. Not allowed — dropped without processing.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -6,15 +6,7 @@
 
 Это замена устаревшему `claude -p` gateway-паттерну (Python-демон, который спавнил новую headless-сессию на каждое сообщение). Cutover deadline — **2026-06-15** (Anthropic разделяет billing, подробности в разделе [13](#13-зачем-переезд--дедлайн-2026-06-15)).
 
-```
-[ Telegram ]
-     │
-     ▼  getUpdates (long polling)
-[ plugin (Bun + TypeScript) ]──── push channel message ───▶ [ Claude Code session ]
-     ▲                                                              │
-     │  reply / status / reactions / media                          │  thinking + tools + final answer
-     └──────────────────────────────────────────────────────────────┘
-```
+![Архитектура — Telegram ↔ плагин ↔ сессия Claude Code](docs/assets/architecture-hero.svg)
 
 Один процесс плагина = один Telegram-бот = один агент. По умолчанию обслуживается **один DM-чат** (legacy single-session режим). При включённом `multichat.enabled` тот же бот раскладывает входящие по нескольким per-chat tmux-сессиям одной identity — см. раздел [3](#3-multichat--как-работает-и-зачем).
 
@@ -101,6 +93,8 @@ TELEGRAM_ALLOWED_USER_IDS=164795011,123456789
 
 ## 3. Multichat — как работает и зачем
 
+![Multichat — один бот раскладывает входящие по нескольким per-chat tmux-сессиям](docs/assets/multichat.svg)
+
 ### Зачем
 
 Иногда нужно вести параллельно несколько чатов одной и той же identity: личный DM вождя + рабочая группа + sandbox. Один бот, одна личность, разные «комнаты» с разными правами и разной приватностью.
@@ -163,6 +157,8 @@ chats:
 ## 4. Hooks плагина
 
 Прогресс в Telegram (`ProgressReporter`, `TaskMirror`, `StatusManager`) питается от Claude Code hooks. Без установки хуков эти поверхности молчат — приходит только финальный ответ.
+
+![Hooks — событие Claude Code проходит через post-hook и webhook-сервер к поверхностям прогресса](docs/assets/hooks.svg)
 
 ### Установка
 
@@ -367,6 +363,8 @@ Runtime-управление: `/mirror on|off|status` без рестарта п
 ## 10. Безопасность — чтобы данные не утекали
 
 Защита эшелонирована — несколько независимых барьеров:
+
+![Безопасность — эшелонированная защита от входящего сообщения до безопасной обработки](docs/assets/security.svg)
 
 **Allowlist-gate (первый барьер).** Любое входящее проверяется ДО обработки (`src/telegram/gate.ts`): в DM — sender_id ∈ `allowed_user_ids` (+ defensive chat_id); в группах (multichat) — chat ∈ `policy.allowlist.chats` И sender ∈ `policy.allowlist.users`. Не прошёл — drop без обработки.
 

--- a/docs/assets/architecture-hero.svg
+++ b/docs/assets/architecture-hero.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 320" width="100%" height="auto">
+  <defs>
+    <linearGradient id="bg-grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a0e14"/>
+      <stop offset="100%" stop-color="#0f141b"/>
+    </linearGradient>
+    <marker id="arrow-blue" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#58a6ff"/>
+    </marker>
+    <marker id="arrow-terra" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#d97757"/>
+    </marker>
+  </defs>
+
+  <!-- Page background -->
+  <rect width="1000" height="320" fill="url(#bg-grad)"/>
+
+  <!-- ===================== EDGES (drawn before nodes so nodes sit on top) ===================== -->
+
+  <!-- Arrow 1: Telegram -> Plugin (top lane, blue, label "message") -->
+  <line x1="222" y1="130" x2="352" y2="130"
+        stroke="#58a6ff" stroke-width="1.6" marker-end="url(#arrow-blue)"/>
+  <text x="287" y="122" text-anchor="middle" font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#58a6ff">message</text>
+
+  <!-- Arrow 2: Plugin -> Claude (top lane, blue, label "push channel message") -->
+  <line x1="648" y1="130" x2="772" y2="130"
+        stroke="#58a6ff" stroke-width="1.6" marker-end="url(#arrow-blue)"/>
+  <text x="710" y="122" text-anchor="middle" font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#58a6ff">push channel message</text>
+
+  <!-- Arrow 3: Claude -> Plugin (bottom lane, terracotta, label "final answer") -->
+  <line x1="772" y1="192" x2="648" y2="192"
+        stroke="#d97757" stroke-width="1.6" marker-end="url(#arrow-terra)"/>
+  <text x="710" y="208" text-anchor="middle" font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#d97757">final answer</text>
+
+  <!-- Arrow 4: Plugin -> Telegram (bottom lane, terracotta, label "reply · media · reactions") -->
+  <line x1="352" y1="192" x2="222" y2="192"
+        stroke="#d97757" stroke-width="1.6" marker-end="url(#arrow-terra)"/>
+  <text x="287" y="208" text-anchor="middle" font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#d97757">reply · media · reactions</text>
+
+  <!-- Arrow 5: Claude self-loop -> Plugin (dotted terracotta arc, "progress hooks") -->
+  <!-- Arc from Claude top, curving up and left toward plugin right -->
+  <path d="M 870,64 C 870,30 640,30 640,64"
+        fill="none" stroke="#d97757" stroke-width="1.4"
+        stroke-dasharray="4 3" opacity="0.55"
+        marker-end="url(#arrow-terra)"/>
+  <text x="755" y="24" text-anchor="middle" font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#8b949e">progress hooks</text>
+
+  <!-- ===================== LEFT NODE: Telegram ===================== -->
+  <rect x="28" y="76" width="194" height="168" rx="14"
+        fill="#11161d" stroke="#58a6ff" stroke-width="1.4"/>
+  <text x="125" y="148" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="22" font-weight="600" fill="#e6edf3">Telegram</text>
+  <text x="125" y="174" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#8b949e">getUpdates · long poll</text>
+
+  <!-- ===================== CENTER NODE: Plugin ===================== -->
+  <rect x="356" y="56" width="288" height="208" rx="14"
+        fill="#0d1219" stroke="#222a33" stroke-width="1.2"/>
+
+  <!-- Plugin header -->
+  <text x="500" y="82" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" letter-spacing="1" fill="#8b949e">PLUGIN · BUN + TS</text>
+
+  <!-- Row 1: TelegramPoller -->
+  <rect x="374" y="90" width="252" height="44" rx="8"
+        fill="#11161d" stroke="#222a33" stroke-width="1"/>
+  <text x="500" y="117" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="12" fill="#e6edf3">TelegramPoller · allowlist gate</text>
+
+  <!-- Row 2: safe-telegram-api -->
+  <rect x="374" y="142" width="252" height="44" rx="8"
+        fill="#11161d" stroke="#222a33" stroke-width="1"/>
+  <text x="500" y="169" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="12" fill="#e6edf3">safe-telegram-api</text>
+
+  <!-- Row 3: redact etc. (muted) -->
+  <rect x="374" y="194" width="252" height="40" rx="8"
+        fill="#11161d" stroke="#222a33" stroke-width="1"/>
+  <text x="500" y="218" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="11" fill="#8b949e">redact · HTML · chunk · rate-limit</text>
+
+  <!-- ===================== RIGHT NODE: Claude Code session ===================== -->
+  <rect x="776" y="76" width="196" height="168" rx="14"
+        fill="#11161d" stroke="#d97757" stroke-width="1.4"/>
+  <text x="874" y="136" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="20" font-weight="600" fill="#e6edf3">Claude Code</text>
+  <text x="874" y="158" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="16" font-weight="400" fill="#e6edf3">session</text>
+  <text x="874" y="182" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#8b949e">live session</text>
+  <text x="874" y="198" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#8b949e">thinking · tools · MCP</text>
+</svg>

--- a/docs/assets/hooks.svg
+++ b/docs/assets/hooks.svg
@@ -1,0 +1,130 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 360" width="100%" height="auto">
+  <defs>
+    <linearGradient id="bg-grad-hk" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a0e14"/>
+      <stop offset="100%" stop-color="#0f141b"/>
+    </linearGradient>
+    <marker id="arrow-blue-hk" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#58a6ff"/>
+    </marker>
+    <marker id="arrow-terra-hk" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#d97757"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1000" height="360" fill="url(#bg-grad-hk)"/>
+
+  <!-- NODE 1: Claude Code event -->
+  <rect x="20" y="116" width="170" height="80" rx="12"
+        fill="#11161d" stroke="#58a6ff" stroke-width="1.5"/>
+  <text x="105" y="144" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="11" font-weight="600" fill="#e6edf3">Claude Code event</text>
+  <text x="105" y="162" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#8b949e">Pre · PostToolUse</text>
+  <text x="105" y="178" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#8b949e">Stop</text>
+
+  <!-- Arrow 1->2 blue -->
+  <line x1="190" y1="156" x2="228" y2="156"
+        stroke="#58a6ff" stroke-width="1.6" marker-end="url(#arrow-blue-hk)"/>
+
+  <!-- NODE 2: post-hook.ts -->
+  <rect x="232" y="116" width="170" height="80" rx="12"
+        fill="#11161d" stroke="#222a33" stroke-width="1.4"/>
+  <text x="317" y="144" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="11" font-weight="600" fill="#e6edf3">post-hook.ts</text>
+  <text x="317" y="162" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#8b949e">stdout empty</text>
+  <text x="317" y="178" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#8b949e">exit 0</text>
+
+  <!-- Arrow 2->3 blue labeled "Bearer POST" -->
+  <line x1="402" y1="156" x2="440" y2="156"
+        stroke="#58a6ff" stroke-width="1.6" marker-end="url(#arrow-blue-hk)"/>
+  <text x="421" y="148" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#58a6ff">Bearer POST</text>
+
+  <!-- NODE 3: webhook server -->
+  <rect x="444" y="100" width="174" height="112" rx="12"
+        fill="#11161d" stroke="#222a33" stroke-width="1.4"/>
+  <text x="531" y="128" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="11" font-weight="600" fill="#e6edf3">webhook server</text>
+  <text x="531" y="146" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#8b949e">timing-safe</text>
+  <text x="531" y="162" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#8b949e">256 KB limit</text>
+  <text x="531" y="178" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#8b949e">Zod validation</text>
+
+  <!-- Arrow 3->4 blue -->
+  <line x1="618" y1="156" x2="656" y2="156"
+        stroke="#58a6ff" stroke-width="1.6" marker-end="url(#arrow-blue-hk)"/>
+
+  <!-- NODE 4: claude-events.ts -->
+  <rect x="660" y="116" width="160" height="80" rx="12"
+        fill="#11161d" stroke="#d97757" stroke-width="1.5"/>
+  <text x="740" y="144" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="11" font-weight="600" fill="#e6edf3">claude-events.ts</text>
+  <text x="740" y="162" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#8b949e">event bus</text>
+  <text x="740" y="178" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#8b949e">typed dispatch</text>
+
+  <!-- Fan-out: 4 terracotta arrows to right-side nodes -->
+  <!-- StatusManager -->
+  <line x1="820" y1="136" x2="862" y2="70"
+        stroke="#d97757" stroke-width="1.4" marker-end="url(#arrow-terra-hk)"/>
+  <!-- ProgressReporter -->
+  <line x1="820" y1="148" x2="862" y2="148"
+        stroke="#d97757" stroke-width="1.4" marker-end="url(#arrow-terra-hk)"/>
+  <!-- TaskMirror -->
+  <line x1="820" y1="164" x2="862" y2="224"
+        stroke="#d97757" stroke-width="1.4" marker-end="url(#arrow-terra-hk)"/>
+  <!-- MemoryWriter -->
+  <line x1="820" y1="174" x2="862" y2="300"
+        stroke="#d97757" stroke-width="1.4" marker-end="url(#arrow-terra-hk)"/>
+
+  <!-- RIGHT FAN-OUT NODES -->
+  <!-- StatusManager -->
+  <rect x="866" y="44" width="116" height="36" rx="8"
+        fill="#0d1219" stroke="#222a33" stroke-width="1.2"/>
+  <text x="924" y="67" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="11" fill="#e6edf3">StatusManager</text>
+
+  <!-- ProgressReporter -->
+  <rect x="866" y="130" width="116" height="36" rx="8"
+        fill="#0d1219" stroke="#222a33" stroke-width="1.2"/>
+  <text x="924" y="153" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="11" fill="#e6edf3">ProgressReporter</text>
+
+  <!-- TaskMirror -->
+  <rect x="866" y="206" width="116" height="36" rx="8"
+        fill="#0d1219" stroke="#222a33" stroke-width="1.2"/>
+  <text x="924" y="229" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="11" fill="#e6edf3">TaskMirror</text>
+
+  <!-- MemoryWriter -->
+  <rect x="866" y="282" width="116" height="36" rx="8"
+        fill="#0d1219" stroke="#222a33" stroke-width="1.2"/>
+  <text x="924" y="305" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="11" fill="#e6edf3">MemoryWriter</text>
+</svg>

--- a/docs/assets/multichat.svg
+++ b/docs/assets/multichat.svg
@@ -1,0 +1,141 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 420" width="100%" height="auto">
+  <defs>
+    <linearGradient id="bg-grad-mc" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a0e14"/>
+      <stop offset="100%" stop-color="#0f141b"/>
+    </linearGradient>
+    <marker id="arrow-blue-mc" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#58a6ff"/>
+    </marker>
+    <marker id="arrow-terra-mc" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#d97757"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1000" height="420" fill="url(#bg-grad-mc)"/>
+
+  <!-- TOP NODE: one bot -->
+  <rect x="360" y="30" width="280" height="60" rx="14"
+        fill="#11161d" stroke="#58a6ff" stroke-width="1.6"/>
+  <text x="500" y="55" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="14" font-weight="600" fill="#e6edf3">one bot</text>
+  <text x="500" y="74" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#8b949e">@trallvibecoderbot</text>
+
+  <!-- Arrow: one bot -> MultichatRouter -->
+  <line x1="500" y1="90" x2="500" y2="128"
+        stroke="#58a6ff" stroke-width="1.6" marker-end="url(#arrow-blue-mc)"/>
+
+  <!-- CENTER: MultichatRouter diamond -->
+  <polygon points="500,132 590,162 500,192 410,162"
+           fill="#0d1219" stroke="#222a33" stroke-width="1.4"/>
+  <text x="500" y="158" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="12" font-weight="600" fill="#e6edf3">MultichatRouter</text>
+  <text x="500" y="174" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#8b949e">chat_id dispatch</text>
+
+  <!-- Arrow: router -> host session (terracotta, warchief DM) -->
+  <line x1="412" y1="168" x2="245" y2="258"
+        stroke="#d97757" stroke-width="1.6" marker-end="url(#arrow-terra-mc)"/>
+  <text x="305" y="222" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#d97757">warchief DM</text>
+
+  <!-- Arrow: router -> per-chat A (cool-blue) -->
+  <line x1="500" y1="192" x2="500" y2="258"
+        stroke="#58a6ff" stroke-width="1.6" marker-end="url(#arrow-blue-mc)"/>
+  <text x="528" y="232" text-anchor="start"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#58a6ff">group A</text>
+
+  <!-- Arrow: router -> per-chat B (cool-blue) -->
+  <line x1="588" y1="168" x2="755" y2="258"
+        stroke="#58a6ff" stroke-width="1.6" marker-end="url(#arrow-blue-mc)"/>
+  <text x="700" y="222" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#58a6ff">group B</text>
+
+  <!-- SESSION NODES row -->
+  <!-- host session / channel-thrall (terracotta border = private) -->
+  <rect x="60" y="260" width="240" height="72" rx="12"
+        fill="#11161d" stroke="#d97757" stroke-width="1.5"/>
+  <text x="180" y="288" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="12" font-weight="600" fill="#e6edf3">host session</text>
+  <text x="180" y="306" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#8b949e">channel-thrall</text>
+  <text x="180" y="322" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#d97757">private</text>
+
+  <!-- per-chat tmux A -->
+  <rect x="380" y="260" width="240" height="72" rx="12"
+        fill="#11161d" stroke="#222a33" stroke-width="1.4"/>
+  <text x="500" y="288" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="12" font-weight="600" fill="#e6edf3">per-chat tmux · A</text>
+  <text x="500" y="306" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#8b949e">isolated session</text>
+  <text x="500" y="322" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#8b949e">group A</text>
+
+  <!-- per-chat tmux B -->
+  <rect x="700" y="260" width="240" height="72" rx="12"
+        fill="#11161d" stroke="#222a33" stroke-width="1.4"/>
+  <text x="820" y="288" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="12" font-weight="600" fill="#e6edf3">per-chat tmux · B</text>
+  <text x="820" y="306" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#8b949e">isolated session</text>
+  <text x="820" y="322" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#8b949e">group B</text>
+
+  <!-- OUTBOX store -->
+  <rect x="350" y="368" width="300" height="38" rx="18"
+        fill="#0d1219" stroke="#222a33" stroke-width="1.4"/>
+  <text x="500" y="392" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="12" fill="#e6edf3">outbox store</text>
+
+  <!-- Dotted terracotta: host session -> outbox -->
+  <line x1="180" y1="332" x2="390" y2="370"
+        stroke="#d97757" stroke-width="1.4" stroke-dasharray="4 3"
+        marker-end="url(#arrow-terra-mc)"/>
+  <text x="258" y="362" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#8b949e">Stop hook</text>
+
+  <!-- Dotted terracotta: per-chat A -> outbox -->
+  <line x1="500" y1="332" x2="500" y2="365"
+        stroke="#d97757" stroke-width="1.4" stroke-dasharray="4 3"
+        marker-end="url(#arrow-terra-mc)"/>
+  <text x="526" y="355" text-anchor="start"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#8b949e">Stop hook</text>
+
+  <!-- Dotted terracotta: per-chat B -> outbox -->
+  <line x1="820" y1="332" x2="612" y2="370"
+        stroke="#d97757" stroke-width="1.4" stroke-dasharray="4 3"
+        marker-end="url(#arrow-terra-mc)"/>
+  <text x="742" y="362" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="9" fill="#8b949e">Stop hook</text>
+
+  <!-- Solid cool-blue: outbox -> one bot (right side arc) -->
+  <path d="M 650,387 C 740,387 780,60 640,60"
+        fill="none" stroke="#58a6ff" stroke-width="1.6"
+        marker-end="url(#arrow-blue-mc)"/>
+  <text x="756" y="260" text-anchor="start"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#58a6ff">send queue</text>
+</svg>

--- a/docs/assets/security.svg
+++ b/docs/assets/security.svg
@@ -1,0 +1,130 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 520" width="100%" height="auto">
+  <defs>
+    <linearGradient id="bg-grad-sc" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a0e14"/>
+      <stop offset="100%" stop-color="#0f141b"/>
+    </linearGradient>
+    <marker id="arrow-blue-sc" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#58a6ff"/>
+    </marker>
+    <marker id="arrow-terra-sc" markerWidth="8" markerHeight="8" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#d97757"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1000" height="520" fill="url(#bg-grad-sc)"/>
+
+  <!-- TOP CAPSULE: inbound message (cool-blue) -->
+  <rect x="340" y="22" width="320" height="46" rx="23"
+        fill="#11161d" stroke="#58a6ff" stroke-width="1.6"/>
+  <text x="500" y="51" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="14" font-weight="600" fill="#e6edf3">inbound message</text>
+
+  <!-- Arrow top capsule -> layer 1 -->
+  <line x1="500" y1="68" x2="500" y2="88"
+        stroke="#d97757" stroke-width="1.5" marker-end="url(#arrow-terra-sc)"/>
+
+  <!-- LAYER 1: allowlist gate  y=92 -->
+  <rect x="200" y="92" width="600" height="52" rx="10"
+        fill="#11161d" stroke="#222a33" stroke-width="1.5"/>
+  <text x="254" y="124" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="22" font-weight="700" fill="#d97757">1</text>
+  <line x1="278" y1="102" x2="278" y2="134"
+        stroke="#222a33" stroke-width="1"/>
+  <text x="510" y="124" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="13" fill="#e6edf3">allowlist gate</text>
+  <text x="830" y="124" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#8b949e">user_id check</text>
+
+  <!-- Arrow 1->2 -->
+  <line x1="500" y1="144" x2="500" y2="162"
+        stroke="#d97757" stroke-width="1.5" marker-end="url(#arrow-terra-sc)"/>
+
+  <!-- LAYER 2: anti-spoof addressing  y=166 -->
+  <rect x="200" y="166" width="600" height="52" rx="10"
+        fill="#11161d" stroke="#222a33" stroke-width="1.5"/>
+  <text x="254" y="198" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="22" font-weight="700" fill="#d97757">2</text>
+  <line x1="278" y1="176" x2="278" y2="208"
+        stroke="#222a33" stroke-width="1"/>
+  <text x="510" y="198" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="13" fill="#e6edf3">anti-spoof addressing</text>
+  <text x="830" y="198" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#8b949e">chat_id verify</text>
+
+  <!-- Arrow 2->3 -->
+  <line x1="500" y1="218" x2="500" y2="236"
+        stroke="#d97757" stroke-width="1.5" marker-end="url(#arrow-terra-sc)"/>
+
+  <!-- LAYER 3: secret redaction  y=240 -->
+  <rect x="200" y="240" width="600" height="52" rx="10"
+        fill="#11161d" stroke="#222a33" stroke-width="1.5"/>
+  <text x="254" y="272" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="22" font-weight="700" fill="#d97757">3</text>
+  <line x1="278" y1="250" x2="278" y2="282"
+        stroke="#222a33" stroke-width="1"/>
+  <text x="510" y="272" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="13" fill="#e6edf3">secret redaction</text>
+  <text x="830" y="272" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#8b949e">regex scrub</text>
+
+  <!-- Arrow 3->4 -->
+  <line x1="500" y1="292" x2="500" y2="310"
+        stroke="#d97757" stroke-width="1.5" marker-end="url(#arrow-terra-sc)"/>
+
+  <!-- LAYER 4: path-traversal guard  y=314 -->
+  <rect x="200" y="314" width="600" height="52" rx="10"
+        fill="#11161d" stroke="#222a33" stroke-width="1.5"/>
+  <text x="254" y="346" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="22" font-weight="700" fill="#d97757">4</text>
+  <line x1="278" y1="324" x2="278" y2="356"
+        stroke="#222a33" stroke-width="1"/>
+  <text x="510" y="346" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="13" fill="#e6edf3">path-traversal guard</text>
+  <text x="830" y="346" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#8b949e">../ block</text>
+
+  <!-- Arrow 4->5 -->
+  <line x1="500" y1="366" x2="500" y2="384"
+        stroke="#d97757" stroke-width="1.5" marker-end="url(#arrow-terra-sc)"/>
+
+  <!-- LAYER 5: tmux env isolation  y=388 -->
+  <rect x="200" y="388" width="600" height="52" rx="10"
+        fill="#11161d" stroke="#222a33" stroke-width="1.5"/>
+  <text x="254" y="420" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="22" font-weight="700" fill="#d97757">5</text>
+  <line x1="278" y1="398" x2="278" y2="430"
+        stroke="#222a33" stroke-width="1"/>
+  <text x="510" y="420" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="13" fill="#e6edf3">tmux env isolation</text>
+  <text x="830" y="420" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="10" fill="#8b949e">per-chat pane</text>
+
+  <!-- Arrow layer 5 -> bottom capsule -->
+  <line x1="500" y1="440" x2="500" y2="460"
+        stroke="#d97757" stroke-width="1.5" marker-end="url(#arrow-terra-sc)"/>
+
+  <!-- BOTTOM CAPSULE: processed safely (terracotta) -->
+  <rect x="340" y="464" width="320" height="46" rx="23"
+        fill="#11161d" stroke="#d97757" stroke-width="1.6"/>
+  <text x="500" y="493" text-anchor="middle"
+        font-family="ui-monospace,'JetBrains Mono','SF Mono',monospace"
+        font-size="14" font-weight="600" fill="#e6edf3">processed safely</text>
+</svg>


### PR DESCRIPTION
## What

Add four self-contained dark-minimalist SVG diagrams to the README, embedded in both the English and Russian versions.

| Diagram | README section | File |
|---|---|---|
| Architecture / message flow (hero) | intro (replaces ASCII) | `docs/assets/architecture-hero.svg` |
| Multichat routing | section 3 | `docs/assets/multichat.svg` |
| Hooks → progress surfaces | section 4 | `docs/assets/hooks.svg` |
| Security defence-in-depth | section 10 | `docs/assets/security.svg` |

## Notes

- Pure SVG (no `<script>`, no `<foreignObject>`, no external fonts/CDN) — renders on GitHub via `<img>` and works offline. Chosen over Mermaid because Mermaid needs a client-side renderer that isn't always available.
- Single-accent dark palette (terracotta `#d97757` + cool `#58a6ff` on `#0a0e14`), monospace, no emoji.
- Docs-only change; no source, tests, or behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)