### PR TITLE
Фикс форматирования Telegram: одиночные safe-теги (личка) + format=auto для outbox (группы)

### DIFF
--- a/plugin/src/chats/hooks/stop-to-outbox.py
+++ b/plugin/src/chats/hooks/stop-to-outbox.py
@@ -421,7 +421,11 @@ def main() -> int:
         "text": assistant_text,
         "chat_id": chat_id,  # strictly from env, never from transcript
         "timestamp": now_iso,
-        "format": "text",
+        # 'auto' (2026-06-05): the router converts markdown -> Telegram HTML
+        # with the shared TS converter and chunks at 4000 chars. The previous
+        # hardcoded 'text' shipped agent markdown as literal **bold** into
+        # group chats (no parse_mode at all).
+        "format": "auto",
     }
 
     final_path = outbox_dir / build_filename()

--- a/plugin/src/format/html.ts
+++ b/plugin/src/format/html.ts
@@ -195,12 +195,84 @@ function stashTables(input: string, store: Placeholder[]): string {
   })
 }
 
+interface SafeTagToken {
+  /** Offset of `<` in the input. */
+  start: number
+  /** Offset just past `>`. */
+  end: number
+  /** The full raw tag text, e.g. `</pre>`. */
+  raw: string
+  /** Lowercased tag name. */
+  name: string
+  /** True for `</foo>`. */
+  closing: boolean
+}
+
 function stashSafeTags(input: string, store: Placeholder[]): string {
-  return input.replace(SAFE_TAG_RE, match => {
-    const key = sentinel('TG', store.length)
-    store.push({ key, html: match })
-    return key
+  // Tokenize safe-tag candidates with positions, then keep only tags that
+  // form properly-nested OPEN/CLOSE pairs (void <br> always kept, closing
+  // </br> never). Everything else falls through to the escape pass.
+  //
+  // Why balance-aware: a lone `<pre>` mentioned in prose («два сообщения
+  // с <pre>») used to survive verbatim, reach Telegram as an unclosed tag,
+  // and trip the pre-send validator's whole-message plain-text downgrade —
+  // the warchief saw literal &lt;b&gt; soup instead of formatting
+  // (2026-06-05). Escaping the unpaired tag keeps the rest of the message
+  // valid HTML so formatting ships.
+  const tokens: SafeTagToken[] = []
+  for (const m of input.matchAll(SAFE_TAG_RE)) {
+    const raw = m[0]
+    const name = (/^<\/?\s*([a-zA-Z][a-zA-Z0-9-]*)/.exec(raw)?.[1] ?? '').toLowerCase()
+    tokens.push({
+      start: m.index,
+      end: m.index + raw.length,
+      raw,
+      name,
+      closing: raw.startsWith('</'),
+    })
+  }
+
+  const keep = new Set<number>()
+  const stack: number[] = []
+  tokens.forEach((t, idx) => {
+    if (t.name === 'br') {
+      // Void element: bare/self-closing form is valid on its own; the
+      // closing form `</br>` is invalid HTML — leave it for escaping.
+      if (!t.closing) keep.add(idx)
+      return
+    }
+    if (!t.closing) {
+      stack.push(idx)
+      return
+    }
+    const top = stack[stack.length - 1]
+    if (top !== undefined && tokens[top]!.name === t.name) {
+      // Properly-nested pair — keep both ends. Strict top-of-stack match
+      // guarantees every kept pair contains only kept (balanced) tags, so
+      // the preserved subset always passes Telegram's nesting rules.
+      stack.pop()
+      keep.add(top)
+      keep.add(idx)
+      return
+    }
+    // Mismatched closing tag (`</b>` with no open `<b>` on top) — escape.
   })
+  // Anything left on the stack is an unclosed opener — not kept.
+
+  if (keep.size === 0) return input
+
+  let out = ''
+  let cursor = 0
+  tokens.forEach((t, idx) => {
+    if (!keep.has(idx)) return
+    out += input.slice(cursor, t.start)
+    const key = sentinel('TG', store.length)
+    store.push({ key, html: t.raw })
+    out += key
+    cursor = t.end
+  })
+  out += input.slice(cursor)
+  return out
 }
 
 function stashMdLinks(input: string, store: Placeholder[]): string {
@@ -233,7 +305,9 @@ function restoreAll(input: string, stores: Placeholder[][]): string {
  * apply markdown transforms on the escaped text, then restore sentinels.
  * This guarantees that:
  *   - HTML never appears inside a code block (we stashed code first)
- *   - User-typed `<script>` etc gets escaped, agent-written `<b>` survives
+ *   - User-typed `<script>` etc gets escaped; agent-written `<b>…</b>`
+ *     survives only as balanced pairs — an unpaired safe tag (a lone
+ *     `<pre>` mentioned in prose) is escaped like ordinary text
  *   - snake_case identifiers don't get accidentally italicized
  */
 export function markdownToTelegramHtml(text: string): string {

--- a/plugin/src/router/inbox-bridge.ts
+++ b/plugin/src/router/inbox-bridge.ts
@@ -100,8 +100,17 @@ export type InboundMessage = {
 // because the only known in-tree writer path is the channel reply
 // tool itself (PR #22), which uses 'html' by default and converts
 // markdown→HTML before shipping.
+//
+// 'auto' (2026-06-05): the router runs `markdownToTelegramHtml` over
+// the payload at send time, then ships with parse_mode='HTML'. This
+// is the contract for writers that CANNOT convert on their side —
+// concretely the Python Stop hook (stop-to-outbox.py), which used to
+// hardcode `format: 'text'` and shipped agent markdown as literal
+// `**bold**` into group chats. One TS converter serves both the
+// in-process reply tool and the tmux outbox path; the router stays a
+// thin transport for every other format value (opt-in only).
 export const OutboxMessageFormatSchema = z
-  .enum(['html', 'markdown', 'text'])
+  .enum(['auto', 'html', 'markdown', 'text'])
   .default('html')
 export type OutboxMessageFormat = z.infer<typeof OutboxMessageFormatSchema>
 

--- a/plugin/src/router/multichat-router.ts
+++ b/plugin/src/router/multichat-router.ts
@@ -29,6 +29,8 @@ import { readdir, unlink } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import type { TelegramApi } from '../channel/tools.js'
+import { splitMessage } from '../format/chunk.js'
+import { markdownToTelegramHtml } from '../format/html.js'
 import type { Logger } from '../log.js'
 import {
   assertValidChatId,
@@ -785,22 +787,71 @@ export class MultichatRouter {
     // were delivered as literal text — regressing PR #22 which made
     // 'html' the default for the channel reply tool.
     //
-    // We deliberately do NOT call markdownToTelegramHtml here: the
-    // outbox writer (the tmux-side reply tool) owns text shape — the
-    // router is a thin transport. A writer that wants markdown→HTML
-    // conversion must do it before the outbox file lands; this mirrors
-    // how the in-process channel reply tool calls markdownToTelegramHtml
-    // before pushing to sendMessage.
-    if (message.format === 'html') {
+    // For 'html' / 'markdown' / 'text' we deliberately do NOT call
+    // markdownToTelegramHtml here: the outbox writer (the tmux-side
+    // reply tool) owns text shape — the router is a thin transport. A
+    // writer that wants markdown→HTML conversion must do it before the
+    // outbox file lands; this mirrors how the in-process channel reply
+    // tool calls markdownToTelegramHtml before pushing to sendMessage.
+    //
+    // 'auto' (2026-06-05) is the explicit opt-in for writers that
+    // cannot convert on their side — the Python Stop hook. The router
+    // converts markdown→HTML with the SAME converter the reply tool
+    // uses (one implementation, no Python re-impl drift) and chunks at
+    // the same 4000-char boundary so a long group answer doesn't trip
+    // Telegram's 4096 cap. safe-telegram-api still validates/redacts
+    // each chunk on the way out.
+    let text = message.text
+    if (message.format === 'auto') {
+      text = markdownToTelegramHtml(text)
+      opts.parse_mode = 'HTML'
+    } else if (message.format === 'html') {
       opts.parse_mode = 'HTML'
     } else if (message.format === 'markdown') {
       opts.parse_mode = 'MarkdownV2'
     }
     // format === 'text' → omit parse_mode entirely.
+    //
+    // Partial-delivery policy for multi-chunk sends (Codex review
+    // 2026-06-05, MED #1): if chunk 0 fails, nothing reached the user —
+    // dead-letter the claim like any single-message failure (operator
+    // retry is safe). If a LATER chunk fails, the head of the answer is
+    // already user-visible — retrying the whole payload would duplicate
+    // it, so we log `partial_delivery` and CONFIRM the claim instead
+    // (same «never duplicate the user-visible message» stance as the
+    // confirm-failure path below).
+    let sentChunks = 0
     try {
-      await this.telegramApi.sendMessage(chatId, message.text, opts)
+      const chunks = message.format === 'auto' ? splitMessage(text) : [text]
+      for (let i = 0; i < chunks.length; i++) {
+        // reply_to threads only the first chunk — mirrors the reply
+        // tool's chunking contract (no quote-spam on long answers).
+        const chunkOpts = i === 0 ? opts : { ...opts }
+        if (i > 0) delete chunkOpts.reply_to_message_id
+        await this.telegramApi.sendMessage(chatId, chunks[i] as string, chunkOpts)
+        sentChunks++
+      }
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err)
+      if (sentChunks > 0) {
+        this.logger.error('router.outbox.partial_delivery', {
+          chat_id: chatId,
+          original: claim.originalName,
+          sent_chunks: sentChunks,
+          error: reason,
+        })
+        await confirmOutboxClaim(claim).catch((confirmErr: unknown) => {
+          this.logger.warn('router.outbox.confirm_failed', {
+            chat_id: chatId,
+            original: claim.originalName,
+            error:
+              confirmErr instanceof Error
+                ? confirmErr.message
+                : String(confirmErr),
+          })
+        })
+        return
+      }
       this.logger.warn('router.outbox.send_failed', {
         chat_id: chatId,
         error: reason,

--- a/plugin/tests/chats/stop-to-outbox.test.ts
+++ b/plugin/tests/chats/stop-to-outbox.test.ts
@@ -148,7 +148,9 @@ describe('stop-to-outbox.py — extraction', () => {
     const payload = readOutboxPayload(files[0]!)
     expect(payload.text).toBe('final answer')
     expect(payload.chat_id).toBe(CHAT_ID)
-    expect(payload.format).toBe('text')
+    // 'auto' (2026-06-05): router converts markdown→HTML at send time —
+    // the Python hook cannot run the TS converter itself.
+    expect(payload.format).toBe('auto')
     expect(typeof payload.timestamp).toBe('string')
     expect((payload.timestamp as string).length).toBeGreaterThan(0)
   })

--- a/plugin/tests/format/html.test.ts
+++ b/plugin/tests/format/html.test.ts
@@ -6,6 +6,7 @@ import {
   isTelegramHtmlParseError,
   markdownToTelegramHtml,
 } from '../../src/format/html.js'
+import { validateTelegramHtml } from '../../src/safety/html-validator.js'
 
 describe('escapeHtml / escapeHtmlAttr', () => {
   test('escapes ampersand angle brackets in plain text', () => {
@@ -111,6 +112,55 @@ describe('markdownToTelegramHtml', () => {
 
   test('handles empty string', () => {
     expect(markdownToTelegramHtml('')).toBe('')
+  })
+
+  // Balance-aware safe-tag stashing (2026-06-05): a lone safe tag in prose
+  // must be escaped, not preserved — preserved-verbatim it reaches Telegram
+  // as an unclosed tag and trips the validator's whole-message plain-text
+  // downgrade, mangling every other tag into literal &lt;b&gt; text.
+  describe('unbalanced safe tags', () => {
+    test('lone <pre> in prose is escaped while markdown bold still converts', () => {
+      const md = '**Жирный заголовок** и вопрос: ты видишь ДВА окна (два сообщения с <pre>) в личке?'
+      const html = markdownToTelegramHtml(md)
+      expect(html).toContain('<b>Жирный заголовок</b>')
+      expect(html).toContain('&lt;pre&gt;')
+      expect(html).not.toContain('(два сообщения с <pre>)')
+      // The whole point: the rendered body must survive pre-send validation.
+      expect(validateTelegramHtml(html).downgraded).toBe(false)
+    })
+
+    test('balanced agent-written pair still survives verbatim', () => {
+      const html = markdownToTelegramHtml('see <pre>raw block</pre> and <b>bold</b>')
+      expect(html).toContain('<pre>raw block</pre>')
+      expect(html).toContain('<b>bold</b>')
+      expect(validateTelegramHtml(html).downgraded).toBe(false)
+    })
+
+    test('mismatched closing tag is escaped, surrounding pair kept', () => {
+      const html = markdownToTelegramHtml('<i>a</b>b</i> tail')
+      expect(html).toContain('<i>a&lt;/b&gt;b</i>')
+      expect(validateTelegramHtml(html).downgraded).toBe(false)
+    })
+
+    test('improperly nested tags are all escaped rather than shipped broken', () => {
+      const html = markdownToTelegramHtml('<b>a<pre>b</b> c')
+      expect(html).toContain('&lt;b&gt;a&lt;pre&gt;b&lt;/b&gt; c')
+      expect(html).not.toContain('<b>')
+      expect(validateTelegramHtml(html).downgraded).toBe(false)
+    })
+
+    test('void <br> is kept without a closing pair, </br> is escaped', () => {
+      const html = markdownToTelegramHtml('line<br>break</br>')
+      expect(html).toContain('line<br>break')
+      expect(html).toContain('&lt;/br&gt;')
+      expect(validateTelegramHtml(html).downgraded).toBe(false)
+    })
+
+    test('nested same-name pairs survive', () => {
+      const html = markdownToTelegramHtml('<b>out <b>in</b> out</b>')
+      expect(html).toContain('<b>out <b>in</b> out</b>')
+      expect(validateTelegramHtml(html).downgraded).toBe(false)
+    })
   })
 })
 

--- a/plugin/tests/router/fix-f.test.ts
+++ b/plugin/tests/router/fix-f.test.ts
@@ -55,6 +55,7 @@ import {
   OutboxMessageSchema,
   type OutboxMessage,
 } from '../../src/router/inbox-bridge.js'
+import { validateTelegramHtml } from '../../src/safety/html-validator.js'
 
 // ──────────────────────────────────────────────────────────────────────
 // Shared helpers (mirrored from multichat-router.gate.test.ts so the
@@ -283,6 +284,16 @@ describe('OutboxMessageSchema (FIX-F)', () => {
     expect(parsed.format).toBe('html')
   })
 
+  test('format=auto parses (2026-06-05 Stop-hook contract)', () => {
+    const parsed = OutboxMessageSchema.parse({
+      text: '**bold**',
+      chat_id: '164795011',
+      timestamp: '2026-06-05T00:00:00Z',
+      format: 'auto',
+    })
+    expect(parsed.format).toBe('auto')
+  })
+
   test('format=rich (invalid enum) → ZodError', () => {
     const result = OutboxMessageSchema.safeParse({
       text: 'x',
@@ -425,6 +436,91 @@ describe('deliverClaim format → parse_mode mapping (FIX-F)', () => {
     expect(fx.telegram.calls[0]?.opts.parse_mode).toBe('HTML')
   }, 5_000)
 
+  test('format=auto → markdown converted to HTML, parse_mode=HTML', async () => {
+    // 2026-06-05: the Python Stop hook cannot run the TS converter, so
+    // it writes format='auto' and the router converts at send time.
+    // Pre-fix the hook hardcoded 'text' and group chats saw literal
+    // `**bold**`.
+    const router = makeRouter(fx, policyForOwner())
+    await seedOutboxFile(fx.stateDir, ownerChat, `${Date.now()}-auto.json`, {
+      text: '**жирный** и одиночный <pre> в прозе',
+      chat_id: ownerChat,
+      timestamp: '2026-06-05T00:00:00Z',
+      format: 'auto',
+    })
+
+    await router.start()
+    await new Promise((r) => setTimeout(r, 600))
+    await router.stop()
+
+    expect(fx.telegram.calls.length).toBe(1)
+    const call = fx.telegram.calls[0]!
+    expect(call.opts.parse_mode).toBe('HTML')
+    // ** converted, lone <pre> escaped (balance-aware stash) — the body
+    // must survive Telegram's HTML parser without the plain-text downgrade.
+    expect(call.text).toContain('<b>жирный</b>')
+    expect(call.text).toContain('&lt;pre&gt;')
+    expect(call.text).not.toContain('**')
+  }, 5_000)
+
+  test('format=auto long payload → chunked into multiple sends', async () => {
+    const router = makeRouter(fx, policyForOwner())
+    const para = `${'строка анализа воркшопа '.repeat(40)}\n\n`
+    await seedOutboxFile(fx.stateDir, ownerChat, `${Date.now()}-long.json`, {
+      // ~9.6k chars → must split into 3 chunks at the 4000 boundary.
+      text: para.repeat(10),
+      chat_id: ownerChat,
+      reply_to: '77',
+      timestamp: '2026-06-05T00:00:00Z',
+      format: 'auto',
+    })
+
+    await router.start()
+    await new Promise((r) => setTimeout(r, 600))
+    await router.stop()
+
+    expect(fx.telegram.calls.length).toBeGreaterThan(1)
+    for (const call of fx.telegram.calls) {
+      expect((call.text as string).length).toBeLessThanOrEqual(4000)
+      expect(call.opts.parse_mode).toBe('HTML')
+    }
+    // reply_to threads only the first chunk — no quote-spam.
+    expect(fx.telegram.calls[0]?.opts.reply_to_message_id).toBe(77)
+    for (const call of fx.telegram.calls.slice(1)) {
+      expect('reply_to_message_id' in call.opts).toBe(false)
+    }
+  }, 5_000)
+
+  test('format=auto long MARKDOWN payload → every chunk is valid Telegram HTML', async () => {
+    // Codex review 2026-06-05 LOW #1: the risky path is long markdown
+    // whose conversion produces real HTML tags near chunk boundaries.
+    // Every sent chunk must survive validateTelegramHtml (no downgrade)
+    // — splitMessage's tag-balancing has to keep <b>/<code>/<pre> pairs
+    // intact per chunk.
+    const router = makeRouter(fx, policyForOwner())
+    const para =
+      '**Сервис ReplyGuy** ищет посты по теме и пишет `комментарии` от агента.\n' +
+      '```python\nfor post in feed:\n    comment(post)\n```\n' +
+      'Подробнее: [док](https://example.com/doc) и одиночный <pre> в прозе.\n\n'
+    await seedOutboxFile(fx.stateDir, ownerChat, `${Date.now()}-mdlong.json`, {
+      text: para.repeat(30), // ~6.5k chars source → multiple chunks
+      chat_id: ownerChat,
+      timestamp: '2026-06-05T00:00:00Z',
+      format: 'auto',
+    })
+
+    await router.start()
+    await new Promise((r) => setTimeout(r, 600))
+    await router.stop()
+
+    expect(fx.telegram.calls.length).toBeGreaterThan(1)
+    for (const call of fx.telegram.calls) {
+      expect(call.opts.parse_mode).toBe('HTML')
+      const verdict = validateTelegramHtml(call.text)
+      expect(verdict.downgraded).toBe(false)
+    }
+  }, 5_000)
+
   test('invalid format → file dead-lettered, sendMessage never called', async () => {
     const router = makeRouter(fx, policyForOwner())
     const filename = `${Date.now()}-eeee.json`
@@ -468,6 +564,79 @@ describe('deliverClaim format → parse_mode mapping (FIX-F)', () => {
     expect((sidecarMeta.reason as string).startsWith('parse_failed:')).toBe(
       true,
     )
+  }, 5_000)
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// Partial delivery (Codex review 2026-06-05 MED #1): a failure AFTER the
+// first chunk shipped must NOT dead-letter the claim — an operator retry
+// would duplicate the already-visible head of the answer. The claim is
+// confirmed (consumed) and `router.outbox.partial_delivery` is logged.
+// A failure on chunk 0 keeps the old dead-letter semantics.
+// ──────────────────────────────────────────────────────────────────────
+
+describe('deliverClaim partial delivery (format=auto)', () => {
+  let fx: Fixture
+  const ownerChat = '164795011'
+
+  beforeEach(() => {
+    fx = setupFixture()
+  })
+  afterEach(() => {
+    cleanupFixture(fx)
+  })
+
+  test('second chunk fails → claim consumed, partial_delivery logged, no dead-letter', async () => {
+    // Failing spy: first sendMessage succeeds, the rest throw.
+    let calls = 0
+    const api: MultichatTelegramApi = {
+      sendMessage: async () => {
+        calls++
+        if (calls > 1) throw new Error('network blip')
+        return { message_id: 1 } as unknown as Awaited<
+          ReturnType<MultichatTelegramApi['sendMessage']>
+        >
+      },
+      sendChatAction: async () => {},
+    }
+    const policy = makePolicy({
+      chats: { [ownerChat]: makeChatPolicy() },
+      allowlist_users: [ownerChat],
+    })
+    const router = new MultichatRouter({
+      policy,
+      pool: fx.pool as unknown as TmuxSessionPool,
+      stateDir: fx.stateDir,
+      workspaceDir: fx.workspaceDir,
+      telegramApi: api,
+      logger: fx.loggerState.logger,
+    })
+    await seedOutboxFile(fx.stateDir, ownerChat, `${Date.now()}-part.json`, {
+      text: `${'абзац текста про воркшоп '.repeat(40)}\n\n`.repeat(10),
+      chat_id: ownerChat,
+      timestamp: '2026-06-05T00:00:00Z',
+      format: 'auto',
+    })
+
+    await router.start()
+    await new Promise((r) => setTimeout(r, 600))
+    await router.stop()
+
+    expect(calls).toBeGreaterThan(1)
+    // Logged as partial delivery…
+    expect(
+      fx.loggerState.logs.some((l) => l.msg === 'router.outbox.partial_delivery'),
+    ).toBe(true)
+    // …and NOT dead-lettered (no retry-able copy left behind).
+    const deadLetterDir = join(
+      fx.stateDir,
+      'chats',
+      ownerChat,
+      'outbox',
+      'dead-letter',
+    )
+    const entries = existsSync(deadLetterDir) ? readdirSync(deadLetterDir) : []
+    expect(entries.length).toBe(0)
   }, 5_000)
 })
 


### PR DESCRIPTION
## Два production-бага (2026-06-05)

### 1. Личка: literal `&lt;b&gt;` вместо форматирования
Одиночный `<pre>`, упомянутый в прозе, проходил `stashSafeTags` как «безопасный тег агента» и доезжал до pre-send валидатора незакрытым тегом → `validateTelegramHtml` давал whole-message downgrade → весь текст (включая сгенерированные `<b>`) уходил заэкранированным plain-text.

**Фикс** (`format/html.ts`): балансная проверка в `stashSafeTags` — сохраняются только правильно вложенные пары open/close (strict top-of-stack matching), `<br>` как void (а `</br>` экранируется), одиночные/несогласованные теги экранируются как обычный текст. Markdown-форматирование при этом доезжает.

### 2. Группы: сырой `**markdown**` в воркшоп-чате
`stop-to-outbox.py` жёстко писал `format: "text"` → router слал без конвертации и parse_mode.

**Фикс**: новое значение `format: "auto"` в `OutboxMessageSchema` — hook пишет `auto`, router конвертирует markdown→HTML общим TS-конвертером (`markdownToTelegramHtml`), ставит `parse_mode=HTML` и чанкует через `splitMessage` на границе 4000 (reply_to только на первом chunk). Один конвертер на оба пути, без Python-реимплементации.

## Double review
Codex GPT-5.5 (adversarial): **Critical/High — нет.**
- MED (partial delivery на multi-chunk): закрыт — падение ПОСЛЕ первого chunk теперь confirm claim + лог `router.outbox.partial_delivery` (не dead-letter), чтобы retry не дублировал уже видимое сообщение; падение на chunk 0 — прежний dead-letter.
- LOW (тест chunk-валидности): добавлен — каждый chunk длинного markdown-ответа проходит `validateTelegramHtml` без downgrade.
- LOW (deployment race): см. порядок активации ниже.

## Тесты
77 pass в затронутых файлах; полный набор 1199 pass / 1 fail (pre-existing WIP memory_search, не из этого PR). tsc чист вне того же WIP.

## Активация (порядок важен)
1. Рестарт плагина (новая схема + router + конвертер).
2. ПОСЛЕ — синк workspace-копии хука (`~/.claude-lab/thrall/.claude/chats/hooks/stop-to-outbox.py`): работающий старый router не знает `auto` и завернул бы outbox-файлы в dead-letter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)