### PR TITLE
Доктор для переезда: skill doctor-dashi-plugin (gateway → channel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 It replaces the deprecated `claude -p` gateway pattern (a Python daemon that spawned a fresh headless session for every message). Cutover deadline — **2026-06-15** (Anthropic is splitting billing; details in section [13](#13-why-migrate--the-2026-06-15-deadline)).
 
+> **Migrating from the old gateway? There is now a doctor.** The read-only [`doctor-dashi-plugin`](skills/doctor-dashi-plugin/SKILL.md) skill diagnoses the whole cutover — workspace placement, hooks, MCP comms config, allowlist, and live-session health — and encodes every mistake we already paid for so you don't repeat them. Run `bun skills/doctor-dashi-plugin/scripts/doctor.ts --help`.
+
 ![Architecture — Telegram ↔ plugin ↔ Claude Code session](docs/assets/architecture-hero.svg)
 
 One plugin process = one Telegram bot = one agent. By default it serves **a single DM chat** (legacy single-session mode). With `multichat.enabled` turned on, the same bot fans incoming messages out across several per-chat tmux sessions of one identity — see section [3](#3-multichat--how-it-works-and-why).

--- a/README.md
+++ b/README.md
@@ -440,9 +440,15 @@ claude --dangerously-load-development-channels server:dashi-channel
 # 6. MANDATORY — install the hooks (otherwise there's no progress in Telegram)
 bash scripts/install-hooks.sh --settings ~/.claude/settings.json \
   --chat-id <your-chat-id> --webhook-url http://127.0.0.1:8089/hooks/agent --agent-id dashi-channel
+
+# 7. Migrating from the old gateway? Run the doctor before AND after cutover
+bun skills/doctor-dashi-plugin/scripts/doctor.ts \
+  --plugin-dir "$PWD" --settings ~/.claude/settings.json --session channel-myagent
 ```
 
 On the first launch, Claude Code asks 2 interactive questions (allow external imports + dev channels) — **once**; answer `1` to both.
+
+> **Migration doctor.** If you are moving an agent off the legacy gateway, the [`doctor-dashi-plugin`](skills/doctor-dashi-plugin/SKILL.md) skill diagnoses the whole cutover — toolchain floors, workspace placement (identity drift), settings/hook registration, MCP comms consistency, the Telegram allowlist, and live-session signals (welcome hang, expired auth, 409 conflict, crash loop). It is read-only — it never restarts a service or prints a secret — and it encodes every mistake we already paid for so you don't repeat them. Run `bun skills/doctor-dashi-plugin/scripts/doctor.ts --help`.
 
 **Stack:** Bun 1.3+ / TypeScript strict, Claude Code v2.1.80+ ([Channels reference](https://code.claude.com/docs/en/channels-reference)), grammY 1.21+, Zod 3.23+, systemd/launchd supervisor.
 
@@ -453,6 +459,7 @@ On the first launch, Claude Code asks 2 interactive questions (allow external im
 | [docs/03-installation.md](docs/03-installation.md) | systemd / launchd, EnvironmentFile, the welcome-prompt fix, smoke test |
 | [docs/03-installation-linux.md](docs/03-installation-linux.md) · [macos](docs/03-installation-macos.md) | OS-specific unit/plist |
 | [docs/04-migration-from-gateway.md](docs/04-migration-from-gateway.md) | Step-by-step migration from `jarvis-telegram-gateway`, with a rollback at each step |
+| [skills/doctor-dashi-plugin/SKILL.md](skills/doctor-dashi-plugin/SKILL.md) | **Migration doctor** — read-only diagnostic skill that checks placement, hooks, comms config, allowlist, and live-session health before/after cutover |
 | [docs/05-troubleshooting.md](docs/05-troubleshooting.md) | Common errors: symptom → root cause → fix |
 | [docs/06-how-claude-loads-session.md](docs/06-how-claude-loads-session.md) | How Claude Code finds `CLAUDE.md`, CWD upward search, `@-include` |
 | [plugin/docs/progress-reporter-setup.md](plugin/docs/progress-reporter-setup.md) | Installing the hooks in 3 steps + troubleshooting |

--- a/skills/doctor-dashi-plugin/SKILL.md
+++ b/skills/doctor-dashi-plugin/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: doctor-dashi-plugin
+description: Diagnose and safely complete a migration from the legacy Telegram gateway to the dashi-plugin-claude-code channel. Use this whenever an agent is moving off the old gateway, when a freshly migrated bot is silent / hangs / answers as "default Claude", when you hit a Telegram 409 conflict, or when planning the cutover. Trigger on phrases like "переезд на плагин", "migrate from gateway", "доктор для переезда", "бот молчит после миграции", "409 conflict", "channel plugin not responding". Run the doctor BEFORE and AFTER cutover — it encodes every mistake we already paid for so a student's agent migrates without repeating them.
+---
+
+# Doctor: migrate from the gateway to the channel plugin
+
+This skill helps an agent move from the **old gateway** (a Python daemon that
+spawns a fresh `claude -p` session for every Telegram message) to the **new
+channel plugin** (one long-running Claude session per agent), and diagnose what
+went wrong if the migrated bot misbehaves.
+
+Why migrate at all: the old gateway hits a permission-dialog hang without a
+bypass flag, has no guarantee the final answer is sent, and — past **2026-06-15**
+— becomes expensive because per-message `claude -p` spawn moves to a separate
+billing pool. The plugin keeps one live session inside the Max subscription.
+
+The doctor is **read-only**. It never restarts a service, never writes config,
+never prints a secret. It tells you what is wrong and points at the fix; you (or
+the operator) apply it.
+
+## The one rule that prevents the worst outcome
+
+**Never restart your own channel/gateway from inside your own session.** That
+kills the only comms link mid-turn, and the supervisor relaunches you into a
+loop. Apply config changes without restarting (the old process keeps running old
+code), and let an *external* actor do the restart — the operator in their
+terminal, or another service. This is non-negotiable; see
+`references/03-lessons-learned.md` §3.
+
+## Workflow
+
+### 1. Run the doctor
+
+```bash
+bun skills/doctor-dashi-plugin/scripts/doctor.ts \
+  --plugin-dir <workspace>/.claude/dashi-plugin-claude-code/plugin \
+  --settings ~/.claude/settings.json \
+  --mcp <workspace>/.claude/.mcp.json \
+  --settings-local <workspace>/.claude/settings.local.json \
+  --env <channel.env path> \
+  --user <your numeric Telegram id> \
+  --session channel-<agent>      # only if the channel is already running
+```
+
+Every flag is optional — pass what you have. `--json` gives machine-readable
+output for an agent to parse. Exit code: `0` = no FAIL, `1` = at least one FAIL,
+`2` = usage error.
+
+The doctor checks, in order: toolchain floors (Claude Code ≥ 2.1, Bun ≥ 1.3.14,
+tmux), **workspace placement** (the #1 first-run failure — identity drift),
+settings.json hooks + token leak, **MCP comms consistency** (the latent
+silent-channel landmine), the Telegram allowlist, and live-session signals
+(welcome-prompt hang, expired auth, crash loop).
+
+### 2. Read the result top-down and fix the first FAIL
+
+Checks are ordered by causality: a failure early on explains failures later, so
+**fix the first FAIL, re-run, repeat**. Don't chase a downstream symptom while an
+upstream cause is still red. Each FAIL/WARN carries a one-line `fix:` pointer.
+
+### 3. Reach for the right reference
+
+- Planning or running the move? → `references/01-migration-steps.md`
+  (pre-flight, ordered steps, the cutover order, rollback, Linux vs macOS).
+- A specific symptom (silent bot, 409, reactions-but-no-reply, crash loop)? →
+  `references/02-failure-modes.md` (problems 1–10: symptom → root cause → fix).
+- Want to avoid the mistakes we already made? → `references/03-lessons-learned.md`
+  (dev-vs-runtime copies, comms-config breakage, self-restart loop, token leak,
+  fallback-reply, FTS, push-on-assign, and more — each with a detection check).
+
+### 4. Verify after cutover
+
+A green doctor run is necessary, not sufficient — the only proof is a real
+message. Send the bot a message and watch for the reaction flow `👀 → ⚙️ → ✅`
+and an actual reply. If silent, diagnose **by architecture, not by symptom**
+(service status → tmux capture → identity → only then the Telegram queue); the
+order matters and is spelled out in `references/02-failure-modes.md` (Problem 4).
+
+## Diagnostic decision tree (quick reference)
+
+```
+bot silent after cutover?
+├─ service "active" but no reactions at all
+│   └─ welcome-prompt hang → attach tmux, press Enter (Problem 1)
+├─ reactions (👀) but no text reply
+│   └─ OAuth expired → attach tmux, /login (Problem 7)
+├─ logs show "409 Conflict"
+│   └─ two consumers on one token → stop the channel, wait 45s, re-test;
+│      if 409 persists the second consumer is EXTERNAL — hunt it (Problem 3, §4)
+├─ answers but as "default Claude"
+│   └─ wrong WorkingDirectory → CLAUDE.md unreachable (Problem 2)
+├─ pending=0, no reply, no error
+│   └─ allowlist drops your id (Problem 5)
+└─ service "activating (auto-restart)", exit 0/SUCCESS, tmux gone
+    └─ crash loop — run claude by hand with a TTY to see the real error (Problem 9)
+```
+
+## Safety boundaries
+
+- Read-only diagnosis only. Restarts and config edits are the operator's to run.
+- Never copy a token between hosts, never print a token (the doctor redacts; keep
+  it that way if you extend it).
+- Telegram user-account access (Telethon/MTProto) is out of scope and must go
+  through the telegram-chip skill, never a direct client.
+- Production cutover is a deliberate act — confirm with the operator before the
+  stop-old / start-new step on a production bot.
+
+## Extending the doctor
+
+The diagnostic is a single standalone file, `scripts/doctor.ts`, with no
+plugin-internal imports (so it keeps working even when the plugin checkout is
+broken — diagnosing that is one of its jobs). Pure check functions are exported
+and unit-tested in `scripts/doctor.test.ts` (`bun test`). Add a new check as a
+pure function returning a `Check`, wire it into `gatherChecks`, and add a test.
+Keep every probe read-only and run all output through `redact()`.

--- a/skills/doctor-dashi-plugin/references/01-migration-steps.md
+++ b/skills/doctor-dashi-plugin/references/01-migration-steps.md
@@ -1,0 +1,201 @@
+# Migration steps: gateway → channel plugin
+
+Ordered procedure. The doctor automates the checks; this is the human/agent
+playbook around them. Commands are verbatim; substitute `<agent>`,
+`<service-user>`, paths, and tokens.
+
+> Concepts. **OLD** = Python daemon (`qwwiwi/jarvis-telegram-gateway`), spawns a
+> new `claude -p` per message. **NEW** = Bun+TypeScript plugin, one live session,
+> polls Telegram via `getUpdates`. Invariant: one process = one agent = one bot =
+> one workspace. Migration deadline: **2026-06-15** (per-message spawn moves to a
+> separate billing pool).
+
+## 0. Pre-flight (the doctor checks most of these)
+
+| Check | Command | Pass |
+|---|---|---|
+| OS | — | linux→systemd, macos→launchd |
+| Claude Code ≥ 2.1 | `claude --version` | `2.1.x`+ (persistent welcome-accepts need `2.1.140+`) |
+| Bun ≥ 1.3.14 | `bun --version` | `>= 1.3.14` |
+| tmux | `which tmux` | found; **record the exact path** (it goes in the unit/plist) |
+| Max login | `claude` then OAuth | login saved under the service user |
+| Old gateway inventoried | see below | token, allowed ids, workspace, unit name recorded |
+| Tokens on hand | — | `TELEGRAM_BOT_TOKEN`, your numeric id (`@userinfobot`), group id if any |
+| **Workspace placement planned** | — | plugin goes under `<workspace>/.claude/...` |
+| Backup taken | `tar czf` (below) | archive path recorded |
+| Quiet window agreed | — | users warned, rollback understood |
+
+Inventory the old gateway:
+```bash
+# Linux
+sudo systemctl list-units --type=service | grep -iE "gateway|jarvis"
+sudo systemctl cat <gateway-unit> | grep -E "EnvironmentFile|Environment|WorkingDirectory"
+ps -ef | grep -E "python.*gateway|claude.*-p" | grep -v grep
+```
+Record four things: bot token, allowed user ids, old workspace path, unit name.
+
+Backup before any change:
+```bash
+sudo tar czf /var/backups/pre-plugin-migration-$(date +%Y%m%d).tgz \
+  ~/jarvis-telegram-gateway ~/.claude-lab \
+  /etc/systemd/system/*gateway*.service /etc/dashi-plugin 2>/dev/null
+```
+
+**Workspace placement is load-bearing.** The plugin MUST live inside the agent
+workspace so Claude Code's upward CWD search finds the project `CLAUDE.md`:
+```
+✓ ~/.claude-lab/<agent>/.claude/dashi-plugin-claude-code/plugin/
+✗ ~/projects/dashi-plugin-claude-code/plugin/    (identity drift — bot answers as default Claude)
+✗ /opt/dashi-plugin/plugin/
+```
+
+## 1–2. Clone the plugin INSIDE the workspace and build
+
+```bash
+mkdir -p ~/.claude-lab/<agent>/.claude
+cd ~/.claude-lab/<agent>/.claude
+git clone https://github.com/qwwiwi/dashi-plugin-claude-code.git
+cd dashi-plugin-claude-code/plugin
+bun install
+bun run typecheck     # 0 errors
+bun test tests/       # if core tests fail, STOP — broken checkout, do not continue
+```
+
+## 3. Carry over identity and config
+
+```bash
+cp <old-workspace>/CLAUDE.md   ~/.claude-lab/<agent>/.claude/
+cp -a <old-workspace>/core     ~/.claude-lab/<agent>/.claude/
+cp <old-workspace>/.mcp.json   ~/.claude-lab/<agent>/.claude/
+```
+Do **not** delete the old path (rollback needs it). Do **not** create a second
+`CLAUDE.md` inside the plugin directory — the upward search would pick the nearer
+one and kill identity.
+
+## 4. channel.env (map the old variables)
+
+Copy `examples/channel.env.example`. Linux →
+`/etc/dashi-plugin/<agent>/channel.env` (`chown root:<group>`, `chmod 640`);
+macOS → `~/.claude-lab/<agent>/secrets/channel.env` (`chmod 600`).
+
+| Gateway (Python) | Plugin (channel.env) |
+|---|---|
+| `TELEGRAM_BOT_TOKEN` | `TELEGRAM_BOT_TOKEN` |
+| `ALLOWED_USER_IDS` | `TELEGRAM_ALLOWED_USER_IDS` |
+| `ALLOWED_GROUP_IDS` | `TELEGRAM_ALLOWED_CHAT_IDS` |
+| `WORKSPACE_DIR` | `TELEGRAM_WORKSPACE_ROOT` (points at `<agent>/.claude/`) |
+| `WEBHOOK_PORT` | `TELEGRAM_WEBHOOK_PORT` |
+| (new) | `TELEGRAM_EXPECTED_BOT_ID` (digits before `:` in the token, anti-spoof) |
+| (new) | `AGENT_ID` |
+
+Multiple agents on one host → distinct `TELEGRAM_WEBHOOK_PORT`.
+
+## 5. Supervisor unit with the correct CWD
+
+The bypass flag in both is `--dangerously-load-development-channels server:dashi-channel`.
+
+**Linux** `/etc/systemd/system/channel-<agent>.service` (from
+`examples/systemd-unit.service.example`):
+```ini
+[Service]
+Type=forking
+User=<service-user>
+EnvironmentFile=/etc/dashi-plugin/<agent>/channel.env
+Environment=HOME=/home/<service-user>
+Environment=PATH=/home/<service-user>/.bun/bin:/usr/local/bin:/usr/bin:/bin
+WorkingDirectory=/home/<service-user>/.claude-lab/<agent>/.claude/dashi-plugin-claude-code/plugin
+ExecStart=/usr/bin/tmux new-session -d -s channel-<agent> \
+  claude --dangerously-load-development-channels server:dashi-channel
+ExecStartPost=/bin/sh -c 'sleep 6 && /usr/bin/tmux send-keys -t channel-<agent> Enter && sleep 2 && /usr/bin/tmux send-keys -t channel-<agent> Enter'
+ExecStop=/usr/bin/tmux kill-session -t channel-<agent>
+Restart=on-failure
+RestartSec=15s
+```
+`Type=forking` is required (`tmux new-session -d` forks). Activate:
+```bash
+sudo systemctl daemon-reload && sudo systemctl enable --now channel-<agent>
+sudo systemctl status channel-<agent> --no-pager -l
+```
+
+**macOS** `~/Library/LaunchAgents/com.dashi-plugin.channel-<agent>.plist` (from
+`examples/launchd-plist.example.plist`). Secrets are sourced from the env file in
+`ProgramArguments`, never inlined. `WorkingDirectory` = `.../plugin`,
+`RunAtLoad=true`, `KeepAlive.Crashed=true`, logs to
+`~/Library/Logs/dashi-plugin/`. Load:
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.dashi-plugin.channel-<agent>.plist
+launchctl kickstart gui/$(id -u)/com.dashi-plugin.channel-<agent>
+```
+
+## 6. Pass the two welcome prompts (first run)
+
+1. "Allow external CLAUDE.md file imports?" → `1` (the `@-include`s target
+   `<workspace>/core/*`, above CWD, so they read as external).
+2. "--dangerously-load-development-channels is for local development only" → `1`.
+
+`ExecStartPost`/plist send Enter automatically. If not, attach and press Enter:
+```bash
+tmux attach -t channel-<agent>     # Linux: sudo -u <service-user> tmux attach ...
+```
+Success line: `Listening for channel messages from: server:dashi-channel`.
+
+Persistent fix (Claude Code `2.1.140+`) — capture the exact accepted keys from
+`~/.claude/settings.json` after passing the prompts once, rather than guessing.
+
+## 7. Cutover — order is critical (never two consumers on one token)
+
+```bash
+sudo systemctl stop <gateway-unit> && sudo systemctl disable <gateway-unit>
+sleep 30                                  # let Telegram drop the old long-poll client
+sudo systemctl restart channel-<agent>
+tmux capture-pane -t channel-<agent> -p | tail -30   # welcome? press Enter
+# send the bot a message — expect 👀 → ⚙️ → ✅ and a real reply
+```
+A `409 Conflict` here means both processes hold the token — see Problem 3.
+
+## 8. Verify identity + memory parity
+
+In tmux: `/memory` shows BOTH CLAUDE.md (global + project). In Telegram ask "who
+are you?" — the answer must be the agent's name, not "I'm Claude, an AI assistant
+made by Anthropic". If it's default Claude, `WorkingDirectory` is wrong (Problem 2).
+
+## 9. Hooks (optional — status + memory)
+
+```bash
+bash <plugin>/scripts/install-hooks.sh \
+  --settings ~/.claude/settings.json \
+  --chat-id <your-telegram-chat-id> \
+  --webhook-url http://127.0.0.1:8089/hooks/agent \
+  --agent-id <agent>
+# then restart the channel (externally — never self-restart)
+```
+This registers five hook events with marker `dashi-channel-hook`. The webhook
+token is read from runtime env and is **never** written to settings.json.
+
+## 10. Remove the gateway — after 7–14 days, not immediately
+
+Snapshot, then remove the unit and the gateway dir. Keep the old workspace ~a
+month longer.
+
+## Rollback
+
+```bash
+sudo systemctl stop channel-<agent>
+sleep 30
+sudo systemctl start <gateway-unit>
+# smoke in Telegram
+```
+Because cutover does not delete the old gateway or workspace, rollback is always
+available. From backup: `sudo tar xzf /var/backups/pre-plugin-migration-<date>.tgz -C /`.
+
+## Linux vs macOS cheat-sheet
+
+| | Linux (systemd) | macOS (launchd) |
+|---|---|---|
+| Service file | `/etc/systemd/system/channel-<agent>.service` | `~/Library/LaunchAgents/com.dashi-plugin.channel-<agent>.plist` |
+| Status | `systemctl status channel-<agent>` | `launchctl print gui/$(id -u)/com.dashi-plugin.channel-<agent>` |
+| Restart | `systemctl restart channel-<agent>` | `launchctl kickstart -k gui/$(id -u)/com.dashi-plugin.channel-<agent>` |
+| Stop | `systemctl stop channel-<agent>` | `launchctl kill SIGTERM gui/$(id -u)/com.dashi-plugin.channel-<agent>` |
+| Logs | `journalctl -u channel-<agent> -n 50` | `tail ~/Library/Logs/dashi-plugin/channel-<agent>.{out,err}.log` |
+| tmux path | `/usr/bin/tmux` | `/opt/homebrew/bin/tmux` (Apple Silicon) / `/usr/local/bin/tmux` (Intel) |
+| Auto-start | `systemctl enable` (works headless) | `RunAtLoad=true` — only after GUI login (use `/Library/LaunchDaemons/` for pre-login) |

--- a/skills/doctor-dashi-plugin/references/02-failure-modes.md
+++ b/skills/doctor-dashi-plugin/references/02-failure-modes.md
@@ -1,0 +1,134 @@
+# Failure modes (Problems 1–10)
+
+Every known way a migrated bot misbehaves: symptom → root cause → fix. Diagnose
+**by architecture, not by symptom**: service status → tmux capture → identity →
+only then the Telegram queue (Problem 4 is the trap that skips this order).
+
+## Problem 1 — service "active" but Telegram is silent
+
+- **Symptom**: `systemctl status` = `active (running)`, but the bot answers
+  nothing — no reactions, no replies.
+- **Cause**: Claude is stuck on one of the two welcome prompts; until passed, the
+  plugin never activates and polling never starts. `active` only means the tmux
+  process and the forked claude are alive — claude is blocked on a prompt.
+- **Fix**: `tmux attach -t channel-<agent>` → Enter (and a second Enter if
+  present) → detach `Ctrl-B D` → confirm `Listening for channel messages from:
+  server:dashi-channel`. Prevent with the `ExecStartPost` double-Enter and the
+  persistent accepts in settings.json.
+- **Lesson**: "active" = "process alive", not "working".
+
+## Problem 2 — agent answers as "default Claude" (identity drift)
+
+- **Symptom**: "who are you?" → "I'm Claude, an AI assistant made by Anthropic".
+- **Cause**: `WorkingDirectory=` is not inside the workspace, so the upward CWD
+  search never found the project `CLAUDE.md` — only the global one loaded.
+- **Fix**: correct `WorkingDirectory=` to a directory under which `CLAUDE.md`
+  exists; `ls -la <workspace>/CLAUDE.md`; in tmux `/memory` must show both
+  CLAUDE.md. After any `WorkingDirectory` change, ping "who are you?".
+- **Lesson**: silent bug — the bot works sensibly, just without your identity.
+
+## Problem 3 — `getUpdates conflict` (two sessions on one bot)
+
+- **Symptom (logs)**: `409 Conflict: terminated by other getUpdates request`.
+- **Cause**: the Bot API allows exactly one active `getUpdates` client per token;
+  two processes with the same `TELEGRAM_BOT_TOKEN` steal each other's updates.
+  Scenarios: old `gateway.py` still alive; staging+prod sharing a token; a
+  forgotten local `bun run start`; a PM2 app with a leaked token.
+- **Fix**: stop one consumer, wait 30–45s, restart the channel. Decisive test —
+  stop the channel, wait, `curl getUpdates`; if 409 **persists** the second
+  consumer is external; hunt it across a time window (`pgrep -af bun`,
+  `pgrep -af bot.start`, `pm2 list` + `pm2 env <id>`), not a single snapshot.
+- **Lesson**: do not theorise about a Claude version regression — find the second
+  process.
+
+## Problem 4 — polling vs webhook (a false trail)
+
+- **Symptom**: bot silent; operator checks `getWebhookInfo` → `url_set: false`,
+  concludes "webhook broken", loses 30 minutes.
+- **Cause**: the plugin polls by default (`getUpdates`); the webhook port (8089)
+  is only for Claude hooks, not Telegram. `url_set: false` is normal for polling.
+- **Fix**: diagnose in order — `systemctl status` → tmux capture (welcome?) →
+  identity (`/memory`) → only then the Telegram queue.
+- **Lesson**: diagnose by architecture, not by symptom.
+
+## Problem 5 — allowlist drops the message
+
+- **Symptom**: `getUpdates pending=0` (plugin is draining), tmux active, but no
+  reaction and no reply, no error in the log.
+- **Cause**: `TELEGRAM_ALLOWED_USER_IDS`/`TELEGRAM_ALLOWED_CHAT_IDS` does not
+  contain your id, so the plugin silently drops the update (by design). The code
+  default `[164795011]` applies only when the env is empty.
+- **Fix**: get your id from `@userinfobot`; set
+  `TELEGRAM_ALLOWED_USER_IDS=<your_id>` (group ids look like `-100123456789`);
+  restart. Right after start, send `/help` — silence on an out-of-band command
+  means allowlist.
+
+## Problem 6 — state loss on migration
+
+- **Symptom**: bot starts blank, remembers no conversations, `recent.md` empty.
+- **Cause**: `TELEGRAM_STATE_DIR` points at a recreated/moved/unmounted path. The
+  dir holds `bot.pid`, `config.json`, `inbox/`, `logs/permissions.jsonl`, plus
+  `<workspace>/core/hot/recent.md` if memory hooks are on.
+- **Fix/prevent**: before moving, `stop` + tar-snapshot the workspace, state dir,
+  and unit; after, verify `ls -la $TELEGRAM_STATE_DIR/{bot.pid,config.json,inbox,logs}`
+  before starting. Never `rm -rf` the old workspace without a snapshot.
+
+## Problem 7 — reactions but no reply (OAuth expired)
+
+- **Symptom**: emoji reactions (👀) appear, but no text replies; service active.
+- **Cause**: the Claude Code OAuth token expired; the plugin layer (reactions)
+  still works, but claude returns `401` / "Please run /login".
+- **Fix**: `tmux attach -t channel-<agent>` → `/login` → open URL → auth under
+  Anthropic Max → detach. Prevent with a cron healthcheck that greps the tmux
+  capture for `login`/`401`.
+- **Lesson**: "active" ≠ "authenticated"; reactions without replies ⇒ check auth
+  first.
+
+## Problem 8 — agent self-destruction (`rm -rf` its own OAuth state) ⚠️
+
+- **Symptom**: bot suddenly dies; status `activating (auto-restart)`, exit
+  `0/SUCCESS`, restarting every 15s; `tmux capture-pane` → `no server running`.
+- **Cause**: the agent used `sudo` to delete the directory holding its OAuth
+  state (`~/.openclaw/` or `~/.claude/`). Real incident 2026-05-20: a "cleanup"
+  removed root-owned subdirs along with OAuth + `.secrets/`.
+- **Fix**: stop the service, run claude by hand with a TTY, `/login`, restore
+  `.secrets` from a restic snapshot, restart.
+- **Prevent (critical)**: permission rules — destructive sudo
+  (`Bash(sudo rm:*)`, `Bash(sudo rm -rf:*)`, `Bash(rm -rf /home/*/.openclaw*)`,
+  `Bash(rm -rf /home/*/.claude*)`) always in **deny**; blanket `Bash(sudo:*)` on
+  a host with OAuth/secrets is a catastrophe.
+
+## Problem 9 — tmux death loop
+
+- **Symptom**: `activating (auto-restart)`, `status=0/SUCCESS`, ~15s restarts;
+  `tmux capture-pane` → `no server running`.
+- **Cause**: `Type=forking` expects the tmux server to persist, but it only lives
+  while a window is open; claude in the pane dies (OAuth fail / wrong CWD /
+  missing CLAUDE.md import / ENOENT on the plugin path) → window closes → session
+  closes → tmux server stops → systemd sees "exited 0" → `Restart=on-failure`
+  loops without fixing the cause.
+- **Fix**: stop the service; run claude by hand from the unit's
+  `WorkingDirectory` with the env sourced, read the real error, fix it, start.
+  Add a watchdog cron checking `tmux has-session` separately from
+  `systemctl is-active`.
+- **Lesson**: "exit 0 SUCCESS" is misleading — check `tmux has-session`.
+
+## Problem 10 — sudo deny baseline (what must always be blocked)
+
+Even with broad sudo-allow, keep a baseline deny (deny beats allow):
+`Bash(rm -rf /)`, `Bash(rm -rf ~)`, `Bash(rm -rf /home/*/.openclaw*)`,
+`Bash(rm -rf /home/*/.claude*)`, `Bash(rm -rf /home/*/.secrets*)`,
+`Bash(sudo rm -rf:*)`, `Bash(sudo userdel:*)`, `Bash(sudo chown -R:*)`,
+`Bash(curl * | bash)`, `Bash(git push --force:*)`, `Bash(git reset --hard:*)`.
+Smoke the permissions after install: destructive commands must be blocked,
+`sudo systemctl restart X` may ask/allow.
+
+## When nothing helps
+
+```bash
+journalctl -u channel-<agent> --since "1 hour ago" --no-pager -l   # Linux
+tmux capture-pane -t channel-<agent> -p -S -200
+ps -ef | grep bun | grep -v grep      # expect one `bun ./src/server.ts`
+cat $TELEGRAM_STATE_DIR/logs/permissions.jsonl
+cd <plugin> && bun test               # failing core tests ⇒ broken checkout, not env
+```

--- a/skills/doctor-dashi-plugin/references/03-lessons-learned.md
+++ b/skills/doctor-dashi-plugin/references/03-lessons-learned.md
@@ -1,0 +1,149 @@
+# Lessons learned (mistakes already paid for)
+
+Each item is a real incident turned into a detection check. The doctor encodes
+the mechanical ones; the rest are judgement rules an agent must hold while
+migrating. Format: symptom → root cause → how to detect → how to avoid.
+
+## 1. Dev copy vs runtime copy
+
+- **Symptom**: you patch/update the plugin, restart the channel — behaviour does
+  not change.
+- **Cause**: two independent source copies on the host. The service runs
+  `bun ./src/server.ts` with CWD = the agent workspace, so it resolves `./src/`
+  from the **runtime** copy. Patching the git/dev copy does nothing.
+- **Detect**: `pwdx $(pgrep -f "bun.*src/server.ts")` shows the real runtime CWD;
+  `diff -q <dev>/file.ts <runtime>/file.ts`.
+- **Avoid**: patch both paths (dev for the PR, runtime for the live fix), copy
+  changed files into the runtime copy, then restart — and re-`pwdx` the new PID.
+
+## 2. Comms-config breakage — `enableAllProjectMcpServers:false` drops a channel
+
+- **Symptom**: the live session works, but after the **next** restart the agent
+  goes silent. Latent — shows up hours later.
+- **Cause** (2026-06-02): setting `enableAllProjectMcpServers` to false while
+  `enabledMcpjsonServers` omits a server that lives only in `.mcp.json` (e.g.
+  `dashi-channel`) drops it. MCP servers load at session start, so the live
+  session survives; the next boot has zero comms tools.
+- **Detect**: the doctor's `comms-consistency` check — if
+  `enableAllProjectMcpServers !== true`, every `.mcp.json` server must be in
+  `enabledMcpjsonServers`.
+- **Avoid**: treat MCP/settings edits as **deploy-class**; before flipping the
+  flag, diff what is enabled; never drop another agent's comms server.
+
+## 3. Self-restart = suicide + loop
+
+- **Symptom**: the agent "restarts" its own channel, the reply never sends, the
+  supervisor relaunches it, the new process gets the next message and restarts
+  again → infinite loop, comms fully severed.
+- **Cause** (2026-04-16): `launchctl kickstart -k .../gateway` from inside the
+  agent's own subprocess killed itself before sending; KeepAlive relaunched it.
+- **Detect**: grep the agent's hooks/scripts for `launchctl kickstart`,
+  `systemctl restart channel-`, any self-targeting restart of the comms service.
+- **Avoid**: never restart your own channel from a Bash tool. Edits without a
+  restart are safe (old process runs old code). Delegate the restart to an
+  external actor (operator, or another service).
+
+## 4. Two getUpdates consumers → 409 → channel down
+
+- **Symptom**: DMs never reach the session; the channel crashes on boot with 409.
+- **Cause**: a second consumer holds the same bot token. Real causes seen: a
+  separate debug session, and a PM2 app (`telegram-publisher`) running with the
+  agent's token leaked via saved PM2 env. A theorised "claude polls natively"
+  cause was **disproven** — the plugin's poller is the only intended consumer.
+- **Detect**: on 409, check ALL processes/sessions holding the token over a time
+  window. Decisive test: stop the channel, wait ~45s, `curl getUpdates` → if 409
+  persists, the consumer is external.
+- **Avoid**: one token = one consumer; separate tokens for staging/debug; fix a
+  PM2 app's env before restarting it.
+
+## 5. Token leak via PM2 saved env
+
+- **Symptom**: causes 409 (#4); a foreign process polls the agent's token.
+- **Cause**: PM2 `dump`/saved env overrides an app's `.env`; an app started with
+  the agent token in its environment steals it.
+- **Detect**: `pm2 env <id> | grep -i token` on every PM2 app; compare with the
+  token the app actually reads in code.
+- **Avoid**: fix the app's env to its own token before restart. Claude Code
+  `2.1.163+` strips `TELEGRAM_*` from MCP-child env — then the channel needs a
+  bootstrap `.env` in `STATE_ROOT/.env` for `server.ts` to read the token.
+
+## 6. DM fallback-reply Stop-hook (PR #47)
+
+- **Symptom**: in a DM the agent finishes a turn with a plain text block but
+  never calls the reply tool — the text stays in the transcript, the chief sees
+  silence. A broken hook could instead eat or duplicate the reply.
+- **Design**: a Stop-hook forwards the final assistant text to Telegram **only**
+  when the turn ended without `mcp__dashi-channel__reply`. If reply was called →
+  silent (no dup). `chat_id` comes only from the leading `<channel>` envelope
+  (anti-injection); per-session dedup; `send_failed` is **not** deduped (so it
+  retries next Stop); >4096 chars truncated with a marker.
+- **Detect**: the doctor's `fallback-reply-hook` check — Stop has a
+  `dashi-channel-fallback-reply` entry; the `/hooks/fallback-reply` route is up;
+  the channel was restarted after registration.
+- **Avoid**: comms code gets double review (Codex+Opus) — Codex's first pass
+  caught a `send_failed`-deduped-as-delivered bug that would have silenced
+  replies forever.
+
+## 7. Stop-hook × extended-thinking race (groups)
+
+- **Symptom**: the bot answers @mentions but silently loses reply-to-bot
+  follow-ups in groups.
+- **Cause** (M5b): an extended-thinking turn writes two transcript rows
+  (`[thinking]` then `[text]`); the outbox hook read between them, saw a
+  thinking-only assistant, and emitted nothing.
+- **Fix** (PR #43): bounded retry on empty extraction
+  (`STOP_OUTBOX_RETRY_ATTEMPTS=4`, `STOP_OUTBOX_RETRY_DELAY_MS=120`).
+
+## 8. SQLite FTS L2 (memory.db)
+
+- **Symptom**: `memory_search` crashes on special chars, matches everything, or
+  misses old rows.
+- **Cause/fix** (2026-05-29): sanitise Unicode/NUL in the query (raw FTS `MATCH`
+  crashes; a NUL-only `LIKE` matches all); `COALESCE(session_id,'')` for backfill
+  idempotency; `rebuild` mode for trigram schema evolution. Check
+  `PRAGMA compile_options` for `trigram`.
+
+## 9. push-on-assign wakes only agents with a live listener
+
+- **Symptom**: an agent is assigned a task but does not wake.
+- **Cause** (2026-06-03): assignment enqueues into `delivery_outbox`; a worker
+  pushes to the assignee's webhook — but only reaches agents with a live listener
+  in `AGENT_GATEWAYS`.
+- **Detect/avoid**: confirm the agent's webhook listener is up and registered
+  before relying on assignment-wakes.
+
+## 10. Restart kills the only comms channel — operator permission required
+
+The channel tmux session **is** the agent's live session; restarting it drops
+comms (and erases an untyped prompt). Apply edits without a restart; restart only
+on the operator's OK or via an external actor. Never change gateway
+config/allowlist/tokens without permission.
+
+## 11. Telethon firewall — MTProto only via the telegram-chip skill
+
+Direct `import telethon`/`pyrogram`/`aiotdlib` outside the skill dir is blocked
+by a PreToolUse hook. One user account = one Telethon process; a duplicate
+session revokes the chief's session. All user-account access goes through the
+telegram-chip skill's HTTP API; Bot API (`api.telegram.org/bot...`) is unaffected.
+
+## 12. Telegram HTML pipeline — a lone safe tag downgrades the whole message
+
+- **Symptom** (DM): literal `&lt;b&gt;` entities everywhere; (groups) raw
+  `**bold**`.
+- **Cause/fix** (PR #48): a lone safe-listed tag (e.g. `<pre>`) survived
+  unescaped → `validateTelegramHtml` saw an unclosed tag → plain-text downgrade.
+  Fixed with balance-aware tag stashing and `format="auto"` in the group outbox
+  hook. Grep the log for `telegram html downgrade`.
+
+## Cross-cutting rules for the migrating agent
+
+1. MCP/settings edits are **deploy-class** — breakage is latent, surfaces on the
+   next restart, not in the live session.
+2. **Never** self-restart the channel; delegate to an external actor.
+3. Two copies (dev/runtime) — always `pwdx` the live PID before trusting a path.
+4. Comms code → double review (Opus+Codex); single-mind review misses
+   reply-eating bugs.
+5. On 409, hunt the second consumer over a time window — do not blame a version.
+6. `chat_id` only from the leading `<channel>` envelope (anti-injection).
+7. The runtime plugin and `services/task_mcp/` are outside git — durable state is
+   the live file plus a `.bak`, not a commit.

--- a/skills/doctor-dashi-plugin/scripts/doctor.test.ts
+++ b/skills/doctor-dashi-plugin/scripts/doctor.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  checkAllowlist,
+  checkCommsConsistency,
+  checkSettingsHooks,
+  checkVersion,
+  checkWorkspacePlacement,
+  classifyQueue,
+  cmpSemver,
+  detectAuthExpired,
+  detectCrashLoop,
+  detectListening,
+  detectOS,
+  detectWelcomeHang,
+  findEnclosingClaudeMd,
+  MIN_BUN,
+  MIN_CLAUDE,
+  parseEnvList,
+  parseSemver,
+  redact,
+  redactCheck,
+  renderReport,
+  sameTree,
+  worstStatus,
+  type Check,
+} from './doctor.ts'
+
+/** A settings hook entry with a runnable command (what install-hooks writes). */
+const hookEntry = (marker: string) => ({ marker, hooks: [{ type: 'command', command: "bun 'scripts/post-hook.ts'" }] })
+
+describe('detectOS', () => {
+  test('maps node platform strings', () => {
+    expect(detectOS('linux')).toBe('linux')
+    expect(detectOS('darwin')).toBe('macos')
+    expect(detectOS('win32')).toBe('other')
+  })
+})
+
+describe('redact — no secret survives the report', () => {
+  test('masks a telegram bot token (bare and in an assignment)', () => {
+    expect(redact('saw 8338508613:AAH1234567890abcdefghijklmnopqrstuvw here')).toContain('<bot-token>')
+    const assigned = redact('TELEGRAM_BOT_TOKEN=8338508613:AAH1234567890abcdefghijklmnopqrstuvw')
+    expect(assigned).not.toContain('AAH1234567890')
+  })
+  test('masks groq, openai, bearer and ip', () => {
+    expect(redact('gsk_abcdefghijklmnopqrstuvwxyz0123')).toContain('<groq-key>')
+    expect(redact('sk-proj-abcdefghijklmnopqrst')).toContain('<api-key>')
+    expect(redact('Authorization: Bearer abcdef.ghijk-lmnop')).toContain('Bearer <redacted>')
+    expect(redact('listening on 100.104.191.127')).toContain('<ip>')
+  })
+  test('masks quoted secret values with spaces/commas/newlines (review P1)', () => {
+    expect(redact('PASSWORD="abc def"')).not.toContain('abc def')
+    expect(redact('PASSWORD="abc,def"')).not.toContain('abc,def')
+    expect(redact('"MY_SECRET":"abc def"')).not.toContain('abc def')
+    expect(redact('PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nMIIabc\n-----END-----"')).not.toContain('MIIabc')
+  })
+  test('leaves ordinary text untouched', () => {
+    expect(redact('the channel is listening')).toBe('the channel is listening')
+  })
+})
+
+describe('sameTree — path boundary aware', () => {
+  test('identical and nested trees match', () => {
+    expect(sameTree('/srv/agent/plugin', '/srv/agent/plugin')).toBe(true)
+    expect(sameTree('/srv/agent/plugin/sub', '/srv/agent/plugin')).toBe(true)
+    expect(sameTree('/srv/agent/plugin/', '/srv/agent/plugin')).toBe(true)
+  })
+  test('sibling paths do NOT match (review P2)', () => {
+    expect(sameTree('/srv/agent/plugin', '/srv/agent/plugin-old')).toBe(false)
+  })
+})
+
+describe('semver', () => {
+  test('parses x.y.z and x.y', () => {
+    expect(parseSemver('2.1.161')).toEqual([2, 1, 161])
+    expect(parseSemver('bun 1.3.14')).toEqual([1, 3, 14])
+    expect(parseSemver('no version here')).toBeNull()
+  })
+  test('compares', () => {
+    expect(cmpSemver([2, 1, 0], [2, 1, 0])).toBe(0)
+    expect(cmpSemver([2, 0, 9], [2, 1, 0])).toBeLessThan(0)
+    expect(cmpSemver([2, 1, 5], [2, 1, 0])).toBeGreaterThan(0)
+  })
+  test('checkVersion passes at and above the floor, fails below', () => {
+    expect(checkVersion('c', 'claude', '2.1.0', MIN_CLAUDE).status).toBe('pass')
+    expect(checkVersion('c', 'claude', '2.5.3', MIN_CLAUDE).status).toBe('pass')
+    expect(checkVersion('c', 'claude', '2.0.9', MIN_CLAUDE).status).toBe('fail')
+    expect(checkVersion('b', 'bun', '1.3.13', MIN_BUN).status).toBe('fail')
+    expect(checkVersion('b', 'bun', '1.3.14', MIN_BUN).status).toBe('pass')
+  })
+  test('checkVersion fails on unparseable output without leaking it raw', () => {
+    const c = checkVersion('c', 'claude', 'command not found: claude', MIN_CLAUDE)
+    expect(c.status).toBe('fail')
+  })
+})
+
+describe('findEnclosingClaudeMd / workspace placement', () => {
+  const fs = (present: string[]) => (p: string) => present.includes(p)
+
+  test('finds CLAUDE.md walking up', () => {
+    const present = ['/home/u/.claude-lab/a/.claude/CLAUDE.md']
+    const found = findEnclosingClaudeMd('/home/u/.claude-lab/a/.claude/dashi-plugin-claude-code/plugin', fs(present))
+    expect(found).toBe('/home/u/.claude-lab/a/.claude/CLAUDE.md')
+  })
+  test('passes when plugin is under .claude with CLAUDE.md', () => {
+    const present = ['/home/u/.claude-lab/a/.claude/CLAUDE.md']
+    const c = checkWorkspacePlacement('/home/u/.claude-lab/a/.claude/dashi-plugin-claude-code/plugin', fs(present))
+    expect(c.status).toBe('pass')
+  })
+  test('fails when no CLAUDE.md anywhere above (identity drift)', () => {
+    const c = checkWorkspacePlacement('/home/u/projects/dashi-plugin-claude-code/plugin', fs([]))
+    expect(c.status).toBe('fail')
+    expect(c.fix).toContain('identity')
+  })
+  test('warns when CLAUDE.md exists but plugin is outside .claude', () => {
+    const present = ['/home/u/projects/CLAUDE.md']
+    const c = checkWorkspacePlacement('/home/u/projects/dashi-plugin-claude-code/plugin', fs(present))
+    expect(c.status).toBe('warn')
+  })
+})
+
+describe('checkSettingsHooks', () => {
+  const good = {
+    hooks: {
+      SessionStart: [hookEntry('dashi-channel-hook')],
+      UserPromptSubmit: [hookEntry('dashi-channel-hook')],
+      PreToolUse: [{ ...hookEntry('dashi-channel-hook'), matcher: '.*' }],
+      PostToolUse: [{ ...hookEntry('dashi-channel-hook'), matcher: '.*' }],
+      Stop: [hookEntry('dashi-channel-hook'), hookEntry('dashi-channel-fallback-reply')],
+    },
+  }
+
+  test('all five events present → pass, fallback present → pass', () => {
+    const checks = checkSettingsHooks(good)
+    const byId = Object.fromEntries(checks.map((c) => [c.id, c.status]))
+    expect(byId['settings-no-token']).toBe('pass')
+    for (const ev of ['SessionStart', 'UserPromptSubmit', 'PreToolUse', 'PostToolUse', 'Stop']) {
+      expect(byId[`hook-${ev}`]).toBe('pass')
+    }
+    expect(byId['fallback-reply-hook']).toBe('pass')
+  })
+
+  test('missing event → warn for that event only', () => {
+    const partial = { hooks: { ...good.hooks, PostToolUse: [] } }
+    const post = checkSettingsHooks(partial).find((c) => c.id === 'hook-PostToolUse')
+    expect(post?.status).toBe('warn')
+  })
+
+  test('marker present but NO command → warn (hook would never fire)', () => {
+    const markerOnly = { hooks: { ...good.hooks, Stop: [{ marker: 'dashi-channel-hook' }, hookEntry('dashi-channel-fallback-reply')] } }
+    const stop = checkSettingsHooks(markerOnly).find((c) => c.id === 'hook-Stop')
+    expect(stop?.status).toBe('warn')
+    expect(stop?.detail).toContain('no runnable command')
+  })
+
+  test('webhook token in settings → FAIL', () => {
+    const leaked = { hooks: good.hooks, env: { TELEGRAM_WEBHOOK_TOKEN: 'secret' } }
+    expect(checkSettingsHooks(leaked).find((c) => c.id === 'settings-no-token')?.status).toBe('fail')
+  })
+
+  test('secret-shaped value under a DIFFERENT key → FAIL (shape detection)', () => {
+    const leaked = { hooks: good.hooks, custom: { MY_API_KEY: 'gsk_abcdefghijklmnopqrstuvwxyz0123' } }
+    expect(checkSettingsHooks(leaked).find((c) => c.id === 'settings-no-token')?.status).toBe('fail')
+  })
+
+  test('no fallback hook → warn', () => {
+    const noFallback = { hooks: { ...good.hooks, Stop: [hookEntry('dashi-channel-hook')] } }
+    expect(checkSettingsHooks(noFallback).find((c) => c.id === 'fallback-reply-hook')?.status).toBe('warn')
+  })
+})
+
+describe('checkCommsConsistency — the latent silent-channel landmine', () => {
+  test('enableAllProjectMcpServers=true covers everything', () => {
+    const mcp = { mcpServers: { 'dashi-channel': {}, 'dashi-gbrain-swarm': {} } }
+    const sl = { enableAllProjectMcpServers: true }
+    expect(checkCommsConsistency(mcp, sl).status).toBe('pass')
+  })
+  test('false + missing server → FAIL (dropped on next restart)', () => {
+    const mcp = { mcpServers: { 'dashi-channel': {}, 'dashi-gbrain-swarm': {} } }
+    const sl = { enableAllProjectMcpServers: false, enabledMcpjsonServers: ['dashi-gbrain-swarm'] }
+    const c = checkCommsConsistency(mcp, sl)
+    expect(c.status).toBe('fail')
+    expect(c.detail).toContain('dashi-channel')
+  })
+  test('false + all listed → pass', () => {
+    const mcp = { mcpServers: { 'dashi-channel': {} } }
+    const sl = { enableAllProjectMcpServers: false, enabledMcpjsonServers: ['dashi-channel'] }
+    expect(checkCommsConsistency(mcp, sl).status).toBe('pass')
+  })
+  test('no servers declared → skip', () => {
+    expect(checkCommsConsistency({ mcpServers: {} }, {}).status).toBe('skip')
+  })
+  test('malformed enabledMcpjsonServers (object, not array) → fail, no crash', () => {
+    const mcp = { mcpServers: { 'dashi-channel': {} } }
+    const sl = { enableAllProjectMcpServers: false, enabledMcpjsonServers: { 'dashi-channel': true } }
+    expect(checkCommsConsistency(mcp, sl).status).toBe('fail')
+  })
+})
+
+describe('parseEnvList — tolerates real .env noise', () => {
+  test('plain CSV', () => {
+    expect(parseEnvList('TELEGRAM_ALLOWED_USER_IDS=1,2,3', 'TELEGRAM_ALLOWED_USER_IDS')).toEqual(['1', '2', '3'])
+  })
+  test('strips inline comment, quotes, and export prefix', () => {
+    expect(parseEnvList('TELEGRAM_ALLOWED_USER_IDS=42 # me', 'TELEGRAM_ALLOWED_USER_IDS')).toEqual(['42'])
+    expect(parseEnvList('TELEGRAM_ALLOWED_USER_IDS="1,2"', 'TELEGRAM_ALLOWED_USER_IDS')).toEqual(['1', '2'])
+    expect(parseEnvList('export TELEGRAM_ALLOWED_USER_IDS=7', 'TELEGRAM_ALLOWED_USER_IDS')).toEqual(['7'])
+  })
+  test('missing key → null, empty value → []', () => {
+    expect(parseEnvList('OTHER=1', 'TELEGRAM_ALLOWED_USER_IDS')).toBeNull()
+    expect(parseEnvList('TELEGRAM_ALLOWED_USER_IDS=', 'TELEGRAM_ALLOWED_USER_IDS')).toEqual([])
+  })
+})
+
+describe('checkAllowlist (user AND chat)', () => {
+  test('user present → pass', () => {
+    const c = checkAllowlist('TELEGRAM_ALLOWED_USER_IDS=164795011,42', '42')
+    expect(c.find((x) => x.id === 'allowlist-user')?.status).toBe('pass')
+  })
+  test('user absent → fail with inline-comment value still parsed', () => {
+    const c = checkAllowlist('TELEGRAM_ALLOWED_USER_IDS=164795011 # chief', '42')
+    const user = c.find((x) => x.id === 'allowlist-user')
+    expect(user?.status).toBe('fail')
+    expect(user?.detail).toContain('silently dropped')
+  })
+  test('empty user allowlist → warn', () => {
+    expect(checkAllowlist('TELEGRAM_ALLOWED_USER_IDS=', '42')[0]?.status).toBe('warn')
+  })
+  test('chat list present and chat id missing → fail', () => {
+    const c = checkAllowlist('TELEGRAM_ALLOWED_USER_IDS=42\nTELEGRAM_ALLOWED_CHAT_IDS=-100123', '42', '-100999')
+    expect(c.find((x) => x.id === 'allowlist-chat')?.status).toBe('fail')
+  })
+  test('user-only DM setup → no chat check emitted', () => {
+    const c = checkAllowlist('TELEGRAM_ALLOWED_USER_IDS=42', '42')
+    expect(c.find((x) => x.id === 'allowlist-chat')).toBeUndefined()
+  })
+})
+
+describe('classifyQueue', () => {
+  test('409 → fail with hunt-the-second-consumer guidance', () => {
+    const c = classifyQueue({ ok: false, error_code: 409 })
+    expect(c.status).toBe('fail')
+    expect(c.fix).toContain('second consumer')
+  })
+  test('ok with no pending → pass', () => {
+    expect(classifyQueue({ ok: true, result: [] }).status).toBe('pass')
+  })
+  test('ok but pending after messaging → warn (poller stuck)', () => {
+    expect(classifyQueue({ ok: true, result: [{}, {}] }, true).status).toBe('warn')
+  })
+})
+
+describe('live-session signal detectors', () => {
+  test('welcome hang detected POSITIVELY by prompt text', () => {
+    expect(detectWelcomeHang('Do you trust the files in this folder?')).toBe(true)
+    expect(detectWelcomeHang('--dangerously-load-development-channels is for local development only')).toBe(true)
+  })
+  test('busy session with scrolled-out marker is NOT a hang (was the false-positive)', () => {
+    const busy = Array.from({ length: 80 }, (_, i) => `turn line ${i}`).join('\n')
+    expect(detectWelcomeHang(busy)).toBe(false)
+  })
+  test('detectListening confirms the live marker', () => {
+    expect(detectListening('Listening for channel messages from: server:dashi-channel')).toBe(true)
+    expect(detectListening('turn line 5')).toBe(false)
+  })
+  test('auth expired only on line-anchored login/401', () => {
+    expect(detectAuthExpired('Please run /login')).toBe(true)
+    expect(detectAuthExpired('API Error: 401')).toBe(true)
+    expect(detectAuthExpired('all good')).toBe(false)
+  })
+  test('auth NOT tripped by login words inside prose (was a false-positive)', () => {
+    expect(detectAuthExpired('the docs say: if you see please run /login then reauth')).toBe(false)
+  })
+  test('crash loop on no-server / auto-restart success', () => {
+    expect(detectCrashLoop('no server running on /tmp/tmux-1000/default')).toBe(true)
+    expect(detectCrashLoop('activating (auto-restart) (Result: exit-code) status=0/SUCCESS')).toBe(true)
+    expect(detectCrashLoop('active (running)')).toBe(false)
+  })
+})
+
+describe('report aggregation', () => {
+  const checks: Check[] = [
+    { id: 'a', title: 'A', status: 'pass', detail: 'ok' },
+    { id: 'b', title: 'B', status: 'warn', detail: 'meh', fix: 'do x' },
+    { id: 'c', title: 'C', status: 'fail', detail: 'token 8338508613:AAH1234567890abcdefghijklmnopqrstuvw', fix: 'redact me' },
+  ]
+  test('worstStatus picks the most severe', () => {
+    expect(worstStatus(checks)).toBe('fail')
+    expect(worstStatus([{ id: 'x', title: 'x', status: 'pass', detail: '' }])).toBe('pass')
+    expect(worstStatus([])).toBe('skip')
+  })
+  test('renderReport redacts secrets and counts fails/warns', () => {
+    const r = renderReport(checks)
+    expect(r).not.toContain('AAH1234567890')
+    expect(r).toContain('1 FAIL')
+    expect(r).toContain('1 WARN')
+  })
+  test('redactCheck scrubs detail and fix (the --json output path)', () => {
+    const c = redactCheck({ id: 'x', title: 'token 100.104.191.127', status: 'fail', detail: 'leak 8338508613:AAH1234567890abcdefghijklmnopqrstuvw', fix: 'GROQ_API_KEY=gsk_abcdefghijklmnopqrstuvwxyz0123' })
+    const json = JSON.stringify(c)
+    expect(json).not.toContain('AAH1234567890')
+    expect(json).not.toContain('gsk_abcdefghijklmnopqrstuvwxyz0123')
+    expect(json).not.toContain('100.104.191.127')
+  })
+  test('redact masks secret-key assignments regardless of value shape', () => {
+    expect(redact('TELEGRAM_WEBHOOK_TOKEN=super-secret-xyz')).not.toContain('super-secret-xyz')
+    expect(redact('"MY_SECRET":"whatever-123"')).not.toContain('whatever-123')
+  })
+})

--- a/skills/doctor-dashi-plugin/scripts/doctor.ts
+++ b/skills/doctor-dashi-plugin/scripts/doctor.ts
@@ -1,0 +1,798 @@
+#!/usr/bin/env bun
+/**
+ * doctor-dashi-plugin — migration & health diagnostic.
+ *
+ * Helps an agent move from the legacy telegram-gateway (per-message `claude -p`
+ * spawn) to the dashi-plugin-claude-code channel (one live session) without
+ * repeating the mistakes we already paid for.
+ *
+ * Standalone by design: it imports nothing from the plugin's `src/` so it keeps
+ * working even when the plugin checkout is broken — diagnosing a broken checkout
+ * is one of its jobs. All probes are read-only; the doctor never restarts a
+ * service, never writes config, never touches a token. Output is redacted.
+ *
+ * Run:  bun skills/doctor-dashi-plugin/scripts/doctor.ts [--json] [options]
+ * Exit: 0 = no FAIL, 1 = at least one FAIL, 2 = usage error.
+ */
+import { spawnSync } from 'child_process'
+import { existsSync, readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { homedir, platform } from 'os'
+
+export type Status = 'pass' | 'warn' | 'fail' | 'skip'
+
+export interface Check {
+  id: string
+  title: string
+  status: Status
+  detail: string
+  /** One-line remediation pointer shown when status is warn/fail. */
+  fix?: string
+}
+
+export type OS = 'linux' | 'macos' | 'other'
+
+/** Required floors. Below these, migration is unsupported. */
+export const MIN_CLAUDE = [2, 1, 0] as const
+export const MIN_BUN = [1, 3, 14] as const
+
+/** The five hook events install-hooks.sh must register. */
+export const REQUIRED_HOOK_EVENTS = [
+  'SessionStart',
+  'UserPromptSubmit',
+  'PreToolUse',
+  'PostToolUse',
+  'Stop',
+] as const
+
+export const HOOK_MARKER = 'dashi-channel-hook'
+export const FALLBACK_MARKER = 'dashi-channel-fallback-reply'
+export const LIVE_MARKER = 'Listening for channel messages from: server:dashi-channel'
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested)
+// ---------------------------------------------------------------------------
+
+export function detectOS(p: string = platform()): OS {
+  if (p === 'linux') return 'linux'
+  if (p === 'darwin') return 'macos'
+  return 'other'
+}
+
+/**
+ * Mask anything that looks like a secret. We are often run in a public group
+ * where the transcript is shown to students, so leaking a token is a real
+ * incident, not a cosmetic one.
+ */
+/** Env/JSON keys whose value must never reach the output, whatever its shape. */
+const SECRET_WORDS = 'TOKEN|SECRET|PASSWORD|API_KEY|PRIVATE_KEY|BEARER'
+// Quoted value (handles spaces, commas, escapes, JSON `"KEY":"v"`): mask to the
+// closing quote. Bare value: mask to the next whitespace/comma/quote/brace.
+const SECRET_QUOTED = new RegExp(`("?[A-Za-z0-9_]*(?:${SECRET_WORDS})[A-Za-z0-9_]*"?\\s*[=:]\\s*)(["'])[\\s\\S]*?\\2`, 'gi')
+const SECRET_BARE = new RegExp(`([A-Za-z0-9_]*(?:${SECRET_WORDS})[A-Za-z0-9_]*\\s*[=:]\\s*)([^\\s"',}]+)`, 'gi')
+
+export function redact(input: string): string {
+  return input
+    // Known secret assignments — mask the value regardless of its shape, so an
+    // unusual or quoted token still does not leak. Quoted form first.
+    .replace(SECRET_QUOTED, '$1$2<redacted>$2')
+    .replace(SECRET_BARE, '$1<redacted>')
+    .replace(/\b\d{8,12}:[A-Za-z0-9_-]{30,}\b/g, '<bot-token>')
+    .replace(/\bgsk_[A-Za-z0-9]{20,}\b/g, '<groq-key>')
+    .replace(/\bsk-[A-Za-z0-9-]{20,}\b/g, '<api-key>')
+    .replace(/[Bb]earer\s+[A-Za-z0-9._-]{10,}/g, 'Bearer <redacted>')
+    .replace(/\b(\d{1,3}\.){3}\d{1,3}\b/g, '<ip>')
+}
+
+/** Redact every string field of a check — the single boundary for safe output. */
+export function redactCheck(c: Check): Check {
+  return {
+    id: redact(c.id),
+    title: redact(c.title),
+    status: c.status,
+    detail: redact(c.detail),
+    ...(c.fix !== undefined ? { fix: redact(c.fix) } : {}),
+  }
+}
+
+/**
+ * Path-boundary aware "same tree" test — `/srv/agent/plugin` and
+ * `/srv/agent/plugin-old` are NOT the same tree, which a bare startsWith would
+ * get wrong.
+ */
+export function sameTree(a: string, b: string): boolean {
+  const na = a.replace(/\/+$/, '') + '/'
+  const nb = b.replace(/\/+$/, '') + '/'
+  return na.startsWith(nb) || nb.startsWith(na)
+}
+
+export function parseSemver(v: string): [number, number, number] | null {
+  const m = v.match(/(\d+)\.(\d+)(?:\.(\d+))?/)
+  if (!m) return null
+  return [Number(m[1] ?? 0), Number(m[2] ?? 0), Number(m[3] ?? 0)]
+}
+
+/** Returns negative if a<b, 0 if equal, positive if a>b. */
+export function cmpSemver(
+  a: readonly [number, number, number],
+  b: readonly [number, number, number],
+): number {
+  return a[0] - b[0] || a[1] - b[1] || a[2] - b[2]
+}
+
+export function checkVersion(
+  id: string,
+  title: string,
+  rawOutput: string,
+  min: readonly [number, number, number],
+): Check {
+  const parsed = parseSemver(rawOutput)
+  if (!parsed) {
+    return {
+      id,
+      title,
+      status: 'fail',
+      detail: `could not parse version from: ${redact(rawOutput.trim().slice(0, 80))}`,
+      fix: 'install/upgrade the tool, then re-run the doctor',
+    }
+  }
+  const ok = cmpSemver(parsed, min) >= 0
+  const got = parsed.join('.')
+  const want = min.join('.')
+  return ok
+    ? { id, title, status: 'pass', detail: `${got} (>= ${want})` }
+    : {
+        id,
+        title,
+        status: 'fail',
+        detail: `${got} is below the required ${want}`,
+        fix: `upgrade to >= ${want}`,
+      }
+}
+
+/**
+ * Walk up from the plugin directory looking for the workspace CLAUDE.md.
+ * The plugin MUST live inside `<workspace>/.claude/...` so Claude Code's
+ * upward CWD search picks up the agent's project CLAUDE.md. Placing it in
+ * ~/projects or /opt is the single most common first-run failure (identity
+ * drift — the bot answers as "default Claude").
+ */
+export function findEnclosingClaudeMd(
+  pluginDir: string,
+  fileExists: (p: string) => boolean = existsSync,
+): string | null {
+  let dir = pluginDir
+  for (let i = 0; i < 12; i++) {
+    const candidate = join(dir, 'CLAUDE.md')
+    if (fileExists(candidate)) return candidate
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return null
+}
+
+export function checkWorkspacePlacement(
+  pluginDir: string,
+  fileExists: (p: string) => boolean = existsSync,
+): Check {
+  const claudeMd = findEnclosingClaudeMd(pluginDir, fileExists)
+  if (!claudeMd) {
+    return {
+      id: 'workspace-placement',
+      title: 'Plugin inside an agent workspace (CLAUDE.md reachable)',
+      status: 'fail',
+      detail: `no CLAUDE.md found walking up from ${pluginDir}`,
+      fix: 'move the plugin under <workspace>/.claude/dashi-plugin-claude-code/plugin so CLAUDE.md is reachable, else the agent loses its identity',
+    }
+  }
+  const insideDotClaude = pluginDir.includes(`${join('.claude')}/`) || pluginDir.includes('/.claude/')
+  if (!insideDotClaude) {
+    return {
+      id: 'workspace-placement',
+      title: 'Plugin inside an agent workspace (CLAUDE.md reachable)',
+      status: 'warn',
+      detail: `CLAUDE.md found at ${claudeMd} but plugin is not under a .claude/ directory`,
+      fix: 'conventionally the plugin lives at <workspace>/.claude/dashi-plugin-claude-code/plugin',
+    }
+  }
+  return {
+    id: 'workspace-placement',
+    title: 'Plugin inside an agent workspace (CLAUDE.md reachable)',
+    status: 'pass',
+    detail: `CLAUDE.md reachable at ${claudeMd}`,
+  }
+}
+
+interface SettingsHookEntry {
+  marker?: string
+  hooks?: Array<{ command?: string }>
+  command?: string
+}
+interface SettingsShape {
+  hooks?: Record<string, SettingsHookEntry[]>
+}
+
+/** Collect every command string reachable from a settings hook entry. */
+function entryCommands(entry: SettingsHookEntry): string[] {
+  const cmds: string[] = []
+  if (typeof entry.command === 'string') cmds.push(entry.command)
+  for (const h of entry.hooks ?? []) {
+    if (typeof h.command === 'string') cmds.push(h.command)
+  }
+  return cmds
+}
+
+/**
+ * True only when an entry both carries the marker AND has a runnable command —
+ * a marker on an entry with no command would pass a substring test but never
+ * actually fire the hook.
+ */
+function hasWorkingHook(entries: SettingsHookEntry[], marker: string): boolean {
+  return entries.some((e) => e.marker === marker && entryCommands(e).some((c) => c.length > 0))
+}
+
+/**
+ * Verify the five channel hook events are registered with a runnable command,
+ * and that no secret ever leaked into settings.json (the patcher refuses to
+ * write the webhook token; anything secret-shaped here is about to be committed).
+ */
+export function checkSettingsHooks(settings: unknown): Check[] {
+  const out: Check[] = []
+  const raw = JSON.stringify(settings ?? {})
+  // Shape-based leak detection: if redaction changes the serialized settings,
+  // something secret-shaped is present (a token value, a bearer literal, a known
+  // secret-key assignment) regardless of the key name.
+  const leaked = /TELEGRAM_WEBHOOK_TOKEN/.test(raw) || redact(raw) !== raw
+  out.push(
+    leaked
+      ? {
+          id: 'settings-no-token',
+          title: 'No secret leaked into settings.json',
+          status: 'fail',
+          detail: 'a secret-shaped value is present in settings.json',
+          fix: 'remove it — tokens belong in runtime env only, never in settings.json (it gets committed)',
+        }
+      : {
+          id: 'settings-no-token',
+          title: 'No secret leaked into settings.json',
+          status: 'pass',
+          detail: 'no secret leaked into settings',
+        },
+  )
+
+  const hooks = (settings as SettingsShape)?.hooks ?? {}
+  for (const ev of REQUIRED_HOOK_EVENTS) {
+    const entries = Array.isArray(hooks[ev]) ? hooks[ev] : []
+    const working = hasWorkingHook(entries, HOOK_MARKER)
+    const markerOnly = !working && JSON.stringify(entries).includes(HOOK_MARKER)
+    out.push(
+      working
+        ? { id: `hook-${ev}`, title: `Hook registered: ${ev}`, status: 'pass', detail: `marker ${HOOK_MARKER} with a runnable command` }
+        : {
+            id: `hook-${ev}`,
+            title: `Hook registered: ${ev}`,
+            status: 'warn',
+            detail: markerOnly ? `${ev} has a ${HOOK_MARKER} entry but no runnable command` : `no ${HOOK_MARKER} entry for ${ev}`,
+            fix: 'run plugin/scripts/install-hooks.sh to register status + memory hooks',
+          },
+    )
+  }
+
+  // DM fallback-reply (PR #47) — optional but recommended: guarantees the chief
+  // gets an answer even when the agent forgets to call the reply tool.
+  const stopEntries = Array.isArray(hooks['Stop']) ? hooks['Stop'] : []
+  out.push(
+    hasWorkingHook(stopEntries, FALLBACK_MARKER)
+      ? { id: 'fallback-reply-hook', title: 'DM fallback-reply Stop-hook (PR #47)', status: 'pass', detail: 'silent-turn fallback is registered' }
+      : {
+          id: 'fallback-reply-hook',
+          title: 'DM fallback-reply Stop-hook (PR #47)',
+          status: 'warn',
+          detail: 'no fallback-reply Stop-hook — a forgotten reply will be silently lost in DMs',
+          fix: 'register the fallback-reply Stop-hook so a silent turn still reaches the chief',
+        },
+  )
+  return out
+}
+
+interface McpShape {
+  mcpServers?: Record<string, unknown>
+}
+interface SettingsLocalShape {
+  enableAllProjectMcpServers?: boolean
+  enabledMcpjsonServers?: string[]
+}
+
+/**
+ * The landmine from 2026-06-02: with enableAllProjectMcpServers=false, every
+ * server declared in .mcp.json must be listed explicitly in
+ * enabledMcpjsonServers, or it is silently dropped on the NEXT restart — the
+ * live session survives, so the breakage is latent and shows up hours later as
+ * "the agent went silent".
+ */
+export function checkCommsConsistency(mcp: unknown, settingsLocal: unknown): Check {
+  const servers = Object.keys((mcp as McpShape)?.mcpServers ?? {})
+  const sl = (settingsLocal as SettingsLocalShape) ?? {}
+  if (servers.length === 0) {
+    return {
+      id: 'comms-consistency',
+      title: 'MCP comms servers enabled consistently',
+      status: 'skip',
+      detail: 'no .mcp.json servers declared',
+    }
+  }
+  if (sl.enableAllProjectMcpServers === true) {
+    return {
+      id: 'comms-consistency',
+      title: 'MCP comms servers enabled consistently',
+      status: 'pass',
+      detail: `enableAllProjectMcpServers=true covers all ${servers.length} server(s)`,
+    }
+  }
+  if (sl.enabledMcpjsonServers !== undefined && !Array.isArray(sl.enabledMcpjsonServers)) {
+    return {
+      id: 'comms-consistency',
+      title: 'MCP comms servers enabled consistently',
+      status: 'fail',
+      detail: 'enabledMcpjsonServers is not an array — settings.local.json is malformed',
+      fix: 'make enabledMcpjsonServers a JSON array of server names',
+    }
+  }
+  const enabled = new Set(Array.isArray(sl.enabledMcpjsonServers) ? sl.enabledMcpjsonServers : [])
+  const missing = servers.filter((s) => !enabled.has(s))
+  if (missing.length > 0) {
+    return {
+      id: 'comms-consistency',
+      title: 'MCP comms servers enabled consistently',
+      status: 'fail',
+      detail: `dropped on next restart: ${missing.join(', ')}`,
+      fix: 'add every .mcp.json server to enabledMcpjsonServers (or set enableAllProjectMcpServers=true) — a missing comms server goes silent after the next restart',
+    }
+  }
+  return {
+    id: 'comms-consistency',
+    title: 'MCP comms servers enabled consistently',
+    status: 'pass',
+    detail: `all ${servers.length} server(s) explicitly enabled`,
+  }
+}
+
+/**
+ * Read a CSV env var value, tolerating `export ` prefixes, surrounding quotes,
+ * and trailing `# comments` — all of which appear in real channel.env files and
+ * would otherwise corrupt the parse (e.g. `=42 # me` → id "42 # me").
+ */
+export function parseEnvList(envText: string, key: string): string[] | null {
+  const m = envText.match(new RegExp(`^(?:export\\s+)?${key}=(.*)$`, 'm'))
+  if (!m) return null
+  let v = (m[1] ?? '').trim()
+  v = v.replace(/\s+#.*$/, '').trim() // strip inline comment
+  v = v.replace(/^["']|["']$/g, '') // strip surrounding quotes
+  return v
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+function allowlistCheck(id: string, title: string, key: string, ids: string[] | null, wanted?: string): Check {
+  if (ids === null || ids.length === 0) {
+    return { id, title, status: 'warn', detail: `${key} empty — the code default applies`, fix: `set ${key} to your numeric id (ask @userinfobot)` }
+  }
+  if (!wanted) {
+    return { id, title, status: 'pass', detail: `${key} set (${ids.length} id(s)); pass the id to verify membership` }
+  }
+  return ids.includes(wanted)
+    ? { id, title, status: 'pass', detail: `${wanted} is in ${key}` }
+    : { id, title, status: 'fail', detail: `${wanted} is NOT in ${key} — your messages are silently dropped`, fix: `add ${wanted} to ${key}` }
+}
+
+/**
+ * The runtime gate requires BOTH user and chat membership (in a DM chat.id ==
+ * user.id, but a drifted config can allow a user without the matching chat and
+ * silently drop). So we verify both lists. Symptom of a miss: queue pending=0
+ * but no reply and no error.
+ */
+export function checkAllowlist(envText: string, userId?: string, chatId?: string): Check[] {
+  const out: Check[] = [
+    allowlistCheck('allowlist-user', 'Telegram user allowlist', 'TELEGRAM_ALLOWED_USER_IDS', parseEnvList(envText, 'TELEGRAM_ALLOWED_USER_IDS'), userId),
+  ]
+  const chats = parseEnvList(envText, 'TELEGRAM_ALLOWED_CHAT_IDS')
+  // A DM uses chat.id == user.id; only flag the chat list when it exists or a
+  // chat id was provided to verify, to avoid noise on a user-only DM setup.
+  if (chats !== null || chatId) {
+    out.push(allowlistCheck('allowlist-chat', 'Telegram chat allowlist', 'TELEGRAM_ALLOWED_CHAT_IDS', chats, chatId))
+  }
+  return out
+}
+
+/**
+ * Interpret a getUpdates response. A 409 means a second consumer holds the same
+ * bot token — the most common migration landmine. Do NOT theorise about a
+ * Claude version regression; hunt the second process.
+ */
+export function classifyQueue(getUpdatesJson: unknown, justMessaged = false): Check {
+  const r = getUpdatesJson as { ok?: boolean; error_code?: number; result?: unknown[] }
+  if (r?.error_code === 409) {
+    return {
+      id: 'telegram-queue',
+      title: 'Telegram getUpdates has a single consumer',
+      status: 'fail',
+      detail: '409 Conflict — a second process holds the same bot token',
+      fix: 'stop the channel, wait 45s, curl getUpdates again. If 409 persists, the second consumer is external (old gateway / debug session / a PM2 app with a leaked token). Find and stop it.',
+    }
+  }
+  if (r?.ok !== true) {
+    return {
+      id: 'telegram-queue',
+      title: 'Telegram getUpdates has a single consumer',
+      status: 'warn',
+      detail: 'getUpdates did not return ok=true',
+      fix: 'check the bot token and network',
+    }
+  }
+  const pending = Array.isArray(r.result) ? r.result.length : 0
+  if (justMessaged && pending > 0) {
+    return {
+      id: 'telegram-queue',
+      title: 'Telegram getUpdates has a single consumer',
+      status: 'warn',
+      detail: `pending=${pending} after you messaged — the poller is not draining updates`,
+      fix: 'the polling loop is stuck; check the channel is running and past the welcome prompt',
+    }
+  }
+  return {
+    id: 'telegram-queue',
+    title: 'Telegram getUpdates has a single consumer',
+    status: 'pass',
+    detail: `ok, pending=${pending}`,
+  }
+}
+
+/** The two first-run prompts that block the channel until answered. */
+const WELCOME_PROMPT_RE =
+  /Do you trust the files|dangerously-load-development-channels is for local|external CLAUDE\.md file imports|❯\s*1\.\s*Yes/i
+
+/**
+ * A stuck welcome prompt is detected POSITIVELY — by the prompt text — not by
+ * the absence of the startup marker. On a busy session the one-time
+ * "Listening…" line scrolls out of the capture window, so marker-absence alone
+ * is not evidence of a hang (that was a false-positive in review).
+ */
+export function detectWelcomeHang(tmuxCapture: string): boolean {
+  return WELCOME_PROMPT_RE.test(tmuxCapture)
+}
+
+/** True when we can positively confirm the channel is listening. */
+export function detectListening(tmuxCapture: string): boolean {
+  return tmuxCapture.includes(LIVE_MARKER)
+}
+
+export function detectAuthExpired(tmuxCapture: string): boolean {
+  // Line-anchored so the words appearing inside a quoted error, a memory note,
+  // or this skill's own prose scrolling through the pane do not trip a scary
+  // "re-login" FAIL on an already-authenticated session.
+  return /^.*(?:API Error: 401|Invalid authentication credentials)/m.test(tmuxCapture) || /^\s*(?:Please run )?\/login\b/im.test(tmuxCapture)
+}
+
+export function detectCrashLoop(serviceStatus: string): boolean {
+  return (
+    /no server running on/.test(serviceStatus) ||
+    (/activating \(auto-restart\)/.test(serviceStatus) && /status=0\/SUCCESS/.test(serviceStatus))
+  )
+}
+
+export function worstStatus(checks: Check[]): Status {
+  if (checks.some((c) => c.status === 'fail')) return 'fail'
+  if (checks.some((c) => c.status === 'warn')) return 'warn'
+  if (checks.some((c) => c.status === 'pass')) return 'pass'
+  return 'skip'
+}
+
+const ICON: Record<Status, string> = { pass: 'OK  ', warn: 'WARN', fail: 'FAIL', skip: 'SKIP' }
+
+export function renderReport(checks: Check[]): string {
+  const lines: string[] = []
+  for (const c of checks) {
+    lines.push(`[${ICON[c.status]}] ${c.title}`)
+    if (c.detail) lines.push(`        ${redact(c.detail)}`)
+    if (c.fix && (c.status === 'warn' || c.status === 'fail')) {
+      lines.push(`        fix: ${redact(c.fix)}`)
+    }
+  }
+  const fails = checks.filter((c) => c.status === 'fail').length
+  const warns = checks.filter((c) => c.status === 'warn').length
+  lines.push('')
+  lines.push(`Summary: ${checks.length} checks, ${fails} FAIL, ${warns} WARN`)
+  return lines.join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Impure probes (not unit-tested; thin wrappers over the system)
+// ---------------------------------------------------------------------------
+
+interface ProbeResult {
+  code: number
+  stdout: string
+  stderr: string
+}
+
+function probe(cmd: string, args: string[], timeoutMs = 8000): ProbeResult {
+  try {
+    const r = spawnSync(cmd, args, { encoding: 'utf8', timeout: timeoutMs })
+    return { code: r.status ?? -1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' }
+  } catch {
+    return { code: -1, stdout: '', stderr: '' }
+  }
+}
+
+function readFileSafe(p: string): string | null {
+  try {
+    return existsSync(p) ? readFileSync(p, 'utf8') : null
+  } catch {
+    return null
+  }
+}
+
+/** Working directory of a live PID — cross-platform (no `pwdx`, absent on macOS). */
+function liveCwd(pid: string, os: OS): string {
+  if (os === 'linux') {
+    const r = probe('readlink', ['-f', `/proc/${pid}/cwd`])
+    if (r.stdout.trim()) return r.stdout.trim()
+  }
+  // lsof exists on both macOS and Linux. `-Fn` prints an `n<path>` field line.
+  const r = probe('lsof', ['-a', '-p', pid, '-d', 'cwd', '-Fn'])
+  const line = r.stdout.split('\n').find((l) => l.startsWith('n'))
+  return line ? line.slice(1).trim() : ''
+}
+
+function parseJsonSafe(text: string | null): unknown {
+  if (text == null) return null
+  try {
+    return JSON.parse(text)
+  } catch {
+    return null
+  }
+}
+
+interface Options {
+  json: boolean
+  os: OS
+  pluginDir: string
+  settingsPath: string
+  mcpPath?: string
+  settingsLocalPath?: string
+  envPath?: string
+  userId?: string
+  chatId?: string
+  tmuxSession?: string
+  queueJsonPath?: string
+}
+
+function parseArgs(argv: string[]): Options | { error: string } {
+  const opts: Options = {
+    json: false,
+    os: detectOS(),
+    pluginDir: process.cwd(),
+    settingsPath: join(homedir(), '.claude', 'settings.json'),
+  }
+  let err = ''
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    // Consume the next token as a flag value. A following token that itself
+    // looks like a flag means the value was omitted (e.g. `--user --json`).
+    const next = (): string => {
+      const v = argv[i + 1]
+      if (v === undefined || v.startsWith('--')) {
+        err = `missing value for ${a}`
+        return ''
+      }
+      i++
+      return v
+    }
+    switch (a) {
+      case '--json':
+        opts.json = true
+        break
+      case '--plugin-dir':
+        opts.pluginDir = next()
+        break
+      case '--settings':
+        opts.settingsPath = next()
+        break
+      case '--mcp':
+        opts.mcpPath = next()
+        break
+      case '--settings-local':
+        opts.settingsLocalPath = next()
+        break
+      case '--env':
+        opts.envPath = next()
+        break
+      case '--user':
+        opts.userId = next()
+        break
+      case '--chat':
+        opts.chatId = next()
+        break
+      case '--session':
+        opts.tmuxSession = next()
+        break
+      case '--queue-json':
+        opts.queueJsonPath = next()
+        break
+      case '--help':
+      case '-h':
+        return { error: 'help' }
+      default:
+        return { error: `unknown argument: ${a}` }
+    }
+    if (err) return { error: err }
+  }
+  return opts
+}
+
+const USAGE = `doctor-dashi-plugin — migrate from the legacy gateway to the channel plugin safely.
+
+Usage:
+  bun skills/doctor-dashi-plugin/scripts/doctor.ts [options]
+
+Options:
+  --plugin-dir <path>      plugin directory (default: cwd)
+  --settings <path>        ~/.claude/settings.json to inspect
+  --mcp <path>             project .mcp.json
+  --settings-local <path>  project .claude/settings.local.json
+  --env <path>             channel.env to inspect (allowlists)
+  --user <id>              your numeric Telegram user id
+  --chat <id>              a Telegram chat id to verify (group id is -100...)
+  --session <name>         tmux channel session (e.g. channel-myagent)
+  --queue-json <path>      a saved getUpdates JSON response to classify (409 / drain)
+  --json                   machine-readable output
+  -h, --help               this help
+
+Read-only: never restarts a service, never writes config, never prints a secret.
+Exit 0 = no FAIL, 1 = at least one FAIL, 2 = usage error.`
+
+function gatherChecks(opts: Options): Check[] {
+  const checks: Check[] = []
+
+  // Pre-flight: toolchain
+  const claude = probe('claude', ['--version'])
+  checks.push(
+    claude.code === 0 || claude.stdout
+      ? checkVersion('claude-version', 'Claude Code >= 2.1', claude.stdout || claude.stderr, MIN_CLAUDE)
+      : {
+          id: 'claude-version',
+          title: 'Claude Code >= 2.1',
+          status: 'fail',
+          detail: 'claude CLI not found on PATH',
+          fix: 'install Claude Code and log in with Anthropic Max',
+        },
+  )
+  const bun = probe(process.execPath.endsWith('bun') ? process.execPath : 'bun', ['--version'])
+  checks.push(
+    bun.stdout
+      ? checkVersion('bun-version', 'Bun >= 1.3.14', bun.stdout, MIN_BUN)
+      : { id: 'bun-version', title: 'Bun >= 1.3.14', status: 'fail', detail: 'bun not found', fix: 'install bun' },
+  )
+  const tmux = probe('tmux', ['-V'])
+  checks.push(
+    tmux.stdout
+      ? { id: 'tmux', title: 'tmux installed (TTY supervisor)', status: 'pass', detail: tmux.stdout.trim() }
+      : { id: 'tmux', title: 'tmux installed (TTY supervisor)', status: 'fail', detail: 'tmux not found', fix: 'install tmux — the channel runs claude inside a tmux session' },
+  )
+
+  // Workspace placement (identity)
+  checks.push(checkWorkspacePlacement(opts.pluginDir))
+
+  // Dev-copy vs runtime-copy divergence (lessons §1). The service runs the
+  // RUNTIME copy; patching a different checkout silently does nothing. Read-only
+  // probe: find the live server's CWD and compare to the inspected plugin dir.
+  const live = probe('pgrep', ['-f', 'bun.*src/server.ts'])
+  const pid = live.stdout.trim().split(/\s+/).filter(Boolean)[0]
+  if (pid) {
+    const cwd = liveCwd(pid, opts.os)
+    if (cwd) {
+      checks.push(
+        sameTree(opts.pluginDir, cwd)
+          ? { id: 'dev-vs-runtime', title: 'Inspected plugin matches the running copy', status: 'pass', detail: `runtime CWD ${cwd}` }
+          : {
+              id: 'dev-vs-runtime',
+              title: 'Inspected plugin matches the running copy',
+              status: 'warn',
+              detail: `running copy CWD ${cwd} differs from --plugin-dir ${opts.pluginDir}`,
+              fix: 'patch the RUNTIME copy (the one the service runs), not just the dev/git checkout',
+            },
+      )
+    }
+  }
+
+  // settings.json hooks + token leak
+  const settings = parseJsonSafe(readFileSafe(opts.settingsPath))
+  if (settings == null) {
+    checks.push({
+      id: 'settings-readable',
+      title: 'settings.json readable',
+      status: 'warn',
+      detail: `could not read/parse ${opts.settingsPath}`,
+      fix: 'pass --settings <path> to the agent settings.json',
+    })
+  } else {
+    checks.push(...checkSettingsHooks(settings))
+  }
+
+  // comms consistency (.mcp.json vs settings.local.json) — distinguish a missing
+  // file from one present but unparseable (a malformed .mcp.json is itself a bug).
+  if (opts.mcpPath || opts.settingsLocalPath) {
+    const mcpRaw = readFileSafe(opts.mcpPath ?? '')
+    const slRaw = readFileSafe(opts.settingsLocalPath ?? '')
+    if (opts.mcpPath && mcpRaw !== null && parseJsonSafe(mcpRaw) === null) {
+      checks.push({ id: 'comms-consistency', title: 'MCP comms servers enabled consistently', status: 'fail', detail: `${opts.mcpPath} is present but not valid JSON`, fix: 'fix the .mcp.json syntax' })
+    } else {
+      checks.push(checkCommsConsistency(parseJsonSafe(mcpRaw), parseJsonSafe(slRaw)))
+    }
+  }
+
+  // allowlists (user AND chat)
+  if (opts.envPath) {
+    const env = readFileSafe(opts.envPath)
+    if (env == null) {
+      checks.push({ id: 'allowlist-user', title: 'Telegram user allowlist', status: 'warn', detail: `could not read ${opts.envPath}` })
+    } else {
+      checks.push(...checkAllowlist(env, opts.userId, opts.chatId))
+    }
+  }
+
+  // Telegram queue (409 / drain) from a saved getUpdates response
+  if (opts.queueJsonPath) {
+    const raw = readFileSafe(opts.queueJsonPath)
+    const parsed = parseJsonSafe(raw)
+    if (parsed == null) {
+      checks.push({ id: 'telegram-queue', title: 'Telegram getUpdates has a single consumer', status: 'warn', detail: `could not read/parse ${opts.queueJsonPath}` })
+    } else {
+      checks.push(classifyQueue(parsed))
+    }
+  }
+
+  // live session state (crash loop / auth / welcome hang / listening)
+  if (opts.tmuxSession) {
+    const cap = probe('tmux', ['capture-pane', '-t', opts.tmuxSession, '-p', '-S', '-200'])
+    const text = `${cap.stdout}\n${cap.stderr}`
+    if (cap.code !== 0 || detectCrashLoop(text)) {
+      checks.push({ id: 'live-session', title: `Channel session ${opts.tmuxSession} alive`, status: 'fail', detail: detectCrashLoop(text) ? 'tmux server gone — crash loop (claude exits, supervisor relaunches)' : 'tmux session not found', fix: 'stop the service, run claude by hand with a TTY to read the real error, fix it, then start' })
+    } else if (detectAuthExpired(cap.stdout)) {
+      checks.push({ id: 'auth', title: 'Claude Code authenticated', status: 'fail', detail: 'session shows a /login or 401 prompt', fix: 'attach the tmux session and run /login under Anthropic Max' })
+    } else if (detectWelcomeHang(cap.stdout)) {
+      checks.push({ id: 'welcome-hang', title: 'Channel past the welcome prompts', status: 'fail', detail: 'a welcome prompt is on screen — the channel has not started', fix: 'attach the tmux session and press Enter through the welcome prompts' })
+    } else if (detectListening(cap.stdout)) {
+      checks.push({ id: 'live-session', title: `Channel session ${opts.tmuxSession} listening`, status: 'pass', detail: 'live marker present' })
+    } else {
+      checks.push({ id: 'live-session', title: `Channel session ${opts.tmuxSession} listening`, status: 'warn', detail: 'no welcome prompt and no live marker in view — the marker may have scrolled out', fix: 'send the bot a test message; expect the reaction flow 👀 → ⚙️ → ✅' })
+    }
+  }
+
+  return checks
+}
+
+function main(): void {
+  const parsed = parseArgs(process.argv.slice(2))
+  if ('error' in parsed) {
+    if (parsed.error === 'help') {
+      process.stdout.write(USAGE + '\n')
+      process.exit(0)
+    }
+    process.stderr.write(`${parsed.error}\n\n${USAGE}\n`)
+    process.exit(2)
+  }
+  const checks = gatherChecks(parsed)
+  // Redact at the single output boundary so BOTH the text and JSON paths are safe.
+  const safe = checks.map(redactCheck)
+  if (parsed.json) {
+    process.stdout.write(JSON.stringify({ os: parsed.os, summary: worstStatus(safe), checks: safe }, null, 2) + '\n')
+  } else {
+    process.stdout.write(renderReport(safe) + '\n')
+  }
+  process.exit(checks.some((c) => c.status === 'fail') ? 1 : 0)
+}
+
+if (import.meta.main) main()


### PR DESCRIPTION
## Что

Read-only скилл-доктор, который проводит агента ученика через миграцию со старого telegram-gateway на этот плагин **без повторения наших ошибок**. Запускается до и после cutover, говорит что не так и куда смотреть — сам ничего не рестартит, не пишет конфиг, не печатает секреты.

```bash
bun skills/doctor-dashi-plugin/scripts/doctor.ts --help
```

## Проверки

- **preflight** — claude ≥ 2.1, bun ≥ 1.3.14, tmux
- **identity drift** — плагин вне `<workspace>/.claude/` → `CLAUDE.md` недостижим, бот отвечает как «default Claude»
- **settings.json** — 5 hook-событий с рабочей командой (marker + наличие команды, не пустой marker) + shape-детектор утечки секретов
- **comms-consistency** — `enableAllProjectMcpServers:false` + неполный `enabledMcpjsonServers` молча выкидывает MCP-канал на следующем рестарте (latent landmine 2026-06-02)
- **allowlist** — user И chat (runtime-gate требует оба)
- **live-сигналы** — welcome-hang (позитивный матч промпта), OAuth expired (line-anchored), 409 conflict (`--queue-json`), crash loop
- **dev-vs-runtime** — расхождение CWD живого `server.ts` с инспектируемым плагином (кросс-платформенно: readlink/lsof)

## Архитектура

`scripts/doctor.ts` — standalone bun/TS, **без импортов плагина** (диагностирует даже битый checkout). Весь вывод через `redact()` на обоих путях (text + json) — секрет не утекает даже в `--json`. Чистые check-функции экспортированы и покрыты `scripts/doctor.test.ts` (**47 тестов**, strict `tsc` чист).

3 reference-дока: `01-migration-steps` (preflight / cutover / rollback / Linux↔macOS), `02-failure-modes` (10 проблем symptom→cause→fix), `03-lessons-learned` (13 наших инцидентов как детект-проверки). README обновлён (callout + строка в таблице доков + шаг quick-start).

## Ревью

Двойное ревью Codex GPT-5.5 + Opus, 3 итерации. Закрыты: **P0** — утечка секрета в `--json` (не редактировался); **P1** — welcome-hang false-positive на живой сессии, redact пропускал quoted/multiline секреты, allowlist игнорил chat-ids, hook-чек принимал пустой marker, классификаторы 409/crash не были подключены к CLI; **P2** — `pwdx`→`lsof` (нет на macOS), sibling-path false-match, malformed-guards, parseArgs missing-value. Каждая находка закрыта регресс-тестом.

## Тесты

`bun test skills/doctor-dashi-plugin/scripts/doctor.test.ts` → 47 pass / 0 fail. Strict tsc (noUncheckedIndexedAccess, exactOptionalPropertyTypes) — чисто. 4 несвязанных пре-существующих теста плагина (hook E2E dedup, pre-tool-use.sh multichat) падают на origin/main — вне этого изменения.

🤖 Generated with [Claude Code](https://claude.com/claude-code)