### PR TITLE
Фикс незасабмиченного первого сообщения мультичата: readiness gate + bracketed paste + verify-loop

### DIFF
--- a/plugin/src/chats/hooks/multichat-entrypoint.sh
+++ b/plugin/src/chats/hooks/multichat-entrypoint.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# multichat-entrypoint.sh — tmux session entrypoint for per-chat `claude`.
+#
+# Spawned by TmuxSessionPool.spawnInternal() instead of `claude` directly.
+# Responsibilities:
+#   1. Start a background inbox-watcher that polls (or inotifywait-watches)
+#      ${MULTICHAT_STATE_DIR}/chats/${CHAT_ID}/inbox/ for new *.json files.
+#   2. For each committed JSON: parse text + reply_context + media_paths,
+#      build a single prompt string, and inject it into the tmux pane as a
+#      bracketed paste (`tmux load-buffer` + `paste-buffer -p`) followed by
+#      a VERIFIED Enter — see "Submit reliability" below.
+#   3. Move processed files to inbox/.processed/ so the watcher does not
+#      reprocess on the next pass.
+#   4. exec claude in the foreground so the pane runs the interactive REPL
+#      while the background watcher feeds it inbound messages.
+#
+# Submit reliability (FIX 2026-06-05): the original implementation used
+# `send-keys -l "$text"` + `sleep 0.05` + `send-keys Enter`. Two failure
+# mechanisms were observed in production (first message of a fresh spawn
+# sat un-submitted in the composer until a human pressed Enter):
+#   a) First-spawn race — the watcher's initial drain fires while the
+#      Claude Code TUI is still booting (banner render, MCP loading), so
+#      the trailing Enter lands before the input keymap is mounted.
+#   b) Paste-burst grouping — the TUI groups a rapid keystroke burst as a
+#      paste; an Enter 50ms behind a multi-line literal is swallowed into
+#      the group as a soft newline instead of submitting.
+# Countermeasures, in order: readiness gate (poll for the composer prompt
+# before first injection), bracketed paste for the body (atomic — never
+# grouped with later keys), a paste→submit separation pause, and an
+# Enter-only verify loop (re-sends ONLY Enter, never the body, so a
+# false "not submitted" reading can never duplicate the message).
+#
+# Fail-safe behaviour:
+#   * CHAT_ID or MULTICHAT_STATE_DIR missing -> exit 2 (refuse to start).
+#     This prevents a misconfigured spawn from running a stray master
+#     claude with no chat isolation.
+#   * TMUX_PANE missing (we are not inside tmux) -> watcher self-disables,
+#     but claude still launches so the operator can attach and recover.
+#   * python3 / json parse failure on a single file -> log to stderr,
+#     skip the file (do NOT move to .processed/ — operator can retry).
+#   * Submit unconfirmed after all retries -> the file is moved to
+#     .processed/ with a `submit-unconfirmed-` prefix (NOT requeued: the
+#     body already sits in the composer, so a re-paste would duplicate
+#     it; the next inbound message's Enter flushes the stuck composer).
+#
+# Concurrency note: the watcher runs as a subshell in the background.
+# `trap ... EXIT` ensures we tear it down when claude exits so we do not
+# leak watchers across tmux restarts.
+
+set -euo pipefail
+
+# ───── Tunables (env-overridable; tests set tiny values) ─────
+# Seconds between TUI-readiness polls, and max polls before giving up
+# and injecting anyway (degraded mode = old fixed-sleep behaviour).
+READY_POLL_INTERVAL="${MULTICHAT_READY_POLL_INTERVAL:-0.5}"
+READY_POLL_MAX="${MULTICHAT_READY_POLL_MAX:-60}"
+# Pause between the bracketed paste and the first Enter — must outlast
+# the TUI's paste-burst detection window.
+PASTE_SETTLE="${MULTICHAT_PASTE_SETTLE:-0.6}"
+# Verify-loop: initial post-Enter wait, growth factor applied per retry,
+# and total attempts.
+SUBMIT_RETRY_DELAY="${MULTICHAT_SUBMIT_RETRY_DELAY:-0.4}"
+SUBMIT_RETRY_FACTOR="${MULTICHAT_SUBMIT_RETRY_FACTOR:-1.8}"
+SUBMIT_RETRY_MAX="${MULTICHAT_SUBMIT_RETRY_MAX:-5}"
+
+# ───── Injection helpers ─────
+# All helpers read $PANE (the target tmux pane id) as a global set by the
+# watcher subshell. Defined at top level so a test harness can source
+# this file (MULTICHAT_ENTRYPOINT_TEST_ONLY=1) and exercise them with a
+# stub `tmux` on PATH.
+
+# Plain-text snapshot of the pane. -p strips attributes, -J rejoins
+# wrapped lines (so fingerprints survive narrow panes), -S -200 reaches
+# back far enough that a long prompt's head is still visible.
+pane_text() {
+  tmux capture-pane -t "$PANE" -p -J -S -200 2>/dev/null || true
+}
+
+# Block until the Claude Code composer is accepting input. The composer
+# renders a `❯` prompt char once the input handler is mounted; the boot
+# banner does not contain one. On timeout we proceed anyway — worst case
+# we degrade to the pre-fix behaviour instead of dropping the message.
+wait_claude_ready() {
+  local i
+  for ((i = 0; i < READY_POLL_MAX; i++)); do
+    if pane_text | grep -q '❯'; then
+      # The prompt can render a beat before the keymap is live; one more
+      # poll interval of settle keeps the first Enter from racing it.
+      sleep "$READY_POLL_INTERVAL"
+      return 0
+    fi
+    sleep "$READY_POLL_INTERVAL"
+  done
+  echo "multichat-entrypoint(watcher): TUI readiness timeout, injecting anyway" >&2
+  return 0
+}
+
+# A distinctive substring of the prompt used to judge "still sitting in
+# the composer". Heuristic only: a false "still there" costs one extra
+# Enter on an idle composer, which is harmless.
+prompt_fingerprint() {
+  printf '%s' "$1" | grep -m1 -E '.{8,}' | cut -c1-60 || true
+}
+
+# Paste the body, then press Enter until the turn provably started.
+# Success signals (either suffices):
+#   * footer shows "esc to interrupt" — generation is running;
+#   * the fingerprint vanished from the pane — composer cleared (covers
+#     turns that finish faster than our poll).
+# The body is pasted exactly once; only Enter is ever retried.
+submit_prompt() {
+  local msg_text="$1"
+  local fp attempt delay buf
+  fp="$(prompt_fingerprint "$msg_text")"
+
+  wait_claude_ready
+
+  # Bracketed paste: the TUI receives one atomic paste event, so embedded
+  # newlines stay soft newlines and the later Enter can never be grouped
+  # into the paste. printf (not heredoc/<<<) avoids a trailing newline.
+  buf="multichat-${CHAT_ID}-$$"
+  printf '%s' "$msg_text" | tmux load-buffer -b "$buf" -
+  tmux paste-buffer -d -t "$PANE" -b "$buf" -p
+
+  sleep "$PASTE_SETTLE"
+
+  delay="$SUBMIT_RETRY_DELAY"
+  for ((attempt = 1; attempt <= SUBMIT_RETRY_MAX; attempt++)); do
+    tmux send-keys -t "$PANE" Enter
+    sleep "$delay"
+
+    if pane_text | grep -qiE 'esc to interrupt'; then
+      return 0
+    fi
+    if [[ -z "$fp" ]] || ! pane_text | grep -qF -- "$fp"; then
+      return 0
+    fi
+
+    delay="$(awk -v d="$delay" -v f="$SUBMIT_RETRY_FACTOR" \
+      'BEGIN { printf "%.2f", d * f }')"
+  done
+
+  echo "multichat-entrypoint(watcher): submit not confirmed after ${SUBMIT_RETRY_MAX} attempts" >&2
+  return 1
+}
+
+# Parse one JSON file into a single prompt string. Reads the file path
+# from $INBOX_FILE so nothing user-controlled is interpolated into shell.
+build_prompt() {
+  INBOX_FILE="$1" python3 - <<'PYEOF'
+import json
+import os
+import sys
+
+path = os.environ.get('INBOX_FILE', '')
+try:
+    with open(path, 'r', encoding='utf-8') as f:
+        d = json.load(f)
+except Exception as e:  # noqa: BLE001
+    print(f'multichat-entrypoint(watcher): parse failed for {path}: {e}',
+          file=sys.stderr)
+    sys.exit(1)
+
+if not isinstance(d, dict):
+    print(f'multichat-entrypoint(watcher): {path} is not a JSON object',
+          file=sys.stderr)
+    sys.exit(1)
+
+parts = []
+
+reply_context = d.get('reply_context')
+if isinstance(reply_context, str) and reply_context:
+    parts.append(reply_context)
+
+text = d.get('text', '') or ''
+user = d.get('user', '') or ''
+if user:
+    parts.append(f'[from @{user}] {text}')
+else:
+    parts.append(text)
+
+media_paths = d.get('media_paths') or []
+if isinstance(media_paths, list):
+    for p in media_paths:
+        if isinstance(p, str) and p:
+            parts.append(f'[media: {p}]')
+
+# Two-newline join so the model sees explicit paragraph breaks between
+# the reply context, the main text, and the media descriptors.
+sys.stdout.write('\n\n'.join(parts))
+PYEOF
+}
+
+# Drain every committed *.json in inbox/ (sorted = ms-time order).
+# NOTE: We deliberately do NOT recurse into .processed/ — `find -maxdepth 1`
+# plus the leading-dot exclusion handled by the *.json glob keeps us safe.
+process_inbox() {
+  local f msg_text
+  while IFS= read -r -d '' f; do
+    [[ -f "$f" ]] || continue
+    msg_text="$(build_prompt "$f" || true)"
+    if [[ -n "$msg_text" ]]; then
+      if submit_prompt "$msg_text"; then
+        mv "$f" "${PROCESSED}/$(basename "$f")"
+      else
+        # Body is in the composer but submit never confirmed. Do NOT
+        # requeue (a re-paste would duplicate the message) — mark for
+        # operator triage; the next message's Enter flushes the stuck
+        # composer.
+        mv "$f" "${PROCESSED}/submit-unconfirmed-$(basename "$f")"
+      fi
+    else
+      # Parse failed — leave the file in place for operator triage but
+      # rename it so we don't spin on it.
+      mv "$f" "${PROCESSED}/parse-failed-$(basename "$f")"
+    fi
+  done < <(find "$INBOX" -maxdepth 1 -name '*.json' -print0 | sort -z)
+}
+
+# ───── Test seam ─────
+# When sourced with MULTICHAT_ENTRYPOINT_TEST_ONLY=1 the file defines the
+# helpers above and stops: no env validation, no watcher, no exec. Lets
+# tests drive submit_prompt/process_inbox against a stub tmux.
+if [[ "${MULTICHAT_ENTRYPOINT_TEST_ONLY:-}" == "1" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+# ───── Required env (fail-safe) ─────
+if [[ -z "${CHAT_ID:-}" || -z "${MULTICHAT_STATE_DIR:-}" ]]; then
+  echo "multichat-entrypoint: CHAT_ID or MULTICHAT_STATE_DIR not set, refusing to start" >&2
+  exit 2
+fi
+
+INBOX="${MULTICHAT_STATE_DIR}/chats/${CHAT_ID}/inbox"
+PROCESSED="${INBOX}/.processed"
+mkdir -p "$INBOX" "$PROCESSED"
+
+# ───── Background inbox watcher ─────
+(
+  # tmux exports TMUX_PANE inside every pane. Without it we cannot inject
+  # — the watcher logs a warning and exits cleanly so claude still runs.
+  PANE="${TMUX_PANE:-}"
+  if [[ -z "$PANE" ]]; then
+    echo "multichat-entrypoint(watcher): TMUX_PANE not set, watcher disabled" >&2
+    exit 0
+  fi
+
+  # Initial drain catches any pending messages that arrived between
+  # writeToInbox() and our exec — see PLAN.md H5 (spawn order fix).
+  # submit_prompt's readiness gate handles the boot race (no fixed sleep).
+  process_inbox
+
+  # Prefer inotifywait when available; fall back to polling.
+  if command -v inotifywait >/dev/null 2>&1; then
+    # --include filters to *.json so we ignore .tmp writes mid-rename.
+    while inotifywait -q -e create,moved_to --include '\.json$' "$INBOX" \
+        >/dev/null 2>&1; do
+      sleep 0.1  # debounce — rename() is atomic but bursts can stack
+      process_inbox
+    done
+  else
+    # 500ms cadence matches the outbox poller's order of magnitude.
+    while true; do
+      sleep 0.5
+      process_inbox
+    done
+  fi
+) &
+WATCHER_PID=$!
+
+# Tear down the watcher when claude (or this script) exits. `kill -0` test
+# avoids `kill: no such process` noise when the watcher already died.
+cleanup() {
+  if kill -0 "$WATCHER_PID" 2>/dev/null; then
+    kill "$WATCHER_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+# Hand the pane over to claude. tmux runs us in the foreground process
+# of the session; exec keeps claude as the leaf process so tmux's
+# remain-on-exit semantics work as expected.
+exec claude

--- a/plugin/src/chats/hooks/multichat-entrypoint.sh
+++ b/plugin/src/chats/hooks/multichat-entrypoint.sh
@@ -69,11 +69,14 @@ SUBMIT_RETRY_MAX="${MULTICHAT_SUBMIT_RETRY_MAX:-5}"
 # this file (MULTICHAT_ENTRYPOINT_TEST_ONLY=1) and exercise them with a
 # stub `tmux` on PATH.
 
-# Plain-text snapshot of the pane. -p strips attributes, -J rejoins
-# wrapped lines (so fingerprints survive narrow panes), -S -200 reaches
-# back far enough that a long prompt's head is still visible.
+# Plain-text snapshot of the VISIBLE pane only. -p strips attributes,
+# -J rejoins wrapped lines (so fingerprints survive narrow panes). We
+# deliberately do NOT pass -S: Claude Code's TUI scrolls (no alternate
+# screen), so pane history contains stale frames — an old generating
+# footer ("esc to interrupt") in scrollback would read as a false
+# submit-success. The composer always sits in the visible region.
 pane_text() {
-  tmux capture-pane -t "$PANE" -p -J -S -200 2>/dev/null || true
+  tmux capture-pane -t "$PANE" -p -J 2>/dev/null || true
 }
 
 # Block until the Claude Code composer is accepting input. The composer
@@ -97,42 +100,79 @@ wait_claude_ready() {
 
 # A distinctive substring of the prompt used to judge "still sitting in
 # the composer". Heuristic only: a false "still there" costs one extra
-# Enter on an idle composer, which is harmless.
+# Enter on an idle composer, which is harmless. python3 (already a hard
+# dependency via build_prompt) keeps the 60-char truncation UTF-8-safe —
+# byte-oriented `cut -c` would split multibyte Russian text and produce
+# a pattern that can never match the pane.
 prompt_fingerprint() {
-  printf '%s' "$1" | grep -m1 -E '.{8,}' | cut -c1-60 || true
+  printf '%s' "$1" | python3 -c '
+import sys
+for line in sys.stdin.read().splitlines():
+    line = line.strip()
+    if len(line) >= 4:
+        sys.stdout.write(line[:60])
+        break
+' || true
 }
 
 # Paste the body, then press Enter until the turn provably started.
-# Success signals (either suffices):
-#   * footer shows "esc to interrupt" — generation is running;
+# Success signals:
+#   * footer shows "esc to interrupt" AND generation was NOT already
+#     running before our paste — a pre-existing turn would read as a
+#     false success, so when one is in flight we fall back to the
+#     fingerprint signal only (Claude Code queues submits made during
+#     generation, so pasting immediately is still correct);
 #   * the fingerprint vanished from the pane — composer cleared (covers
-#     turns that finish faster than our poll).
-# The body is pasted exactly once; only Enter is ever retried.
+#     turns that finish faster than our poll, and queued submits).
+# The body is pasted exactly once; only Enter is ever retried, so a
+# false "not submitted" reading can never duplicate the message.
 submit_prompt() {
   local msg_text="$1"
-  local fp attempt delay buf
+  local fp attempt delay buf out pre_generating
   fp="$(prompt_fingerprint "$msg_text")"
 
   wait_claude_ready
 
+  pre_generating=0
+  if pane_text | grep -qiE 'esc to interrupt'; then
+    pre_generating=1
+  fi
+
   # Bracketed paste: the TUI receives one atomic paste event, so embedded
   # newlines stay soft newlines and the later Enter can never be grouped
   # into the paste. printf (not heredoc/<<<) avoids a trailing newline.
+  # Explicit `|| return 1` on each tmux op: these run with errexit
+  # suppressed (callers invoke us in `if` context), and a silently failed
+  # paste would otherwise read as "fingerprint vanished" = false success
+  # — losing the message entirely.
   buf="multichat-${CHAT_ID}-$$"
-  printf '%s' "$msg_text" | tmux load-buffer -b "$buf" -
-  tmux paste-buffer -d -t "$PANE" -b "$buf" -p
+  printf '%s' "$msg_text" | tmux load-buffer -b "$buf" - || {
+    echo "multichat-entrypoint(watcher): load-buffer failed" >&2
+    return 1
+  }
+  tmux paste-buffer -d -t "$PANE" -b "$buf" -p || {
+    echo "multichat-entrypoint(watcher): paste-buffer failed" >&2
+    return 1
+  }
 
   sleep "$PASTE_SETTLE"
 
   delay="$SUBMIT_RETRY_DELAY"
   for ((attempt = 1; attempt <= SUBMIT_RETRY_MAX; attempt++)); do
-    tmux send-keys -t "$PANE" Enter
+    tmux send-keys -t "$PANE" Enter || true
     sleep "$delay"
 
-    if pane_text | grep -qiE 'esc to interrupt'; then
+    out="$(pane_text)"
+    if [[ "$pre_generating" == "0" ]] \
+        && grep -qiE 'esc to interrupt' <<<"$out"; then
       return 0
     fi
-    if [[ -z "$fp" ]] || ! pane_text | grep -qF -- "$fp"; then
+    if [[ -n "$fp" ]] && ! grep -qF -- "$fp" <<<"$out"; then
+      return 0
+    fi
+    if [[ -z "$fp" ]]; then
+      # Nothing to verify against (empty/whitespace-only body) — assume
+      # the Enter landed. Degraded path, equals the pre-fix behaviour.
       return 0
     fi
 
@@ -250,17 +290,29 @@ mkdir -p "$INBOX" "$PROCESSED"
   # submit_prompt's readiness gate handles the boot race (no fixed sleep).
   process_inbox
 
+  # Watcher-leak guard (2026-06-05): `exec claude` below replaces the
+  # entrypoint shell, so the EXIT trap never fires when claude exits and
+  # this subshell would outlive the session — a leaked watcher targeting
+  # a dead pane still MOVES inbox files, eating messages meant for the
+  # chat's next spawn. $$ inside the subshell is the original entrypoint
+  # PID (= claude after the exec); when it dies, we exit too.
+  parent_alive() {
+    kill -0 "$$" 2>/dev/null
+  }
+
   # Prefer inotifywait when available; fall back to polling.
   if command -v inotifywait >/dev/null 2>&1; then
     # --include filters to *.json so we ignore .tmp writes mid-rename.
-    while inotifywait -q -e create,moved_to --include '\.json$' "$INBOX" \
+    while parent_alive \
+        && inotifywait -q -e create,moved_to --include '\.json$' "$INBOX" \
         >/dev/null 2>&1; do
       sleep 0.1  # debounce — rename() is atomic but bursts can stack
+      parent_alive || exit 0
       process_inbox
     done
   else
     # 500ms cadence matches the outbox poller's order of magnitude.
-    while true; do
+    while parent_alive; do
       sleep 0.5
       process_inbox
     done

--- a/plugin/tests/chats/multichat-entrypoint-submit.test.ts
+++ b/plugin/tests/chats/multichat-entrypoint-submit.test.ts
@@ -49,6 +49,9 @@ function installStubTmux(): void {
   const stub = `#!/usr/bin/env bash
 DIR="$(cd "$(dirname "\${BASH_SOURCE[0]}")/.." && pwd)"
 echo "$@" >> "$DIR/tmux.log"
+if [[ "$1" == "load-buffer" && -n "\${TMUX_STUB_FAIL_LOAD:-}" ]]; then
+  exit 1
+fi
 if [[ "$1" == "capture-pane" ]]; then
   n=$(cat "$DIR/capture-count" 2>/dev/null || echo 0)
   n=$((n + 1))
@@ -69,7 +72,10 @@ exit 0
 
 // Run a bash snippet with the script's helpers sourced, the stub tmux
 // first on PATH, and fast test timings.
-function runHelpers(snippet: string): {
+function runHelpers(
+  snippet: string,
+  extraEnv: Record<string, string> = {},
+): {
   code: number
   stdout: string
   stderr: string
@@ -94,6 +100,7 @@ ${snippet}`,
         MULTICHAT_SUBMIT_RETRY_DELAY: '0.01',
         MULTICHAT_SUBMIT_RETRY_FACTOR: '1.0',
         MULTICHAT_SUBMIT_RETRY_MAX: '3',
+        ...extraEnv,
       },
       encoding: 'utf8',
       timeout: 15_000,
@@ -206,6 +213,73 @@ describe('submit_prompt', () => {
     writeFileSync(join(dir, 'pane-3.txt'), `❯ \nanswer rendered above\n`)
 
     const res = runHelpers(`submit_prompt 'fast turn message goes here ok'`)
+
+    expect(res.code).toBe(0)
+    expect(
+      tmuxLog().filter((l) => l === 'send-keys -t %1 Enter').length,
+    ).toBe(1)
+  })
+
+  test('load-buffer failure: exit 1, no paste, no Enter', () => {
+    installStubTmux()
+    writeFileSync(join(dir, 'pane-1.txt'), READY_PANE)
+
+    const res = runHelpers(`submit_prompt 'a message that will not load'`, {
+      TMUX_STUB_FAIL_LOAD: '1',
+    })
+
+    expect(res.code).toBe(1)
+    expect(res.stderr).toContain('load-buffer failed')
+    const log = tmuxLog()
+    expect(log.filter((l) => l.startsWith('paste-buffer')).length).toBe(0)
+    expect(log.filter((l) => l === 'send-keys -t %1 Enter').length).toBe(0)
+  })
+
+  test('pre-existing generation: interrupt footer is NOT trusted as success', () => {
+    installStubTmux()
+    // Generating already before the paste (previous turn in flight) and
+    // the fingerprint stays visible after Enter — must retry, not
+    // false-succeed off the old turn's footer.
+    const stuckWhileGenerating = `✻ Reticulating…\n❯ queued message sitting in composer\nesc to interrupt\n`
+    writeFileSync(join(dir, 'pane-1.txt'), READY_PANE.replace('\n', '\nesc to interrupt\n'))
+    writeFileSync(join(dir, 'pane-3.txt'), stuckWhileGenerating)
+    // Eventually the composer clears (queued submit accepted).
+    writeFileSync(join(dir, 'pane-5.txt'), `✻ Reticulating…\n❯ \nesc to interrupt\n`)
+
+    const res = runHelpers(
+      `submit_prompt 'queued message sitting in composer'`,
+    )
+
+    expect(res.code).toBe(0)
+    expect(
+      tmuxLog().filter((l) => l === 'send-keys -t %1 Enter').length,
+    ).toBeGreaterThanOrEqual(2)
+  })
+
+  test('cyrillic fingerprint survives 60-char truncation (UTF-8 safe)', () => {
+    installStubTmux()
+    const ru =
+      '[from @dashieshiev] Проверь пожалуйста последние коммиты плагина и скажи решили ли мы все фиксы по репорту ученика'
+    writeFileSync(join(dir, 'pane-1.txt'), READY_PANE)
+    // Fingerprint (first 60 chars) still visible → not submitted → retry;
+    // a byte-split fingerprint would never match and false-succeed on the
+    // first Enter instead.
+    writeFileSync(join(dir, 'pane-3.txt'), `❯ ${ru}\n`)
+    writeFileSync(join(dir, 'pane-5.txt'), GENERATING_PANE)
+
+    const res = runHelpers(`submit_prompt '${ru}'`)
+
+    expect(res.code).toBe(0)
+    expect(
+      tmuxLog().filter((l) => l === 'send-keys -t %1 Enter').length,
+    ).toBeGreaterThanOrEqual(2)
+  })
+
+  test('short body without fingerprint: single Enter, assume success', () => {
+    installStubTmux()
+    writeFileSync(join(dir, 'pane-1.txt'), READY_PANE)
+
+    const res = runHelpers(`submit_prompt 'да'`)
 
     expect(res.code).toBe(0)
     expect(

--- a/plugin/tests/chats/multichat-entrypoint-submit.test.ts
+++ b/plugin/tests/chats/multichat-entrypoint-submit.test.ts
@@ -1,0 +1,265 @@
+// Tests for the verified-submit injection logic in
+// src/chats/hooks/multichat-entrypoint.sh (FIX 2026-06-05).
+//
+// Production bug: the first message of a fresh per-chat spawn landed in
+// the Claude Code composer but its trailing Enter never submitted (TUI
+// boot race + paste-burst grouping). The fix is a readiness gate +
+// bracketed paste + an Enter-only verify loop. We exercise the real bash
+// helpers by sourcing the script with MULTICHAT_ENTRYPOINT_TEST_ONLY=1
+// and a stub `tmux` on PATH that logs every invocation and serves
+// scripted capture-pane output, then assert on the tmux call log.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { spawnSync } from 'child_process'
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const SCRIPT = join(
+  import.meta.dir,
+  '..',
+  '..',
+  'src',
+  'chats',
+  'hooks',
+  'multichat-entrypoint.sh',
+)
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'entrypoint-submit-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+// Install a stub tmux into {dir}/bin. capture-pane output is read from
+// {dir}/pane-N.txt where N starts at 1 and advances after each
+// capture-pane call (sticking to the last file) — lets a test script the
+// pane evolving over time. Every invocation is appended to {dir}/tmux.log.
+function installStubTmux(): void {
+  const stub = `#!/usr/bin/env bash
+DIR="$(cd "$(dirname "\${BASH_SOURCE[0]}")/.." && pwd)"
+echo "$@" >> "$DIR/tmux.log"
+if [[ "$1" == "capture-pane" ]]; then
+  n=$(cat "$DIR/capture-count" 2>/dev/null || echo 0)
+  n=$((n + 1))
+  echo "$n" > "$DIR/capture-count"
+  f="$DIR/pane-$n.txt"
+  while [[ ! -f "$f" && $n -gt 1 ]]; do n=$((n - 1)); f="$DIR/pane-$n.txt"; done
+  cat "$f" 2>/dev/null || true
+fi
+if [[ "$1" == "load-buffer" ]]; then
+  cat > "$DIR/loaded-buffer.txt"
+fi
+exit 0
+`
+  spawnSync('mkdir', ['-p', join(dir, 'bin')])
+  writeFileSync(join(dir, 'bin', 'tmux'), stub)
+  chmodSync(join(dir, 'bin', 'tmux'), 0o755)
+}
+
+// Run a bash snippet with the script's helpers sourced, the stub tmux
+// first on PATH, and fast test timings.
+function runHelpers(snippet: string): {
+  code: number
+  stdout: string
+  stderr: string
+} {
+  const res = spawnSync(
+    'bash',
+    [
+      '-c',
+      `set -uo pipefail
+MULTICHAT_ENTRYPOINT_TEST_ONLY=1 source "${SCRIPT}"
+PANE='%1'
+CHAT_ID='test-chat'
+${snippet}`,
+    ],
+    {
+      env: {
+        ...process.env,
+        PATH: `${join(dir, 'bin')}:${process.env['PATH'] ?? ''}`,
+        MULTICHAT_READY_POLL_INTERVAL: '0.01',
+        MULTICHAT_READY_POLL_MAX: '5',
+        MULTICHAT_PASTE_SETTLE: '0.01',
+        MULTICHAT_SUBMIT_RETRY_DELAY: '0.01',
+        MULTICHAT_SUBMIT_RETRY_FACTOR: '1.0',
+        MULTICHAT_SUBMIT_RETRY_MAX: '3',
+      },
+      encoding: 'utf8',
+      timeout: 15_000,
+    },
+  )
+  return {
+    code: res.status ?? -1,
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? '',
+  }
+}
+
+function tmuxLog(): string[] {
+  try {
+    return readFileSync(join(dir, 'tmux.log'), 'utf8').trim().split('\n')
+  } catch {
+    return []
+  }
+}
+
+const READY_PANE = '❯ \n⏵⏵ bypass permissions on (shift+tab to cycle)\n'
+const GENERATING_PANE = '✻ Reticulating…\n❯ \nesc to interrupt\n'
+
+describe('submit_prompt', () => {
+  test('happy path: ready pane → single paste, single Enter, exit 0', () => {
+    installStubTmux()
+    writeFileSync(join(dir, 'pane-1.txt'), READY_PANE)
+    // After the first Enter the turn is generating.
+    writeFileSync(join(dir, 'pane-3.txt'), GENERATING_PANE)
+
+    const res = runHelpers(`submit_prompt 'hello from telegram, long enough'`)
+
+    expect(res.code).toBe(0)
+    const log = tmuxLog()
+    expect(log.filter((l) => l.startsWith('load-buffer')).length).toBe(1)
+    expect(log.filter((l) => l.startsWith('paste-buffer')).length).toBe(1)
+    expect(log.filter((l) => l === 'send-keys -t %1 Enter').length).toBe(1)
+    // Bracketed paste requested.
+    expect(log.find((l) => l.startsWith('paste-buffer'))).toContain('-p')
+    // Body delivered via buffer, exactly once, without trailing newline.
+    expect(readFileSync(join(dir, 'loaded-buffer.txt'), 'utf8')).toBe(
+      'hello from telegram, long enough',
+    )
+  })
+
+  test('readiness gate: paste waits until ❯ appears', () => {
+    installStubTmux()
+    // Boot banner (no ❯) for the first two captures, then ready, then
+    // generating after Enter.
+    writeFileSync(join(dir, 'pane-1.txt'), 'Welcome back!\nLoading MCP…\n')
+    writeFileSync(join(dir, 'pane-3.txt'), READY_PANE)
+    writeFileSync(join(dir, 'pane-5.txt'), GENERATING_PANE)
+
+    const res = runHelpers(`submit_prompt 'message during boot race here'`)
+
+    expect(res.code).toBe(0)
+    const log = tmuxLog()
+    // At least 3 captures happened BEFORE the paste (gate polled).
+    const pasteIdx = log.findIndex((l) => l.startsWith('paste-buffer'))
+    const capturesBefore = log
+      .slice(0, pasteIdx)
+      .filter((l) => l.startsWith('capture-pane')).length
+    expect(capturesBefore).toBeGreaterThanOrEqual(3)
+  })
+
+  test('swallowed Enter: retries Enter only, never re-pastes', () => {
+    installStubTmux()
+    // Ready, then the fingerprint stays visible in the composer (Enter
+    // swallowed) for one verify round, then generation starts.
+    const stuck = `❯ stuck message that did not submit yet\n`
+    writeFileSync(join(dir, 'pane-1.txt'), READY_PANE)
+    writeFileSync(join(dir, 'pane-3.txt'), stuck)
+    writeFileSync(join(dir, 'pane-5.txt'), GENERATING_PANE)
+
+    const res = runHelpers(
+      `submit_prompt 'stuck message that did not submit yet'`,
+    )
+
+    expect(res.code).toBe(0)
+    const log = tmuxLog()
+    expect(log.filter((l) => l.startsWith('paste-buffer')).length).toBe(1)
+    expect(
+      log.filter((l) => l === 'send-keys -t %1 Enter').length,
+    ).toBeGreaterThanOrEqual(2)
+  })
+
+  test('never confirmed: exits 1 after max attempts, body pasted once', () => {
+    installStubTmux()
+    // Composer keeps showing the fingerprint forever, no generation.
+    writeFileSync(
+      join(dir, 'pane-1.txt'),
+      `❯ permanently stuck composer text\n⏵⏵ bypass permissions on\n`,
+    )
+
+    const res = runHelpers(`submit_prompt 'permanently stuck composer text'`)
+
+    expect(res.code).toBe(1)
+    expect(res.stderr).toContain('submit not confirmed')
+    const log = tmuxLog()
+    expect(log.filter((l) => l.startsWith('load-buffer')).length).toBe(1)
+    // MULTICHAT_SUBMIT_RETRY_MAX=3 → exactly 3 Enters.
+    expect(log.filter((l) => l === 'send-keys -t %1 Enter').length).toBe(3)
+  })
+
+  test('fingerprint vanished counts as submitted (fast turn)', () => {
+    installStubTmux()
+    writeFileSync(join(dir, 'pane-1.txt'), READY_PANE)
+    // After Enter: no "esc to interrupt" (turn already finished), and the
+    // composer no longer shows the message.
+    writeFileSync(join(dir, 'pane-3.txt'), `❯ \nanswer rendered above\n`)
+
+    const res = runHelpers(`submit_prompt 'fast turn message goes here ok'`)
+
+    expect(res.code).toBe(0)
+    expect(
+      tmuxLog().filter((l) => l === 'send-keys -t %1 Enter').length,
+    ).toBe(1)
+  })
+})
+
+describe('process_inbox', () => {
+  test('unconfirmed submit moves file to submit-unconfirmed-, no requeue', () => {
+    installStubTmux()
+    // Permanently stuck composer → submit_prompt fails.
+    writeFileSync(
+      join(dir, 'pane-1.txt'),
+      `❯ [from @telegram] stuck forever in composer\n`,
+    )
+    const inbox = join(dir, 'inbox')
+    const processed = join(inbox, '.processed')
+    spawnSync('mkdir', ['-p', processed])
+    writeFileSync(
+      join(inbox, '100-aa.json'),
+      JSON.stringify({ text: 'stuck forever in composer', user: 'telegram' }),
+    )
+
+    const res = runHelpers(
+      `INBOX='${inbox}'; PROCESSED='${processed}'; process_inbox`,
+    )
+
+    expect(res.code).toBe(0)
+    const ls = spawnSync('ls', [processed], { encoding: 'utf8' })
+    expect(ls.stdout).toContain('submit-unconfirmed-100-aa.json')
+    const inboxLs = spawnSync('ls', [inbox], { encoding: 'utf8' })
+    expect(inboxLs.stdout).not.toContain('100-aa.json\n')
+  })
+
+  test('confirmed submit moves file to .processed/ unprefixed', () => {
+    installStubTmux()
+    writeFileSync(join(dir, 'pane-1.txt'), READY_PANE)
+    writeFileSync(join(dir, 'pane-3.txt'), GENERATING_PANE)
+    const inbox = join(dir, 'inbox')
+    const processed = join(inbox, '.processed')
+    spawnSync('mkdir', ['-p', processed])
+    writeFileSync(
+      join(inbox, '200-bb.json'),
+      JSON.stringify({ text: 'a normal message that submits', user: 'dashi' }),
+    )
+
+    const res = runHelpers(
+      `INBOX='${inbox}'; PROCESSED='${processed}'; process_inbox`,
+    )
+
+    expect(res.code).toBe(0)
+    const ls = spawnSync('ls', [processed], { encoding: 'utf8' })
+    expect(ls.stdout).toContain('200-bb.json')
+    expect(ls.stdout).not.toContain('submit-unconfirmed-200-bb.json')
+  })
+})


### PR DESCRIPTION
## Проблема

Воспроизведено в проде 2026-06-05 (первое сообщение в новой группе -1003955016794): per-chat сессия спавнится, промпт ложится в композер Claude Code, но Enter не срабатывает — сессия висит, пока человек не нажмёт Enter в pane руками.

Два механизма:
1. **Гонка первого запуска** — initial drain watcher'а шлёт send-keys до того, как TUI смонтировал input handler (баннер, загрузка MCP)
2. **Paste-burst группировка** — `send-keys -l` + Enter через 50ms: TUI группирует burst как вставку и съедает Enter как soft newline

## Фикс (дизайн — Codex GPT-5.5)

- **Readiness gate**: поллинг `capture-pane` на `❯` перед первой инъекцией (вместо слепого `sleep 2`)
- **Bracketed paste**: тело через `load-buffer` + `paste-buffer -p` — атомарная вставка, Enter не группируется
- **Пауза 0.6s** между paste и Enter — закрывает paste-burst окно
- **Verify-loop**: ретраит ТОЛЬКО Enter (тело не перешлётся — дублей нет); успех = `esc to interrupt` (если генерация не шла до paste) или исчезновение fingerprint; 5 попыток с backoff
- Неподтверждённый submit → `.processed/submit-unconfirmed-*` (не requeue — re-paste дал бы дубль)

## Adversarial review Codex — учтено 5 фиксов

- visible-only capture (без `-S`): scrollback хранил старые кадры с `esc to interrupt` → ложный успех
- `pre_generating`: футер идущей генерации не считается подтверждением нового submit
- явные `|| return 1` на load/paste (errexit подавлен в if-контексте; молчаливый сбой = потеря сообщения)
- UTF-8-safe fingerprint через python3 (cut -c рвал кириллицу побайтово)
- watcher-leak guard: `exec claude` гасит EXIT trap, осиротевший watcher жрал inbox следующего спавна (пре-существующий баг)

Отклонено: ожидание конца генерации перед paste (сломало бы штатный queue Claude Code).

## Дополнительно

Entrypoint теперь шипуется в репо (`src/chats/hooks/multichat-entrypoint.sh`) как канонический источник — раньше жил только деплой-артефактом в workspace (комментарий в spawn-chat-shell.sh «NOT shipped in this repo» это фиксировал).

## Тесты

11 новых (bun, стаб tmux на PATH): happy path, readiness gate, проглоченный Enter (ретрай без re-paste), исчерпание попыток, fast turn, сбой load-buffer, pre-existing generation, кириллический fingerprint, короткое тело, process_inbox confirmed/unconfirmed. Suite: 1268 pass / 1 fail — падение в tools.test.ts от незакоммиченного WIP (memory_search/fts) на машине, к этому PR не относится.

## Активация

Файл читается при спавне сессии — рестарт плагина не нужен для новых сессий, но деплой-копию в workspace (`chats/hooks/multichat-entrypoint.sh`) надо синхронизировать после мержа.

🤖 Generated with [Claude Code](https://claude.com/claude-code)