### PR TITLE
Доктор: fleet-режим — проверка инвариантов мультиагентности (--fleet)

### DIFF
--- a/skills/doctor-dashi-plugin/SKILL.md
+++ b/skills/doctor-dashi-plugin/SKILL.md
@@ -47,6 +47,17 @@ Every flag is optional — pass what you have. `--json` gives machine-readable
 output for an agent to parse. Exit code: `0` = no FAIL, `1` = at least one FAIL,
 `2` = usage error.
 
+**Multi-agent fleet mode** (README section 14): add `--fleet` to discover every
+`channel-*.service` unit on the host (helper units without a tmux Exec line are
+skipped) and verify the five isolation invariants ACROSS agents — unique
+webhook ports, unique bot tokens (sha256 digests, never printed), a dedicated
+tmux socket per unit (duplicates incl. two-on-default fail; a single default
+socket is a warn), the shared `~/.claude/settings.json` free of channel hooks,
+`webhook.enabled=true` in every agent's state config, and each agent's hooks
+pointing at its OWN webhook port (the last-install-wins disaster). Use
+`--fleet-dir <dir>` for a non-standard unit directory or in tests. Run it
+before and after adding agent #2..N.
+
 The doctor checks, in order: toolchain floors (Claude Code ≥ 2.1, Bun ≥ 1.3.9,
 tmux), **workspace placement** (the #1 first-run failure — identity drift),
 settings.json hooks + token leak, **MCP comms consistency** (the latent

--- a/skills/doctor-dashi-plugin/scripts/doctor.test.ts
+++ b/skills/doctor-dashi-plugin/scripts/doctor.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test'
 import {
   checkAllowlist,
+  checkFleet,
+  envValue,
+  hookPortsInSettings,
+  parseUnitFile,
+  type FleetAgent,
   checkCommsConsistency,
   checkSettingsHooks,
   checkVersion,
@@ -349,5 +354,145 @@ describe('report aggregation', () => {
   test('redact masks secret-key assignments regardless of value shape', () => {
     expect(redact('TELEGRAM_WEBHOOK_TOKEN=super-secret-xyz')).not.toContain('super-secret-xyz')
     expect(redact('"MY_SECRET":"whatever-123"')).not.toContain('whatever-123')
+  })
+})
+
+describe('fleet (multi-agent) checks', () => {
+  const agent = (over: Partial<FleetAgent>): FleetAgent => ({
+    name: 'a',
+    unitPath: '/etc/systemd/system/channel-a.service',
+    sockets: ['channel-a'],
+    envPath: '/etc/dashi-plugin/a/channel.env',
+    envReadable: true,
+    port: '8089',
+    tokenDigest: 'digest-a',
+    stateDir: '/var/lib/dashi-channel/a',
+    workspaceRoot: '/srv/agents/a',
+    webhookEnabled: true,
+    hookPorts: ['8089'],
+    ...over,
+  })
+  const byId = (checks: Check[]): Record<string, Check> => Object.fromEntries(checks.map((c) => [c.id, c]))
+
+  test('parseUnitFile extracts EnvironmentFile and per-Exec-line sockets', () => {
+    const unit = [
+      '[Service]',
+      'EnvironmentFile=/etc/dashi-plugin/arthas/channel.env',
+      "ExecStart=/usr/bin/tmux -L channel-arthas new-session -d -s channel-arthas 'claude ...'",
+      'ExecStartPost=/usr/local/bin/confirm.sh',
+      'ExecStop=/usr/bin/tmux -L channel-arthas kill-session -t channel-arthas',
+    ].join('\n')
+    const parsed = parseUnitFile(unit)
+    expect(parsed.envPath).toBe('/etc/dashi-plugin/arthas/channel.env')
+    expect(parsed.sockets).toEqual(['channel-arthas'])
+  })
+
+  test('parseUnitFile: default socket registers as empty string; mixed sockets both appear', () => {
+    const unit = [
+      'ExecStart=/usr/bin/tmux new-session -d -s channel-thrall claude',
+      'ExecStop=/usr/bin/tmux -L other kill-session -t channel-thrall',
+    ].join('\n')
+    const parsed = parseUnitFile(unit)
+    expect(parsed.sockets.sort()).toEqual(['', 'other'])
+  })
+
+  test('envValue picks the first assignment and trims', () => {
+    expect(envValue('A=1\nTELEGRAM_WEBHOOK_PORT=8103\n', 'TELEGRAM_WEBHOOK_PORT')).toBe('8103')
+    expect(envValue('TELEGRAM_WEBHOOK_PORT=\n', 'TELEGRAM_WEBHOOK_PORT')).toBeNull()
+  })
+
+  test('hookPortsInSettings finds webhook ports in hook commands', () => {
+    const raw = JSON.stringify({ hooks: { Stop: [{ hooks: [{ command: "X bun 'http://127.0.0.1:8103/hooks/agent'".replace('X', "TELEGRAM_WEBHOOK_URL='http://127.0.0.1:8103/hooks/agent'") }] }] } })
+    expect(hookPortsInSettings(raw)).toEqual(['8103'])
+    expect(hookPortsInSettings(null)).toEqual([])
+  })
+
+  test('healthy two-agent fleet passes everything', () => {
+    const checks = byId(checkFleet([
+      agent({ name: 'thrall', sockets: [''], port: '8093', tokenDigest: 'd1', stateDir: '/s/1', workspaceRoot: '/w/1', hookPorts: ['8093'] }),
+      agent({ name: 'arthas', sockets: ['channel-arthas'], port: '8103', tokenDigest: 'd2', stateDir: '/s/2', workspaceRoot: '/w/2', hookPorts: ['8103'] }),
+    ], '{"hooks":{}}'))
+    expect(checks['fleet-size']?.status).toBe('pass')
+    expect(checks['fleet-ports-unique']?.status).toBe('pass')
+    expect(checks['fleet-tokens-unique']?.status).toBe('pass')
+    // exactly one agent on the default socket = warn (recommendation), not fail
+    expect(checks['fleet-sockets']?.status).toBe('warn')
+    expect(checks['fleet-shared-settings']?.status).toBe('pass')
+    expect(checks['fleet-webhook-enabled']?.status).toBe('pass')
+    expect(checks['fleet-hook-ports']?.status).toBe('pass')
+  })
+
+  test('duplicate port / token / socket fail with agent names', () => {
+    const checks = byId(checkFleet([
+      agent({ name: 'a', port: '8089', tokenDigest: 'same', sockets: ['s1'] }),
+      agent({ name: 'b', port: '8089', tokenDigest: 'same', sockets: ['s1'], stateDir: '/s/b', workspaceRoot: '/w/b' }),
+    ], null))
+    expect(checks['fleet-ports-unique']?.status).toBe('fail')
+    expect(checks['fleet-ports-unique']?.detail).toContain('a & b')
+    expect(checks['fleet-tokens-unique']?.status).toBe('fail')
+    expect(checks['fleet-sockets']?.status).toBe('fail')
+  })
+
+  test('two agents both on the default socket = fail, not warn', () => {
+    const checks = byId(checkFleet([
+      agent({ name: 'a', sockets: [''] }),
+      agent({ name: 'b', sockets: [''], port: '8090', tokenDigest: 'd2', stateDir: '/s/b', workspaceRoot: '/w/b' }),
+    ], null))
+    expect(checks['fleet-sockets']?.status).toBe('fail')
+  })
+
+  test('inconsistent -L inside one unit = fail', () => {
+    const checks = byId(checkFleet([agent({ sockets: ['x', 'y'] })], null))
+    expect(checks['fleet-sockets']?.status).toBe('fail')
+    expect(checks['fleet-sockets']?.detail).toContain('disagree')
+  })
+
+  test('channel hooks in the shared settings = fail', () => {
+    const shared = JSON.stringify({ hooks: { Stop: [{ marker: 'dashi-channel-hook', hooks: [{ command: 'bun post-hook.ts' }] }] } })
+    const checks = byId(checkFleet([agent({})], shared))
+    expect(checks['fleet-shared-settings']?.status).toBe('fail')
+  })
+
+  test('webhook disabled or state config missing = warn with reason', () => {
+    const checks = byId(checkFleet([
+      agent({ name: 'off', webhookEnabled: false }),
+      agent({ name: 'missing', webhookEnabled: null, port: '8090', tokenDigest: 'd2', stateDir: '/s/2', workspaceRoot: '/w/2' }),
+    ], null))
+    expect(checks['fleet-webhook-enabled']?.status).toBe('warn')
+    expect(checks['fleet-webhook-enabled']?.detail).toContain('off (enabled=false)')
+    expect(checks['fleet-webhook-enabled']?.detail).toContain('missing (state config missing)')
+  })
+
+  test('hooks pointing at a foreign port = fail (the last-install-wins disaster)', () => {
+    const checks = byId(checkFleet([agent({ name: 'arthas', port: '8103', hookPorts: ['8093'] })], null))
+    expect(checks['fleet-hook-ports']?.status).toBe('fail')
+    expect(checks['fleet-hook-ports']?.detail).toContain('8093')
+  })
+
+  test('unreadable env degrades to warn, not crash', () => {
+    const checks = byId(checkFleet([
+      agent({}),
+      agent({ name: 'locked', envReadable: false, port: null, tokenDigest: null, stateDir: null, workspaceRoot: null, webhookEnabled: null, hookPorts: [], sockets: ['s2'] }),
+    ], null))
+    expect(checks['fleet-env-readable']?.status).toBe('warn')
+    expect(checks['fleet-env-readable']?.detail).toContain('locked')
+  })
+
+  test('empty fleet fails discovery', () => {
+    const checks = byId(checkFleet([], null))
+    expect(checks['fleet-size']?.status).toBe('fail')
+  })
+
+  test('token digests never expose the token in any rendered output', () => {
+    const checks = checkFleet([agent({ tokenDigest: 'a'.repeat(64) })], null)
+    const text = renderReport(checks)
+    expect(text).not.toContain('a'.repeat(64))
+  })
+})
+
+describe('fleet discovery filter', () => {
+  test('units without tmux Exec lines are not channels', () => {
+    const helper = parseUnitFile('ExecStart=/usr/bin/python3 /srv/listener.py\nEnvironmentFile=/etc/x.env')
+    expect(helper.sockets).toEqual([])
   })
 })

--- a/skills/doctor-dashi-plugin/scripts/doctor.test.ts
+++ b/skills/doctor-dashi-plugin/scripts/doctor.test.ts
@@ -370,6 +370,7 @@ describe('fleet (multi-agent) checks', () => {
     workspaceRoot: '/srv/agents/a',
     webhookEnabled: true,
     hookPorts: ['8089'],
+    settingsPath: '/srv/agents/a/settings.json',
     ...over,
   })
   const byId = (checks: Check[]): Record<string, Check> => Object.fromEntries(checks.map((c) => [c.id, c]))
@@ -472,7 +473,7 @@ describe('fleet (multi-agent) checks', () => {
   test('unreadable env degrades to warn, not crash', () => {
     const checks = byId(checkFleet([
       agent({}),
-      agent({ name: 'locked', envReadable: false, port: null, tokenDigest: null, stateDir: null, workspaceRoot: null, webhookEnabled: null, hookPorts: [], sockets: ['s2'] }),
+      agent({ name: 'locked', envReadable: false, port: null, tokenDigest: null, stateDir: null, workspaceRoot: null, webhookEnabled: null, hookPorts: [], settingsPath: null, sockets: ['s2'] }),
     ], null))
     expect(checks['fleet-env-readable']?.status).toBe('warn')
     expect(checks['fleet-env-readable']?.detail).toContain('locked')
@@ -494,5 +495,60 @@ describe('fleet discovery filter', () => {
   test('units without tmux Exec lines are not channels', () => {
     const helper = parseUnitFile('ExecStart=/usr/bin/python3 /srv/listener.py\nEnvironmentFile=/etc/x.env')
     expect(helper.sockets).toEqual([])
+  })
+})
+
+describe('fleet checks — review fixes (Codex HOLD round)', () => {
+  const agent = (over: Partial<FleetAgent>): FleetAgent => ({
+    name: 'a',
+    unitPath: '/etc/systemd/system/channel-a.service',
+    sockets: ['channel-a'],
+    envPath: '/etc/dashi-plugin/a/channel.env',
+    envReadable: true,
+    port: '8089',
+    tokenDigest: 'digest-a',
+    stateDir: '/var/lib/dashi-channel/a',
+    workspaceRoot: '/srv/agents/a',
+    webhookEnabled: true,
+    hookPorts: ['8089'],
+    settingsPath: '/srv/agents/a/settings.json',
+    ...over,
+  })
+  const byId = (checks: Check[]): Record<string, Check> => Object.fromEntries(checks.map((c) => [c.id, c]))
+
+  test('readable env missing PORT/TOKEN surfaces as warn, not hollow pass', () => {
+    const checks = byId(checkFleet([agent({ name: 'bare', port: null, tokenDigest: null })], null))
+    expect(checks['fleet-env-keys']?.status).toBe('warn')
+    expect(checks['fleet-env-keys']?.detail).toContain('bare')
+    expect(checks['fleet-env-keys']?.detail).toContain('TELEGRAM_WEBHOOK_PORT')
+  })
+
+  test('foreign port NEXT TO the own port still fails (stale last-install hook)', () => {
+    const checks = byId(checkFleet([agent({ name: 'arthas', port: '8103', hookPorts: ['8103', '8093'] })], null))
+    expect(checks['fleet-hook-ports']?.status).toBe('fail')
+    expect(checks['fleet-hook-ports']?.detail).toContain('8093')
+    expect(checks['fleet-hook-ports']?.detail).not.toContain('8103,')
+  })
+
+  test('workspace settings not found = warn (unverified), not pass', () => {
+    const checks = byId(checkFleet([agent({ settingsPath: null, hookPorts: [] })], null))
+    expect(checks['fleet-hook-ports']?.status).toBe('warn')
+    expect(checks['fleet-hook-ports']?.detail).toContain('unverified')
+  })
+
+  test('hookPortsInSettings catches localhost spellings', () => {
+    expect(hookPortsInSettings('x http://localhost:8089/hooks/agent y')).toEqual(['8089'])
+    expect(hookPortsInSettings('x http://0.0.0.0:8090/hooks/agent y')).toEqual(['8090'])
+    expect(hookPortsInSettings('x http://[::1]:8091/hooks/agent y')).toEqual(['8091'])
+  })
+
+  test('-L inside the quoted nested command is NOT a tmux socket', () => {
+    const unit = "ExecStart=/usr/bin/tmux new-session -d -s s 'claude -L sneaky --flag'"
+    expect(parseUnitFile(unit).sockets).toEqual([''])
+  })
+
+  test('-L in tmux argv before the quoted payload IS the socket', () => {
+    const unit = "ExecStart=/usr/bin/tmux -L real new-session -d -s s 'claude -L sneaky'"
+    expect(parseUnitFile(unit).sockets).toEqual(['real'])
   })
 })

--- a/skills/doctor-dashi-plugin/scripts/doctor.ts
+++ b/skills/doctor-dashi-plugin/scripts/doctor.ts
@@ -601,6 +601,8 @@ export interface FleetAgent {
   webhookEnabled: boolean | null
   /** Webhook ports referenced by hook commands in the agent's workspace settings. */
   hookPorts: string[]
+  /** Path of the workspace settings.json actually found; null = could not locate/read. */
+  settingsPath: string | null
 }
 
 /** Parse a systemd unit: EnvironmentFile + tmux socket per Exec line. Pure. */
@@ -611,7 +613,13 @@ export function parseUnitFile(text: string): { envPath: string | null; sockets: 
     const env = line.match(/^\s*EnvironmentFile=-?(\S+)/)
     if (env?.[1]) envPath = env[1]
     if (/^\s*Exec(Start|StartPost|Stop|StopPost)=.*tmux/.test(line)) {
-      const sock = line.match(/tmux\s+(?:[^-]|-(?!L))*?-L\s+(\S+)/) ?? line.match(/-L\s+(\S+)/)
+      // Only inspect tmux's OWN argv: everything before the first quote is
+      // tmux args, the quoted tail is the nested payload (`'claude ... -L x'`
+      // must not read as a tmux socket).
+      const cmdPart = line.slice(line.indexOf('tmux'))
+      const quoteIdx = cmdPart.search(/['"]/)
+      const argsPart = quoteIdx === -1 ? cmdPart : cmdPart.slice(0, quoteIdx)
+      const sock = argsPart.match(/\s-L\s+(\S+)/)
       sockets.add(sock?.[1] ?? '')
     }
   }
@@ -631,7 +639,8 @@ export function envValue(envText: string, key: string): string | null {
 export function hookPortsInSettings(settingsRaw: string | null): string[] {
   if (!settingsRaw) return []
   const ports = new Set<string>()
-  for (const m of settingsRaw.matchAll(/127\.0\.0\.1:(\d+)\/hooks\/agent/g)) {
+  // Any localhost spelling counts — 127.0.0.1, localhost, 0.0.0.0, [::1].
+  for (const m of settingsRaw.matchAll(/(?:127\.0\.0\.1|localhost|0\.0\.0\.0|\[::1\]):(\d+)\/hooks\/agent/g)) {
     const p = m[1]
     if (p !== undefined) ports.add(p)
   }
@@ -657,6 +666,25 @@ export function checkFleet(agents: FleetAgent[], sharedSettingsRaw: string | nul
       status: 'warn',
       detail: `cannot read channel.env for: ${unreadable.join(', ')} — port/token checks are partial`,
       fix: 'run the doctor as a user that can read the env files',
+    })
+  }
+
+  // A readable env that lacks PORT or TOKEN makes the uniqueness checks below
+  // silently skip that agent — surface it instead of reporting a hollow PASS.
+  const missingKeys = agents
+    .filter((a) => a.envReadable)
+    .map((a) => {
+      const miss = [a.port == null ? 'TELEGRAM_WEBHOOK_PORT' : null, a.tokenDigest == null ? 'TELEGRAM_BOT_TOKEN' : null].filter(Boolean)
+      return miss.length > 0 ? `${a.name} (${miss.join(', ')})` : null
+    })
+    .filter((x): x is string => x != null)
+  if (missingKeys.length > 0) {
+    out.push({
+      id: 'fleet-env-keys',
+      title: 'Fleet env files carry PORT and TOKEN',
+      status: 'warn',
+      detail: `missing keys: ${missingKeys.join('; ')} — these agents are excluded from the uniqueness checks`,
+      fix: 'set TELEGRAM_WEBHOOK_PORT and TELEGRAM_BOT_TOKEN in each channel.env',
     })
   }
 
@@ -726,14 +754,24 @@ export function checkFleet(agents: FleetAgent[], sharedSettingsRaw: string | nul
       : { id: 'fleet-webhook-enabled', title: 'webhook.enabled=true in every state config', status: 'warn', detail: webhookOff.join('; '), fix: 'env only sets host/port — write {"webhook":{"enabled":true,...}} to <state-dir>/config.json (invariant e)' },
   )
 
+  // ANY foreign port is a failure even when the own port is also present —
+  // a stale last-install-wins hook next to a correct one still double-routes.
   const foreign = agents
-    .filter((a) => a.port != null && a.hookPorts.length > 0 && !a.hookPorts.includes(a.port))
-    .map((a) => `${a.name} hooks point at port(s) ${a.hookPorts.join(',')} but its webhook is ${a.port}`)
-  out.push(
-    foreign.length === 0
-      ? { id: 'fleet-hook-ports', title: 'Each agent\'s hooks point at its own port', status: 'pass', detail: 'no foreign-port hooks' }
-      : { id: 'fleet-hook-ports', title: 'Each agent\'s hooks point at its own port', status: 'fail', detail: foreign.join('; '), fix: 're-run install-hooks.sh with --settings <that agent\'s settings.json> and the agent\'s own --webhook-url' },
-  )
+    .filter((a) => a.port != null)
+    .map((a) => ({ a, alien: a.hookPorts.filter((p) => p !== a.port) }))
+    .filter(({ alien }) => alien.length > 0)
+    .map(({ a, alien }) => `${a.name} hooks point at foreign port(s) ${alien.join(',')} (own webhook: ${a.port})`)
+  // Hooks we could not inspect are an unverified state, not a pass.
+  const unverified = agents
+    .filter((a) => a.envReadable && a.settingsPath == null)
+    .map((a) => a.name)
+  if (foreign.length > 0) {
+    out.push({ id: 'fleet-hook-ports', title: 'Each agent\'s hooks point at its own port', status: 'fail', detail: foreign.join('; '), fix: 're-run install-hooks.sh with --settings <that agent\'s settings.json> and the agent\'s own --webhook-url, and remove stale hook blocks' })
+  } else if (unverified.length > 0) {
+    out.push({ id: 'fleet-hook-ports', title: 'Each agent\'s hooks point at its own port', status: 'warn', detail: `workspace settings not found for: ${unverified.join(', ')} — hook routing unverified`, fix: 'expected at <TELEGRAM_WORKSPACE_ROOT>/settings.json or <root>/.claude/settings.json' })
+  } else {
+    out.push({ id: 'fleet-hook-ports', title: 'Each agent\'s hooks point at its own port', status: 'pass', detail: 'no foreign-port hooks' })
+  }
 
   return out
 }
@@ -770,11 +808,13 @@ export function scanFleet(unitDir: string): FleetAgent[] {
     // IS the .claude dir (settings.json directly inside), or the root contains
     // a .claude/ subdir.
     let hookPorts: string[] = []
+    let settingsPath: string | null = null
     if (workspaceRoot) {
       for (const cand of [join(workspaceRoot, 'settings.json'), join(workspaceRoot, '.claude', 'settings.json')]) {
         const raw = readFileSafe(cand)
         if (raw != null) {
           hookPorts = hookPortsInSettings(raw)
+          settingsPath = cand
           break
         }
       }
@@ -791,6 +831,7 @@ export function scanFleet(unitDir: string): FleetAgent[] {
       workspaceRoot,
       webhookEnabled,
       hookPorts,
+      settingsPath,
     })
   }
   return agents

--- a/skills/doctor-dashi-plugin/scripts/doctor.ts
+++ b/skills/doctor-dashi-plugin/scripts/doctor.ts
@@ -15,7 +15,8 @@
  * Exit: 0 = no FAIL, 1 = at least one FAIL, 2 = usage error.
  */
 import { spawnSync } from 'child_process'
-import { existsSync, readFileSync } from 'fs'
+import { createHash } from 'crypto'
+import { existsSync, readFileSync, readdirSync } from 'fs'
 import { dirname, join } from 'path'
 import { homedir, platform } from 'os'
 
@@ -575,6 +576,226 @@ function parseJsonSafe(text: string | null): unknown {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Fleet (multi-agent) checks — README section 14. N agents on one host under
+// one subscription is only safe when the five isolation invariants hold:
+// per-workspace hooks, distinct webhook ports, distinct bot tokens, dedicated
+// tmux sockets, webhook.enabled per state config. `--fleet` discovers every
+// channel-*.service unit and verifies the invariants ACROSS agents — the
+// single-agent checks above cannot see cross-agent collisions.
+// ---------------------------------------------------------------------------
+
+export interface FleetAgent {
+  name: string
+  unitPath: string
+  /** Distinct tmux socket names used by the unit's Exec lines ('' = default socket). */
+  sockets: string[]
+  envPath: string | null
+  envReadable: boolean
+  port: string | null
+  /** sha256 hex digest of the bot token — never the token itself. */
+  tokenDigest: string | null
+  stateDir: string | null
+  workspaceRoot: string | null
+  /** true/false from <state-dir>/config.json; null = config missing/unreadable. */
+  webhookEnabled: boolean | null
+  /** Webhook ports referenced by hook commands in the agent's workspace settings. */
+  hookPorts: string[]
+}
+
+/** Parse a systemd unit: EnvironmentFile + tmux socket per Exec line. Pure. */
+export function parseUnitFile(text: string): { envPath: string | null; sockets: string[] } {
+  let envPath: string | null = null
+  const sockets = new Set<string>()
+  for (const line of text.split('\n')) {
+    const env = line.match(/^\s*EnvironmentFile=-?(\S+)/)
+    if (env?.[1]) envPath = env[1]
+    if (/^\s*Exec(Start|StartPost|Stop|StopPost)=.*tmux/.test(line)) {
+      const sock = line.match(/tmux\s+(?:[^-]|-(?!L))*?-L\s+(\S+)/) ?? line.match(/-L\s+(\S+)/)
+      sockets.add(sock?.[1] ?? '')
+    }
+  }
+  return { envPath, sockets: [...sockets] }
+}
+
+/** First value of KEY=... in env-file text. Pure. */
+export function envValue(envText: string, key: string): string | null {
+  for (const line of envText.split('\n')) {
+    const m = line.match(new RegExp(`^\\s*${key}=(.*)$`))
+    if (m) return (m[1] ?? '').trim() || null
+  }
+  return null
+}
+
+/** Webhook ports referenced by hook commands in a serialized settings.json. Pure. */
+export function hookPortsInSettings(settingsRaw: string | null): string[] {
+  if (!settingsRaw) return []
+  const ports = new Set<string>()
+  for (const m of settingsRaw.matchAll(/127\.0\.0\.1:(\d+)\/hooks\/agent/g)) {
+    const p = m[1]
+    if (p !== undefined) ports.add(p)
+  }
+  return [...ports]
+}
+
+/** Cross-agent invariant checks. Pure — agents prepared by scanFleet. */
+export function checkFleet(agents: FleetAgent[], sharedSettingsRaw: string | null): Check[] {
+  const out: Check[] = []
+  const names = agents.map((a) => a.name).join(', ')
+  out.push(
+    agents.length > 0
+      ? { id: 'fleet-size', title: 'Fleet discovery', status: 'pass', detail: `${agents.length} channel unit(s): ${names}` }
+      : { id: 'fleet-size', title: 'Fleet discovery', status: 'fail', detail: 'no channel-*.service units found', fix: 'pass --fleet-dir <dir with channel-*.service files>' },
+  )
+  if (agents.length === 0) return out
+
+  const unreadable = agents.filter((a) => !a.envReadable).map((a) => a.name)
+  if (unreadable.length > 0) {
+    out.push({
+      id: 'fleet-env-readable',
+      title: 'Fleet env files readable',
+      status: 'warn',
+      detail: `cannot read channel.env for: ${unreadable.join(', ')} — port/token checks are partial`,
+      fix: 'run the doctor as a user that can read the env files',
+    })
+  }
+
+  const dupBy = (label: string, key: (a: FleetAgent) => string | null): string[] => {
+    const seen = new Map<string, string[]>()
+    for (const a of agents) {
+      const v = key(a)
+      if (v == null) continue
+      seen.set(v, [...(seen.get(v) ?? []), a.name])
+    }
+    return [...seen.values()].filter((group) => group.length > 1).map((group) => `${group.join(' & ')} share a ${label}`)
+  }
+
+  const portDupes = dupBy('webhook port', (a) => a.port)
+  out.push(
+    portDupes.length === 0
+      ? { id: 'fleet-ports-unique', title: 'Webhook ports unique across agents', status: 'pass', detail: agents.map((a) => `${a.name}:${a.port ?? '?'}`).join(', ') }
+      : { id: 'fleet-ports-unique', title: 'Webhook ports unique across agents', status: 'fail', detail: portDupes.join('; '), fix: 'give every agent its own TELEGRAM_WEBHOOK_PORT (invariant b)' },
+  )
+
+  const tokenDupes = dupBy('bot token', (a) => a.tokenDigest)
+  out.push(
+    tokenDupes.length === 0
+      ? { id: 'fleet-tokens-unique', title: 'Bot tokens unique across agents', status: 'pass', detail: 'all token digests differ' }
+      : { id: 'fleet-tokens-unique', title: 'Bot tokens unique across agents', status: 'fail', detail: tokenDupes.join('; '), fix: 'one token = one getUpdates consumer; a shared token means 409 Conflict (invariant c)' },
+  )
+
+  // Sockets: a unit whose Exec lines disagree is broken on its own; across
+  // units, any duplicate socket (including two on the default '') races at boot.
+  const inconsistent = agents.filter((a) => a.sockets.length > 1).map((a) => a.name)
+  const socketOf = (a: FleetAgent): string | null => (a.sockets.length === 1 ? (a.sockets[0] ?? null) : null)
+  const socketDupes = dupBy('tmux socket', (a) => socketOf(a) === '' ? '<default>' : socketOf(a))
+  const onDefault = agents.filter((a) => socketOf(a) === '').map((a) => a.name)
+  if (inconsistent.length > 0) {
+    out.push({ id: 'fleet-sockets', title: 'Dedicated tmux socket per unit', status: 'fail', detail: `Exec lines disagree on -L inside: ${inconsistent.join(', ')}`, fix: 'use the same tmux -L <socket> in ExecStart, ExecStartPost AND ExecStop' })
+  } else if (socketDupes.length > 0) {
+    out.push({ id: 'fleet-sockets', title: 'Dedicated tmux socket per unit', status: 'fail', detail: socketDupes.join('; '), fix: 'two Type=forking units on one socket race at boot — give each unit tmux -L channel-<agent> (invariant d)' })
+  } else if (onDefault.length === 1 && agents.length > 1) {
+    out.push({ id: 'fleet-sockets', title: 'Dedicated tmux socket per unit', status: 'warn', detail: `${onDefault[0]} runs on the default socket (no -L)`, fix: 'works while unique, but a future unit without -L will race it — prefer a dedicated socket' })
+  } else {
+    out.push({ id: 'fleet-sockets', title: 'Dedicated tmux socket per unit', status: 'pass', detail: agents.map((a) => `${a.name}:${socketOf(a) === '' ? '<default>' : socketOf(a)}`).join(', ') })
+  }
+
+  const sharedDirty = sharedSettingsRaw != null && /dashi-channel-hook|post-hook\.ts|read-receipt-hook\.ts|fallback-reply-hook\.ts/.test(sharedSettingsRaw)
+  out.push(
+    sharedDirty
+      ? { id: 'fleet-shared-settings', title: 'Shared ~/.claude/settings.json free of channel hooks', status: 'fail', detail: 'channel hooks found in the user-level settings — they fire in EVERY agent session and route through one agent\'s bot/port', fix: 'move channel hooks into each agent\'s <workspace>/.claude/settings.json (invariant a)' }
+      : { id: 'fleet-shared-settings', title: 'Shared ~/.claude/settings.json free of channel hooks', status: 'pass', detail: 'no channel hook markers in the shared file' },
+  )
+
+  for (const [id, label, key, fix] of [
+    ['fleet-state-dirs-unique', 'State dirs unique across agents', (a: FleetAgent) => a.stateDir, 'give every agent its own TELEGRAM_STATE_DIR'],
+    ['fleet-workspaces-unique', 'Workspace roots unique across agents', (a: FleetAgent) => a.workspaceRoot, 'give every agent its own TELEGRAM_WORKSPACE_ROOT (identity isolation)'],
+  ] as const) {
+    const dupes = dupBy(label.toLowerCase(), key)
+    out.push(
+      dupes.length === 0
+        ? { id, title: label, status: 'pass', detail: 'no collisions' }
+        : { id, title: label, status: 'fail', detail: dupes.join('; '), fix },
+    )
+  }
+
+  const webhookOff = agents.filter((a) => a.webhookEnabled !== true).map((a) => `${a.name} (${a.webhookEnabled === false ? 'enabled=false' : 'state config missing'})`)
+  out.push(
+    webhookOff.length === 0
+      ? { id: 'fleet-webhook-enabled', title: 'webhook.enabled=true in every state config', status: 'pass', detail: 'all agents have a live webhook endpoint' }
+      : { id: 'fleet-webhook-enabled', title: 'webhook.enabled=true in every state config', status: 'warn', detail: webhookOff.join('; '), fix: 'env only sets host/port — write {"webhook":{"enabled":true,...}} to <state-dir>/config.json (invariant e)' },
+  )
+
+  const foreign = agents
+    .filter((a) => a.port != null && a.hookPorts.length > 0 && !a.hookPorts.includes(a.port))
+    .map((a) => `${a.name} hooks point at port(s) ${a.hookPorts.join(',')} but its webhook is ${a.port}`)
+  out.push(
+    foreign.length === 0
+      ? { id: 'fleet-hook-ports', title: 'Each agent\'s hooks point at its own port', status: 'pass', detail: 'no foreign-port hooks' }
+      : { id: 'fleet-hook-ports', title: 'Each agent\'s hooks point at its own port', status: 'fail', detail: foreign.join('; '), fix: 're-run install-hooks.sh with --settings <that agent\'s settings.json> and the agent\'s own --webhook-url' },
+  )
+
+  return out
+}
+
+/** Discover channel-*.service units and build FleetAgents. IO wrapper around the pure parsers. */
+export function scanFleet(unitDir: string): FleetAgent[] {
+  let entries: string[] = []
+  try {
+    entries = readdirSync(unitDir).filter((f) => /^channel-.+\.service$/.test(f))
+  } catch {
+    return []
+  }
+  const agents: FleetAgent[] = []
+  for (const f of entries.sort()) {
+    const unitPath = join(unitDir, f)
+    const text = readFileSafe(unitPath)
+    if (text == null) continue
+    const name = f.replace(/^channel-/, '').replace(/\.service$/, '')
+    const { envPath, sockets } = parseUnitFile(text)
+    // Not every channel-*.service is a channel: helper units (webhook
+    // listeners, sync timers) share the prefix but never run tmux. A channel
+    // unit always supervises a tmux session — skip anything that doesn't.
+    if (sockets.length === 0) continue
+    const envText = envPath ? readFileSafe(envPath) : null
+    const token = envText ? envValue(envText, 'TELEGRAM_BOT_TOKEN') : null
+    const stateDir = envText ? envValue(envText, 'TELEGRAM_STATE_DIR') : null
+    const workspaceRoot = envText ? envValue(envText, 'TELEGRAM_WORKSPACE_ROOT') : null
+    let webhookEnabled: boolean | null = null
+    if (stateDir) {
+      const stateConfig = parseJsonSafe(readFileSafe(join(stateDir, 'config.json'))) as { webhook?: { enabled?: boolean } } | null
+      webhookEnabled = stateConfig?.webhook?.enabled === true ? true : stateConfig ? false : null
+    }
+    // Workspace settings: both layouts exist in the wild — the workspace root
+    // IS the .claude dir (settings.json directly inside), or the root contains
+    // a .claude/ subdir.
+    let hookPorts: string[] = []
+    if (workspaceRoot) {
+      for (const cand of [join(workspaceRoot, 'settings.json'), join(workspaceRoot, '.claude', 'settings.json')]) {
+        const raw = readFileSafe(cand)
+        if (raw != null) {
+          hookPorts = hookPortsInSettings(raw)
+          break
+        }
+      }
+    }
+    agents.push({
+      name,
+      unitPath,
+      sockets,
+      envPath,
+      envReadable: envText != null,
+      port: envText ? envValue(envText, 'TELEGRAM_WEBHOOK_PORT') : null,
+      tokenDigest: token ? createHash('sha256').update(token).digest('hex') : null,
+      stateDir,
+      workspaceRoot,
+      webhookEnabled,
+      hookPorts,
+    })
+  }
+  return agents
+}
+
 interface Options {
   json: boolean
   os: OS
@@ -587,6 +808,8 @@ interface Options {
   chatId?: string
   tmuxSession?: string
   queueJsonPath?: string
+  fleet?: boolean
+  fleetDir?: string
 }
 
 function parseArgs(argv: string[]): Options | { error: string } {
@@ -641,6 +864,12 @@ function parseArgs(argv: string[]): Options | { error: string } {
       case '--queue-json':
         opts.queueJsonPath = next()
         break
+      case '--fleet':
+        opts.fleet = true
+        break
+      case '--fleet-dir':
+        opts.fleetDir = next()
+        break
       case '--help':
       case '-h':
         return { error: 'help' }
@@ -667,6 +896,10 @@ Options:
   --chat <id>              a Telegram chat id to verify (group id is -100...)
   --session <name>         tmux channel session (e.g. channel-myagent)
   --queue-json <path>      a saved getUpdates JSON response to classify (409 / drain)
+  --fleet                  multi-agent mode: discover channel-*.service units and
+                           verify the five isolation invariants ACROSS agents
+                           (README section 14)
+  --fleet-dir <path>       where to look for unit files (default: /etc/systemd/system)
   --json                   machine-readable output
   -h, --help               this help
 
@@ -772,6 +1005,15 @@ function gatherChecks(opts: Options): Check[] {
     } else {
       checks.push(classifyQueue(parsed))
     }
+  }
+
+  // Fleet (multi-agent) invariants — cross-agent collisions invisible to the
+  // single-agent checks above. The shared-settings probe always reads the
+  // USER-level file (the one that fires in every session), regardless of
+  // where --settings points.
+  if (opts.fleet) {
+    const agents = scanFleet(opts.fleetDir ?? '/etc/systemd/system')
+    checks.push(...checkFleet(agents, readFileSafe(join(homedir(), '.claude', 'settings.json'))))
   }
 
   // live session state (crash loop / auth / welcome hang / listening)


### PR DESCRIPTION
## Что
`doctor.ts --fleet` (+ `--fleet-dir` для тестов/нестандартных путей): автообнаружение всех `channel-*.service` на хосте (хелперы без tmux в Exec-строках отсеиваются) и проверка пяти инвариантов изоляции из README раздела 14 МЕЖДУ агентами:

- уникальные webhook-порты
- уникальные bot-токены (sha256-дайджесты, токен никогда не печатается)
- выделенный tmux-сокет на юнит: дубликаты (включая два на дефолтном) = FAIL, единственный дефолтный = WARN, рассинхрон -L внутри юнита = FAIL
- общий ~/.claude/settings.json чист от channel-хуков
- webhook.enabled=true в state config каждого агента
- хуки каждого агента ходят в СВОЙ порт (last-install-wins ловится, включая stale-хук рядом с корректным)
- + warn на нечитаемый env и на env без PORT/TOKEN (без полых PASS), unverified вместо pass когда settings не найден

## Ревью
Dual review: Codex GPT-5.5 HOLD (2 High, 2 Medium, 1 Low — все исправлены: полый PASS при неполном env, foreign-port рядом со своим, unverified-состояние, localhost-варианты URL, -L из вложенной команды) → SHIP.

## Тесты
70 тестов (20 новых fleet), 0 fail. Боевой прогон на реальном флоте этого хоста: 2 канала найдены, хелпер-юнит отсеян, все инварианты зелёные, один честный WARN (thrall на дефолтном сокете).

SKILL.md дополнен fleet-режимом.

🤖 Generated with [Claude Code](https://claude.com/claude-code)