### PR TITLE
TmuxMirror: socket_name для выделенного tmux-сокета (-L)

### DIFF
--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -173,6 +173,12 @@ export const AppConfigSchema = z.object({
   tmux_mirror: z.object({
     enabled: z.boolean().default(false),
     pane_target: z.string().default(''),
+    // tmux socket name (`tmux -L <name>`). Empty = default socket. Needed
+    // when the channel unit runs its session on a dedicated socket (two
+    // Type=forking channel units on one host race at boot on the default
+    // socket) — capture-pane must address the same socket or it finds
+    // nothing (Arthas migration, 2026-06-05).
+    socket_name: z.string().default(''),
     poll_interval_ms: z.number().int().min(500).default(5000),
     line_count: z.number().int().min(5).max(500).default(50),
     // Segments to drop from the rendered mirror. Default hides the boot

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -498,6 +498,7 @@ if (config.tmux_mirror.enabled) {
       log,
       chatId: mirrorChatId,
       paneTarget: target,
+      socketName: config.tmux_mirror.socket_name,
       pollIntervalMs: config.tmux_mirror.poll_interval_ms,
       lineCount: config.tmux_mirror.line_count,
       hideSegments: config.tmux_mirror.hide_segments,

--- a/plugin/src/status/tmux-mirror.ts
+++ b/plugin/src/status/tmux-mirror.ts
@@ -88,6 +88,10 @@ export interface TmuxMirrorOptions {
   chatId: string
   // tmux target spec, e.g. `channel-thrall:0.0` (session:window.pane).
   paneTarget: string
+  // Optional tmux socket name (`tmux -L <name>`). Empty/omitted = default
+  // socket. Channel units on a dedicated socket (boot-race isolation)
+  // need every capture-pane addressed to that socket.
+  socketName?: string
   // Polling cadence. Tests usually drive `onPoll()` directly and pass a
   // long interval so the interval never fires within the test window.
   pollIntervalMs: number
@@ -249,6 +253,7 @@ export class TmuxMirror {
   private readonly log: Logger
   private readonly chatId: string
   private readonly paneTarget: string
+  private readonly socketName: string
   private readonly pollIntervalMs: number
   private readonly lineCount: number
   private readonly exec: TmuxExec
@@ -289,6 +294,7 @@ export class TmuxMirror {
     this.log = opts.log
     this.chatId = opts.chatId
     this.paneTarget = opts.paneTarget
+    this.socketName = opts.socketName ?? ''
     this.pollIntervalMs = opts.pollIntervalMs
     this.lineCount = opts.lineCount
     this.exec = opts.exec ?? defaultTmuxExec
@@ -572,7 +578,10 @@ export class TmuxMirror {
     this.inFlight = true
     try {
       this.lastPollAt = this.now()
+      // Socket flag must precede the tmux command word.
+      const socketArgs = this.socketName ? ['-L', this.socketName] : []
       const result = await this.exec([
+        ...socketArgs,
         'capture-pane',
         '-p',
         '-t',

--- a/plugin/tests/channel/permissions.test.ts
+++ b/plugin/tests/channel/permissions.test.ts
@@ -87,7 +87,7 @@ function mkConfig(allowedIds: number[] = [164795011]): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
-    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    tmux_mirror: { enabled: false, pane_target: '', socket_name: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
   }

--- a/plugin/tests/channel/tools.test.ts
+++ b/plugin/tests/channel/tools.test.ts
@@ -82,7 +82,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
-    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    tmux_mirror: { enabled: false, pane_target: '', socket_name: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     ...overrides,

--- a/plugin/tests/commands/oob.test.ts
+++ b/plugin/tests/commands/oob.test.ts
@@ -50,7 +50,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
-    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    tmux_mirror: { enabled: false, pane_target: '', socket_name: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     ...overrides,

--- a/plugin/tests/prompt/media-prompt.test.ts
+++ b/plugin/tests/prompt/media-prompt.test.ts
@@ -58,7 +58,7 @@ const voiceConfig: AppConfig = {
     debounce_ms: 10_000,
     busy_threshold_ms: 30_000,
   },
-  tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+  tmux_mirror: { enabled: false, pane_target: '', socket_name: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
   multichat: { enabled: false },
   ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
 }

--- a/plugin/tests/security/paths.test.ts
+++ b/plugin/tests/security/paths.test.ts
@@ -71,7 +71,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
-    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    tmux_mirror: { enabled: false, pane_target: '', socket_name: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     ...overrides,

--- a/plugin/tests/status/progress-reporter.test.ts
+++ b/plugin/tests/status/progress-reporter.test.ts
@@ -83,7 +83,7 @@ function makeConfig(overrides: Partial<AppConfig['progress']> = {}): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
-    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    tmux_mirror: { enabled: false, pane_target: '', socket_name: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
   }

--- a/plugin/tests/status/status-manager.multichat.test.ts
+++ b/plugin/tests/status/status-manager.multichat.test.ts
@@ -111,7 +111,7 @@ function makeConfig(): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
-    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    tmux_mirror: { enabled: false, pane_target: '', socket_name: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
   }

--- a/plugin/tests/status/status-manager.test.ts
+++ b/plugin/tests/status/status-manager.test.ts
@@ -60,7 +60,7 @@ function makeConfig(overrides: Partial<AppConfig['status']> = {}): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
-    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    tmux_mirror: { enabled: false, pane_target: '', socket_name: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
   }

--- a/plugin/tests/status/task-mirror.test.ts
+++ b/plugin/tests/status/task-mirror.test.ts
@@ -71,7 +71,7 @@ function makeConfig(overrides: Partial<AppConfig['task_mirror']> = {}): AppConfi
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
-    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    tmux_mirror: { enabled: false, pane_target: '', socket_name: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
   }

--- a/plugin/tests/status/tmux-mirror.test.ts
+++ b/plugin/tests/status/tmux-mirror.test.ts
@@ -140,6 +140,50 @@ describe('TmuxMirror — lifecycle', () => {
     await mirror.stop()
   })
 
+  test('socketName prepends -L to every capture-pane exec; empty omits it', async () => {
+    const calls: string[][] = []
+    const recordingExec: TmuxExec = async (args) => {
+      calls.push([...args])
+      return ok('pane content')
+    }
+    const withSocket = new TmuxMirror({
+      api: makeStubApi().api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-arthas:0.0',
+      socketName: 'channel-arthas',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec: recordingExec,
+    })
+    await withSocket.start()
+    await withSocket.onPoll()
+    await withSocket.stop()
+    expect(calls.length).toBeGreaterThan(0)
+    for (const args of calls.filter((a) => a.includes('capture-pane'))) {
+      expect(args.slice(0, 2)).toEqual(['-L', 'channel-arthas'])
+    }
+
+    calls.length = 0
+    const noSocket = new TmuxMirror({
+      api: makeStubApi().api,
+      log: stubLog,
+      chatId: '100',
+      paneTarget: 'channel-thrall:0.0',
+      pollIntervalMs: 1000,
+      lineCount: 50,
+      exec: recordingExec,
+    })
+    await noSocket.start()
+    await noSocket.onPoll()
+    await noSocket.stop()
+    expect(calls.length).toBeGreaterThan(0)
+    for (const args of calls) {
+      expect(args[0]).toBe('capture-pane')
+      expect(args).not.toContain('-L')
+    }
+  })
+
   test('changed pane content triggers editMessageText', async () => {
     const stub = makeStubApi()
     const exec = makeExec([ok('one'), ok('two'), ok('three')])

--- a/plugin/tests/telegram/gate.test.ts
+++ b/plugin/tests/telegram/gate.test.ts
@@ -47,7 +47,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
-    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    tmux_mirror: { enabled: false, pane_target: '', socket_name: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     ...overrides,

--- a/plugin/tests/telegram/handlers.test.ts
+++ b/plugin/tests/telegram/handlers.test.ts
@@ -75,7 +75,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
       debounce_ms: 10_000,
       busy_threshold_ms: 30_000,
     },
-    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    tmux_mirror: { enabled: false, pane_target: '', socket_name: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     ...overrides,

--- a/plugin/tests/telegram/watcher.test.ts
+++ b/plugin/tests/telegram/watcher.test.ts
@@ -54,7 +54,7 @@ function makeConfig(overrides: Partial<AppConfig['watcher']> = {}): AppConfig {
       busy_threshold_ms: 30_000,
       ...overrides,
     },
-    tmux_mirror: { enabled: false, pane_target: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
+    tmux_mirror: { enabled: false, pane_target: '', socket_name: '', poll_interval_ms: 5000, line_count: 50, hide_segments: ['boot_banner', 'inbound_warning', 'footer_hints', 'input_box'], mode: 'latest_inbound_only', max_lines: 14 },
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
   }


### PR DESCRIPTION
## Зачем
channel-arthas живёт на выделенном tmux-сокете (`tmux -L channel-arthas`) — два Type=forking юнита на дефолтном сокете гонятся при одновременном старте (P0 из флота ученика). Но TmuxMirror зовёт `tmux capture-pane` без сокета и не находит сессию → терминал-миррор для Артаса невозможен.

## Что
- `tmux_mirror.socket_name` в схеме state-config (default '' = дефолтный сокет, поведение не меняется)
- `TmuxMirror` прокидывает `['-L', socketName]` перед командой в каждый exec
- server.ts передаёт из конфига

## Тесты
- Новый: с socketName все capture-pane exec начинаются с `-L <name>`; без — `-L` отсутствует
- Фикстуры конфига дополнены полем (12 файлов)
- typecheck 0, 1267 тестов 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)