### PR TITLE
Doctor: resolve относительного --plugin-dir (ложный FAIL workspace-placement)

### DIFF
--- a/skills/doctor-dashi-plugin/scripts/doctor.test.ts
+++ b/skills/doctor-dashi-plugin/scripts/doctor.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test'
+import { dirname, join } from 'path'
 import {
   checkAllowlist,
   checkProgressSurfaces,
+  findEnclosingClaudeMd,
   checkFleet,
   envValue,
   hookPortsInSettings,
@@ -628,5 +630,15 @@ describe('checkProgressSurfaces — exactly one activity surface', () => {
   test('unreadable config is a warn, not a crash', () => {
     const c = checkProgressSurfaces('not an object')
     expect(c.status).toBe('warn')
+  })
+})
+
+describe('findEnclosingClaudeMd — relative plugin dir', () => {
+  test('relative path is resolved against cwd before walking up', () => {
+    const cwd = process.cwd()
+    const found = new Set([join(dirname(dirname(cwd)), 'CLAUDE.md')])
+    const fe = (p: string) => found.has(p)
+    // grandparent of cwd holds CLAUDE.md: cwd/plugin -> cwd -> parent -> grandparent
+    expect(findEnclosingClaudeMd('plugin', fe)).not.toBeNull()
   })
 })

--- a/skills/doctor-dashi-plugin/scripts/doctor.ts
+++ b/skills/doctor-dashi-plugin/scripts/doctor.ts
@@ -17,7 +17,7 @@
 import { spawnSync } from 'child_process'
 import { createHash } from 'crypto'
 import { existsSync, readFileSync, readdirSync } from 'fs'
-import { dirname, join } from 'path'
+import { dirname, join, resolve } from 'path'
 import { homedir, platform } from 'os'
 
 export type Status = 'pass' | 'warn' | 'fail' | 'skip'
@@ -183,7 +183,12 @@ export function findEnclosingClaudeMd(
   pluginDir: string,
   fileExists: (p: string) => boolean = existsSync,
 ): string | null {
-  let dir = pluginDir
+  // A relative pluginDir (e.g. `--plugin-dir plugin`) must not break the
+  // upward walk: dirname('plugin') is '.', dirname('.') is '.', and the
+  // parent===dir guard exits after two levels — reporting a false FAIL
+  // even though <workspace>/.claude/CLAUDE.md exists (fleet doctor sweep,
+  // 2026-06-09). Resolve against cwd first so the walk sees real ancestors.
+  let dir = resolve(pluginDir)
   for (let i = 0; i < 12; i++) {
     const candidate = join(dir, 'CLAUDE.md')
     if (fileExists(candidate)) return candidate


### PR DESCRIPTION
С relative `--plugin-dir plugin` walk-up утыкался в '.' за два шага и репортил FAIL «no CLAUDE.md found», хотя <workspace>/.claude/CLAUDE.md существует — весь fleet-прогон 2026-06-09 показывал ложный FAIL. resolve() против cwd + регрессионный тест (81 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)