### PR TITLE
README: мультиагент — флот агентов под одной подпиской (EN+RU)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ One plugin process = one Telegram bot = one agent. By default it serves **a sing
 11. [Telegram API rate limits](#11-telegram-api-rate-limits)
 12. [Quick start and documentation](#12-quick-start-and-documentation)
 13. [Why migrate — the 2026-06-15 deadline](#13-why-migrate--the-2026-06-15-deadline)
+14. [Multi-agent — a fleet of agents under one subscription](#14-multi-agent--a-fleet-of-agents-under-one-subscription)
 
 ---
 
@@ -482,6 +483,269 @@ Source: [Use the Claude Agent SDK with your Claude plan](https://support.claude.
 The old gateway architecture (a Python daemon spawning `claude -p` on every Telegram turn) will burn SDK credit on every message after the cutover. This plugin keeps **one live, interactive session** (or a pool of per-chat tmux sessions in multichat) — usage stays within your normal Max quota and does not grow with the number of messages. The full plan — [DEPRECATION-PATH.md](DEPRECATION-PATH.md).
 
 **Trade-offs:** one process = one bot (need 5 bots → 5 processes); a session restart = loss of the current context (but `core/hot/recent.md` keeps the tail); multichat = more memory and a mandatory, carefully written `policy.yaml`; you need Bun + Claude Code v2.1.80+ (not a Python-only host).
+
+---
+
+## 14. Multi-agent — a fleet of agents under one subscription
+
+### What it is
+
+You can run N independent Claude Code agents on one host under one Claude Code Max subscription.
+
+Each agent is a long-lived interactive Claude session with its own:
+
+| Part | Per-agent value |
+|---|---|
+| Terminal | tmux session on a dedicated tmux socket |
+| Telegram | its own bot token and polling consumer |
+| Identity | workspace `CLAUDE.md` |
+| Plugin checkout | inside that agent's workspace |
+| Skills | local to that workspace |
+| Memory/state | own state dir and config |
+
+This is verified in production:
+
+| Fleet | Host / agents | Notes |
+|---|---|---|
+| 2-agent fleet | one VPS: `thrall`, `arthas` | cut over 2026-06-05, see the live example below |
+| 5-agent fleet | `jarvis`, `koder`, `secretary`, `researcher`, `analyst` | webhook ports `8089–8093` |
+
+The important part: this is not N API clients. It is N interactive Claude Code sessions under one OAuth login — usage stays inside the Max subscription (see section 13).
+
+### Architecture
+
+```text
+one unix user
+one Claude Code OAuth login
+        |
+        v
++----------------------------- host -----------------------------+
+|                                                                |
+|  systemd: channel-thrall.service                               |
+|    Type=forking                                                |
+|    tmux -L channel-thrall                                      |
+|      claude session                                            |
+|        --dangerously-load-development-channels server:dashi-channel
+|        workspace: /srv/agents/thrall   (CLAUDE.md = identity)  |
+|        plugin: /srv/agents/thrall/.claude/dashi-plugin-claude-code/plugin
+|        env: /etc/dashi-plugin/thrall/channel.env               |
+|        state: /var/lib/dashi-channel/thrall                    |
+|        Telegram bot token A · TELEGRAM_WEBHOOK_PORT=8089       |
+|        getUpdates poller A                                     |
+|                                                                |
+|  systemd: channel-arthas.service                               |
+|    Type=forking                                                |
+|    tmux -L channel-arthas                                      |
+|      claude session                                            |
+|        workspace: /srv/agents/arthas   (CLAUDE.md = identity)  |
+|        plugin: /srv/agents/arthas/.claude/dashi-plugin-claude-code/plugin
+|        env: /etc/dashi-plugin/arthas/channel.env               |
+|        state: /var/lib/dashi-channel/arthas                    |
+|        Telegram bot token B · TELEGRAM_WEBHOOK_PORT=8090       |
+|        getUpdates poller B                                     |
++----------------------------------------------------------------+
+```
+
+Each agent has its own `channel.env` (see `examples/channel.env.example` for the full list):
+
+```bash
+TELEGRAM_BOT_TOKEN=123456:agent-specific-token
+TELEGRAM_EXPECTED_BOT_ID=123456
+TELEGRAM_ALLOWED_USER_IDS=<your numeric id>
+TELEGRAM_ALLOWED_CHAT_IDS=<your numeric id>
+TELEGRAM_WORKSPACE_ROOT=/srv/agents/arthas
+AGENT_ID=arthas
+TELEGRAM_STATE_DIR=/var/lib/dashi-channel/arthas
+TELEGRAM_WEBHOOK_HOST=127.0.0.1
+TELEGRAM_WEBHOOK_PORT=8090
+TELEGRAM_WEBHOOK_TOKEN=<random hex>
+```
+
+And its own state config (`<state-dir>/config.json`):
+
+```json
+{
+  "webhook": {
+    "enabled": true,
+    "host": "127.0.0.1",
+    "port": 8090
+  }
+}
+```
+
+`TELEGRAM_WEBHOOK_HOST` / `TELEGRAM_WEBHOOK_PORT` only set host/port. They do **not** enable the webhook endpoint by themselves — that is invariant (e) below.
+
+### The five isolation invariants
+
+These are not preferences. Each one came from a real production failure.
+
+| Invariant | Why it matters |
+|---|---|
+| (a) Hooks are per-workspace only | Install hooks into `<workspace>/.claude/settings.json` with `install-hooks.sh --settings`, never into the shared `~/.claude/settings.json`. The shared file fires in **every** Claude session of the unix user — one agent's read-receipt/fallback hooks will send another agent's text through the wrong bot. Worse, the settings patcher dedups by one marker per file, so a shared file can only hold ONE agent's hook: last install wins, every other agent silently routes to a foreign port. See section 4. |
+| (b) Distinct `TELEGRAM_WEBHOOK_PORT` | Every agent needs its own local HTTP port for hooks/mirror/read-receipts. |
+| (c) Distinct bot token | Telegram allows one `getUpdates` consumer per token. Sharing a token = `409 Conflict`, and one of the bots goes deaf. |
+| (d) Dedicated tmux socket | `tmux -L channel-<agent>` in `ExecStart`, `ExecStartPost` AND `ExecStop`. Two `Type=forking` units on the default socket race at simultaneous boot: the second session lands inside the first unit's tmux server and cgroup — systemd loses it, and stopping unit A kills agent B. Real incident: 1 of 4 agents alive after a reboot; with `-L`: 4 of 4. |
+| (e) `webhook.enabled=true` in state config | The default is `false`, and env vars only set host/port. Without `<state-dir>/config.json` enabling it, the hooks/read-receipt/fallback endpoints silently stay dead while the bot still replies through the channel — a confusing partial failure. |
+
+### Readiness: don't trust timed Enters
+
+On a cold start the dev-channels welcome prompt can render after 8+ seconds. A blind `sleep 6 && tmux send-keys Enter` in `ExecStartPost` fires into the void, systemd marks the unit ready, and the channel never starts listening.
+
+Use a confirm loop instead: capture the pane every 3 seconds, send Enter only when a confirm prompt is actually visible, and exit `0` only when the channel banner appears. Then the `ExecStartPost` exit code equals real readiness.
+
+```bash
+#!/usr/bin/env bash
+# /usr/local/bin/channel-confirm-arthas.sh
+for i in $(seq 1 30); do
+  pane="$(tmux -L channel-arthas capture-pane -pt channel-arthas 2>/dev/null || true)"
+  if printf '%s' "$pane" | grep -q 'messages from server:dashi-channel inject\|Listening for channel messages'; then
+    exit 0
+  fi
+  if printf '%s' "$pane" | grep -q 'Enter to confirm\|I am using this for local development\|Do you trust'; then
+    tmux -L channel-arthas send-keys -t channel-arthas Enter
+  fi
+  sleep 3
+done
+exit 1
+```
+
+### Pros
+
+| Benefit | Detail |
+|---|---|
+| One subscription | The whole fleet runs on one Claude Code Max subscription. No per-message SDK credits (section 13). |
+| Real isolation | Identity, skills, memory, bot token, state dir, tmux socket, workspace — all per agent. |
+| Parallel work | Agents work on different tasks at the same time. |
+| Per-agent terminal mirror | Each agent can expose its own mirror via `tmux_mirror.socket_name` (section 6). |
+| Smaller blast radius | One agent crashing or restarting does not touch the rest. |
+
+### Cons and limits
+
+| Limit | Detail |
+|---|---|
+| Shared subscription quota | All sessions share one subscription's rate limits. N busy agents burn the quota N times faster. |
+| RAM | Each Claude session holds memory — expect hundreds of MB per agent. |
+| Shared unix user | `~/.claude` is global to the user. Keep hooks, identity, plugin checkout, state and skills strictly per workspace. |
+| More moving parts | N units, N tokens, N ports, N sockets, N state dirs. |
+| No orchestration layer | The plugin gives each agent a channel, not coordination. How agents divide work is up to you. |
+
+Security notes from section 10 apply to every agent in the fleet.
+
+### Live example: a two-agent fleet (thrall + arthas)
+
+A real production layout (architecture only, no secrets):
+
+| | `thrall` | `arthas` |
+|---|---|---|
+| Role | architect / coder — the owner's right hand | monitoring + inbox collector |
+| Bot | own bot, full DM + group multichat (section 3) | own bot, DM-only (multichat off) |
+| Unit | `channel-thrall.service` | `channel-arthas.service` |
+| tmux | session `channel-thrall` | session `channel-arthas` on socket `-L channel-arthas` |
+| Webhook | `127.0.0.1:8093` | `127.0.0.1:8103` |
+| Workspace | `~/.claude-lab/thrall/.claude` | `~/.claude-lab/arthas/.claude` |
+| Identity / skills | own `CLAUDE.md`, own `skills/` | own `CLAUDE.md`, own `skills/` |
+| Terminal mirror | on (section 6) | on, via `tmux_mirror.socket_name` |
+
+Both run as one unix user under one Max subscription. They coordinate through a shared task board and an inter-agent message bus — deliberately **outside** the plugin (see "no orchestration layer" above). `arthas` was migrated off a legacy python gateway on 2026-06-05; the first cutover attempt auto-rolled back and produced invariants (d) and (e) above — the table you just read is paid for in incidents, not theory.
+
+### Checklist: add agent #2..N
+
+Assume an existing single-agent install and a new agent named `arthas`.
+
+1. Create the workspace and identity:
+
+```bash
+export AGENT=arthas
+export WORKSPACE=/srv/agents/$AGENT
+export STATE_DIR=/var/lib/dashi-channel/$AGENT
+export PORT=8090
+
+mkdir -p "$WORKSPACE/.claude" "$STATE_DIR"
+$EDITOR "$WORKSPACE/CLAUDE.md"     # who this agent is
+```
+
+2. Clone the plugin **inside** the agent workspace (identity depends on it — section 1, docs/02):
+
+```bash
+cd "$WORKSPACE/.claude"
+git clone https://github.com/qwwiwi/dashi-plugin-claude-code.git
+cd dashi-plugin-claude-code/plugin
+bun install
+```
+
+3. Create this agent's `channel.env` (own token, own port — invariants (b), (c)):
+
+```bash
+sudo mkdir -p /etc/dashi-plugin/$AGENT
+sudo cp examples/channel.env.example /etc/dashi-plugin/$AGENT/channel.env
+sudo chmod 640 /etc/dashi-plugin/$AGENT/channel.env
+sudo $EDITOR /etc/dashi-plugin/$AGENT/channel.env   # token, port, ids, paths
+```
+
+4. Enable the webhook in the state config (invariant (e)):
+
+```bash
+cat > "$STATE_DIR/config.json" <<EOF
+{ "webhook": { "enabled": true, "host": "127.0.0.1", "port": $PORT } }
+EOF
+```
+
+5. Install hooks into **this agent's** settings only (invariant (a)):
+
+```bash
+bash scripts/install-hooks.sh \
+  --settings "$WORKSPACE/.claude/settings.json" \
+  --chat-id <your numeric id> \
+  --webhook-url "http://127.0.0.1:$PORT/hooks/agent" \
+  --agent-id $AGENT
+```
+
+6. Create the systemd unit with a dedicated tmux socket (invariant (d)) — start from `examples/systemd-unit.service.example` and add `-L`:
+
+```ini
+[Unit]
+Description=Dashi Channel agent arthas
+After=network-online.target
+Requires=network-online.target
+
+[Service]
+Type=forking
+User=<service-user>
+Environment=HOME=/home/<service-user>
+Environment=PATH=/home/<service-user>/.bun/bin:/usr/local/bin:/usr/bin:/bin
+WorkingDirectory=/srv/agents/arthas/.claude/dashi-plugin-claude-code/plugin
+EnvironmentFile=/etc/dashi-plugin/arthas/channel.env
+ExecStart=/usr/bin/tmux -L channel-arthas new-session -d -s channel-arthas 'claude --dangerously-load-development-channels server:dashi-channel'
+ExecStartPost=/usr/local/bin/channel-confirm-arthas.sh
+ExecStop=/usr/bin/tmux -L channel-arthas kill-session -t channel-arthas
+Restart=on-failure
+RestartSec=15
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`ExecStartPost` is the confirm loop from "Readiness" above. The key part is `tmux -L channel-arthas` **everywhere**.
+
+7. If the bot token is already polled by something (an old gateway, another process) — cut over as a single poller: stop the old consumer first, wait ~30 seconds for Telegram to release the `getUpdates` slot, only then start the new unit. Two consumers on one token = `409 Conflict`.
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now channel-arthas.service
+```
+
+8. Run the doctor (from the repo root) and send the bot a real message:
+
+```bash
+cd "$WORKSPACE/.claude/dashi-plugin-claude-code"
+bun skills/doctor-dashi-plugin/scripts/doctor.ts \
+  --plugin-dir "$PWD/plugin" \
+  --settings "$WORKSPACE/.claude/settings.json" \
+  --env /etc/dashi-plugin/$AGENT/channel.env \
+  --user <your numeric id>
+```
+
+For migration context see `docs/04-migration-from-gateway.md` and section 13.
 
 ---
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -29,6 +29,7 @@
 11. [Rate limits Telegram API](#11-rate-limits-telegram-api)
 12. [Быстрый старт и документация](#12-быстрый-старт-и-документация)
 13. [Зачем переезд — дедлайн 2026-06-15](#13-зачем-переезд--дедлайн-2026-06-15)
+14. [Мультиагент — флот агентов под одной подпиской](#14-мультиагент--флот-агентов-под-одной-подпиской)
 
 ---
 
@@ -465,6 +466,269 @@ bash scripts/install-hooks.sh --settings ~/.claude/settings.json \
 Старая gateway-архитектура (Python-демон спавнит `claude -p` на каждый Telegram-turn) после cutover жжёт SDK-кредит на каждое сообщение. Этот плагин держит **одну живую interactive сессию** (или пул per-chat tmux-сессий при multichat) — расход остаётся в обычной Max-квоте и не растёт от числа сообщений. Полный план — [DEPRECATION-PATH.md](DEPRECATION-PATH.md).
 
 **Trade-offs:** один процесс = один бот (нужно 5 ботов → 5 процессов); рестарт сессии = потеря текущего контекста (но `core/hot/recent.md` хранит хвост); multichat = больше памяти и обязательная аккуратная `policy.yaml`; нужен Bun + Claude Code v2.1.80+ (не Python-only хост).
+
+---
+
+## 14. Мультиагент — флот агентов под одной подпиской
+
+### Что это
+
+На одном хосте под одной подпиской Claude Code Max можно запустить N независимых агентов.
+
+Каждый агент — долгоживущая интерактивная Claude-сессия со своими:
+
+| Часть | Значение на агента |
+|---|---|
+| Терминал | tmux-сессия на выделенном tmux-сокете |
+| Telegram | свой bot token и свой polling consumer |
+| Identity | `CLAUDE.md` workspace'а |
+| Plugin checkout | внутри workspace агента |
+| Skills | локальные для workspace |
+| Memory/state | свой state dir и config |
+
+Проверено в production:
+
+| Флот | Хост / агенты | Заметки |
+|---|---|---|
+| 2 агента | один VPS: `thrall`, `arthas` | cutover 2026-06-05, живой пример ниже |
+| 5 агентов | `jarvis`, `koder`, `secretary`, `researcher`, `analyst` | webhook-порты `8089–8093` |
+
+Главное: это не N API-клиентов. Это N интерактивных Claude Code сессий под одним OAuth-логином — usage остаётся внутри подписки Max (см. раздел 13).
+
+### Архитектура
+
+```text
+один unix user
+один Claude Code OAuth login
+        |
+        v
++----------------------------- host -----------------------------+
+|                                                                |
+|  systemd: channel-thrall.service                               |
+|    Type=forking                                                |
+|    tmux -L channel-thrall                                      |
+|      claude session                                            |
+|        --dangerously-load-development-channels server:dashi-channel
+|        workspace: /srv/agents/thrall   (CLAUDE.md = identity)  |
+|        plugin: /srv/agents/thrall/.claude/dashi-plugin-claude-code/plugin
+|        env: /etc/dashi-plugin/thrall/channel.env               |
+|        state: /var/lib/dashi-channel/thrall                    |
+|        Telegram bot token A · TELEGRAM_WEBHOOK_PORT=8089       |
+|        getUpdates poller A                                     |
+|                                                                |
+|  systemd: channel-arthas.service                               |
+|    Type=forking                                                |
+|    tmux -L channel-arthas                                      |
+|      claude session                                            |
+|        workspace: /srv/agents/arthas   (CLAUDE.md = identity)  |
+|        plugin: /srv/agents/arthas/.claude/dashi-plugin-claude-code/plugin
+|        env: /etc/dashi-plugin/arthas/channel.env               |
+|        state: /var/lib/dashi-channel/arthas                    |
+|        Telegram bot token B · TELEGRAM_WEBHOOK_PORT=8090       |
+|        getUpdates poller B                                     |
++----------------------------------------------------------------+
+```
+
+У каждого агента свой `channel.env` (полный список — `examples/channel.env.example`):
+
+```bash
+TELEGRAM_BOT_TOKEN=123456:agent-specific-token
+TELEGRAM_EXPECTED_BOT_ID=123456
+TELEGRAM_ALLOWED_USER_IDS=<ваш числовой id>
+TELEGRAM_ALLOWED_CHAT_IDS=<ваш числовой id>
+TELEGRAM_WORKSPACE_ROOT=/srv/agents/arthas
+AGENT_ID=arthas
+TELEGRAM_STATE_DIR=/var/lib/dashi-channel/arthas
+TELEGRAM_WEBHOOK_HOST=127.0.0.1
+TELEGRAM_WEBHOOK_PORT=8090
+TELEGRAM_WEBHOOK_TOKEN=<random hex>
+```
+
+И свой state config (`<state-dir>/config.json`):
+
+```json
+{
+  "webhook": {
+    "enabled": true,
+    "host": "127.0.0.1",
+    "port": 8090
+  }
+}
+```
+
+`TELEGRAM_WEBHOOK_HOST` / `TELEGRAM_WEBHOOK_PORT` только задают host/port. Сами по себе они webhook **не включают** — это инвариант (e) ниже.
+
+### Пять инвариантов изоляции
+
+Это не вкусовщина. Каждый пункт — реальный production-инцидент.
+
+| Инвариант | Почему важно |
+|---|---|
+| (a) Hooks только per-workspace | Ставьте hooks в `<workspace>/.claude/settings.json` через `install-hooks.sh --settings`, никогда — в общий `~/.claude/settings.json`. Общий файл срабатывает в **каждой** Claude-сессии unix-юзера: read-receipt/fallback hooks одного агента отправят текст другого агента через чужого бота. Хуже того, settings-патчер дедуплицирует по одному маркеру на файл — общий файл способен держать hook только ОДНОГО агента: последний install побеждает, остальные молча ходят в чужой порт. См. раздел 4. |
+| (b) Отдельный `TELEGRAM_WEBHOOK_PORT` | Каждому агенту — свой локальный HTTP-порт для hooks/mirror/read-receipts. |
+| (c) Отдельный bot token | Telegram допускает одного `getUpdates`-консьюмера на токен. Общий токен = `409 Conflict`, один из ботов глохнет. |
+| (d) Выделенный tmux-сокет | `tmux -L channel-<agent>` в `ExecStart`, `ExecStartPost` И `ExecStop`. Два `Type=forking` юнита на дефолтном сокете гонятся при одновременном старте: сессия второго оказывается внутри tmux-сервера и cgroup первого — systemd её теряет, а stop юнита A убивает агента B. Реальный инцидент: после ребута жив 1 из 4 агентов; с `-L` — 4 из 4. |
+| (e) `webhook.enabled=true` в state config | Дефолт — `false`, env-переменные задают только host/port. Без `<state-dir>/config.json` с включённым webhook эндпоинты hooks/read-receipt/fallback молча мертвы, при этом бот продолжает отвечать через канал — сбивающий с толку частичный отказ. |
+
+### Readiness: не доверяйте Enter по таймеру
+
+На холодном старте welcome-промпт dev-channels может отрисоваться позже 8 секунд. Слепой `sleep 6 && tmux send-keys Enter` в `ExecStartPost` стреляет в пустоту, systemd помечает юнит готовым, а канал так и не начинает слушать.
+
+Вместо этого — confirm-цикл: capture-pane каждые 3 секунды, Enter только когда промпт реально виден на экране, exit `0` только при появлении баннера канала. Тогда exit-код `ExecStartPost` равен реальной готовности.
+
+```bash
+#!/usr/bin/env bash
+# /usr/local/bin/channel-confirm-arthas.sh
+for i in $(seq 1 30); do
+  pane="$(tmux -L channel-arthas capture-pane -pt channel-arthas 2>/dev/null || true)"
+  if printf '%s' "$pane" | grep -q 'messages from server:dashi-channel inject\|Listening for channel messages'; then
+    exit 0
+  fi
+  if printf '%s' "$pane" | grep -q 'Enter to confirm\|I am using this for local development\|Do you trust'; then
+    tmux -L channel-arthas send-keys -t channel-arthas Enter
+  fi
+  sleep 3
+done
+exit 1
+```
+
+### Плюсы
+
+| Плюс | Детали |
+|---|---|
+| Одна подписка | Весь флот работает на одной подписке Claude Code Max. Никаких per-message SDK-кредитов (раздел 13). |
+| Настоящая изоляция | Identity, skills, память, bot token, state dir, tmux-сокет, workspace — всё per-agent. |
+| Параллельная работа | Агенты одновременно ведут разные задачи. |
+| Terminal mirror на каждого | У каждого агента свой миррор через `tmux_mirror.socket_name` (раздел 6). |
+| Меньше blast radius | Падение или рестарт одного агента не трогает остальных. |
+
+### Минусы и ограничения
+
+| Ограничение | Детали |
+|---|---|
+| Общая квота подписки | Все сессии делят rate limits одной подписки. N занятых агентов сжигают квоту в N раз быстрее. |
+| RAM | Каждая Claude-сессия держит память — считайте сотни MB на агента. |
+| Общий unix user | `~/.claude` глобален для юзера. Hooks, identity, plugin checkout, state, skills — строго per-workspace. |
+| Больше движущихся частей | N юнитов, N токенов, N портов, N сокетов, N state dirs. |
+| Нет слоя оркестрации | Плагин даёт каждому агенту канал, а не координацию. Как агенты делят работу — решать вам. |
+
+Замечания по безопасности из раздела 10 действуют для каждого агента флота.
+
+### Живой пример: флот из двух агентов (thrall + arthas)
+
+Реальная production-раскладка (только архитектура, без секретов):
+
+| | `thrall` | `arthas` |
+|---|---|---|
+| Роль | архитектор / кодер — правая рука владельца | мониторинг + inbox-коллектор |
+| Бот | свой бот, DM + групповой multichat (раздел 3) | свой бот, только DM (multichat выключен) |
+| Юнит | `channel-thrall.service` | `channel-arthas.service` |
+| tmux | сессия `channel-thrall` | сессия `channel-arthas` на сокете `-L channel-arthas` |
+| Webhook | `127.0.0.1:8093` | `127.0.0.1:8103` |
+| Workspace | `~/.claude-lab/thrall/.claude` | `~/.claude-lab/arthas/.claude` |
+| Identity / skills | свой `CLAUDE.md`, свои `skills/` | свой `CLAUDE.md`, свои `skills/` |
+| Terminal mirror | включён (раздел 6) | включён, через `tmux_mirror.socket_name` |
+
+Оба работают под одним unix-юзером и одной подпиской Max. Координируются через общий task board и межагентскую шину сообщений — сознательно **вне** плагина (см. «нет слоя оркестрации» выше). `arthas` переехал со старого python-gateway 2026-06-05; первая попытка cutover автоматически откатилась и породила инварианты (d) и (e) — таблица выше оплачена инцидентами, а не теорией.
+
+### Чек-лист: добавить агента #2..N
+
+Дано: рабочая single-agent установка, новый агент `arthas`.
+
+1. Создайте workspace и identity:
+
+```bash
+export AGENT=arthas
+export WORKSPACE=/srv/agents/$AGENT
+export STATE_DIR=/var/lib/dashi-channel/$AGENT
+export PORT=8090
+
+mkdir -p "$WORKSPACE/.claude" "$STATE_DIR"
+$EDITOR "$WORKSPACE/CLAUDE.md"     # кто этот агент
+```
+
+2. Склонируйте плагин **внутрь** workspace агента (от этого зависит identity — раздел 1, docs/02):
+
+```bash
+cd "$WORKSPACE/.claude"
+git clone https://github.com/qwwiwi/dashi-plugin-claude-code.git
+cd dashi-plugin-claude-code/plugin
+bun install
+```
+
+3. Создайте `channel.env` этого агента (свой токен, свой порт — инварианты (b), (c)):
+
+```bash
+sudo mkdir -p /etc/dashi-plugin/$AGENT
+sudo cp examples/channel.env.example /etc/dashi-plugin/$AGENT/channel.env
+sudo chmod 640 /etc/dashi-plugin/$AGENT/channel.env
+sudo $EDITOR /etc/dashi-plugin/$AGENT/channel.env   # токен, порт, id, пути
+```
+
+4. Включите webhook в state config (инвариант (e)):
+
+```bash
+cat > "$STATE_DIR/config.json" <<EOF
+{ "webhook": { "enabled": true, "host": "127.0.0.1", "port": $PORT } }
+EOF
+```
+
+5. Поставьте hooks только в settings **этого агента** (инвариант (a)):
+
+```bash
+bash scripts/install-hooks.sh \
+  --settings "$WORKSPACE/.claude/settings.json" \
+  --chat-id <ваш числовой id> \
+  --webhook-url "http://127.0.0.1:$PORT/hooks/agent" \
+  --agent-id $AGENT
+```
+
+6. Создайте systemd-юнит с выделенным tmux-сокетом (инвариант (d)) — за основу возьмите `examples/systemd-unit.service.example` и добавьте `-L`:
+
+```ini
+[Unit]
+Description=Dashi Channel agent arthas
+After=network-online.target
+Requires=network-online.target
+
+[Service]
+Type=forking
+User=<service-user>
+Environment=HOME=/home/<service-user>
+Environment=PATH=/home/<service-user>/.bun/bin:/usr/local/bin:/usr/bin:/bin
+WorkingDirectory=/srv/agents/arthas/.claude/dashi-plugin-claude-code/plugin
+EnvironmentFile=/etc/dashi-plugin/arthas/channel.env
+ExecStart=/usr/bin/tmux -L channel-arthas new-session -d -s channel-arthas 'claude --dangerously-load-development-channels server:dashi-channel'
+ExecStartPost=/usr/local/bin/channel-confirm-arthas.sh
+ExecStop=/usr/bin/tmux -L channel-arthas kill-session -t channel-arthas
+Restart=on-failure
+RestartSec=15
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`ExecStartPost` — confirm-цикл из «Readiness» выше. Ключевое: `tmux -L channel-arthas` **везде**.
+
+7. Если токен бота уже кто-то поллит (старый gateway, другой процесс) — cutover строго как single poller: сначала остановите старого консьюмера, подождите ~30 секунд, пока Telegram отпустит слот `getUpdates`, и только потом стартуйте новый юнит. Два консьюмера на одном токене = `409 Conflict`.
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now channel-arthas.service
+```
+
+8. Прогоните доктора (из корня репо) и отправьте боту настоящее сообщение:
+
+```bash
+cd "$WORKSPACE/.claude/dashi-plugin-claude-code"
+bun skills/doctor-dashi-plugin/scripts/doctor.ts \
+  --plugin-dir "$PWD/plugin" \
+  --settings "$WORKSPACE/.claude/settings.json" \
+  --env /etc/dashi-plugin/$AGENT/channel.env \
+  --user <ваш числовой id>
+```
+
+Контекст миграции: `docs/04-migration-from-gateway.md` и раздел 13.
 
 ---
 


### PR DESCRIPTION
## Что
Новый раздел 14 в README.md (EN, canonical) и README.ru.md + строки в оба TOC.

Содержание:
- Что это: N интерактивных Claude-сессий под одним OAuth/Max — не N API-клиентов
- ASCII-архитектура: unit → выделенный tmux-сокет → сессия → workspace/identity → свой бот
- **Пять инвариантов изоляции** — каждый из реального инцидента: (a) hooks per-workspace (общий settings.json + один marker = чужой порт у всех кроме последнего), (b) свой webhook-порт, (c) свой токен (409), (d) свой tmux-сокет (гонка Type=forking юнитов на дефолтном: 1/4 живых после ребута), (e) webhook.enabled=true в state config (env только host/port)
- Readiness: confirm-цикл вместо слепых Enter по таймеру
- Плюсы/минусы честно: одна подписка на флот vs общая квота, RAM, дисциплина общего unix-юзера, нет слоя оркестрации
- **Живой пример**: флот thrall+arthas (роли, юниты, сокеты, порты 8093/8103, workspaces) — только архитектура, без секретов
- Чек-лист добавления агента #2..N: 8 шагов с реальными командами (install-hooks со всеми обязательными флагами, юнит с -L, single-poller cutover, doctor)

## Откуда
Боевой опыт сегодняшней миграции arthas (cutover + авто-rollback) и флот 5 агентов ученика. Драфт — GPT-5.5, фактология выверена по живым конфигам (исправлены выдуманные env-имена, несуществующий скрипт юнита, неполный install-hooks, doctor из неверной директории).

Docs-only, код не тронут.

🤖 Generated with [Claude Code](https://claude.com/claude-code)