### PR TITLE
fix(multichat): claude в bypassPermissions — автономная сессия (hook = гейт)

### DIFF
--- a/plugin/src/chats/hooks/multichat-entrypoint.sh
+++ b/plugin/src/chats/hooks/multichat-entrypoint.sh
@@ -332,4 +332,14 @@ trap cleanup EXIT INT TERM
 # Hand the pane over to claude. tmux runs us in the foreground process
 # of the session; exec keeps claude as the leaf process so tmux's
 # remain-on-exit semantics work as expected.
-exec claude
+#
+# Permission mode (2026-06-06): a multichat session has NO human at the
+# terminal — the warchief drives it over Telegram and cannot answer Claude
+# Code's interactive permission prompts, so a default-mode session STALLS on
+# the first gated tool call (every Bash/edit/MCP/network use). We run in
+# bypassPermissions so the session is autonomous; the SECURITY GATE is the
+# PreToolUse hook (chats/hooks/pre-tool-use.sh enforcing policy.yaml deny),
+# which still blocks regardless of permission mode. The hook holds the iron
+# limit (secrets / .env / keys / server creds / private profiles).
+# Override with MULTICHAT_PERMISSION_MODE if a deployment needs a stricter mode.
+exec claude --permission-mode "${MULTICHAT_PERMISSION_MODE:-bypassPermissions}"


### PR DESCRIPTION
## Проблема
Мультичат-сессией управляет вождь через Telegram. У терминала никого нет, а claude запускался в дефолтном permission-режиме → первый же gated tool-call (Bash/edit/MCP/network) показывает интерактивный запрос подтверждения в tmux, который из Telegram нажать нельзя → ход зависает. Это и есть «блокирует каждое сообщение».

## Фикс
`exec claude --permission-mode "${MULTICHAT_PERMISSION_MODE:-bypassPermissions}"`. Гейт безопасности — PreToolUse hook (pre-tool-use.sh, читает policy.yaml deny), который блокирует НЕЗАВИСИМО от permission-режима. Переопределяемо env для деплоев, которым нужен строгий режим.

## Безопасность (double review)
Codex GPT-5.5 xhigh + автоматический security-review плагина флагнули bypass (deny-список, не allow-список). Закрыто харденингом deny в policy.yaml: env-дереф ($TOKEN/$KEY/$SECRET), process.env/os.environ/getenv, /proc/environ+cmdline, не-cat чтение секретов (grep/rg), internal-brain MCP (recall/memory), IP-команды (ip addr/tailscale). Проверено прогоном хука на атаках (echo $TOKEN → BLOCK, grep function → ALLOW). Железный предел держится.

policy.yaml + персоны — деплойный конфиг Thrall (не в этом репо), правятся в .claude/chats/ с бэкапом.

🤖 Generated with [Claude Code](https://claude.com/claude-code)