### PR TITLE
Доктор: false positive утечки на loopback URL + floor Bun 1.3.9

### DIFF
--- a/skills/doctor-dashi-plugin/SKILL.md
+++ b/skills/doctor-dashi-plugin/SKILL.md
@@ -47,7 +47,7 @@ Every flag is optional — pass what you have. `--json` gives machine-readable
 output for an agent to parse. Exit code: `0` = no FAIL, `1` = at least one FAIL,
 `2` = usage error.
 
-The doctor checks, in order: toolchain floors (Claude Code ≥ 2.1, Bun ≥ 1.3.14,
+The doctor checks, in order: toolchain floors (Claude Code ≥ 2.1, Bun ≥ 1.3.9,
 tmux), **workspace placement** (the #1 first-run failure — identity drift),
 settings.json hooks + token leak, **MCP comms consistency** (the latent
 silent-channel landmine), the Telegram allowlist, and live-session signals

--- a/skills/doctor-dashi-plugin/references/01-migration-steps.md
+++ b/skills/doctor-dashi-plugin/references/01-migration-steps.md
@@ -16,7 +16,7 @@ playbook around them. Commands are verbatim; substitute `<agent>`,
 |---|---|---|
 | OS | — | linux→systemd, macos→launchd |
 | Claude Code ≥ 2.1 | `claude --version` | `2.1.x`+ (persistent welcome-accepts need `2.1.140+`) |
-| Bun ≥ 1.3.14 | `bun --version` | `>= 1.3.14` |
+| Bun ≥ 1.3.9 | `bun --version` | `>= 1.3.9` (lowest verified in production) |
 | tmux | `which tmux` | found; **record the exact path** (it goes in the unit/plist) |
 | Max login | `claude` then OAuth | login saved under the service user |
 | Old gateway inventoried | see below | token, allowed ids, workspace, unit name recorded |

--- a/skills/doctor-dashi-plugin/scripts/doctor.test.ts
+++ b/skills/doctor-dashi-plugin/scripts/doctor.test.ts
@@ -85,8 +85,8 @@ describe('semver', () => {
     expect(checkVersion('c', 'claude', '2.1.0', MIN_CLAUDE).status).toBe('pass')
     expect(checkVersion('c', 'claude', '2.5.3', MIN_CLAUDE).status).toBe('pass')
     expect(checkVersion('c', 'claude', '2.0.9', MIN_CLAUDE).status).toBe('fail')
-    expect(checkVersion('b', 'bun', '1.3.13', MIN_BUN).status).toBe('fail')
-    expect(checkVersion('b', 'bun', '1.3.14', MIN_BUN).status).toBe('pass')
+    expect(checkVersion('b', 'bun', '1.3.8', MIN_BUN).status).toBe('fail')
+    expect(checkVersion('b', 'bun', '1.3.9', MIN_BUN).status).toBe('pass')
   })
   test('checkVersion fails on unparseable output without leaking it raw', () => {
     const c = checkVersion('c', 'claude', 'command not found: claude', MIN_CLAUDE)
@@ -160,6 +160,50 @@ describe('checkSettingsHooks', () => {
 
   test('secret-shaped value under a DIFFERENT key → FAIL (shape detection)', () => {
     const leaked = { hooks: good.hooks, custom: { MY_API_KEY: 'gsk_abcdefghijklmnopqrstuvwxyz0123' } }
+    expect(checkSettingsHooks(leaked).find((c) => c.id === 'settings-no-token')?.status).toBe('fail')
+  })
+
+  test('canonical install-hooks command with loopback webhook URL → PASS (no IP false positive)', () => {
+    // install-hooks.sh writes exactly this shape into every correct setup;
+    // the leak check must not flag the 127.0.0.1 webhook URL as a secret.
+    const canonical = {
+      hooks: {
+        ...good.hooks,
+        Stop: [
+          {
+            marker: 'dashi-channel-hook',
+            hooks: [
+              {
+                type: 'command',
+                command:
+                  "TELEGRAM_HOOK_CHAT_ID='164795011' TELEGRAM_HOOK_AGENT_ID='arthas' TELEGRAM_WEBHOOK_URL='http://127.0.0.1:8103/hooks/agent' bun '/srv/agent/.claude/jarvis-channel/plugin/scripts/post-hook.ts'",
+              },
+            ],
+          },
+          hookEntry('dashi-channel-fallback-reply'),
+        ],
+      },
+    }
+    expect(checkSettingsHooks(canonical).find((c) => c.id === 'settings-no-token')?.status).toBe('pass')
+  })
+
+  test('bot token in a hook command → still FAIL with strict secret rules', () => {
+    const leaked = {
+      hooks: {
+        ...good.hooks,
+        Stop: [
+          {
+            marker: 'dashi-channel-hook',
+            hooks: [
+              {
+                type: 'command',
+                command: "TELEGRAM_BOT_TOKEN='8338508613:AAH1234567890abcdefghijklmnopqrstuvw' bun 'scripts/post-hook.ts'",
+              },
+            ],
+          },
+        ],
+      },
+    }
     expect(checkSettingsHooks(leaked).find((c) => c.id === 'settings-no-token')?.status).toBe('fail')
   })
 

--- a/skills/doctor-dashi-plugin/scripts/doctor.ts
+++ b/skills/doctor-dashi-plugin/scripts/doctor.ts
@@ -34,7 +34,11 @@ export type OS = 'linux' | 'macos' | 'other'
 
 /** Required floors. Below these, migration is unsupported. */
 export const MIN_CLAUDE = [2, 1, 0] as const
-export const MIN_BUN = [1, 3, 14] as const
+// 1.3.9 is the lowest Bun verified in production (Thrall VPS fleet: live
+// channel + 1266 plugin tests green). The previous 1.3.14 floor was the
+// authoring machine's version, not a real requirement, and failed working
+// hosts for no reason.
+export const MIN_BUN = [1, 3, 9] as const
 
 /** The five hook events install-hooks.sh must register. */
 export const REQUIRED_HOOK_EVENTS = [
@@ -71,7 +75,14 @@ const SECRET_WORDS = 'TOKEN|SECRET|PASSWORD|API_KEY|PRIVATE_KEY|BEARER'
 const SECRET_QUOTED = new RegExp(`("?[A-Za-z0-9_]*(?:${SECRET_WORDS})[A-Za-z0-9_]*"?\\s*[=:]\\s*)(["'])[\\s\\S]*?\\2`, 'gi')
 const SECRET_BARE = new RegExp(`([A-Za-z0-9_]*(?:${SECRET_WORDS})[A-Za-z0-9_]*\\s*[=:]\\s*)([^\\s"',}]+)`, 'gi')
 
-export function redact(input: string): string {
+/**
+ * Secret-class masking only — the rules that detect ACTUAL credentials.
+ * Used both by `redact` (display) and by the settings leak CHECK, which
+ * must not fire on privacy-only maskings like IP addresses: install-hooks
+ * legitimately writes `http://127.0.0.1:<port>/hooks/agent` into every
+ * hook command, and flagging that as a leak failed every correct setup.
+ */
+export function redactSecretsStrict(input: string): string {
   return input
     // Known secret assignments — mask the value regardless of its shape, so an
     // unusual or quoted token still does not leak. Quoted form first.
@@ -81,6 +92,13 @@ export function redact(input: string): string {
     .replace(/\bgsk_[A-Za-z0-9]{20,}\b/g, '<groq-key>')
     .replace(/\bsk-[A-Za-z0-9-]{20,}\b/g, '<api-key>')
     .replace(/[Bb]earer\s+[A-Za-z0-9._-]{10,}/g, 'Bearer <redacted>')
+}
+
+export function redact(input: string): string {
+  return redactSecretsStrict(input)
+    // Privacy-only masking (NOT a secret): server IPs in output shown to
+    // public groups. Kept out of redactSecretsStrict so the leak check
+    // doesn't false-positive on the loopback webhook URL.
     .replace(/\b(\d{1,3}\.){3}\d{1,3}\b/g, '<ip>')
 }
 
@@ -240,10 +258,12 @@ function hasWorkingHook(entries: SettingsHookEntry[], marker: string): boolean {
 export function checkSettingsHooks(settings: unknown): Check[] {
   const out: Check[] = []
   const raw = JSON.stringify(settings ?? {})
-  // Shape-based leak detection: if redaction changes the serialized settings,
-  // something secret-shaped is present (a token value, a bearer literal, a known
-  // secret-key assignment) regardless of the key name.
-  const leaked = /TELEGRAM_WEBHOOK_TOKEN/.test(raw) || redact(raw) !== raw
+  // Shape-based leak detection: if SECRET-class redaction changes the
+  // serialized settings, something secret-shaped is present (a token value, a
+  // bearer literal, a known secret-key assignment) regardless of the key name.
+  // Strict variant on purpose: full redact() also masks IPs, and the loopback
+  // webhook URL that install-hooks writes would false-positive every setup.
+  const leaked = /TELEGRAM_WEBHOOK_TOKEN/.test(raw) || redactSecretsStrict(raw) !== raw
   out.push(
     leaked
       ? {
@@ -672,8 +692,8 @@ function gatherChecks(opts: Options): Check[] {
   const bun = probe(process.execPath.endsWith('bun') ? process.execPath : 'bun', ['--version'])
   checks.push(
     bun.stdout
-      ? checkVersion('bun-version', 'Bun >= 1.3.14', bun.stdout, MIN_BUN)
-      : { id: 'bun-version', title: 'Bun >= 1.3.14', status: 'fail', detail: 'bun not found', fix: 'install bun' },
+      ? checkVersion('bun-version', 'Bun >= 1.3.9', bun.stdout, MIN_BUN)
+      : { id: 'bun-version', title: 'Bun >= 1.3.9', status: 'fail', detail: 'bun not found', fix: 'install bun' },
   )
   const tmux = probe('tmux', ['-V'])
   checks.push(


### PR DESCRIPTION
## Что
1. **Leak-check false positive.** `checkSettingsHooks` использовал полный `redact()` (включая маскировку IP) как детектор секретов: любой корректный settings.json с каноничной командой install-hooks (`http://127.0.0.1:<port>/hooks/agent`) фейлил проверку «No secret leaked». Выделил `redactSecretsStrict()` (только secret-классы: TOKEN/SECRET/PASSWORD/API_KEY/PRIVATE_KEY/BEARER, bot-token, gsk_, sk-, Bearer) — leak-check теперь на нём; `redact()` для вывода по-прежнему маскирует IP.
2. **Floor Bun 1.3.14 → 1.3.9.** 1.3.14 — версия машины автора, не реальное требование. 1.3.9 — минимальная версия, проверенная в проде (живой channel-thrall + 1266 тестов плагина зелёные на Thrall VPS).

## Найдено
Реальным прогоном доктора при миграции Артаса (gateway → channel): оба пункта фейлили корректный setup.

## Тесты
- Новый: каноничная команда install-hooks с loopback URL → PASS (регрессия на false positive)
- Новый: bot-token в hook command → по-прежнему FAIL (strict-правила ловят)
- Обновлены floor-тесты 1.3.8 fail / 1.3.9 pass
- `bun test skills/doctor-dashi-plugin/`: 49 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)