### PR TITLE
MCP-секреты в env-переменные, higgsfield убран

### DIFF
--- a/plugin/.env.example
+++ b/plugin/.env.example
@@ -1,0 +1,10 @@
+# MCP credentials for plugin/.mcp.json (${VAR} interpolation).
+# Copy to plugin/.env and fill real values. plugin/.env is gitignored.
+# These vars must be present in the environment where `claude` launches,
+# otherwise the chatplace/gbrain MCP servers fail auth ("Missing environment variables").
+
+# ChatPlace MCP key — sent as `Authorization: Bearer`. Source: ~/.secrets/chatplace.key
+CHATPLACE_API_KEY=cpk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# gbrain (mcp.orgrimmar.xyz) Bearer — shared across memory/recall/swarm/tasks servers
+GBRAIN_BEARER=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,44 @@
   "mcpServers": {
     "dashi-channel": {
       "command": "bun",
-      "args": ["./src/server.ts"]
+      "args": [
+        "./src/server.ts"
+      ]
+    },
+    "chatplace": {
+      "type": "http",
+      "url": "https://mcp.chatplace.io/mcp",
+      "headers": {
+        "Authorization": "Bearer ${CHATPLACE_API_KEY}"
+      }
+    },
+    "dashi-gbrain-memory": {
+      "type": "http",
+      "url": "https://mcp.orgrimmar.xyz/memory/mcp",
+      "headers": {
+        "Authorization": "Bearer ${GBRAIN_BEARER}"
+      }
+    },
+    "dashi-gbrain-recall": {
+      "type": "http",
+      "url": "https://mcp.orgrimmar.xyz/recall/mcp",
+      "headers": {
+        "Authorization": "Bearer ${GBRAIN_BEARER}"
+      }
+    },
+    "dashi-gbrain-swarm": {
+      "type": "http",
+      "url": "https://mcp.orgrimmar.xyz/swarm/mcp",
+      "headers": {
+        "Authorization": "Bearer ${GBRAIN_BEARER}"
+      }
+    },
+    "dashi-gbrain-tasks": {
+      "type": "http",
+      "url": "https://mcp.orgrimmar.xyz/task/mcp",
+      "headers": {
+        "Authorization": "Bearer ${GBRAIN_BEARER}"
+      }
     }
   }
 }


### PR DESCRIPTION
## Что
- `plugin/.mcp.json`: chatplace + 4 gbrain (memory/recall/swarm/tasks) через `${CHATPLACE_API_KEY}` / `${GBRAIN_BEARER}` — plaintext-токенов в конфиге больше нет
- higgsfield убран (больше не используется, директива принца 2026-06-09)
- `plugin/.env.example`: шаблон с документацией; реальные значения в gitignored `plugin/.env`

## Ревью
- Автор: Кельтас (double-review code-reviewer Opus: APPROVE)
- Cross-review: Сильвана — APPROVE. Проверено: `.env` в gitignore и не трекается; токены в git-истории отсутствуют (`git log -S` по значениям, все ветки = 0); в main токенов не было; `${VAR}`-интерполяция корректна (с env → 5 серверов Connected, без env → "Missing environment variables")
- Env прокинут в Tier-1: vars добавлены в `secrets/channel.env` (его сорсит launchd-wrapper), проверено на живом рестарте channel-kaelthas

Мердж одобрен принцем («да, мержи», 2026-06-09).

🤖 Generated with [Claude Code](https://claude.com/claude-code)