### PR TITLE
Редактор: ослабил over-redaction — дефис разрывает токен (только секреты)

### DIFF
--- a/plugin/src/safety/redact.ts
+++ b/plugin/src/safety/redact.ts
@@ -133,17 +133,22 @@ function supabaseReplacer(host: string): string {
 // idempotency.
 const TELEGRAM_TOKEN_PARTIAL_RE = /\b(\d{3})\d{7,}:(AA\w{2})\w+/g
 
-// Generic long token rule (≥24 chars of [A-Za-z0-9_-]). LAST — keeps head
-// and tail visible so a partial mask is still useful for debugging.
+// Generic long token rule (≥24 chars). LAST — keeps head and tail visible
+// so a partial mask is still useful for debugging.
 //
-// URL exemption (2026-06-05): this rule does NOT fire inside http(s) URLs.
-// Long hyphenated path segments are overwhelmingly public identifiers —
-// repo slugs (`dashi-plugin-claude-code`), commit SHAs, PR paths — and
-// masking them produced dead links the warchief could not open. Secrets
-// embedded in URLs are still covered by every SPECIFIC rule above (bot
-// tokens, ghp_/sk- prefixes, ?token= query params, Supabase hosts, IPs),
-// all of which run regardless of URL context.
-const GENERIC_LONG_TOKEN_RE = /\b([A-Za-z0-9_-]{4})[A-Za-z0-9_-]{16,}([A-Za-z0-9_-]{4})\b/g
+// HYPHEN EXEMPTION (2026-06-09): the character class is [A-Za-z0-9_] — a
+// HYPHEN now BREAKS the run instead of extending it. Every false positive
+// the warchief hit was a kebab-case identifier: repo slugs
+// (`dashi-plugin-claude-code`), feature-branch names, multichat link slugs.
+// These are public, not secrets, and masking them ("validate only secrets")
+// produced dead links and noise. Opaque secrets that matter are caught by
+// the SPECIFIC prefix/shape rules above (bot tokens, gsk_/sk-/ghp_ prefixes,
+// Bearer, JWT, ?token= params, Supabase hosts, IPs) plus caller `extras`;
+// a hyphen-free high-entropy run is still masked by this rule as a backstop.
+//
+// URL exemption (2026-06-05): this rule also does NOT fire inside http(s)
+// URLs — long path segments there are overwhelmingly public identifiers.
+const GENERIC_LONG_TOKEN_RE = /\b([A-Za-z0-9_]{4})[A-Za-z0-9_]{16,}([A-Za-z0-9_]{4})\b/g
 
 // URL detector for the exemption above. Tighter than a linkifier needs to
 // be — when in doubt the range SHRINKS, which merely re-enables generic

--- a/plugin/tests/safety/redact.test.ts
+++ b/plugin/tests/safety/redact.test.ts
@@ -181,16 +181,22 @@ describe('redactSecrets — URL exemption for the generic long-token rule', () =
     expect(redactSecrets(url)).toBe(url)
   })
 
-  test('the same long token OUTSIDE a URL is still masked', () => {
+  test('a kebab-case slug OUTSIDE a URL is now left intact (hyphen exemption)', () => {
+    // 2026-06-09: hyphenated identifiers are public, not secrets. The generic
+    // rule no longer masks them anywhere (plain text or URL).
     const out = redactSecrets(
       'slug dashi-plugin-claude-code and https://github.com/qwwiwi/dashi-plugin-claude-code',
     )
-    // Plain-text occurrence masked…
-    expect(out).toContain('dash***code and')
-    // …URL occurrence intact.
+    expect(out).toContain('slug dashi-plugin-claude-code and')
     expect(out).toContain(
       'https://github.com/qwwiwi/dashi-plugin-claude-code',
     )
+  })
+
+  test('a hyphen-free opaque long token is STILL masked (secret backstop)', () => {
+    const out = redactSecrets('opaque abcd1234567890efghij5678WXYZ token')
+    expect(out).not.toContain('abcd1234567890efghij5678WXYZ')
+    expect(out).toMatch(/abcd\*\*\*WXYZ/)
   })
 
   test('?token= query param inside a URL is STILL redacted', () => {


### PR DESCRIPTION
## Проблема
Редактор секретов маскирует исходящий текст. Generic-правило ловит любой «длинный токен» (24+ символов `[A-Za-z0-9_-]`), включая публичные kebab-идентификаторы: слаги репо (`dashi-plugin-claude-code` → `dash***code`), имена feature-веток, ссылки в мультичате. Результат — сломанные ссылки и шум. Вождь: «валидировать только секреты».

## Фикс
Класс символов generic-правила `[A-Za-z0-9_-]` → `[A-Za-z0-9_]`: дефис теперь РАЗРЫВАЕТ длинный токен, а не продлевает. Kebab-слаги перестают маскироваться везде (прозой и в URL). Реальные секреты по-прежнему ловят:
- специфичные prefix/shape-правила: bot-token, `gsk_`/`sk-`/`ghp_`/`re_`/`xoxb-`, Bearer, JWT, `?token=`-параметры, Supabase-хосты, IP, secret-пути, Firebase-поля;
- caller `extras` (точные подстроки, напр. webhook-токен);
- hyphen-free opaque-токен остаётся под generic-маской как backstop.

URL-исключение (PR #50) сохранено.

## Тесты
47 зелёных. Обновлён тест поведения kebab-слага (теперь не маскируется) + добавлен тест что hyphen-free opaque-токен всё ещё маскируется.

Двойное ревью: Fable 5 + Codex (в процессе).
