### PR TITLE
Доктор: глубокая диагностика — мультиагент, профили hooks, permission gate, мультичат, безопасность, autodetect

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 
 It replaces the deprecated `claude -p` gateway pattern (a Python daemon that spawned a fresh headless session for every message). Cutover deadline — **2026-06-15** (Anthropic is splitting billing; details in section [13](#13-why-migrate--the-2026-06-15-deadline)).
 
-> **Migrating from the old gateway? There is now a doctor.** The read-only [`doctor-dashi-plugin`](skills/doctor-dashi-plugin/SKILL.md) skill diagnoses the whole cutover — workspace placement, hooks, MCP comms config, allowlist, and live-session health — and encodes every mistake we already paid for so you don't repeat them. Run `bun skills/doctor-dashi-plugin/scripts/doctor.ts --help`.
+> **Migrating from the old gateway? There is now a doctor — use it.** The read-only [`doctor-dashi-plugin`](skills/doctor-dashi-plugin/SKILL.md) skill diagnoses the whole cutover — workspace placement, hooks (profile-aware), the permission gate and its policy, multichat invariants, webhook bind + token-file hygiene, MCP comms config, allowlist, fleet isolation, and live-session health — and encodes every mistake we already paid for so you don't repeat them. Run it during EVERY migration and whenever the bridge misbehaves: `bun skills/doctor-dashi-plugin/scripts/doctor.ts` (on a systemd host it autodetects the rest).
+>
+> **And one hard rule: migrate from a Claude Code terminal session, not through Telegram.** The migration changes the very bridge that carries your Telegram messages — if it breaks mid-change, the agent you were instructing through Telegram goes silent and can no longer fix itself. Work in a terminal (`tmux attach`, or a plain `claude` session on the host); let Telegram be the thing you test, not the thing you work through.
 
 ![Architecture — Telegram ↔ plugin ↔ Claude Code session](docs/assets/architecture-hero.svg)
 
@@ -445,13 +447,16 @@ bash scripts/install-hooks.sh --settings ~/.claude/settings.json \
   --chat-id <your-chat-id> --webhook-url http://127.0.0.1:8089/hooks/agent --agent-id dashi-channel
 
 # 7. Migrating from the old gateway? Run the doctor before AND after cutover
-bun skills/doctor-dashi-plugin/scripts/doctor.ts \
-  --plugin-dir "$PWD" --settings ~/.claude/settings.json --session channel-myagent
+#    (flag-less on a systemd host — it autodetects the unit/env/session; add
+#    flags only for unusual layouts, see --help)
+bun skills/doctor-dashi-plugin/scripts/doctor.ts --plugin-dir "$PWD"
 ```
 
 On the first launch, Claude Code asks 2 interactive questions (allow external imports + dev channels) — **once**; answer `1` to both.
 
-> **Migration doctor.** If you are moving an agent off the legacy gateway, the [`doctor-dashi-plugin`](skills/doctor-dashi-plugin/SKILL.md) skill diagnoses the whole cutover — toolchain floors, workspace placement (identity drift), settings/hook registration, MCP comms consistency, the Telegram allowlist, and live-session signals (welcome hang, expired auth, 409 conflict, crash loop). It is read-only — it never restarts a service or prints a secret — and it encodes every mistake we already paid for so you don't repeat them. Run `bun skills/doctor-dashi-plugin/scripts/doctor.ts --help`.
+> **Migration doctor.** If you are moving an agent off the legacy gateway — or fixing a bot that misbehaves — start with the [`doctor-dashi-plugin`](skills/doctor-dashi-plugin/SKILL.md) skill. It diagnoses the whole bridge: toolchain floors, workspace placement (identity drift), dev-vs-runtime copy (multi-agent aware), settings/hook registration with hook-profile awareness (a tmux-mirror-only setup is not punished for feeder hooks it deliberately lacks), the permission gate (ask-relay, policy file, `confirm_overrides` must never lift `sudo`/`rm -rf`), multichat (terminal mirror is DM-only, per-chat policy coverage), security hygiene (webhook must bind loopback only; the env file holding the bot token must not be world-readable), MCP comms consistency, the Telegram allowlist, fleet isolation (`--fleet`), and live-session signals (welcome hang, expired auth, 409 conflict, crash loop). It is read-only — it never restarts a service or prints a secret. On a systemd host `bun skills/doctor-dashi-plugin/scripts/doctor.ts` with no flags autodetects the unit, env, session and state config. Exit codes: `0` no FAIL, `1` at least one FAIL, `2` usage.
+>
+> **Do migrations and bridge surgery from a terminal, not through Telegram.** This work modifies the bridge that delivers your Telegram messages. If it breaks halfway, Telegram goes dark and you lose the channel you were issuing instructions through. Open a terminal session on the host (`tmux attach -t channel-<agent>` for inspection, a separate `claude` session for the work), make the change, run the doctor, send a test message — and only then walk away. Fix bugs and errors the same way: doctor first, then the reference for the failing check.
 
 **Stack:** Bun 1.3+ / TypeScript strict, Claude Code v2.1.80+ ([Channels reference](https://code.claude.com/docs/en/channels-reference)), grammY 1.21+, Zod 3.23+, systemd/launchd supervisor.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -435,9 +435,17 @@ claude --dangerously-load-development-channels server:dashi-channel
 # 6. ОБЯЗАТЕЛЬНО — установить hooks (иначе нет прогресса в Telegram)
 bash scripts/install-hooks.sh --settings ~/.claude/settings.json \
   --chat-id <ваш-chat-id> --webhook-url http://127.0.0.1:8089/hooks/agent --agent-id dashi-channel
+
+# 7. Переезжаете со старого gateway? Прогоните доктора ДО и ПОСЛЕ переключения
+#    (на systemd-хосте — без флагов: юнит/env/сессию он найдёт сам)
+bun skills/doctor-dashi-plugin/scripts/doctor.ts --plugin-dir "$PWD"
 ```
 
 При первом запуске Claude Code задаст 2 интерактивных вопроса (allow external imports + dev channels) — **разово**, ответьте `1` на оба.
+
+> **Доктор — обязательный инструмент переезда и дебага.** Read-only скилл [`doctor-dashi-plugin`](skills/doctor-dashi-plugin/SKILL.md) диагностирует весь мост: toolchain, размещение workspace (дрейф идентичности), dev-vs-runtime копию (учитывает несколько агентов на хосте), hooks с учётом профиля (mirror-конфигурация без feeder-хуков — корректна, доктор её не ругает), permission gate (ask-relay, policy-файл, `confirm_overrides` не может снимать `sudo`/`rm -rf`), мультичат (terminal mirror только в DM, покрытие per-chat policy), гигиену безопасности (webhook слушает ТОЛЬКО loopback — `0.0.0.0` это FAIL; env-файл с токеном не world-readable), консистентность MCP, allowlist, флот (`--fleet`) и живую сессию (welcome-hang, auth, 409, crash loop). Ничего не перезапускает, секретов не печатает. Коды выхода: `0` — нет FAIL, `1` — есть FAIL, `2` — usage.
+>
+> **Железное правило: миграцию и любую хирургию моста делайте из терминала Claude Code, НЕ через Telegram.** Эта работа меняет тот самый мост, который доставляет ваши Telegram-сообщения. Сломается на середине — Telegram замолчит, и канал, через который вы давали команды, исчезнет вместе с возможностью починить. Откройте терминальную сессию на хосте (`tmux attach -t channel-<agent>` для осмотра, отдельная `claude`-сессия для работы), внесите изменение, прогоните доктора, отправьте тестовое сообщение — и только потом уходите. Баги и ошибки чините так же: сначала доктор, потом reference по упавшему чеку.
 
 **Stack:** Bun 1.3+ / TypeScript strict, Claude Code v2.1.80+ ([Channels reference](https://code.claude.com/docs/en/channels-reference)), grammY 1.21+, Zod 3.23+, supervisor systemd/launchd.
 
@@ -448,6 +456,7 @@ bash scripts/install-hooks.sh --settings ~/.claude/settings.json \
 | [docs/03-installation.md](docs/03-installation.md) | systemd / launchd, EnvironmentFile, фикс welcome-промтов, smoke test |
 | [docs/03-installation-linux.md](docs/03-installation-linux.md) · [macos](docs/03-installation-macos.md) | OS-specific unit/plist |
 | [docs/04-migration-from-gateway.md](docs/04-migration-from-gateway.md) | Пошаговая миграция с `jarvis-telegram-gateway`, откат на каждом шаге |
+| [skills/doctor-dashi-plugin/SKILL.md](skills/doctor-dashi-plugin/SKILL.md) | **Доктор миграции** — read-only диагностика: размещение, hooks (профили), permission gate + policy, мультичат, webhook bind, гигиена токена, MCP, allowlist, флот, живая сессия |
 | [docs/05-troubleshooting.md](docs/05-troubleshooting.md) | Типовые ошибки: симптом → корень → фикс |
 | [docs/06-how-claude-loads-session.md](docs/06-how-claude-loads-session.md) | Как Claude Code находит `CLAUDE.md`, CWD upward search, `@-include` |
 | [plugin/docs/progress-reporter-setup.md](plugin/docs/progress-reporter-setup.md) | Установка hooks в 3 шага + troubleshooting |
@@ -721,10 +730,9 @@ sudo systemctl enable --now channel-arthas.service
 
 ```bash
 cd "$WORKSPACE/.claude/dashi-plugin-claude-code"
-bun skills/doctor-dashi-plugin/scripts/doctor.ts \
-  --plugin-dir "$PWD/plugin" \
-  --settings "$WORKSPACE/.claude/settings.json" \
-  --env /etc/dashi-plugin/$AGENT/channel.env \
+# на systemd-хосте доктор сам найдёт юнит, env и сессию; --fleet проверит
+# изоляцию между агентами (порты, токены, сокеты, hooks)
+bun skills/doctor-dashi-plugin/scripts/doctor.ts --plugin-dir "$PWD/plugin" --fleet \
   --user <ваш числовой id>
 ```
 

--- a/skills/doctor-dashi-plugin/SKILL.md
+++ b/skills/doctor-dashi-plugin/SKILL.md
@@ -33,19 +33,28 @@ terminal, or another service. This is non-negotiable; see
 ### 1. Run the doctor
 
 ```bash
+# On a systemd host this is usually ALL you need — the doctor finds the
+# channel-*.service unit whose WorkingDirectory matches the plugin dir and
+# infers --env / --session / the state config from it (autodetect):
+bun skills/doctor-dashi-plugin/scripts/doctor.ts --plugin-dir <...>/plugin
+
+# Explicit flags always win over autodetect; pass them when the layout is unusual:
 bun skills/doctor-dashi-plugin/scripts/doctor.ts \
   --plugin-dir <workspace>/.claude/dashi-plugin-claude-code/plugin \
-  --settings ~/.claude/settings.json \
-  --mcp <workspace>/.claude/.mcp.json \
-  --settings-local <workspace>/.claude/settings.local.json \
+  --settings <plugin-dir>/.claude/settings.json \
+  --mcp <plugin-dir>/.mcp.json \
+  --settings-local <plugin-dir>/.claude/settings.local.json \
   --env <channel.env path> \
   --user <your numeric Telegram id> \
-  --session channel-<agent>      # only if the channel is already running
+  --session channel-<agent> \
+  --no-autodetect                # opt out of systemd unit discovery
 ```
 
 Every flag is optional — pass what you have. `--json` gives machine-readable
 output for an agent to parse. Exit code: `0` = no FAIL, `1` = at least one FAIL,
-`2` = usage error.
+`2` = usage error. Settings default to `<plugin-dir>/.claude/settings.json`
+when it exists (the session-cwd layout Claude Code actually loads hooks from),
+falling back to `~/.claude/settings.json`.
 
 **Multi-agent fleet mode** (README section 14): add `--fleet` to discover every
 `channel-*.service` unit on the host (helper units without a tmux Exec line are
@@ -60,9 +69,24 @@ before and after adding agent #2..N.
 
 The doctor checks, in order: toolchain floors (Claude Code ≥ 2.1, Bun ≥ 1.3.9,
 tmux), **workspace placement** (the #1 first-run failure — identity drift),
-settings.json hooks + token leak, **MCP comms consistency** (the latent
-silent-channel landmine), the Telegram allowlist, and live-session signals
-(welcome-prompt hang, expired auth, crash loop).
+systemd autodetect, dev-vs-runtime copy (multi-agent aware: matches the running
+server by CWD across ALL plugin processes on the host), settings selection +
+hooks + token leak, the **hook profile** (a tmux-mirror-only setup is NOT
+punished for the feeder hooks it deliberately lacks; feeders are demanded only
+when the state config enables a hook-driven status/progress surface), the
+**permission gate deep checks** (ask-relay registered next to the gate, the
+policy file the gate points at exists, `confirm_overrides` does not lift
+`sudo`/`rm -rf`, default tier, the unit carries `--permission-mode
+bypassPermissions`), **multichat** (per-chat policy parses, terminal mirror is
+DM-only — a public chat with `tmux_mirror: true` is a FAIL, every chat dir has
+a policy entry, spawn-chat-shell forwards `TMUX_PANE`), **security hygiene**
+(the hook webhook must listen on loopback ONLY — a `0.0.0.0` bind is a FAIL;
+the channel env file holding the bot token must not be world-readable; the
+user-level `~/.claude/settings.json` must be free of channel hooks), **MCP
+comms consistency** (the latent silent-channel landmine — now checked against
+the plugin-dir `.mcp.json`/`settings.local.json` by default), the Telegram
+allowlist, and live-session signals (welcome-prompt hang, expired auth, crash
+loop).
 
 ### 2. Read the result top-down and fix the first FAIL
 

--- a/skills/doctor-dashi-plugin/scripts/doctor.test.ts
+++ b/skills/doctor-dashi-plugin/scripts/doctor.test.ts
@@ -844,11 +844,29 @@ describe('checkSharedSettingsClean — invariant a outside --fleet', () => {
 describe('permission policy lint', () => {
   test('block-form confirm_overrides extracted', () => {
     const y = ['version: 1', 'confirm_overrides:', '  builtin_rules:', '    - "git push"', '    - sudo ', 'scopes: {}'].join('\n')
-    expect(extractConfirmOverrides(y)).toEqual(['git push', 'sudo'])
+    expect(extractConfirmOverrides(y)).toEqual({ rules: ['git push', 'sudo'], opaque: false })
   })
   test('inline-form confirm_overrides extracted', () => {
     const y = 'confirm_overrides:\n  builtin_rules: ["git push", "rm -rf "]\n'
-    expect(extractConfirmOverrides(y)).toEqual(['git push', 'rm -rf '])
+    expect(extractConfirmOverrides(y)).toEqual({ rules: ['git push', 'rm -rf '], opaque: false })
+  })
+  test('list items at the SAME indent as builtin_rules are read (review H1)', () => {
+    const y = 'confirm_overrides:\n  builtin_rules:\n  - "sudo "\n'
+    expect(extractConfirmOverrides(y).rules).toEqual(['sudo '])
+  })
+  test('trailing comment after an item does not corrupt the value (review H2)', () => {
+    const y = 'confirm_overrides:\n  builtin_rules:\n    - "sudo " # owner-approved?\n    - git push # narrow\n'
+    expect(extractConfirmOverrides(y).rules).toEqual(['sudo ', 'git push'])
+  })
+  test('inline list with a trailing comment still parses (review M1)', () => {
+    const y = 'confirm_overrides:\n  builtin_rules: ["sudo "] # note\n'
+    expect(extractConfirmOverrides(y).rules).toEqual(['sudo '])
+  })
+  test('flow-form confirm_overrides is OPAQUE → lint warns instead of passing (review M1)', () => {
+    const y = 'confirm_overrides: { builtin_rules: ["sudo "] }\n'
+    expect(extractConfirmOverrides(y).opaque).toBe(true)
+    const c = checkPermissionPolicy(y, '/p').find((x) => x.id === 'permission-policy-risky-override')
+    expect(c?.status).toBe('warn')
   })
   test('lifting sudo / rm -rf → FAIL; lifting only git push → pass', () => {
     const bad = 'confirm_overrides:\n  builtin_rules:\n    - "sudo "\n'
@@ -969,5 +987,83 @@ describe('matchAgentForPlugin', () => {
   })
   test('no match → null (no cross-agent false positive)', () => {
     expect(matchAgentForPlugin([agent('arthas', '/srv/a/plugin', '/srv/a/.claude')], '/srv/t/plugin')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Review-round fixes (Codex + Fable double review, 2026-06-09)
+// ---------------------------------------------------------------------------
+
+describe('review fixes — bind, env mode, mirror, stop hook, envValue, redact', () => {
+  test('[::ffff:127.0.0.1] v4-mapped loopback PASSES webhook-bind (review M4)', () => {
+    expect(checkWebhookBind('8093', [{ addr: '[::ffff:127.0.0.1]', port: '8093' }]).status).toBe('pass')
+  })
+  test('env mode: other-write/other-exec FAIL, group-write FAIL (Codex High)', () => {
+    expect(checkEnvFileMode(0o100602, '/e').status).toBe('fail') // other-write
+    expect(checkEnvFileMode(0o100601, '/e').status).toBe('fail') // other-exec
+    expect(checkEnvFileMode(0o100620, '/e').status).toBe('fail') // group-write
+    expect(checkEnvFileMode(0o100640, '/e').status).toBe('warn') // group-read only
+    expect(checkEnvFileMode(0o100600, '/e').status).toBe('pass')
+  })
+  test('group chat (negative id) with mirror and NO explicit private mode → FAIL (Codex M)', () => {
+    expect(checkMultichatMirror([{ id: '-100123', mode: null, tmuxMirror: true }]).status).toBe('fail')
+    expect(checkMultichatMirror([{ id: '-100123', mode: 'privte', tmuxMirror: true }]).status).toBe('fail') // typo ≠ private
+    expect(checkMultichatMirror([{ id: '164795011', mode: null, tmuxMirror: true }]).status).toBe('pass') // positive id = DM
+  })
+  test('mirror profile: fallback-only Stop does NOT satisfy the primary Stop hook (Codex M)', () => {
+    const fallbackOnly = { hooks: { Stop: [hookEntry('dashi-channel-fallback-reply')] } }
+    const c = checkSettingsHooks(fallbackOnly, 'mirror').find((x) => x.id === 'hook-Stop')
+    expect(c?.status).toBe('warn')
+    expect(c?.detail).toContain('fallback')
+  })
+  test('envValue strips quotes, export and trailing comments (review M3)', () => {
+    expect(envValue('TELEGRAM_WEBHOOK_PORT="8093"', 'TELEGRAM_WEBHOOK_PORT')).toBe('8093')
+    expect(envValue("export TELEGRAM_STATE_DIR='/srv/state' # note", 'TELEGRAM_STATE_DIR')).toBe('/srv/state')
+  })
+  test('redact keeps 0.0.0.0 and 127.0.0.1 visible (interface literals, review L3)', () => {
+    expect(redact('port 8091 bound to 0.0.0.0')).toContain('0.0.0.0')
+    expect(redact('bound to 127.0.0.1')).toContain('127.0.0.1')
+    expect(redact('server at 100.104.191.127')).toContain('<ip>')
+  })
+  test('shared-settings markers: generic post-hook.ts alone no longer FAILS (review L2)', () => {
+    expect(checkSharedSettingsClean('{"hooks":{"Stop":[{"command":"bun my-post-hook.ts"}]}}', false).status).toBe('pass')
+    expect(checkSharedSettingsClean('{"hooks":{"Stop":[{"marker":"dashi-channel-fallback-reply"}]}}', false).status).toBe('fail')
+  })
+  test('spawn-chat-shell: TMUX_PANE only in a comment does NOT pass (Codex M)', () => {
+    expect(checkSpawnChatShell('# we forward TMUX_PANE here\nenv -i bash').status).toBe('fail')
+    expect(checkSpawnChatShell('env -i TMUX_PANE="${TMUX_PANE:-}" bash').status).toBe('pass')
+  })
+})
+
+describe('extractChatPolicies — bleed hardening (review M2)', () => {
+  test('block scalar content cannot rewrite the chat policy', () => {
+    const y = [
+      'chats:',
+      '  "-100200":',
+      '    mode: public',
+      '    tmux_mirror: false',
+      '    system_reminder: |',
+      '      mode: private',
+      '      tmux_mirror: true',
+    ].join('\n')
+    expect(extractChatPolicies(y)).toEqual([{ id: '-100200', mode: 'public', tmuxMirror: false }])
+  })
+  test('non-numeric sibling key (default template) closes the chat — no attribution bleed', () => {
+    const y = [
+      'chats:',
+      '  "-100200":',
+      '    mode: public',
+      '    tmux_mirror: false',
+      '  default:',
+      '    mode: private',
+      '    tmux_mirror: true',
+    ].join('\n')
+    expect(extractChatPolicies(y)).toEqual([{ id: '-100200', mode: 'public', tmuxMirror: false }])
+  })
+  test('deeper-nested mode under a sub-map is ignored (exact property indent only)', () => {
+    const y = ['chats:', '  "-100200":', '    delivery: final_only', '    sub:', '      mode: private', '    tmux_mirror: false'].join('\n')
+    const p = extractChatPolicies(y)
+    expect(p[0]?.mode).toBeNull()
+    expect(p[0]?.tmuxMirror).toBe(false)
   })
 })

--- a/skills/doctor-dashi-plugin/scripts/doctor.test.ts
+++ b/skills/doctor-dashi-plugin/scripts/doctor.test.ts
@@ -21,7 +21,6 @@ import {
   detectListening,
   detectOS,
   detectWelcomeHang,
-  findEnclosingClaudeMd,
   MIN_BUN,
   MIN_CLAUDE,
   parseEnvList,
@@ -32,6 +31,23 @@ import {
   sameTree,
   worstStatus,
   type Check,
+  // 2026-06-09 deep checks (multi-agent / multichat / gate / bind / hygiene)
+  selectHookProfile,
+  resolveSettingsPath,
+  findMatchingRuntime,
+  extractEnvAssignment,
+  parseListeners,
+  checkWebhookBind,
+  checkEnvFileMode,
+  checkSharedSettingsClean,
+  extractConfirmOverrides,
+  extractTopLevelScalar,
+  checkPermissionPolicy,
+  extractChatPolicies,
+  checkMultichatMirror,
+  checkMultichatDirs,
+  checkSpawnChatShell,
+  matchAgentForPlugin,
 } from './doctor.ts'
 
 /** A settings hook entry with a runnable command (what install-hooks writes). */
@@ -640,5 +656,318 @@ describe('findEnclosingClaudeMd — relative plugin dir', () => {
     const fe = (p: string) => found.has(p)
     // grandparent of cwd holds CLAUDE.md: cwd/plugin -> cwd -> parent -> grandparent
     expect(findEnclosingClaudeMd('plugin', fe)).not.toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2026-06-09 deep checks — multi-agent, hook profiles, gate, bind, multichat
+// ---------------------------------------------------------------------------
+
+describe('selectHookProfile', () => {
+  test('status or progress reporter enabled → hook-feeders', () => {
+    expect(selectHookProfile({ status: { enabled: true } })).toBe('hook-feeders')
+    expect(selectHookProfile({ progress: { enabled: true }, tmux_mirror: { enabled: true } })).toBe('hook-feeders')
+  })
+  test('mirror only → mirror', () => {
+    expect(selectHookProfile({ tmux_mirror: { enabled: true } })).toBe('mirror')
+  })
+  test('config present, nothing enabled → none', () => {
+    expect(selectHookProfile({})).toBe('none')
+  })
+  test('missing config → unknown (conservative)', () => {
+    expect(selectHookProfile(null)).toBe('unknown')
+    expect(selectHookProfile('garbage')).toBe('unknown')
+  })
+})
+
+describe('checkSettingsHooks — profile aware', () => {
+  const stopOnly = {
+    hooks: { Stop: [hookEntry('dashi-channel-hook')] },
+  }
+  test('mirror profile: Stop-only settings produce ZERO feeder warns', () => {
+    const checks = checkSettingsHooks(stopOnly, 'mirror')
+    const feederWarns = checks.filter((c) => c.id.startsWith('hook-') && c.status === 'warn' && c.id !== 'hook-Stop')
+    expect(feederWarns).toHaveLength(0)
+    expect(checks.find((c) => c.id === 'hook-profile')?.status).toBe('pass')
+    expect(checks.find((c) => c.id === 'hook-Stop')?.status).toBe('pass')
+  })
+  test('mirror profile: missing Stop hook still warns', () => {
+    const checks = checkSettingsHooks({ hooks: {} }, 'mirror')
+    expect(checks.find((c) => c.id === 'hook-Stop')?.status).toBe('warn')
+  })
+  test('hook-feeders profile keeps demanding all five events', () => {
+    const checks = checkSettingsHooks(stopOnly, 'hook-feeders')
+    const warns = checks.filter((c) => c.status === 'warn' && /^hook-/.test(c.id))
+    expect(warns.length).toBeGreaterThanOrEqual(4) // 4 missing feeder events
+  })
+  test('unknown profile behaves conservatively (like hook-feeders) and hints at --env', () => {
+    const checks = checkSettingsHooks(stopOnly, 'unknown')
+    const warn = checks.find((c) => c.id === 'hook-SessionStart')
+    expect(warn?.status).toBe('warn')
+    expect(warn?.detail).toContain('profile unknown')
+  })
+  test('default profile is unknown (backward compatible)', () => {
+    const checks = checkSettingsHooks(stopOnly)
+    expect(checks.some((c) => c.id === 'hook-SessionStart')).toBe(true)
+  })
+})
+
+describe('resolveSettingsPath — session cwd layout first', () => {
+  test('prefers <plugin-dir>/.claude/settings.json when present', () => {
+    const r = resolveSettingsPath('/srv/agent/.claude/jc/plugin', '/home/u/.claude/settings.json', (p) => p === '/srv/agent/.claude/jc/plugin/.claude/settings.json')
+    expect(r.source).toBe('plugin-dir')
+    expect(r.path).toBe('/srv/agent/.claude/jc/plugin/.claude/settings.json')
+  })
+  test('falls back to the user-level file', () => {
+    const r = resolveSettingsPath('/srv/agent/plugin', '/home/u/.claude/settings.json', () => false)
+    expect(r.source).toBe('home')
+    expect(r.path).toBe('/home/u/.claude/settings.json')
+  })
+})
+
+describe('findMatchingRuntime — fleet host, match by CWD not by first PID', () => {
+  test('first candidate foreign, second matches → pass with others counted', () => {
+    const r = findMatchingRuntime(
+      [
+        { pid: '100', cwd: '/srv/arthas/.claude/jc/plugin' },
+        { pid: '200', cwd: '/srv/thrall/.claude/jc/plugin' },
+      ],
+      '/srv/thrall/.claude/jc/plugin',
+    )
+    expect(r.match?.pid).toBe('200')
+    expect(r.others).toBe(1)
+  })
+  test('no candidate matches → null match', () => {
+    const r = findMatchingRuntime([{ pid: '100', cwd: '/srv/other/plugin' }], '/srv/thrall/plugin')
+    expect(r.match).toBeNull()
+    expect(r.others).toBe(1)
+  })
+  test('empty cwd (unreadable /proc) never matches', () => {
+    const r = findMatchingRuntime([{ pid: '100', cwd: '' }], '/srv/thrall/plugin')
+    expect(r.match).toBeNull()
+  })
+})
+
+describe('extractEnvAssignment', () => {
+  test('single-quoted, double-quoted and bare values', () => {
+    expect(extractEnvAssignment("FOO='/a b/c.yaml' bun x.ts", 'FOO')).toBe('/a b/c.yaml')
+    expect(extractEnvAssignment('FOO="/a/c.yaml" bun x.ts', 'FOO')).toBe('/a/c.yaml')
+    expect(extractEnvAssignment('FOO=/a/c.yaml bun x.ts', 'FOO')).toBe('/a/c.yaml')
+  })
+  test('missing key → null', () => {
+    expect(extractEnvAssignment('BAR=1 bun x.ts', 'FOO')).toBeNull()
+  })
+})
+
+describe('checkPermissionGate — ask relay, policy path, unit bypass', () => {
+  const gateCmd = "TELEGRAM_PERMISSION_POLICY_PATH='/ws/chats/permission-policy.yaml' bun '/p/scripts/permission-gate-hook.ts'"
+  const gate = { marker: 'dashi-permission-gate-hook', hooks: [{ type: 'command', command: gateCmd }] }
+  const ask = { marker: 'dashi-ask-user-question-hook', hooks: [{ type: 'command', command: "bun '/p/scripts/ask-user-question-hook.ts'" }] }
+  test('gate + ask + existing policy + unit bypass → all pass', () => {
+    const checks = checkPermissionGate({ hooks: { PreToolUse: [gate, ask] } }, (p) => p === '/ws/chats/permission-policy.yaml', true)
+    expect(checks.find((c) => c.id === 'permission-gate')?.status).toBe('pass')
+    expect(checks.find((c) => c.id === 'permission-gate-ask-hook')?.status).toBe('pass')
+    expect(checks.find((c) => c.id === 'gate-policy-path')?.status).toBe('pass')
+    expect(checks.find((c) => c.id === 'permission-gate-mode')?.status).toBe('pass')
+  })
+  test('gate without the ask relay → warn (question wedges the session)', () => {
+    const checks = checkPermissionGate({ hooks: { PreToolUse: [gate] } }, () => true, true)
+    expect(checks.find((c) => c.id === 'permission-gate-ask-hook')?.status).toBe('warn')
+  })
+  test('policy path missing on disk → warn (fallback policy in force)', () => {
+    const checks = checkPermissionGate({ hooks: { PreToolUse: [gate, ask] } }, () => false, true)
+    expect(checks.find((c) => c.id === 'gate-policy-path')?.status).toBe('warn')
+  })
+  test('mode unset and no unit knowledge → warn stays (old behavior)', () => {
+    const checks = checkPermissionGate({ hooks: { PreToolUse: [gate, ask] } }, () => true, null)
+    expect(checks.find((c) => c.id === 'permission-gate-mode')?.status).toBe('warn')
+  })
+})
+
+describe('parseListeners / checkWebhookBind — loopback or nothing', () => {
+  const ss = [
+    'State  Recv-Q Send-Q Local Address:Port Peer Address:Port',
+    'LISTEN 0      512        127.0.0.1:8093      0.0.0.0:*',
+    'LISTEN 0      2048         0.0.0.0:8091      0.0.0.0:*',
+    'LISTEN 0      512            [::1]:8103         [::]:*',
+    'LISTEN 0      128                *:9000            *:*',
+  ].join('\n')
+  test('parses IPv4, bracketed IPv6 and wildcard listeners', () => {
+    const l = parseListeners(ss)
+    expect(l).toContainEqual({ addr: '127.0.0.1', port: '8093' })
+    expect(l).toContainEqual({ addr: '0.0.0.0', port: '8091' })
+    expect(l).toContainEqual({ addr: '[::1]', port: '8103' })
+    expect(l).toContainEqual({ addr: '*', port: '9000' })
+  })
+  test('loopback bind passes', () => {
+    expect(checkWebhookBind('8093', parseListeners(ss)).status).toBe('pass')
+  })
+  test('0.0.0.0 bind FAILS (network-reachable hook surface)', () => {
+    const c = checkWebhookBind('8091', parseListeners(ss))
+    expect(c.status).toBe('fail')
+    expect(c.detail).toContain('0.0.0.0')
+  })
+  test('IPv6 loopback passes, wildcard fails', () => {
+    expect(checkWebhookBind('8103', parseListeners(ss)).status).toBe('pass')
+    expect(checkWebhookBind('9000', parseListeners(ss)).status).toBe('fail')
+  })
+  test('port not listening → warn; unknown port → skip; no probe → skip', () => {
+    expect(checkWebhookBind('1234', parseListeners(ss)).status).toBe('warn')
+    expect(checkWebhookBind(null, parseListeners(ss)).status).toBe('skip')
+    expect(checkWebhookBind('8093', null).status).toBe('skip')
+  })
+})
+
+describe('checkEnvFileMode — the token file must be private', () => {
+  test('600 passes, 640 warns, 644 fails, unreadable skips', () => {
+    expect(checkEnvFileMode(0o100600, '/e').status).toBe('pass')
+    expect(checkEnvFileMode(0o100640, '/e').status).toBe('warn')
+    expect(checkEnvFileMode(0o100644, '/e').status).toBe('fail')
+    expect(checkEnvFileMode(null, '/e').status).toBe('skip')
+  })
+})
+
+describe('checkSharedSettingsClean — invariant a outside --fleet', () => {
+  test('channel markers in the user-level file → FAIL', () => {
+    const c = checkSharedSettingsClean('{"hooks":{"Stop":[{"marker":"dashi-channel-hook"}]}}', false)
+    expect(c.status).toBe('fail')
+  })
+  test('clean user-level file → pass; missing file → pass', () => {
+    expect(checkSharedSettingsClean('{"theme":"dark"}', false).status).toBe('pass')
+    expect(checkSharedSettingsClean(null, false).status).toBe('pass')
+  })
+  test('user-level file IS the inspected file → skip (legacy layout)', () => {
+    expect(checkSharedSettingsClean('{"hooks":{"Stop":[{"marker":"dashi-channel-hook"}]}}', true).status).toBe('skip')
+  })
+})
+
+describe('permission policy lint', () => {
+  test('block-form confirm_overrides extracted', () => {
+    const y = ['version: 1', 'confirm_overrides:', '  builtin_rules:', '    - "git push"', '    - sudo ', 'scopes: {}'].join('\n')
+    expect(extractConfirmOverrides(y)).toEqual(['git push', 'sudo'])
+  })
+  test('inline-form confirm_overrides extracted', () => {
+    const y = 'confirm_overrides:\n  builtin_rules: ["git push", "rm -rf "]\n'
+    expect(extractConfirmOverrides(y)).toEqual(['git push', 'rm -rf '])
+  })
+  test('lifting sudo / rm -rf → FAIL; lifting only git push → pass', () => {
+    const bad = 'confirm_overrides:\n  builtin_rules:\n    - "sudo "\n'
+    expect(checkPermissionPolicy(bad, '/p').find((c) => c.id === 'permission-policy-risky-override')?.status).toBe('fail')
+    const ok = 'confirm_overrides:\n  builtin_rules:\n    - "git push"\n'
+    expect(checkPermissionPolicy(ok, '/p').find((c) => c.id === 'permission-policy-risky-override')?.status).toBe('pass')
+  })
+  test('default_tier allow → warn; confirm → pass; unset → pass', () => {
+    expect(checkPermissionPolicy('default_tier: allow\n', '/p').find((c) => c.id === 'permission-policy-default-tier')?.status).toBe('warn')
+    expect(checkPermissionPolicy('default_tier: confirm\n', '/p').find((c) => c.id === 'permission-policy-default-tier')?.status).toBe('pass')
+    expect(checkPermissionPolicy('version: 1\n', '/p').find((c) => c.id === 'permission-policy-default-tier')?.status).toBe('pass')
+  })
+  test('empty policy file → warn; unreadable → skip', () => {
+    expect(checkPermissionPolicy('  \n', '/p')[0]?.status).toBe('warn')
+    expect(checkPermissionPolicy(null, '/p')[0]?.status).toBe('skip')
+  })
+  test('extractTopLevelScalar ignores indented and commented keys', () => {
+    expect(extractTopLevelScalar('  default_tier: allow\n', 'default_tier')).toBeNull()
+    expect(extractTopLevelScalar('default_tier: confirm # note\n', 'default_tier')).toBe('confirm')
+  })
+})
+
+describe('multichat lint', () => {
+  const policy = [
+    'version: 1',
+    'allowlist:',
+    '  chats:',
+    '    - "164795011"',
+    'chats:',
+    '  "164795011":',
+    '    mode: private',
+    '    tmux_mirror: true',
+    '  "-1003784643974":',
+    '    mode: public',
+    '    tmux_mirror: false',
+  ].join('\n')
+  test('extractChatPolicies reads mode and tmux_mirror per chat', () => {
+    const p = extractChatPolicies(policy)
+    expect(p).toHaveLength(2)
+    expect(p[0]).toEqual({ id: '164795011', mode: 'private', tmuxMirror: true })
+    expect(p[1]).toEqual({ id: '-1003784643974', mode: 'public', tmuxMirror: false })
+  })
+  test('DM mirror + public no-mirror → pass', () => {
+    expect(checkMultichatMirror(extractChatPolicies(policy)).status).toBe('pass')
+  })
+  test('public chat with tmux_mirror=true → FAIL (kitchen leaks into a group)', () => {
+    const bad = policy.replace('    mode: public\n    tmux_mirror: false', '    mode: public\n    tmux_mirror: true')
+    const c = checkMultichatMirror(extractChatPolicies(bad))
+    expect(c.status).toBe('fail')
+    expect(c.detail).toContain('-1003784643974')
+  })
+  test('chat dir without a policy entry → warn', () => {
+    const c = checkMultichatDirs(['164795011'], ['164795011', '-2000'])
+    expect(c.status).toBe('warn')
+    expect(c.detail).toContain('-2000')
+  })
+  test('all dirs covered → pass', () => {
+    expect(checkMultichatDirs(['164795011', '-2000'], ['164795011']).status).toBe('pass')
+  })
+  test('spawn-chat-shell: TMUX_PANE forwarded → pass, absent → FAIL, missing file → skip', () => {
+    expect(checkSpawnChatShell('env -i TMUX_PANE="${TMUX_PANE:-}" bash').status).toBe('pass')
+    expect(checkSpawnChatShell('env -i bash').status).toBe('fail')
+    expect(checkSpawnChatShell(null).status).toBe('skip')
+  })
+})
+
+describe('parseUnitFile — autodetect fields', () => {
+  const unit = [
+    '[Service]',
+    'EnvironmentFile=/srv/thrall/private/channel.env',
+    'WorkingDirectory=/srv/thrall/.claude/jc/plugin',
+    `ExecStart=/usr/bin/tmux -L channel-thrall new-session -d -s channel-thrall 'claude --model fable --permission-mode bypassPermissions server:dashi-channel'`,
+    `ExecStop=/usr/bin/tmux -L channel-thrall kill-session -t channel-thrall`,
+  ].join('\n')
+  test('reads WorkingDirectory, session name and bypassPermissions', () => {
+    const p = parseUnitFile(unit)
+    expect(p.workingDirectory).toBe('/srv/thrall/.claude/jc/plugin')
+    expect(p.sessionName).toBe('channel-thrall')
+    expect(p.bypassPermissions).toBe(true)
+    expect(p.sockets).toEqual(['channel-thrall'])
+  })
+  test('no bypass flag → false; no -s → null session', () => {
+    const p = parseUnitFile("ExecStart=/usr/bin/tmux new-session -d 'claude server:x'")
+    expect(p.bypassPermissions).toBe(false)
+    expect(p.sessionName).toBeNull()
+  })
+  test('session name is read from tmux argv, not from the quoted payload', () => {
+    const p = parseUnitFile(`ExecStart=/usr/bin/tmux new-session -d -s real 'claude -s fake server:x'`)
+    expect(p.sessionName).toBe('real')
+  })
+})
+
+describe('matchAgentForPlugin', () => {
+  const agent = (name: string, wd: string | null, ws: string | null): FleetAgent => ({
+    name,
+    unitPath: `/etc/systemd/system/channel-${name}.service`,
+    sockets: [`channel-${name}`],
+    envPath: null,
+    envReadable: false,
+    port: null,
+    tokenDigest: null,
+    stateDir: null,
+    workspaceRoot: ws,
+    webhookEnabled: null,
+    hookPorts: [],
+    settingsPath: null,
+    workingDirectory: wd,
+    sessionName: `channel-${name}`,
+    bypassPermissions: false,
+  })
+  test('matches by WorkingDirectory first', () => {
+    const a = matchAgentForPlugin([agent('arthas', '/srv/a/plugin', null), agent('thrall', '/srv/t/plugin', null)], '/srv/t/plugin')
+    expect(a?.name).toBe('thrall')
+  })
+  test('falls back to workspace root containment', () => {
+    const a = matchAgentForPlugin([agent('thrall', null, '/srv/t/.claude')], '/srv/t/.claude/jc/plugin')
+    expect(a?.name).toBe('thrall')
+  })
+  test('no match → null (no cross-agent false positive)', () => {
+    expect(matchAgentForPlugin([agent('arthas', '/srv/a/plugin', '/srv/a/.claude')], '/srv/t/plugin')).toBeNull()
   })
 })

--- a/skills/doctor-dashi-plugin/scripts/doctor.ts
+++ b/skills/doctor-dashi-plugin/scripts/doctor.ts
@@ -117,8 +117,10 @@ export function redact(input: string): string {
   return redactSecretsStrict(input)
     // Privacy-only masking (NOT a secret): server IPs in output shown to
     // public groups. Kept out of redactSecretsStrict so the leak check
-    // doesn't false-positive on the loopback webhook URL.
-    .replace(/\b(\d{1,3}\.){3}\d{1,3}\b/g, '<ip>')
+    // doesn't false-positive on the loopback webhook URL. 0.0.0.0 and
+    // 127.0.0.0/8 are exempt — they identify interfaces, not servers, and
+    // masking them strips the actionable part of the webhook-bind FAIL.
+    .replace(/\b(?!0\.0\.0\.0\b)(?!127\.)(\d{1,3}\.){3}\d{1,3}\b/g, '<ip>')
 }
 
 /** Redact every string field of a check — the single boundary for safe output. */
@@ -345,7 +347,10 @@ export function checkSettingsHooks(settings: unknown, profile: HookProfile = 'un
   } else {
     // mirror / none profile: feeder hooks are NOT required — the tmux mirror
     // (or nothing) carries progress. Only the Stop delivery hook matters.
-    const stopWorking = hasWorkingHook(stopEntries, HOOK_MARKER) || hasWorkingHook(stopEntries, FALLBACK_MARKER)
+    // The fallback hook is a separate safety net and must NOT mask a missing
+    // primary Stop hook (it has its own check below).
+    const stopWorking = hasWorkingHook(stopEntries, HOOK_MARKER)
+    const fallbackOnly = !stopWorking && hasWorkingHook(stopEntries, FALLBACK_MARKER)
     out.push({
       id: 'hook-profile',
       title: `Hook profile: ${profile} (feeder hooks not required)`,
@@ -359,7 +364,7 @@ export function checkSettingsHooks(settings: unknown, profile: HookProfile = 'un
             id: 'hook-Stop',
             title: 'Hook registered: Stop (final-reply delivery)',
             status: 'warn',
-            detail: 'no Stop hook — read receipts and the silent-turn fallback never fire',
+            detail: fallbackOnly ? 'only the fallback-reply Stop hook is registered — the primary Stop delivery (read receipt) hook is missing' : 'no Stop hook — read receipts and the silent-turn fallback never fire',
             fix: 'run plugin/scripts/install-hooks.sh to register the Stop hook',
           },
     )
@@ -704,7 +709,10 @@ export function parseListeners(text: string): Listener[] {
   return out
 }
 
-const LOOPBACK_ADDR_RE = /^(127\.|\[::1\]$)/
+// 127.0.0.0/8, [::1], and the v4-mapped loopback form ([::ffff:127.0.0.1])
+// that ss/lsof emit for dual-stack sockets — a false security FAIL on a
+// legitimate loopback bind trains operators to ignore the check.
+const LOOPBACK_ADDR_RE = /^(127\.|\[::1\]$|\[::ffff:127\.)/
 
 /**
  * The plugin's hook webhook must listen on loopback ONLY. A 0.0.0.0 / public
@@ -743,8 +751,14 @@ export function checkEnvFileMode(mode: number | null, path: string): Check {
   const title = 'Channel env file is private (token inside)'
   if (mode === null) return { id, title, status: 'skip', detail: `cannot stat ${path}` }
   const bits = mode & 0o777
-  if (bits & 0o004) {
-    return { id, title, status: 'fail', detail: `${path} is world-readable (mode ${bits.toString(8)})`, fix: 'chmod 600 the env file — it holds the bot token' }
+  // ANY other-access fails (write is config injection on the next restart,
+  // read is token theft), and group-WRITE fails too — only group-read is a
+  // warn (sometimes a deliberate ops-group share).
+  if (bits & 0o007) {
+    return { id, title, status: 'fail', detail: `${path} is world-accessible (mode ${bits.toString(8)})`, fix: 'chmod 600 the env file — it holds the bot token and is sourced by the service' }
+  }
+  if (bits & 0o020) {
+    return { id, title, status: 'fail', detail: `${path} is group-writable (mode ${bits.toString(8)})`, fix: 'chmod 600 — a group member can inject config the service loads on restart' }
   }
   if (bits & 0o040) {
     return { id, title, status: 'warn', detail: `${path} is group-readable (mode ${bits.toString(8)})`, fix: 'chmod 600 unless the group share is deliberate' }
@@ -752,7 +766,9 @@ export function checkEnvFileMode(mode: number | null, path: string): Check {
   return { id, title, status: 'pass', detail: `mode ${bits.toString(8)}` }
 }
 
-const CHANNEL_HOOK_MARKERS_RE = /dashi-channel-hook|dashi-permission-gate-hook|dashi-ask-user-question-hook|post-hook\.ts|read-receipt-hook\.ts|fallback-reply-hook\.ts|permission-gate-hook\.ts/
+// Dashi-specific markers only: generic filenames like `post-hook.ts` belong
+// to anybody and made an unrelated tool's hook a hard FAIL (review L2).
+const CHANNEL_HOOK_MARKERS_RE = /dashi-channel-hook|dashi-permission-gate-hook|dashi-ask-user-question-hook|dashi-channel-fallback-reply/
 
 /**
  * Channel hooks in the USER-level ~/.claude/settings.json fire in EVERY
@@ -786,25 +802,47 @@ export function checkSharedSettingsClean(homeRaw: string | null, selectedIsHome:
 /** Built-in confirm rules that must NEVER be lifted via confirm_overrides. */
 export const DANGEROUS_OVERRIDE_RULES: readonly string[] = ['sudo ', 'rm -rf ', 'rm -fr ']
 
+/**
+ * One YAML scalar item: quoted → cut at the closing quote (a `#` inside quotes
+ * is data); bare → strip the ` # comment` tail. A trailing comment used to
+ * corrupt the value (`"sudo " # note` ≠ 'sudo ') and silently pass the lint.
+ */
+function yamlScalar(raw: string): string {
+  const s = raw.trim()
+  const quoted = s.match(/^(["'])(.*?)\1/)
+  if (quoted?.[2] !== undefined) return quoted[2]
+  return s.replace(/\s+#.*$/, '').trim()
+}
+
+export interface OverridesExtract {
+  rules: string[]
+  /** confirm_overrides present but in a form the extractor cannot read (flow map etc.). */
+  opaque: boolean
+}
+
 /** Items of `confirm_overrides: { builtin_rules: [...] }` — block or inline form. */
-export function extractConfirmOverrides(policyText: string): string[] {
+export function extractConfirmOverrides(policyText: string): OverridesExtract {
   const lines = policyText.split('\n')
-  const out: string[] = []
+  const rules: string[] = []
+  let opaque = false
   let inOverrides = false
   let inRules = false
   let rulesIndent = 0
   for (const line of lines) {
     if (/^\s*#/.test(line)) continue
-    const overrides = line.match(/^(\s*)confirm_overrides:\s*$/)
+    const overrides = line.match(/^(\s*)confirm_overrides:\s*(\S.*)?$/)
     if (overrides) {
-      inOverrides = true
+      // `confirm_overrides: { ... }` (flow form) — the line-based extractor
+      // cannot read it; a silent pass would invert the lint, so mark opaque.
+      if (overrides[2] !== undefined && overrides[2].trim() !== '') opaque = true
+      inOverrides = overrides[2] === undefined || overrides[2].trim() === ''
       inRules = false
       continue
     }
     if (inOverrides) {
-      const inline = line.match(/^\s*builtin_rules:\s*\[(.*)\]\s*$/)
+      const inline = line.match(/^\s*builtin_rules:\s*\[(.*)\]\s*(#.*)?$/)
       if (inline?.[1] !== undefined) {
-        out.push(...inline[1].split(',').map((s) => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean))
+        rules.push(...inline[1].split(',').map(yamlScalar).filter(Boolean))
         inOverrides = false
         continue
       }
@@ -814,10 +852,20 @@ export function extractConfirmOverrides(policyText: string): string[] {
         rulesIndent = (block[1] ?? '').length
         continue
       }
+      // builtin_rules with an unreadable payload on the same line.
+      if (/^\s*builtin_rules:/.test(line)) {
+        opaque = true
+        inOverrides = false
+        continue
+      }
       if (inRules) {
         const item = line.match(/^(\s*)-\s*(.+?)\s*$/)
-        if (item && (item[1] ?? '').length > rulesIndent) {
-          out.push((item[2] ?? '').replace(/^["']|["']$/g, ''))
+        // YAML allows list items at the key's OWN indent (`builtin_rules:` /
+        // `- "sudo "` at the same column) — `>` missed them and the sudo lint
+        // silently passed. A sibling key cannot match the `- ` regex, so >= is safe.
+        if (item && (item[1] ?? '').length >= rulesIndent) {
+          const v = yamlScalar(item[2] ?? '')
+          if (v) rules.push(v)
           continue
         }
         if (line.trim() !== '') {
@@ -829,7 +877,7 @@ export function extractConfirmOverrides(policyText: string): string[] {
       }
     }
   }
-  return out
+  return { rules, opaque }
 }
 
 /** First top-level `key: value` scalar in the policy text. */
@@ -846,19 +894,27 @@ export function checkPermissionPolicy(policyText: string | null, policyPath: str
   if (policyText.trim() === '') {
     return [{ id: 'permission-policy', title: 'Permission policy lint', status: 'warn', detail: `${policyPath} is empty — the gate falls back to confirm-everything`, fix: 'write a policy or remove the env override' }]
   }
-  const overrides = extractConfirmOverrides(policyText)
+  const { rules: overrides, opaque } = extractConfirmOverrides(policyText)
   const dangerous = overrides.filter((o) => DANGEROUS_OVERRIDE_RULES.some((d) => o === d || o === d.trim()))
-  out.push(
-    dangerous.length > 0
-      ? {
-          id: 'permission-policy-risky-override',
-          title: 'confirm_overrides does not lift sudo / rm -rf',
-          status: 'fail',
-          detail: `confirm_overrides lifts catastrophic rule(s): ${dangerous.join(', ')} — these must always reach the owner`,
-          fix: 'remove sudo / rm -rf from confirm_overrides.builtin_rules; override only narrow rules like git push',
-        }
-      : { id: 'permission-policy-risky-override', title: 'confirm_overrides does not lift sudo / rm -rf', status: 'pass', detail: overrides.length > 0 ? `overrides: ${overrides.join(', ')}` : 'no confirm_overrides' },
-  )
+  if (dangerous.length > 0) {
+    out.push({
+      id: 'permission-policy-risky-override',
+      title: 'confirm_overrides does not lift sudo / rm -rf',
+      status: 'fail',
+      detail: `confirm_overrides lifts catastrophic rule(s): ${dangerous.join(', ')} — these must always reach the owner`,
+      fix: 'remove sudo / rm -rf from confirm_overrides.builtin_rules; override only narrow rules like git push',
+    })
+  } else if (opaque) {
+    out.push({
+      id: 'permission-policy-risky-override',
+      title: 'confirm_overrides does not lift sudo / rm -rf',
+      status: 'warn',
+      detail: 'confirm_overrides is present in a form this lint cannot read (flow/one-line YAML) — review it by hand',
+      fix: 'use the block form (confirm_overrides: / builtin_rules: / - "rule") so the doctor can lint it',
+    })
+  } else {
+    out.push({ id: 'permission-policy-risky-override', title: 'confirm_overrides does not lift sudo / rm -rf', status: 'pass', detail: overrides.length > 0 ? `overrides: ${overrides.join(', ')}` : 'no confirm_overrides' })
+  }
   const tier = extractTopLevelScalar(policyText, 'default_tier')
   out.push(
     tier === 'allow'
@@ -883,7 +939,16 @@ export interface ChatPolicy {
   tmuxMirror: boolean | null
 }
 
-/** Extract per-chat `mode:` and `tmux_mirror:` from the chats: block. */
+/**
+ * Extract per-chat `mode:` and `tmux_mirror:` from the chats: block.
+ * Hardened against two bleed bugs (review M2):
+ *   - block scalars (`system_reminder: |`) — their content lines could parse
+ *     as `mode:`/`tmux_mirror:` and rewrite the chat's policy;
+ *   - non-numeric sibling keys (`default:` templates) — their properties were
+ *     attributed to the PREVIOUS numeric chat.
+ * Properties are accepted only at the exact indent of the chat's first
+ * property, and only while no block scalar is open.
+ */
 export function extractChatPolicies(policyText: string): ChatPolicy[] {
   const lines = policyText.split('\n')
   const out: ChatPolicy[] = []
@@ -891,9 +956,18 @@ export function extractChatPolicies(policyText: string): ChatPolicy[] {
   let chatsIndent = 0
   let current: ChatPolicy | null = null
   let currentIndent = 0
+  /** Indent of the current chat's first property; -1 = not seen yet. */
+  let propIndent = -1
+  /** When >= 0, we are inside a block scalar opened at this key indent. */
+  let scalarIndent = -1
   for (const line of lines) {
     if (/^\s*#/.test(line) || line.trim() === '') continue
     const indent = (line.match(/^(\s*)/)?.[1] ?? '').length
+    // Inside a block scalar: skip every deeper-indented content line.
+    if (scalarIndent >= 0) {
+      if (indent > scalarIndent) continue
+      scalarIndent = -1
+    }
     // Leaving the current block? The very same line may OPEN the real
     // top-level chats: block (allowlist.chats: came first in the file), so
     // fall through to the open-check instead of consuming the line.
@@ -915,26 +989,46 @@ export function extractChatPolicies(policyText: string): ChatPolicy[] {
       if (current) out.push(current)
       current = { id: chatKey[2] ?? '', mode: null, tmuxMirror: null }
       currentIndent = (chatKey[1] ?? '').length
+      propIndent = -1
+      continue
+    }
+    // A non-numeric sibling key at chat level (e.g. a `default:` template)
+    // closes the current chat — its properties are NOT the chat's.
+    if (current && indent <= currentIndent && /^\s*\S+:\s*/.test(line)) {
+      out.push(current)
+      current = null
       continue
     }
     if (current) {
-      const mode = line.match(/^\s*mode:\s*["']?(\w+)["']?/)
-      if (mode) current.mode = mode[1] ?? null
-      const mirror = line.match(/^\s*tmux_mirror:\s*(true|false)/)
-      if (mirror) current.tmuxMirror = mirror[1] === 'true'
+      if (propIndent === -1) propIndent = indent
+      if (indent === propIndent) {
+        const mode = line.match(/^\s*mode:\s*["']?(\w+)["']?\s*(#.*)?$/)
+        if (mode) current.mode = mode[1] ?? null
+        const mirror = line.match(/^\s*tmux_mirror:\s*(true|false)\s*(#.*)?$/)
+        if (mirror) current.tmuxMirror = mirror[1] === 'true'
+      }
+      // A key opening a block scalar (`reminder: |` / `note: >-`): skip its body.
+      if (/:\s*[|>][+-]?\s*$/.test(line)) scalarIndent = indent
     }
   }
   if (current) out.push(current)
   return out
 }
 
-/** Mirror is DM-only: a public chat with tmux_mirror=true leaks the terminal. */
+/**
+ * Mirror is DM-only: a public chat with tmux_mirror=true leaks the terminal.
+ * A NEGATIVE chat id is a group/channel by Telegram convention — mirror on a
+ * group fails even when `mode:` is missing or misspelled (a typo must not
+ * disable a security invariant); only an explicit `mode: private` is trusted.
+ */
 export function checkMultichatMirror(policies: ChatPolicy[]): Check {
   const id = 'multichat-dm-mirror'
   const title = 'Terminal mirror is DM-only (public chats: no mirror)'
-  const leaking = policies.filter((p) => p.mode === 'public' && p.tmuxMirror === true)
+  const leaking = policies.filter(
+    (p) => p.tmuxMirror === true && (p.mode === 'public' || (p.id.startsWith('-') && p.mode !== 'private')),
+  )
   if (leaking.length > 0) {
-    return { id, title, status: 'fail', detail: `public chat(s) with tmux_mirror=true: ${leaking.map((p) => p.id).join(', ')} — the terminal (paths, repos, tool output) streams into a group`, fix: 'set tmux_mirror: false for every mode: public chat' }
+    return { id, title, status: 'fail', detail: `group/public chat(s) with tmux_mirror=true: ${leaking.map((p) => p.id).join(', ')} — the terminal (paths, repos, tool output) streams into a group`, fix: 'set tmux_mirror: false for every group/public chat' }
   }
   return { id, title, status: 'pass', detail: `${policies.length} chat polic(ies), no public mirror` }
 }
@@ -951,14 +1045,19 @@ export function checkMultichatDirs(policyIds: string[], dirIds: string[]): Check
   return { id, title, status: 'pass', detail: `${dirIds.length} chat dir(s), all covered` }
 }
 
-/** PR #32 regression guard: spawn-chat-shell must forward TMUX_PANE through env -i. */
+/**
+ * PR #32 regression guard: spawn-chat-shell must FORWARD TMUX_PANE through the
+ * env -i wipe. Require an actual assignment (`TMUX_PANE=...`) outside a
+ * comment — a mention in prose must not satisfy a regression guard.
+ */
 export function checkSpawnChatShell(scriptText: string | null): Check {
   const id = 'spawn-chat-shell-tmux-pane'
   const title = 'spawn-chat-shell forwards TMUX_PANE'
   if (scriptText === null) return { id, title, status: 'skip', detail: 'spawn-chat-shell.sh not found (multichat shells not in use)' }
-  return /TMUX_PANE/.test(scriptText)
+  const forwards = scriptText.split('\n').some((l) => /TMUX_PANE=/.test(l.replace(/#.*$/, '')))
+  return forwards
     ? { id, title, status: 'pass', detail: 'TMUX_PANE forwarding present' }
-    : { id, title, status: 'fail', detail: 'no TMUX_PANE in spawn-chat-shell.sh — the per-chat inbox watcher silently dies (PR #32 regression)', fix: 'forward TMUX and TMUX_PANE through the env -i wipe' }
+    : { id, title, status: 'fail', detail: 'no TMUX_PANE= assignment in spawn-chat-shell.sh — the per-chat inbox watcher silently dies (PR #32 regression)', fix: 'forward TMUX and TMUX_PANE through the env -i wipe' }
 }
 
 /**
@@ -1186,11 +1285,21 @@ export function parseUnitFile(text: string): ParsedUnit {
   return { envPath, sockets: [...sockets], workingDirectory, sessionName, bypassPermissions }
 }
 
-/** First value of KEY=... in env-file text. Pure. */
+/**
+ * First value of KEY=... in env-file text. Pure. Strips `export `, surrounding
+ * quotes and trailing ` # comments` the same way parseEnvList does — systemd's
+ * EnvironmentFile accepts `KEY="value"`, and the raw quotes broke the
+ * webhook-port and state-dir lookups (false "nothing listens" / profile=unknown).
+ */
 export function envValue(envText: string, key: string): string | null {
   for (const line of envText.split('\n')) {
-    const m = line.match(new RegExp(`^\\s*${key}=(.*)$`))
-    if (m) return (m[1] ?? '').trim() || null
+    const m = line.match(new RegExp(`^\\s*(?:export\\s+)?${key}=(.*)$`))
+    if (m) {
+      let v = (m[1] ?? '').trim()
+      v = v.replace(/\s+#.*$/, '').trim()
+      v = v.replace(/^["']|["']$/g, '')
+      return v || null
+    }
   }
   return null
 }
@@ -1288,7 +1397,7 @@ export function checkFleet(agents: FleetAgent[], sharedSettingsRaw: string | nul
     out.push({ id: 'fleet-sockets', title: 'Dedicated tmux socket per unit', status: 'pass', detail: agents.map((a) => `${a.name}:${socketOf(a) === '' ? '<default>' : socketOf(a)}`).join(', ') })
   }
 
-  const sharedDirty = sharedSettingsRaw != null && /dashi-channel-hook|post-hook\.ts|read-receipt-hook\.ts|fallback-reply-hook\.ts/.test(sharedSettingsRaw)
+  const sharedDirty = sharedSettingsRaw != null && CHANNEL_HOOK_MARKERS_RE.test(sharedSettingsRaw)
   out.push(
     sharedDirty
       ? { id: 'fleet-shared-settings', title: 'Shared ~/.claude/settings.json free of channel hooks', status: 'fail', detail: 'channel hooks found in the user-level settings — they fire in EVERY agent session and route through one agent\'s bot/port', fix: 'move channel hooks into each agent\'s <workspace>/.claude/settings.json (invariant a)' }
@@ -1648,6 +1757,19 @@ function gatherChecks(opts: Options): Check[] {
   // host (fleet invariant a) — checked always now, not only under --fleet.
   checks.push(checkSharedSettingsClean(readFileSafe(join(homedir(), '.claude', 'settings.json')), selectedIsHome))
 
+  // No env source at all (launchd host, no matching unit, no --env): the
+  // env-dependent checks below (webhook bind, env mode, allowlist, profile)
+  // silently don't run — leave a breadcrumb instead of false confidence.
+  if (!opts.envPath) {
+    checks.push({
+      id: 'env-unknown',
+      title: 'Channel env located',
+      status: 'skip',
+      detail: 'no channel.env found (no --env, no matching systemd unit — launchd hosts are not autodetected yet) — webhook bind, env-file mode, allowlist and hook profile are NOT checked',
+      fix: 'pass --env <channel.env path> to enable the env-dependent checks',
+    })
+  }
+
   // Hook profile: read the state config (env → TELEGRAM_STATE_DIR → config.json)
   // BEFORE judging hook registration, so a mirror-only setup is not punished
   // for the feeder hooks it deliberately does not have.
@@ -1801,8 +1923,17 @@ function gatherChecks(opts: Options): Check[] {
     // fails, retry on the convention socket before declaring the session dead.
     let cap = probe('tmux', ['capture-pane', '-t', opts.tmuxSession, '-p', '-S', '-200'])
     if (cap.code !== 0) {
-      const socketCap = probe('tmux', ['-L', opts.tmuxSession, 'capture-pane', '-t', opts.tmuxSession, '-p', '-S', '-200'])
-      if (socketCap.code === 0) cap = socketCap
+      // Prefer the REAL socket parsed from the matched unit (socket name and
+      // session name can differ — `-L channel-arthas … -s main` gave a false
+      // "session not found" when we only retried the convention socket).
+      const socketNames = [...new Set([unitAgent?.sockets[0], opts.tmuxSession].filter((s): s is string => !!s))]
+      for (const sock of socketNames) {
+        const socketCap = probe('tmux', ['-L', sock, 'capture-pane', '-t', opts.tmuxSession, '-p', '-S', '-200'])
+        if (socketCap.code === 0) {
+          cap = socketCap
+          break
+        }
+      }
     }
     const text = `${cap.stdout}\n${cap.stderr}`
     if (cap.code !== 0 || detectCrashLoop(text)) {

--- a/skills/doctor-dashi-plugin/scripts/doctor.ts
+++ b/skills/doctor-dashi-plugin/scripts/doctor.ts
@@ -16,7 +16,7 @@
  */
 import { spawnSync } from 'child_process'
 import { createHash } from 'crypto'
-import { existsSync, readFileSync, readdirSync } from 'fs'
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs'
 import { dirname, join, resolve } from 'path'
 import { homedir, platform } from 'os'
 
@@ -55,7 +55,22 @@ export const FALLBACK_MARKER = 'dashi-channel-fallback-reply'
 // Permission-gate PreToolUse hook marker (2026-06-09). Written by
 // patch-claude-settings.ts when --permission-gate-helper is given.
 export const GATE_MARKER = 'dashi-permission-gate-hook'
+// AskUserQuestion relay hook — pairs with the gate so questions reach Telegram.
+export const ASK_MARKER = 'dashi-ask-user-question-hook'
 export const LIVE_MARKER = 'Listening for channel messages from: server:dashi-channel'
+
+/**
+ * Hook profile (2026-06-09). The 5-event feeder set is only REQUIRED when a
+ * hook-driven progress surface (status / progress reporter) is enabled in the
+ * state config. The modern minimal profile is "mirror": the tmux terminal
+ * mirror carries progress, and only the Stop delivery hook (plus the optional
+ * permission gate pair) is needed. Demanding all 5 events on a mirror-profile
+ * host produced 3 false WARNs on every correctly configured agent.
+ */
+export type HookProfile = 'hook-feeders' | 'mirror' | 'none' | 'unknown'
+
+/** Feeder events — required only in the hook-feeders profile. */
+export const FEEDER_HOOK_EVENTS = ['SessionStart', 'UserPromptSubmit', 'PreToolUse', 'PostToolUse'] as const
 
 // ---------------------------------------------------------------------------
 // Pure helpers (unit-tested)
@@ -260,11 +275,27 @@ function hasWorkingHook(entries: SettingsHookEntry[], marker: string): boolean {
 }
 
 /**
- * Verify the five channel hook events are registered with a runnable command,
- * and that no secret ever leaked into settings.json (the patcher refuses to
- * write the webhook token; anything secret-shaped here is about to be committed).
+ * Map the channel state config to the hook profile in force.
+ *   - status/progress reporter enabled → 'hook-feeders' (all 5 events needed);
+ *   - tmux_mirror enabled (and no hook reporter) → 'mirror' (Stop only);
+ *   - config present, nothing enabled → 'none' (Stop only — final replies still ship);
+ *   - config missing/unreadable → 'unknown' (conservative: demand all 5).
  */
-export function checkSettingsHooks(settings: unknown): Check[] {
+export function selectHookProfile(stateConfig: unknown): HookProfile {
+  if (stateConfig === null || typeof stateConfig !== 'object') return 'unknown'
+  const cfg = stateConfig as Record<string, { enabled?: boolean } | undefined>
+  if (cfg['status']?.enabled === true || cfg['progress']?.enabled === true) return 'hook-feeders'
+  if (cfg['tmux_mirror']?.enabled === true) return 'mirror'
+  return 'none'
+}
+
+/**
+ * Verify the channel hook events required by the active profile are registered
+ * with a runnable command, and that no secret ever leaked into settings.json
+ * (the patcher refuses to write the webhook token; anything secret-shaped here
+ * is about to be committed).
+ */
+export function checkSettingsHooks(settings: unknown, profile: HookProfile = 'unknown'): Check[] {
   const out: Check[] = []
   const raw = JSON.stringify(settings ?? {})
   // Shape-based leak detection: if SECRET-class redaction changes the
@@ -291,26 +322,51 @@ export function checkSettingsHooks(settings: unknown): Check[] {
   )
 
   const hooks = (settings as SettingsShape)?.hooks ?? {}
-  for (const ev of REQUIRED_HOOK_EVENTS) {
-    const entries = Array.isArray(hooks[ev]) ? hooks[ev] : []
-    const working = hasWorkingHook(entries, HOOK_MARKER)
-    const markerOnly = !working && JSON.stringify(entries).includes(HOOK_MARKER)
+  const stopEntries = Array.isArray(hooks['Stop']) ? hooks['Stop'] : []
+  const feederRequired = profile === 'hook-feeders' || profile === 'unknown'
+
+  if (feederRequired) {
+    for (const ev of REQUIRED_HOOK_EVENTS) {
+      const entries = Array.isArray(hooks[ev]) ? hooks[ev] : []
+      const working = hasWorkingHook(entries, HOOK_MARKER)
+      const markerOnly = !working && JSON.stringify(entries).includes(HOOK_MARKER)
+      out.push(
+        working
+          ? { id: `hook-${ev}`, title: `Hook registered: ${ev}`, status: 'pass', detail: `marker ${HOOK_MARKER} with a runnable command` }
+          : {
+              id: `hook-${ev}`,
+              title: `Hook registered: ${ev}`,
+              status: 'warn',
+              detail: markerOnly ? `${ev} has a ${HOOK_MARKER} entry but no runnable command` : `no ${HOOK_MARKER} entry for ${ev}${profile === 'unknown' ? ' (profile unknown — pass --env so the doctor can read the state config)' : ''}`,
+              fix: 'run plugin/scripts/install-hooks.sh to register status + memory hooks',
+            },
+      )
+    }
+  } else {
+    // mirror / none profile: feeder hooks are NOT required — the tmux mirror
+    // (or nothing) carries progress. Only the Stop delivery hook matters.
+    const stopWorking = hasWorkingHook(stopEntries, HOOK_MARKER) || hasWorkingHook(stopEntries, FALLBACK_MARKER)
+    out.push({
+      id: 'hook-profile',
+      title: `Hook profile: ${profile} (feeder hooks not required)`,
+      status: 'pass',
+      detail: `state config enables no hook-driven progress surface — SessionStart/UserPromptSubmit/PostToolUse feeders are optional`,
+    })
     out.push(
-      working
-        ? { id: `hook-${ev}`, title: `Hook registered: ${ev}`, status: 'pass', detail: `marker ${HOOK_MARKER} with a runnable command` }
+      stopWorking
+        ? { id: 'hook-Stop', title: 'Hook registered: Stop (final-reply delivery)', status: 'pass', detail: 'a runnable Stop hook is registered' }
         : {
-            id: `hook-${ev}`,
-            title: `Hook registered: ${ev}`,
+            id: 'hook-Stop',
+            title: 'Hook registered: Stop (final-reply delivery)',
             status: 'warn',
-            detail: markerOnly ? `${ev} has a ${HOOK_MARKER} entry but no runnable command` : `no ${HOOK_MARKER} entry for ${ev}`,
-            fix: 'run plugin/scripts/install-hooks.sh to register status + memory hooks',
+            detail: 'no Stop hook — read receipts and the silent-turn fallback never fire',
+            fix: 'run plugin/scripts/install-hooks.sh to register the Stop hook',
           },
     )
   }
 
   // DM fallback-reply (PR #47) — optional but recommended: guarantees the chief
   // gets an answer even when the agent forgets to call the reply tool.
-  const stopEntries = Array.isArray(hooks['Stop']) ? hooks['Stop'] : []
   out.push(
     hasWorkingHook(stopEntries, FALLBACK_MARKER)
       ? { id: 'fallback-reply-hook', title: 'DM fallback-reply Stop-hook (PR #47)', status: 'pass', detail: 'silent-turn fallback is registered' }
@@ -340,7 +396,12 @@ interface SettingsPermShape {
  *   - the session is (or claims to be) in bypassPermissions — the gate is the
  *     SOLE authority only in that mode; otherwise native prompts still wedge.
  */
-export function checkPermissionGate(settings: unknown): Check[] {
+export function checkPermissionGate(
+  settings: unknown,
+  fileExists: (p: string) => boolean = existsSync,
+  /** True when the supervising unit's ExecStart carries --permission-mode bypassPermissions. */
+  unitBypass: boolean | null = null,
+): Check[] {
   const s = (settings as SettingsPermShape) ?? {}
   const pre = Array.isArray(s.hooks?.PreToolUse) ? s.hooks!.PreToolUse! : []
   const gate = pre.find((e) => e.marker === GATE_MARKER)
@@ -382,18 +443,69 @@ export function checkPermissionGate(settings: unknown): Check[] {
   // explicit settings.permissions.defaultMode but the flag is usually on the
   // CLI/systemd ExecStart, so a non-match is unverified, not a hard fail.
   const mode = s.permissions?.defaultMode
+  if (mode === 'bypassPermissions') {
+    out.push({ id: 'permission-gate-mode', title: 'Permission gate: session in bypassPermissions', status: 'pass', detail: 'permissions.defaultMode=bypassPermissions' })
+  } else if (mode === undefined && unitBypass === true) {
+    // The flag usually rides on the unit's ExecStart, not in settings — when
+    // the supervising unit carries it, an unset defaultMode is the normal
+    // layout, not a gap.
+    out.push({ id: 'permission-gate-mode', title: 'Permission gate: session in bypassPermissions', status: 'pass', detail: '--permission-mode bypassPermissions on the unit ExecStart' })
+  } else {
+    out.push({
+      id: 'permission-gate-mode',
+      title: 'Permission gate: session in bypassPermissions',
+      status: 'warn',
+      detail: mode ? `permissions.defaultMode=${mode} (not bypassPermissions)` : 'permissions.defaultMode unset in settings — verify the session runs with --permission-mode bypassPermissions',
+      fix: 'the gate only suppresses native prompts under bypassPermissions; otherwise interactive prompts still wedge the headless session',
+    })
+  }
+
+  // AskUserQuestion relay must ride along with the gate: under
+  // bypassPermissions a bare AskUserQuestion renders in a pane nobody watches,
+  // so without the relay the session silently hangs on the first question.
+  const ask = pre.find((e) => e.marker === ASK_MARKER)
+  const askWorking = ask !== undefined && entryCommands(ask).some((c) => c.includes('ask-user-question-hook.ts'))
   out.push(
-    mode === 'bypassPermissions'
-      ? { id: 'permission-gate-mode', title: 'Permission gate: session in bypassPermissions', status: 'pass', detail: 'permissions.defaultMode=bypassPermissions' }
+    askWorking
+      ? { id: 'permission-gate-ask-hook', title: 'AskUserQuestion relay next to the gate', status: 'pass', detail: `${ASK_MARKER} registered on PreToolUse` }
       : {
-          id: 'permission-gate-mode',
-          title: 'Permission gate: session in bypassPermissions',
+          id: 'permission-gate-ask-hook',
+          title: 'AskUserQuestion relay next to the gate',
           status: 'warn',
-          detail: mode ? `permissions.defaultMode=${mode} (not bypassPermissions)` : 'permissions.defaultMode unset in settings — verify the session runs with --permission-mode bypassPermissions',
-          fix: 'the gate only suppresses native prompts under bypassPermissions; otherwise interactive prompts still wedge the headless session',
+          detail: 'gate is on but no ask-user-question relay — a question in the pane wedges the session',
+          fix: 'register the ask-user-question PreToolUse hook alongside the gate',
         },
   )
+
+  // The policy file the gate command points at must exist. A missing file is
+  // not fatal at runtime (the hook falls back to confirm-everything) but it
+  // means the operator's policy — including confirm_overrides — is silently
+  // not in force.
+  const policyPath = extractEnvAssignment(cmds.join('\n'), 'TELEGRAM_PERMISSION_POLICY_PATH')
+  if (policyPath) {
+    out.push(
+      fileExists(policyPath)
+        ? { id: 'gate-policy-path', title: 'Permission gate: policy file exists', status: 'pass', detail: `policy at ${policyPath}` }
+        : {
+            id: 'gate-policy-path',
+            title: 'Permission gate: policy file exists',
+            status: 'warn',
+            detail: `gate command points at ${policyPath} but the file does not exist — fallback confirm-everything policy is in force`,
+            fix: 'create the policy file or fix TELEGRAM_PERMISSION_POLICY_PATH in the gate hook command',
+          },
+    )
+  }
   return out
+}
+
+/**
+ * Extract a KEY='value' / KEY="value" / KEY=value assignment from a shell
+ * command string (the install scripts prefix hook commands with env vars).
+ */
+export function extractEnvAssignment(command: string, key: string): string | null {
+  const m = command.match(new RegExp(`${key}=('([^']*)'|"([^"]*)"|(\\S+))`))
+  if (!m) return null
+  return m[2] ?? m[3] ?? m[4] ?? null
 }
 
 interface McpShape {
@@ -535,6 +647,318 @@ export function checkProgressSurfaces(stateConfig: unknown): Check {
   }
   const detail = enabled.length === 1 ? `exactly one surface enabled (${enabled[0]})` : 'no surface explicitly enabled (defaults are all-off)'
   return { id, title, status: 'pass', detail }
+}
+
+/**
+ * Pick the settings.json the doctor should inspect. Claude Code loads project
+ * hooks ONLY from the session cwd's .claude/ — for a channel session that is
+ * <plugin-dir>/.claude/settings.json. Defaulting to ~/.claude/settings.json
+ * produced 5 false hook WARNs + a false gate SKIP on every correct setup.
+ */
+export function resolveSettingsPath(
+  pluginDir: string,
+  homeSettingsPath: string,
+  fileExists: (p: string) => boolean = existsSync,
+): { path: string; source: 'plugin-dir' | 'home' } {
+  const pluginSettings = join(resolve(pluginDir), '.claude', 'settings.json')
+  if (fileExists(pluginSettings)) return { path: pluginSettings, source: 'plugin-dir' }
+  return { path: homeSettingsPath, source: 'home' }
+}
+
+export interface RuntimeCandidate {
+  pid: string
+  cwd: string
+}
+
+/**
+ * Multi-agent aware dev-vs-runtime match: on a fleet host several plugin
+ * servers run at once, and "the first pgrep PID" is usually ANOTHER agent's
+ * server — comparing its CWD to our plugin dir produced a false WARN. Match
+ * by CWD across all candidates instead.
+ */
+export function findMatchingRuntime(
+  candidates: RuntimeCandidate[],
+  pluginDir: string,
+): { match: RuntimeCandidate | null; others: number } {
+  const dir = resolve(pluginDir)
+  const match = candidates.find((c) => c.cwd !== '' && sameTree(dir, c.cwd)) ?? null
+  return { match, others: candidates.length - (match ? 1 : 0) }
+}
+
+export interface Listener {
+  addr: string
+  port: string
+}
+
+/**
+ * Parse `ss -ltn` / `lsof -nP -iTCP -sTCP:LISTEN` output into address:port
+ * pairs. Tolerates IPv4, bracketed IPv6, `*` wildcards and surrounding noise.
+ */
+export function parseListeners(text: string): Listener[] {
+  const out: Listener[] = []
+  for (const m of text.matchAll(/(?:^|\s)((?:\d{1,3}\.){3}\d{1,3}|\[[^\]\s]*\]|\*):(\d+)(?:\s|$)/gm)) {
+    const addr = m[1]
+    const port = m[2]
+    if (addr !== undefined && port !== undefined) out.push({ addr, port })
+  }
+  return out
+}
+
+const LOOPBACK_ADDR_RE = /^(127\.|\[::1\]$)/
+
+/**
+ * The plugin's hook webhook must listen on loopback ONLY. A 0.0.0.0 / public
+ * bind exposes the hook surface (and historically a webhook→sudo→root chain)
+ * to the network. FAIL is deliberate — this is a security boundary, not a
+ * style preference.
+ */
+export function checkWebhookBind(port: string | null, listeners: Listener[] | null): Check {
+  const id = 'webhook-bind'
+  const title = 'Webhook listens on loopback only'
+  if (!port) return { id, title, status: 'skip', detail: 'webhook port unknown (no env) — pass --env or run with autodetect' }
+  if (listeners === null) return { id, title, status: 'skip', detail: 'no listener probe available (ss/lsof missing)' }
+  const hits = listeners.filter((l) => l.port === port)
+  if (hits.length === 0) {
+    return { id, title, status: 'warn', detail: `nothing listens on port ${port} — the plugin server is not up (or runs on another host)`, fix: 'start the channel service, then re-run' }
+  }
+  const offending = hits.filter((l) => !LOOPBACK_ADDR_RE.test(l.addr))
+  if (offending.length > 0) {
+    return {
+      id,
+      title,
+      status: 'fail',
+      detail: `port ${port} is bound to ${offending.map((l) => l.addr).join(', ')} — the hook webhook is reachable from the network`,
+      fix: 'bind the webhook to 127.0.0.1 (TELEGRAM_WEBHOOK_HOST) — a public hook surface is a remote-control primitive',
+    }
+  }
+  return { id, title, status: 'pass', detail: `port ${port} bound to loopback only` }
+}
+
+/**
+ * The channel env file carries the bot token. World-readable mode means any
+ * local user can hijack the bot. Cheap stat check, big payoff.
+ */
+export function checkEnvFileMode(mode: number | null, path: string): Check {
+  const id = 'env-file-mode'
+  const title = 'Channel env file is private (token inside)'
+  if (mode === null) return { id, title, status: 'skip', detail: `cannot stat ${path}` }
+  const bits = mode & 0o777
+  if (bits & 0o004) {
+    return { id, title, status: 'fail', detail: `${path} is world-readable (mode ${bits.toString(8)})`, fix: 'chmod 600 the env file — it holds the bot token' }
+  }
+  if (bits & 0o040) {
+    return { id, title, status: 'warn', detail: `${path} is group-readable (mode ${bits.toString(8)})`, fix: 'chmod 600 unless the group share is deliberate' }
+  }
+  return { id, title, status: 'pass', detail: `mode ${bits.toString(8)}` }
+}
+
+const CHANNEL_HOOK_MARKERS_RE = /dashi-channel-hook|dashi-permission-gate-hook|dashi-ask-user-question-hook|post-hook\.ts|read-receipt-hook\.ts|fallback-reply-hook\.ts|permission-gate-hook\.ts/
+
+/**
+ * Channel hooks in the USER-level ~/.claude/settings.json fire in EVERY
+ * session of every agent on the host and route through one agent's bot/port
+ * (fleet invariant a). Previously only the --fleet mode caught this; a
+ * single-agent run must too.
+ */
+export function checkSharedSettingsClean(homeRaw: string | null, selectedIsHome: boolean): Check {
+  const id = 'shared-settings-clean'
+  const title = 'User-level ~/.claude/settings.json free of channel hooks'
+  if (selectedIsHome) {
+    // The operator deliberately keeps hooks in the user file (single-agent
+    // legacy layout). The per-event checks already validate it; flagging it
+    // here would contradict them.
+    return { id, title, status: 'skip', detail: 'user-level settings IS the inspected file (legacy single-agent layout)' }
+  }
+  if (homeRaw === null) return { id, title, status: 'pass', detail: 'no user-level settings.json' }
+  return CHANNEL_HOOK_MARKERS_RE.test(homeRaw)
+    ? { id, title, status: 'fail', detail: 'channel hook markers found in the user-level settings — they fire in EVERY agent session on this host', fix: 'move channel hooks into <plugin-dir>/.claude/settings.json (fleet invariant a)' }
+    : { id, title, status: 'pass', detail: 'no channel hook markers in the shared file' }
+}
+
+// ---------------------------------------------------------------------------
+// Permission-policy lint (P1). The gate's own zod schema rejects unknown
+// confirm_overrides at runtime; the doctor adds an OPERATOR-level lint:
+// even schema-valid overrides can be dangerous (lifting sudo / rm -rf), and
+// a policy that flips the default tier to allow deserves a flag. Minimal
+// line-based extraction — no YAML dependency, conservative on misses.
+// ---------------------------------------------------------------------------
+
+/** Built-in confirm rules that must NEVER be lifted via confirm_overrides. */
+export const DANGEROUS_OVERRIDE_RULES: readonly string[] = ['sudo ', 'rm -rf ', 'rm -fr ']
+
+/** Items of `confirm_overrides: { builtin_rules: [...] }` — block or inline form. */
+export function extractConfirmOverrides(policyText: string): string[] {
+  const lines = policyText.split('\n')
+  const out: string[] = []
+  let inOverrides = false
+  let inRules = false
+  let rulesIndent = 0
+  for (const line of lines) {
+    if (/^\s*#/.test(line)) continue
+    const overrides = line.match(/^(\s*)confirm_overrides:\s*$/)
+    if (overrides) {
+      inOverrides = true
+      inRules = false
+      continue
+    }
+    if (inOverrides) {
+      const inline = line.match(/^\s*builtin_rules:\s*\[(.*)\]\s*$/)
+      if (inline?.[1] !== undefined) {
+        out.push(...inline[1].split(',').map((s) => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean))
+        inOverrides = false
+        continue
+      }
+      const block = line.match(/^(\s*)builtin_rules:\s*$/)
+      if (block) {
+        inRules = true
+        rulesIndent = (block[1] ?? '').length
+        continue
+      }
+      if (inRules) {
+        const item = line.match(/^(\s*)-\s*(.+?)\s*$/)
+        if (item && (item[1] ?? '').length > rulesIndent) {
+          out.push((item[2] ?? '').replace(/^["']|["']$/g, ''))
+          continue
+        }
+        if (line.trim() !== '') {
+          inRules = false
+          inOverrides = false
+        }
+      } else if (/^\S/.test(line)) {
+        inOverrides = false
+      }
+    }
+  }
+  return out
+}
+
+/** First top-level `key: value` scalar in the policy text. */
+export function extractTopLevelScalar(policyText: string, key: string): string | null {
+  const m = policyText.match(new RegExp(`^${key}:\\s*["']?([^"'#\\n]+?)["']?\\s*(#.*)?$`, 'm'))
+  return m?.[1]?.trim() ?? null
+}
+
+export function checkPermissionPolicy(policyText: string | null, policyPath: string): Check[] {
+  const out: Check[] = []
+  if (policyText === null) {
+    return [{ id: 'permission-policy', title: 'Permission policy lint', status: 'skip', detail: `policy file not readable at ${policyPath}` }]
+  }
+  if (policyText.trim() === '') {
+    return [{ id: 'permission-policy', title: 'Permission policy lint', status: 'warn', detail: `${policyPath} is empty — the gate falls back to confirm-everything`, fix: 'write a policy or remove the env override' }]
+  }
+  const overrides = extractConfirmOverrides(policyText)
+  const dangerous = overrides.filter((o) => DANGEROUS_OVERRIDE_RULES.some((d) => o === d || o === d.trim()))
+  out.push(
+    dangerous.length > 0
+      ? {
+          id: 'permission-policy-risky-override',
+          title: 'confirm_overrides does not lift sudo / rm -rf',
+          status: 'fail',
+          detail: `confirm_overrides lifts catastrophic rule(s): ${dangerous.join(', ')} — these must always reach the owner`,
+          fix: 'remove sudo / rm -rf from confirm_overrides.builtin_rules; override only narrow rules like git push',
+        }
+      : { id: 'permission-policy-risky-override', title: 'confirm_overrides does not lift sudo / rm -rf', status: 'pass', detail: overrides.length > 0 ? `overrides: ${overrides.join(', ')}` : 'no confirm_overrides' },
+  )
+  const tier = extractTopLevelScalar(policyText, 'default_tier')
+  out.push(
+    tier === 'allow'
+      ? { id: 'permission-policy-default-tier', title: 'Policy default tier', status: 'warn', detail: 'default_tier: allow — anything the rules miss runs without confirmation', fix: 'prefer default_tier: confirm; allow-list specific safe patterns instead' }
+      : { id: 'permission-policy-default-tier', title: 'Policy default tier', status: 'pass', detail: tier ? `default_tier: ${tier}` : 'default_tier unset (gate default applies: confirm)' },
+  )
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Multichat lint (P1). chats/policy.yaml routes per-chat sessions. Two
+// invariants the plugin cannot enforce for the operator:
+//   - the terminal mirror is DM-only (a mirror in a public group leaks the
+//     kitchen: paths, repo names, sometimes redacted-adjacent output);
+//   - every chat directory on disk has a policy entry (an orphan dir means a
+//     chat is served by defaults nobody reviewed).
+// ---------------------------------------------------------------------------
+
+export interface ChatPolicy {
+  id: string
+  mode: string | null
+  tmuxMirror: boolean | null
+}
+
+/** Extract per-chat `mode:` and `tmux_mirror:` from the chats: block. */
+export function extractChatPolicies(policyText: string): ChatPolicy[] {
+  const lines = policyText.split('\n')
+  const out: ChatPolicy[] = []
+  let inChats = false
+  let chatsIndent = 0
+  let current: ChatPolicy | null = null
+  let currentIndent = 0
+  for (const line of lines) {
+    if (/^\s*#/.test(line) || line.trim() === '') continue
+    const indent = (line.match(/^(\s*)/)?.[1] ?? '').length
+    // Leaving the current block? The very same line may OPEN the real
+    // top-level chats: block (allowlist.chats: came first in the file), so
+    // fall through to the open-check instead of consuming the line.
+    if (inChats && indent <= chatsIndent) {
+      inChats = false
+      if (current) out.push(current)
+      current = null
+    }
+    if (!inChats) {
+      const chats = line.match(/^(\s*)chats:\s*$/)
+      if (chats) {
+        inChats = true
+        chatsIndent = (chats[1] ?? '').length
+      }
+      continue
+    }
+    const chatKey = line.match(/^(\s*)["']?(-?\d+)["']?:\s*$/)
+    if (chatKey && (current === null || (chatKey[1] ?? '').length <= currentIndent)) {
+      if (current) out.push(current)
+      current = { id: chatKey[2] ?? '', mode: null, tmuxMirror: null }
+      currentIndent = (chatKey[1] ?? '').length
+      continue
+    }
+    if (current) {
+      const mode = line.match(/^\s*mode:\s*["']?(\w+)["']?/)
+      if (mode) current.mode = mode[1] ?? null
+      const mirror = line.match(/^\s*tmux_mirror:\s*(true|false)/)
+      if (mirror) current.tmuxMirror = mirror[1] === 'true'
+    }
+  }
+  if (current) out.push(current)
+  return out
+}
+
+/** Mirror is DM-only: a public chat with tmux_mirror=true leaks the terminal. */
+export function checkMultichatMirror(policies: ChatPolicy[]): Check {
+  const id = 'multichat-dm-mirror'
+  const title = 'Terminal mirror is DM-only (public chats: no mirror)'
+  const leaking = policies.filter((p) => p.mode === 'public' && p.tmuxMirror === true)
+  if (leaking.length > 0) {
+    return { id, title, status: 'fail', detail: `public chat(s) with tmux_mirror=true: ${leaking.map((p) => p.id).join(', ')} — the terminal (paths, repos, tool output) streams into a group`, fix: 'set tmux_mirror: false for every mode: public chat' }
+  }
+  return { id, title, status: 'pass', detail: `${policies.length} chat polic(ies), no public mirror` }
+}
+
+/** Every chat dir on disk should have a policy entry (no unreviewed defaults). */
+export function checkMultichatDirs(policyIds: string[], dirIds: string[]): Check {
+  const id = 'multichat-dirs'
+  const title = 'Every chat directory has a policy entry'
+  const known = new Set(policyIds)
+  const orphans = dirIds.filter((d) => !known.has(d))
+  if (orphans.length > 0) {
+    return { id, title, status: 'warn', detail: `chat dir(s) without a policy entry: ${orphans.join(', ')} — these chats run on defaults nobody reviewed`, fix: 'add the chat to chats/policy.yaml or remove the stale directory' }
+  }
+  return { id, title, status: 'pass', detail: `${dirIds.length} chat dir(s), all covered` }
+}
+
+/** PR #32 regression guard: spawn-chat-shell must forward TMUX_PANE through env -i. */
+export function checkSpawnChatShell(scriptText: string | null): Check {
+  const id = 'spawn-chat-shell-tmux-pane'
+  const title = 'spawn-chat-shell forwards TMUX_PANE'
+  if (scriptText === null) return { id, title, status: 'skip', detail: 'spawn-chat-shell.sh not found (multichat shells not in use)' }
+  return /TMUX_PANE/.test(scriptText)
+    ? { id, title, status: 'pass', detail: 'TMUX_PANE forwarding present' }
+    : { id, title, status: 'fail', detail: 'no TMUX_PANE in spawn-chat-shell.sh — the per-chat inbox watcher silently dies (PR #32 regression)', fix: 'forward TMUX and TMUX_PANE through the env -i wipe' }
 }
 
 /**
@@ -713,15 +1137,39 @@ export interface FleetAgent {
   hookPorts: string[]
   /** Path of the workspace settings.json actually found; null = could not locate/read. */
   settingsPath: string | null
+  /** WorkingDirectory= from the unit (autodetect anchor). */
+  workingDirectory: string | null
+  /** tmux session name from ExecStart `new-session -s <name>`. */
+  sessionName: string | null
+  /** ExecStart carries --permission-mode bypassPermissions. */
+  bypassPermissions: boolean
 }
 
-/** Parse a systemd unit: EnvironmentFile + tmux socket per Exec line. Pure. */
-export function parseUnitFile(text: string): { envPath: string | null; sockets: string[] } {
+export interface ParsedUnit {
+  envPath: string | null
+  sockets: string[]
+  workingDirectory: string | null
+  /** tmux session name from `new-session … -s <name>` (ExecStart). */
+  sessionName: string | null
+  /** True when any ExecStart payload carries --permission-mode bypassPermissions. */
+  bypassPermissions: boolean
+}
+
+/** Parse a systemd unit: EnvironmentFile + tmux socket/session per Exec line. Pure. */
+export function parseUnitFile(text: string): ParsedUnit {
   let envPath: string | null = null
+  let workingDirectory: string | null = null
+  let sessionName: string | null = null
+  let bypassPermissions = false
   const sockets = new Set<string>()
   for (const line of text.split('\n')) {
     const env = line.match(/^\s*EnvironmentFile=-?(\S+)/)
     if (env?.[1]) envPath = env[1]
+    const wd = line.match(/^\s*WorkingDirectory=(\S+)/)
+    if (wd?.[1]) workingDirectory = wd[1]
+    if (/^\s*ExecStart=/.test(line) && /--permission-mode\s+bypassPermissions/.test(line)) {
+      bypassPermissions = true
+    }
     if (/^\s*Exec(Start|StartPost|Stop|StopPost)=.*tmux/.test(line)) {
       // Only inspect tmux's OWN argv: everything before the first quote is
       // tmux args, the quoted tail is the nested payload (`'claude ... -L x'`
@@ -731,9 +1179,11 @@ export function parseUnitFile(text: string): { envPath: string | null; sockets: 
       const argsPart = quoteIdx === -1 ? cmdPart : cmdPart.slice(0, quoteIdx)
       const sock = argsPart.match(/\s-L\s+(\S+)/)
       sockets.add(sock?.[1] ?? '')
+      const sess = argsPart.match(/\s-s\s+(\S+)/)
+      if (/^\s*ExecStart=/.test(line) && sess?.[1]) sessionName = sess[1]
     }
   }
-  return { envPath, sockets: [...sockets] }
+  return { envPath, sockets: [...sockets], workingDirectory, sessionName, bypassPermissions }
 }
 
 /** First value of KEY=... in env-file text. Pure. */
@@ -900,7 +1350,7 @@ export function scanFleet(unitDir: string): FleetAgent[] {
     const text = readFileSafe(unitPath)
     if (text == null) continue
     const name = f.replace(/^channel-/, '').replace(/\.service$/, '')
-    const { envPath, sockets } = parseUnitFile(text)
+    const { envPath, sockets, workingDirectory, sessionName, bypassPermissions } = parseUnitFile(text)
     // Not every channel-*.service is a channel: helper units (webhook
     // listeners, sync timers) share the prefix but never run tmux. A channel
     // unit always supervises a tmux session — skip anything that doesn't.
@@ -942,9 +1392,25 @@ export function scanFleet(unitDir: string): FleetAgent[] {
       webhookEnabled,
       hookPorts,
       settingsPath,
+      workingDirectory,
+      sessionName,
+      bypassPermissions,
     })
   }
   return agents
+}
+
+/**
+ * Find the fleet unit this plugin checkout belongs to: WorkingDirectory or
+ * TELEGRAM_WORKSPACE_ROOT shares a tree with the plugin dir. Pure.
+ */
+export function matchAgentForPlugin(agents: FleetAgent[], pluginDir: string): FleetAgent | null {
+  const dir = resolve(pluginDir)
+  return (
+    agents.find((a) => a.workingDirectory != null && sameTree(dir, a.workingDirectory)) ??
+    agents.find((a) => a.workspaceRoot != null && sameTree(dir, a.workspaceRoot)) ??
+    null
+  )
 }
 
 interface Options {
@@ -952,6 +1418,8 @@ interface Options {
   os: OS
   pluginDir: string
   settingsPath: string
+  /** True when --settings was given explicitly (never overridden by resolution). */
+  settingsExplicit: boolean
   mcpPath?: string
   settingsLocalPath?: string
   envPath?: string
@@ -961,6 +1429,7 @@ interface Options {
   queueJsonPath?: string
   fleet?: boolean
   fleetDir?: string
+  noAutodetect?: boolean
 }
 
 function parseArgs(argv: string[]): Options | { error: string } {
@@ -969,6 +1438,7 @@ function parseArgs(argv: string[]): Options | { error: string } {
     os: detectOS(),
     pluginDir: process.cwd(),
     settingsPath: join(homedir(), '.claude', 'settings.json'),
+    settingsExplicit: false,
   }
   let err = ''
   for (let i = 0; i < argv.length; i++) {
@@ -989,10 +1459,17 @@ function parseArgs(argv: string[]): Options | { error: string } {
         opts.json = true
         break
       case '--plugin-dir':
-        opts.pluginDir = next()
+        // Resolve once: every downstream comparison (sameTree, .claude/
+        // detection, unit matching) assumes an absolute path; a relative
+        // `--plugin-dir plugin` broke two checks (fleet sweep, 2026-06-09).
+        opts.pluginDir = resolve(next())
         break
       case '--settings':
         opts.settingsPath = next()
+        opts.settingsExplicit = true
+        break
+      case '--no-autodetect':
+        opts.noAutodetect = true
         break
       case '--mcp':
         opts.mcpPath = next()
@@ -1047,6 +1524,9 @@ Options:
   --chat <id>              a Telegram chat id to verify (group id is -100...)
   --session <name>         tmux channel session (e.g. channel-myagent)
   --queue-json <path>      a saved getUpdates JSON response to classify (409 / drain)
+  --no-autodetect          do not infer --env/--session from systemd channel-*.service
+                           units (default: infer when the unit's WorkingDirectory
+                           matches --plugin-dir)
   --fleet                  multi-agent mode: discover channel-*.service units and
                            verify the five isolation invariants ACROSS agents
                            (README section 14)
@@ -1088,31 +1568,98 @@ function gatherChecks(opts: Options): Check[] {
 
   // Workspace placement (identity)
   checks.push(checkWorkspacePlacement(opts.pluginDir))
+  const claudeMd = findEnclosingClaudeMd(opts.pluginDir)
+  const workspaceDir = claudeMd ? dirname(claudeMd) : null
 
-  // Dev-copy vs runtime-copy divergence (lessons §1). The service runs the
-  // RUNTIME copy; patching a different checkout silently does nothing. Read-only
-  // probe: find the live server's CWD and compare to the inspected plugin dir.
-  const live = probe('pgrep', ['-f', 'bun.*src/server.ts'])
-  const pid = live.stdout.trim().split(/\s+/).filter(Boolean)[0]
-  if (pid) {
-    const cwd = liveCwd(pid, opts.os)
-    if (cwd) {
-      checks.push(
-        sameTree(opts.pluginDir, cwd)
-          ? { id: 'dev-vs-runtime', title: 'Inspected plugin matches the running copy', status: 'pass', detail: `runtime CWD ${cwd}` }
-          : {
-              id: 'dev-vs-runtime',
-              title: 'Inspected plugin matches the running copy',
-              status: 'warn',
-              detail: `running copy CWD ${cwd} differs from --plugin-dir ${opts.pluginDir}`,
-              fix: 'patch the RUNTIME copy (the one the service runs), not just the dev/git checkout',
-            },
-      )
+  // Autodetect (P0): on a systemd host, find the unit whose WorkingDirectory /
+  // workspace covers this plugin dir and fill in --env/--session so the
+  // default flag-less run reaches full coverage. Explicit flags always win.
+  let unitAgent: FleetAgent | null = null
+  if (!opts.noAutodetect && opts.os === 'linux') {
+    const unitDir = opts.fleetDir ?? '/etc/systemd/system'
+    const agents = scanFleet(unitDir)
+    unitAgent = matchAgentForPlugin(agents, opts.pluginDir)
+    if (unitAgent) {
+      const inferred: string[] = []
+      if (!opts.envPath && unitAgent.envPath) {
+        opts.envPath = unitAgent.envPath
+        inferred.push('env')
+      }
+      if (!opts.tmuxSession) {
+        opts.tmuxSession = unitAgent.sessionName ?? `channel-${unitAgent.name}`
+        inferred.push('session')
+      }
+      checks.push({
+        id: 'autodetect',
+        title: 'Autodetect: systemd unit matched to this plugin',
+        status: 'pass',
+        detail: `unit channel-${unitAgent.name}${inferred.length > 0 ? ` — inferred: ${inferred.join(', ')}` : ' — all inputs were explicit'}`,
+      })
+    } else if (agents.length > 0) {
+      checks.push({
+        id: 'autodetect',
+        title: 'Autodetect: systemd unit matched to this plugin',
+        status: 'skip',
+        detail: `${agents.length} channel unit(s) found but none matches this plugin dir — pass --env/--session explicitly`,
+      })
     }
   }
 
+  // Dev-copy vs runtime-copy divergence (lessons §1). The service runs the
+  // RUNTIME copy; patching a different checkout silently does nothing. On a
+  // fleet host several plugin servers run at once — match by CWD across ALL
+  // of them ("first pgrep PID" compared another agent's server, 2026-06-09).
+  const live = probe('pgrep', ['-f', 'bun.*src/server.ts'])
+  const pids = live.stdout.trim().split(/\s+/).filter(Boolean)
+  if (pids.length > 0) {
+    const candidates: RuntimeCandidate[] = pids.map((p) => ({ pid: p, cwd: liveCwd(p, opts.os) }))
+    const { match, others } = findMatchingRuntime(candidates, opts.pluginDir)
+    checks.push(
+      match
+        ? { id: 'dev-vs-runtime', title: 'Inspected plugin matches a running copy', status: 'pass', detail: `runtime CWD ${match.cwd} (PID ${match.pid})${others > 0 ? `; ${others} other channel server(s) on this host` : ''}` }
+        : {
+            id: 'dev-vs-runtime',
+            title: 'Inspected plugin matches a running copy',
+            status: 'warn',
+            detail: `${candidates.length} channel server(s) running, none from ${opts.pluginDir} — this agent's service is down or runs another checkout`,
+            fix: 'if this agent should be live, check its service; if you are patching, remember the service runs ITS copy, not this one',
+          },
+    )
+  }
+
+  // Settings resolution (P0): hooks load from the session cwd's .claude/ —
+  // prefer <plugin-dir>/.claude/settings.json unless --settings was explicit.
+  let selectedIsHome = true
+  if (!opts.settingsExplicit) {
+    const resolved = resolveSettingsPath(opts.pluginDir, opts.settingsPath)
+    opts.settingsPath = resolved.path
+    selectedIsHome = resolved.source === 'home'
+    checks.push({
+      id: 'settings-source',
+      title: 'Settings file selected',
+      status: 'pass',
+      detail: resolved.source === 'plugin-dir' ? `plugin-level ${resolved.path} (session cwd layout)` : `user-level ${resolved.path} (no plugin-level settings.json found)`,
+    })
+  } else {
+    selectedIsHome = resolve(opts.settingsPath) === resolve(join(homedir(), '.claude', 'settings.json'))
+  }
+
+  // Channel hooks in the USER-level file fire in every agent session on the
+  // host (fleet invariant a) — checked always now, not only under --fleet.
+  checks.push(checkSharedSettingsClean(readFileSafe(join(homedir(), '.claude', 'settings.json')), selectedIsHome))
+
+  // Hook profile: read the state config (env → TELEGRAM_STATE_DIR → config.json)
+  // BEFORE judging hook registration, so a mirror-only setup is not punished
+  // for the feeder hooks it deliberately does not have.
+  const envText = opts.envPath ? readFileSafe(opts.envPath) : null
+  const stateDir = envText ? envValue(envText, 'TELEGRAM_STATE_DIR') : null
+  const rawStateText = stateDir ? readFileSafe(join(stateDir, 'config.json')) : null
+  const stateConfig = rawStateText == null ? null : parseJsonSafe(rawStateText)
+  const profile = selectHookProfile(stateConfig)
+
   // settings.json hooks + token leak
   const settings = parseJsonSafe(readFileSafe(opts.settingsPath))
+  let gateRegistered = false
   if (settings == null) {
     checks.push({
       id: 'settings-readable',
@@ -1122,17 +1669,87 @@ function gatherChecks(opts: Options): Check[] {
       fix: 'pass --settings <path> to the agent settings.json',
     })
   } else {
-    checks.push(...checkSettingsHooks(settings))
-    checks.push(...checkPermissionGate(settings))
+    checks.push(...checkSettingsHooks(settings, profile))
+    const gateChecks = checkPermissionGate(settings, existsSync, unitAgent ? unitAgent.bypassPermissions : null)
+    gateRegistered = gateChecks.some((c) => c.id === 'permission-gate' && c.status !== 'skip')
+    checks.push(...gateChecks)
+  }
+
+  // Permission policy lint (P1): the file the gate actually reads — path from
+  // the gate hook command, else the workspace convention.
+  if (gateRegistered) {
+    const gateEntry = ((settings as SettingsPermShape)?.hooks?.PreToolUse ?? []).find((e) => e.marker === GATE_MARKER)
+    const gateCmd = gateEntry ? entryCommands(gateEntry).join('\n') : ''
+    const policyPath =
+      extractEnvAssignment(gateCmd, 'TELEGRAM_PERMISSION_POLICY_PATH') ??
+      (workspaceDir ? join(workspaceDir, 'chats', 'permission-policy.yaml') : null)
+    if (policyPath) {
+      checks.push(...checkPermissionPolicy(readFileSafe(policyPath), policyPath))
+    }
+    // The unit must run bypassPermissions when the gate is the sole authority.
+    if (unitAgent) {
+      checks.push(
+        unitAgent.bypassPermissions
+          ? { id: 'unit-permission-mode', title: 'Unit runs --permission-mode bypassPermissions', status: 'pass', detail: `channel-${unitAgent.name} ExecStart carries the flag` }
+          : { id: 'unit-permission-mode', title: 'Unit runs --permission-mode bypassPermissions', status: 'warn', detail: `gate is registered but channel-${unitAgent.name} ExecStart does not carry --permission-mode bypassPermissions`, fix: 'without bypassPermissions native prompts still render in the unwatched pane and wedge the session' },
+      )
+    }
+  }
+
+  // Multichat lint (P1): only when the workspace uses chats/policy.yaml.
+  if (workspaceDir) {
+    const chatsDir = join(workspaceDir, 'chats')
+    const policyText = readFileSafe(join(chatsDir, 'policy.yaml'))
+    if (policyText !== null) {
+      const policies = extractChatPolicies(policyText)
+      checks.push(checkMultichatMirror(policies))
+      let dirIds: string[] = []
+      try {
+        dirIds = readdirSync(chatsDir).filter((d) => /^-?\d+$/.test(d))
+      } catch {
+        /* unreadable chats dir — dir consistency is simply not checkable */
+      }
+      checks.push(checkMultichatDirs(policies.map((p) => p.id), dirIds))
+      checks.push(checkSpawnChatShell(readFileSafe(join(opts.pluginDir, 'scripts', 'spawn-chat-shell.sh'))))
+    }
+  }
+
+  // Webhook bind (P0, security): the hook webhook must listen on loopback only.
+  const webhookPort = envText ? envValue(envText, 'TELEGRAM_WEBHOOK_PORT') : null
+  if (webhookPort) {
+    let listenersText: string | null = null
+    const ss = probe('ss', ['-ltn'])
+    if (ss.code === 0 && ss.stdout) {
+      listenersText = ss.stdout
+    } else {
+      const lsof = probe('lsof', ['-nP', '-iTCP', '-sTCP:LISTEN'])
+      if (lsof.code === 0 && lsof.stdout) listenersText = lsof.stdout
+    }
+    checks.push(checkWebhookBind(webhookPort, listenersText == null ? null : parseListeners(listenersText)))
+  }
+
+  // Env file privacy (P0, security): the bot token lives here.
+  if (opts.envPath) {
+    let mode: number | null = null
+    try {
+      mode = statSync(opts.envPath).mode
+    } catch {
+      mode = null
+    }
+    checks.push(checkEnvFileMode(mode, opts.envPath))
   }
 
   // comms consistency (.mcp.json vs settings.local.json) — distinguish a missing
-  // file from one present but unparseable (a malformed .mcp.json is itself a bug).
-  if (opts.mcpPath || opts.settingsLocalPath) {
-    const mcpRaw = readFileSafe(opts.mcpPath ?? '')
-    const slRaw = readFileSafe(opts.settingsLocalPath ?? '')
-    if (opts.mcpPath && mcpRaw !== null && parseJsonSafe(mcpRaw) === null) {
-      checks.push({ id: 'comms-consistency', title: 'MCP comms servers enabled consistently', status: 'fail', detail: `${opts.mcpPath} is present but not valid JSON`, fix: 'fix the .mcp.json syntax' })
+  // file from one present but unparseable (a malformed .mcp.json is itself a
+  // bug). Defaults to the plugin-dir copies when no flags are given, so the
+  // silent-after-restart landmine is caught by the flag-less run too.
+  const mcpPath = opts.mcpPath ?? (existsSync(join(opts.pluginDir, '.mcp.json')) ? join(opts.pluginDir, '.mcp.json') : undefined)
+  const settingsLocalPath = opts.settingsLocalPath ?? (existsSync(join(opts.pluginDir, '.claude', 'settings.local.json')) ? join(opts.pluginDir, '.claude', 'settings.local.json') : undefined)
+  if (mcpPath || settingsLocalPath) {
+    const mcpRaw = readFileSafe(mcpPath ?? '')
+    const slRaw = readFileSafe(settingsLocalPath ?? '')
+    if (mcpPath && mcpRaw !== null && parseJsonSafe(mcpRaw) === null) {
+      checks.push({ id: 'comms-consistency', title: 'MCP comms servers enabled consistently', status: 'fail', detail: `${mcpPath} is present but not valid JSON`, fix: 'fix the .mcp.json syntax' })
     } else {
       checks.push(checkCommsConsistency(parseJsonSafe(mcpRaw), parseJsonSafe(slRaw)))
     }
@@ -1149,13 +1766,8 @@ function gatherChecks(opts: Options): Check[] {
   }
 
   // Exactly one progress surface (duplicate-windows guard, 2026-06-09)
-  if (opts.envPath) {
-    const envText = readFileSafe(opts.envPath)
-    const stateDir = envText ? envValue(envText, 'TELEGRAM_STATE_DIR') : null
-    if (stateDir) {
-      const rawState = readFileSafe(join(stateDir, 'config.json'))
-      checks.push(checkProgressSurfaces(rawState == null ? null : parseJsonSafe(rawState)))
-    }
+  if (stateDir) {
+    checks.push(checkProgressSurfaces(stateConfig))
   }
 
   // Telegram queue (409 / drain) from a saved getUpdates response


### PR DESCRIPTION
## Что

Доктор плагина теперь даёт достоверный результат на современных конфигурациях (мультиагентный хост, mirror-only hooks, permission gate, мультичат) и покрывает поверхности безопасности, которых раньше не видел. Запуск без флагов на systemd-хосте даёт полное покрытие.

## Ложные срабатывания устранены

- **dev-vs-runtime на флот-хосте**: матч по CWD среди ВСЕХ серверов плагина (раньше первый pgrep PID — чужой агент → ложный WARN)
- **settings по умолчанию**: `<plugin>/.claude/settings.json` (cwd сессии — то, откуда Claude Code реально грузит hooks), не `~/.claude/`
- **профили hooks**: mirror/none не требуют feeder-хуков (они сознательно убраны при tmux-mirror); hook-feeders требует все 5; unknown консервативен
- относительный `--plugin-dir` больше не ломает чеки

## Новые проверки

- **Permission gate глубоко**: ask-relay рядом с гейтом; policy-файл существует; `confirm_overrides` не может снимать `sudo`/`rm -rf` (FAIL); flow-форма → WARN (не тихий pass); `default_tier: allow` → WARN; юнит несёт `--permission-mode bypassPermissions`
- **Мультичат**: terminal mirror только в DM — группа (отрицательный id) с mirror без явного `mode: private` = FAIL; block-scalar и default-шаблоны не искажают разбор policy; покрытие chat-директорий; TMUX_PANE-форвардинг в spawn-chat-shell (регресс PR #32)
- **Безопасность**: webhook слушает ТОЛЬКО loopback (0.0.0.0/[::]/публичный = FAIL; [::ffff:127.] — легитимен); env-файл с токеном: any other-access/group-write = FAIL; channel-хуки в общем `~/.claude/settings.json` = FAIL всегда (не только --fleet)
- **Autodetect**: systemd-юнит по WorkingDirectory → env/session/state config без флагов; `--no-autodetect`; нет env → явный skip вместо тихого пропуска security-чеков
- comms-consistency по умолчанию из `plugin/.mcp.json` + `settings.local.json`

## README (EN+RU)

Доктор обязателен при каждом переезде/дебаге + железное правило: **миграция и хирургия моста — из терминала Claude Code, не через Telegram** (мост чинить через сам мост нельзя — сломается на середине, канал управления исчезнет).

## Ревью и верификация

- Double review: **Codex GPT-5.5 (high) + Fable-субагент** — оба SHIP-WITH-CHANGES, 0 Critical; все High/Medium фиксы внесены вторым коммитом (+15 тестов на них)
- 143/143 doctor-тестов, полный suite плагина 1431 pass, tsc strict clean
- Живой прогон на 2-агентном хосте (thrall+arthas): 28 чеков, **0 FAIL**, 4 честных WARN; `--fleet` видит оба юнита

🤖 Generated with [Claude Code](https://claude.com/claude-code)
