### PR TITLE
Doctor: фикс status-литерала в checkProgressSurfaces ('ok' → 'pass')

### DIFF
--- a/skills/doctor-dashi-plugin/scripts/doctor.test.ts
+++ b/skills/doctor-dashi-plugin/scripts/doctor.test.ts
@@ -619,11 +619,11 @@ describe('checkProgressSurfaces — exactly one activity surface', () => {
   })
   test('tmux mirror alone passes', () => {
     const c = checkProgressSurfaces({ tmux_mirror: { enabled: true, pane_target: 'channel-x:0.0' } })
-    expect(c.status).toBe('ok')
+    expect(c.status).toBe('pass')
   })
   test('empty config passes (defaults are all-off since 2026-06-09)', () => {
     const c = checkProgressSurfaces({})
-    expect(c.status).toBe('ok')
+    expect(c.status).toBe('pass')
   })
   test('unreadable config is a warn, not a crash', () => {
     const c = checkProgressSurfaces('not an object')

--- a/skills/doctor-dashi-plugin/scripts/doctor.ts
+++ b/skills/doctor-dashi-plugin/scripts/doctor.ts
@@ -529,7 +529,7 @@ export function checkProgressSurfaces(stateConfig: unknown): Check {
     return { id, title, status: 'warn', detail: `${enabled.length} surfaces enabled together (${enabled.join(' + ')}) — the owner gets duplicate Telegram windows`, fix: 'keep exactly one: tmux_mirror for a terminal view, or one hook-driven reporter. Disable the rest in the state config.json' }
   }
   const detail = enabled.length === 1 ? `exactly one surface enabled (${enabled[0]})` : 'no surface explicitly enabled (defaults are all-off)'
-  return { id, title, status: 'ok', detail }
+  return { id, title, status: 'pass', detail }
 }
 
 /**


### PR DESCRIPTION
renderReport печатал [undefined] для нового чека progress-surfaces: Status union = pass|warn|fail|skip, а чек возвращал 'ok'. tsc плагина не покрывает skills/ — поймано живым прогоном doctor по флоту. Тесты обновлены (80 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)