### PR TITLE
Редактор секретов: не маскировать публичные URL (мёртвые ссылки на GitHub)

### DIFF
--- a/plugin/src/safety/redact.ts
+++ b/plugin/src/safety/redact.ts
@@ -58,9 +58,33 @@ const FIREBASE_REs: RedactionRule[] = FIREBASE_FIELDS.map((field) => ({
 // Match the casing flexibly but not the "Bearer" word itself.
 const BEARER_RE = /(Bearer\s+)[A-Za-z0-9._\-+/=]{8,}/gi
 
-// Query-string tokens: ?token=, ?access_token=, ?api_key=, &key=.
-// Anchored by `[?&]` and the param name so we don't match `&keyword=` etc.
-const QUERY_TOKEN_RE = /([?&](?:access_token|api_key|token)=)[^&\s"']+/gi
+// Query-string / fragment tokens. Anchored by `[?&#]` and the param name
+// so we don't match `&keyword=` etc. The name list deliberately covers
+// signed-URL shapes (AWS/GCS/CloudFront) and OAuth params — with the URL
+// exemption on the generic rule (below), these named params are the main
+// line of defense for secrets riding in URLs. `#` anchor: OAuth implicit
+// flow puts access_token in the FRAGMENT, which is easy to forget is
+// sensitive (Codex review 2026-06-05).
+const QUERY_TOKEN_RE =
+  /([?&#](?:access_token|refresh_token|id_token|api_key|apikey|token|key|secret|auth|password|passwd|pwd|sig|signature|code|policy|key-pair-id|x-amz-signature|x-amz-credential|x-goog-signature)=)[^&#\s"']+/gi
+
+// URL userinfo password: `https://user:secret@host/...`. Keep the user
+// visible (debugging), mask the password. Without this the URL exemption
+// would carry basic-auth credentials verbatim.
+const URL_USERINFO_RE = /(https?:\/\/[^/\s:@]+:)[^@/\s]+(@)/gi
+
+// JWT anywhere (path, query, fragment, prose): three dot-separated
+// base64url segments, the first two starting with `eyJ` (= `{"`). The
+// generic rule never caught these reliably (dots break the char class),
+// and the URL exemption would otherwise let them ride inside URLs.
+const JWT_RE =
+  /\beyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g
+
+// Webhook URLs whose PATH SEGMENT is the secret — no prefix and no param
+// name to anchor on, so the URL exemption would leak them verbatim.
+const DISCORD_WEBHOOK_RE =
+  /(discord(?:app)?\.com\/api\/webhooks\/\d+\/)[A-Za-z0-9_-]+/gi
+const SLACK_WEBHOOK_RE = /(hooks\.slack\.com\/services\/)[A-Za-z0-9/]+/gi
 
 // IPv4 — keep first and last octet (helps debugging) and mask the middle
 // two. Loopback (127.*) and 0.* placeholders are pure debug noise; the
@@ -111,7 +135,50 @@ const TELEGRAM_TOKEN_PARTIAL_RE = /\b(\d{3})\d{7,}:(AA\w{2})\w+/g
 
 // Generic long token rule (≥24 chars of [A-Za-z0-9_-]). LAST — keeps head
 // and tail visible so a partial mask is still useful for debugging.
+//
+// URL exemption (2026-06-05): this rule does NOT fire inside http(s) URLs.
+// Long hyphenated path segments are overwhelmingly public identifiers —
+// repo slugs (`dashi-plugin-claude-code`), commit SHAs, PR paths — and
+// masking them produced dead links the warchief could not open. Secrets
+// embedded in URLs are still covered by every SPECIFIC rule above (bot
+// tokens, ghp_/sk- prefixes, ?token= query params, Supabase hosts, IPs),
+// all of which run regardless of URL context.
 const GENERIC_LONG_TOKEN_RE = /\b([A-Za-z0-9_-]{4})[A-Za-z0-9_-]{16,}([A-Za-z0-9_-]{4})\b/g
+
+// URL detector for the exemption above. Tighter than a linkifier needs to
+// be — when in doubt the range SHRINKS, which merely re-enables generic
+// masking for the tail (fail-closed). `,;` excluded entirely: rare in
+// real links, but a comma can glue a secret onto a URL and smuggle it
+// into the exempt range (Codex review 2026-06-05).
+const URL_RE = /https?:\/\/[^\s<>"'),;\]]+/g
+
+// Trailing prose punctuation that linkifiers drop but our char class
+// admits — trimmed off the detected range so `…/pull/49.` doesn't extend
+// the exemption past the real link.
+const URL_TRAILING_PUNCT_RE = /[.:!?]+$/
+
+// Replace GENERIC_LONG_TOKEN_RE matches everywhere EXCEPT inside http(s)
+// URLs. Ranges are recomputed per call from the current text (earlier
+// rules may have shifted offsets). Idempotent: skipped matches are left
+// byte-identical, masked ones no longer match the pattern.
+function maskLongTokensOutsideUrls(text: string): string {
+  const urlRanges: Array<[number, number]> = []
+  for (const m of text.matchAll(URL_RE)) {
+    if (m.index !== undefined) {
+      const trimmed = m[0].replace(URL_TRAILING_PUNCT_RE, '')
+      urlRanges.push([m.index, m.index + trimmed.length])
+    }
+  }
+  return text.replace(
+    GENERIC_LONG_TOKEN_RE,
+    (match: string, head: string, tail: string, offset: number) => {
+      const inUrl = urlRanges.some(
+        ([start, end]) => offset >= start && offset < end,
+      )
+      return inUrl ? match : `${head}***${tail}`
+    },
+  )
+}
 
 // ─────────────────────────────────────────────────────────────────────
 // Public API
@@ -128,9 +195,15 @@ const RULES: ReadonlyArray<RedactionRule> = [
   { pattern: SLACK_BOT_RE, replacement: '[REDACTED]' },
   // 2. Firebase JSON fields — value replaced, key preserved.
   ...FIREBASE_REs,
-  // 3. Auth header + query params — preserve prefix.
+  // 3. Auth header + query/fragment params + URL-borne secrets. These
+  //    MUST stay ahead of the generic rule's URL exemption: they are what
+  //    keeps a secret from riding inside an exempt URL.
   { pattern: BEARER_RE, replacement: '$1[REDACTED]' },
   { pattern: QUERY_TOKEN_RE, replacement: '$1[REDACTED]' },
+  { pattern: URL_USERINFO_RE, replacement: '$1[REDACTED]$2' },
+  { pattern: JWT_RE, replacement: '[REDACTED]' },
+  { pattern: DISCORD_WEBHOOK_RE, replacement: '$1[REDACTED]' },
+  { pattern: SLACK_WEBHOOK_RE, replacement: '$1[REDACTED]' },
   // 4. IPv4 — middle-octet mask.
   { pattern: IPV4_RE, replacement: ipv4Replacer },
   // 5. Secret paths.
@@ -140,8 +213,8 @@ const RULES: ReadonlyArray<RedactionRule> = [
   { pattern: SUPABASE_HOST_RE, replacement: supabaseReplacer },
   // 7. Telegram partial-mask shape (renderer-style).
   { pattern: TELEGRAM_TOKEN_PARTIAL_RE, replacement: '$1***:$2***' },
-  // 8. Generic long-token rule — LAST.
-  { pattern: GENERIC_LONG_TOKEN_RE, replacement: '$1***$2' },
+  // 8. Generic long-token rule — LAST, applied via the URL-aware wrapper
+  //    in redactSecrets() (NOT listed here; see maskLongTokensOutsideUrls).
 ]
 
 /**
@@ -183,5 +256,9 @@ export function redactSecrets(
       out = out.replace(rule.pattern, rule.replacement as (sub: string, ...args: unknown[]) => string)
     }
   }
+  // Generic long-token rule runs LAST and outside RULES: it needs the
+  // final post-specific-rules text to compute URL ranges (offsets shift
+  // as earlier rules rewrite the string).
+  out = maskLongTokensOutsideUrls(out)
   return out
 }

--- a/plugin/tests/safety/redact.test.ts
+++ b/plugin/tests/safety/redact.test.ts
@@ -163,6 +163,152 @@ describe('redactSecrets — generic long token + extras', () => {
   })
 })
 
+describe('redactSecrets — URL exemption for the generic long-token rule', () => {
+  // 2026-06-05: the generic rule masked repo slugs inside GitHub links
+  // (`dashi-plugin-claude-code` → `dash***code`), producing dead URLs the
+  // warchief could not open. Long path segments inside http(s) URLs are
+  // exempt from the GENERIC rule only — every specific rule still fires.
+
+  test('GitHub PR link with a long repo slug survives intact', () => {
+    const url = 'https://github.com/qwwiwi/dashi-plugin-claude-code/pull/49'
+    expect(redactSecrets(`PR готов: ${url}`)).toBe(`PR готов: ${url}`)
+  })
+
+  test('commit-SHA URL survives intact', () => {
+    const url =
+      'https://github.com/qwwiwi/dashi-plugin-claude-code/commit/' +
+      'a'.repeat(40)
+    expect(redactSecrets(url)).toBe(url)
+  })
+
+  test('the same long token OUTSIDE a URL is still masked', () => {
+    const out = redactSecrets(
+      'slug dashi-plugin-claude-code and https://github.com/qwwiwi/dashi-plugin-claude-code',
+    )
+    // Plain-text occurrence masked…
+    expect(out).toContain('dash***code and')
+    // …URL occurrence intact.
+    expect(out).toContain(
+      'https://github.com/qwwiwi/dashi-plugin-claude-code',
+    )
+  })
+
+  test('?token= query param inside a URL is STILL redacted', () => {
+    const out = redactSecrets(
+      'https://example.com/hook?token=supersecretvalue123456',
+    )
+    expect(out).not.toContain('supersecretvalue123456')
+    expect(out).toContain('?token=')
+  })
+
+  test('Telegram bot token inside a URL is STILL redacted', () => {
+    const out = redactSecrets(
+      'https://api.telegram.org/bot8507713167:AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPPQQRR/sendMessage',
+    )
+    expect(out).not.toContain('AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPPQQRR')
+  })
+
+  test('GitHub PAT inside a URL is STILL redacted', () => {
+    const out = redactSecrets(
+      `https://ghp_${'Z'.repeat(36)}@github.com/qwwiwi/repo.git`,
+    )
+    expect(out).not.toContain('Z'.repeat(36))
+  })
+
+  test('extras (exact-substring secrets) inside a URL are STILL redacted', () => {
+    const secret = 'wh_exact_secret_value_42'
+    const out = redactSecrets(`https://example.com/hook/${secret}`, [secret])
+    expect(out).not.toContain(secret)
+  })
+
+  test('URL exemption is idempotent', () => {
+    const input =
+      'see https://github.com/qwwiwi/dashi-plugin-claude-code/pull/49 and token abcd1234567890efghij5678WXYZ'
+    const once = redactSecrets(input)
+    const twice = redactSecrets(once)
+    expect(twice).toBe(once)
+  })
+
+  // ── Codex security review (2026-06-05): URL-borne secret shapes the
+  //    exemption must NOT leak ─────────────────────────────────────────
+
+  test('basic-auth password in URL userinfo is redacted, user kept', () => {
+    const out = redactSecrets(
+      'https://deploy:hunter2secret@registry.example.com/v2/',
+    )
+    expect(out).not.toContain('hunter2secret')
+    expect(out).toContain('https://deploy:')
+    expect(out).toContain('@registry.example.com')
+  })
+
+  test('JWT inside a URL path/fragment is redacted', () => {
+    const jwt = `eyJ${'a'.repeat(12)}.eyJ${'b'.repeat(12)}.${'c'.repeat(12)}`
+    const out = redactSecrets(
+      `https://app.example.com/callback#access_token=${jwt} and bare ${jwt}`,
+    )
+    expect(out).not.toContain(jwt)
+  })
+
+  test('signed-URL params (sig / X-Amz-Signature) are redacted', () => {
+    const out = redactSecrets(
+      'https://bucket.s3.amazonaws.com/file?X-Amz-Signature=deadbeefcafe123456&sig=abc123def456',
+    )
+    expect(out).not.toContain('deadbeefcafe123456')
+    expect(out).not.toContain('abc123def456')
+  })
+
+  test('fragment access_token is redacted', () => {
+    const out = redactSecrets(
+      'https://app.example.com/cb#access_token=secrettokenvalue&state=xyz',
+    )
+    expect(out).not.toContain('secrettokenvalue')
+  })
+
+  test('Discord and Slack webhook path tokens are redacted', () => {
+    const out = redactSecrets(
+      [
+        'https://discord.com/api/webhooks/123456789/AbCdEf-Gh_IjKlMnOpQrStUvWxYz123',
+        'https://hooks.slack.com/services/T0001/B0001/XXXXXXXXXXXXXXXXXXXXXXXX',
+      ].join(' '),
+    )
+    expect(out).not.toContain('AbCdEf-Gh_IjKlMnOpQrStUvWxYz123')
+    expect(out).not.toContain('XXXXXXXXXXXXXXXXXXXXXXXX')
+    // Host + route stay visible for debugging.
+    expect(out).toContain('discord.com/api/webhooks/123456789/')
+    expect(out).toContain('hooks.slack.com/services/')
+  })
+
+  test('comma cannot glue a secret into the exempt URL range', () => {
+    const secret = 'SECRET_0123456789012345678901234567'
+    const out = redactSecrets(`https://github.com/org/repo,${secret}`)
+    expect(out).not.toContain(secret)
+    expect(out).toContain('https://github.com/org/repo')
+  })
+
+  test('trailing punctuation does not extend the exemption', () => {
+    // URL ends with "." — the next long token after whitespace is NOT
+    // part of the link and must still be masked.
+    const out = redactSecrets(
+      'https://github.com/qwwiwi/dashi-plugin-claude-code/pull/49. Token abcd1234567890efghij5678WXYZ',
+    )
+    expect(out).toContain('dashi-plugin-claude-code/pull/49.')
+    expect(out).toContain('abcd***WXYZ')
+  })
+
+  test('URL-borne secret redaction is idempotent', () => {
+    const jwt = `eyJ${'a'.repeat(12)}.eyJ${'b'.repeat(12)}.${'c'.repeat(12)}`
+    const input = [
+      'https://deploy:hunter2secret@host.example.com/x',
+      `https://app.example.com/cb#access_token=${jwt}`,
+      'https://discord.com/api/webhooks/42/tok_enva_lue123456789',
+      'https://github.com/qwwiwi/dashi-plugin-claude-code/pull/49,SECRET_0123456789012345678901234567',
+    ].join(' ')
+    const once = redactSecrets(input)
+    const twice = redactSecrets(once)
+    expect(twice).toBe(once)
+  })
+})
+
 describe('redactSecrets — no false positives', () => {
   test('does not mangle a normal English sentence', () => {
     const s = 'The quick brown fox jumps over the lazy dog.'


### PR DESCRIPTION
## Проблема

Generic-правило редактора (≥24 символов `[A-Za-z0-9_-]` → `first4***last4`) маскировало слаги репозиториев и commit-SHA внутри ссылок: `github.com/qwwiwi/dash***code/pull/49` — вождь получал мёртвые URL (скриншот в чате 2026-06-05).

## Фикс

Generic-правило больше не срабатывает внутри http(s)-URL. Все специфичные правила (bot-токены, sk-/ghp_/gsk_, Bearer, query-параметры, IPv4, Supabase, extras) работают везде, включая URL.

## Security-ревью Codex GPT-5.5: ship-with-changes — все findings закрыты

- **High (утечка URL-shaped секретов):** добавлены правила userinfo-пароль, JWT (везде), расширенный список query/fragment-параметров (sig/X-Amz-Signature/secret/password/code/policy/…, якорь `[?&#]` для OAuth fragment), Discord/Slack webhook path-токены
- **Med (склейка через запятую):** `,;` исключены из URL-класса — секрет, приклеенный запятой, не попадает в exempt-диапазон
- **Med (fragment):** `#access_token=` маскируется
- **Low (идемпотентность):** добавлены adversarial-тесты на повторный проход

Остаточный риск: opaque path-токен на неизвестном хосте (не Discord/Slack/Telegram) пройдёт в URL — осознанный trade-off против тотально мёртвых ссылок; закрывается extras-механизмом для известных секретов.

## Тесты

46 в redact.test.ts (16 новых), suite 1284 pass / 1 fail (pre-existing от незакоммиченного WIP memory_search/fts в tools.test.ts, к PR не относится). Typecheck: 0 ошибок в файлах PR.

## Активация

redact.ts работает в живом bun-процессе плагина — нужен рестарт плагина (через Сильвану с OK вождя).

🤖 Generated with [Claude Code](https://claude.com/claude-code)