### PR TITLE
Permission gate: два живых false positive (kill-в-skill, git -c через пайп) + Codex Critical fix

### DIFF
--- a/plugin/src/security/permission-policy.ts
+++ b/plugin/src/security/permission-policy.ts
@@ -415,13 +415,68 @@ const GIT_HOOKS_WRITE_RE = /(\.git\/hooks\/|core\.hookspath)/i
 const GIT_ENV_INDIRECTION_RE =
   /\b(git_ssh|git_ssh_command|git_askpass|ssh_askpass|git_proxy_command|git_external_diff|git_config_global|git_config_system|git_config_count|git_config_key_[0-9]+|git_config_value_[0-9]+)\s*=/i
 
+/**
+ * Quote-aware split on top-level `|`/`&`/`;`/newline. Unlike segmentBash
+ * (which may over-segment inside quotes — fine for the catastrophic backstop),
+ * the git-exec-surface check needs BOTH directions safe:
+ *   - `git show X | grep -c "Y"` must split at the pipe (else grep's `-c` is
+ *     blamed on git — live false positive, 2026-06-09);
+ *   - `git --work-tree="a|b" -c evil push` must NOT split inside the quotes
+ *     (else the `-c` lands in a git-less segment and the check is evaded).
+ * Returns null on unbalanced quoting — caller falls back to the conservative
+ * whole-string scan (fail-closed).
+ */
+export function segmentBashQuoteAware(command: string): string[] | null {
+  const segs: string[] = []
+  let cur = ''
+  let quote: "'" | '"' | null = null
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i] as string
+    if (quote === "'") {
+      cur += ch
+      if (ch === "'") quote = null
+      continue
+    }
+    if (quote === '"') {
+      if (ch === '\\') {
+        cur += ch + (command[i + 1] ?? '')
+        i++
+        continue
+      }
+      cur += ch
+      if (ch === '"') quote = null
+      continue
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch
+      cur += ch
+      continue
+    }
+    if (ch === '\\') {
+      cur += ch + (command[i + 1] ?? '')
+      i++
+      continue
+    }
+    if (ch === '|' || ch === '&' || ch === ';' || ch === '\n') {
+      segs.push(cur)
+      cur = ''
+      continue
+    }
+    cur += ch
+  }
+  if (quote !== null) return null
+  segs.push(cur)
+  return segs.map((s) => s.trim()).filter((s) => s.length > 0)
+}
+
 function gitExecSurface(commandLower: string): boolean {
-  return (
-    GIT_DASH_C_RE.test(commandLower) ||
-    GIT_FLAG_RE.test(commandLower) ||
-    GIT_HOOKS_WRITE_RE.test(commandLower) ||
-    GIT_ENV_INDIRECTION_RE.test(commandLower)
-  )
+  // Hook-path writes and env indirection are segment-independent.
+  if (GIT_HOOKS_WRITE_RE.test(commandLower) || GIT_ENV_INDIRECTION_RE.test(commandLower)) return true
+  // The -c/--flag scan runs PER SEGMENT so a `-c` of another command in the
+  // pipeline does not implicate git; unparseable quoting → whole string.
+  const segs = segmentBashQuoteAware(commandLower)
+  const targets = segs === null ? [commandLower] : segs.filter((s) => /\bgit\b/.test(s))
+  return targets.some((s) => GIT_DASH_C_RE.test(s) || GIT_FLAG_RE.test(s))
 }
 
 const INTERPRETER_RE = /\b(sh|bash|zsh|ksh|dash|fish|python[0-9.]*|perl|ruby|node|php)\b/
@@ -486,6 +541,16 @@ function bashMatch(pattern: string, commandLower: string): boolean {
   const pat = pattern.toLowerCase()
   const hasMeta = pat.includes('*') || pat.includes('?')
   if (!hasMeta) {
+    // Token-start match, not bare substring: `kill ` must not fire inside
+    // `skill ` / `overkill ` (live false positive: a heredoc mentioning
+    // "material-builder skill + schema" raised a confirm card, 2026-06-09).
+    // A word-ish char right before the pattern means we are inside a longer
+    // token — applies only to patterns that start with a letter/digit, so
+    // operator patterns like `.env` or `-rf ` keep substring semantics.
+    if (/^[a-z0-9]/.test(pat)) {
+      const escaped = pat.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      return new RegExp(`(?<![a-z0-9_-])${escaped}`).test(commandLower)
+    }
     return commandLower.includes(pat)
   }
   // Bash commands routinely contain slashes (paths, URLs), so `*` must cross

--- a/plugin/src/security/permission-policy.ts
+++ b/plugin/src/security/permission-policy.ts
@@ -472,11 +472,26 @@ export function segmentBashQuoteAware(command: string): string[] | null {
 function gitExecSurface(commandLower: string): boolean {
   // Hook-path writes and env indirection are segment-independent.
   if (GIT_HOOKS_WRITE_RE.test(commandLower) || GIT_ENV_INDIRECTION_RE.test(commandLower)) return true
-  // The -c/--flag scan runs PER SEGMENT so a `-c` of another command in the
-  // pipeline does not implicate git; unparseable quoting → whole string.
+  // Fast path: if no config/exec flag appears ANYWHERE, no segmentation can
+  // create one (segments are substrings) — definitively safe.
+  if (!GIT_DASH_C_RE.test(commandLower) && !GIT_FLAG_RE.test(commandLower)) return false
+  // A flag matched somewhere. We only narrow to per-segment scanning (to
+  // suppress a pipeline neighbour's flag, e.g. `git show X | grep -c Y`) when
+  // there is NO shell indirection. Indirection ($var, $(...), `...`, arrays,
+  // wrapper functions) can route argv INTO git from another segment (Codex
+  // Critical: `g(){ git "$@"; }; g -c core.sshCommand=evil fetch`), so we fall
+  // back to the whole-command scan — at least as strict as the pre-segment
+  // behaviour. (Residual, pre-existing in that behaviour too: a flag that
+  // appears textually BEFORE git via a variable — `c='-c …'; git $c` — is not
+  // caught here; closing that needs real argv resolution, out of scope.)
+  if (/[$`]/.test(commandLower)) {
+    return GIT_DASH_C_RE.test(commandLower) || GIT_FLAG_RE.test(commandLower)
+  }
   const segs = segmentBashQuoteAware(commandLower)
-  const targets = segs === null ? [commandLower] : segs.filter((s) => /\bgit\b/.test(s))
-  return targets.some((s) => GIT_DASH_C_RE.test(s) || GIT_FLAG_RE.test(s))
+  if (segs === null) return true // unbalanced quotes → fail-closed
+  // Indirection-free, balanced: the flag can only belong to git if a
+  // git-bearing segment literally carries it.
+  return segs.some((s) => /\bgit\b/.test(s) && (GIT_DASH_C_RE.test(s) || GIT_FLAG_RE.test(s)))
 }
 
 const INTERPRETER_RE = /\b(sh|bash|zsh|ksh|dash|fish|python[0-9.]*|perl|ruby|node|php)\b/

--- a/plugin/tests/security/permission-policy.test.ts
+++ b/plugin/tests/security/permission-policy.test.ts
@@ -99,6 +99,52 @@ describe('built-in confirm bash (interpreter/exfil evasion)', () => {
     expect(v.tier).toBe('confirm')
     expect(v.matchedRule).toContain('builtin:confirm_bash')
   })
+  test('`kill ` does NOT fire inside `skill ` / `overkill ` (token-start, live FP 2026-06-09)', () => {
+    // A heredoc mentioning "material-builder skill + schema" raised a real
+    // confirm card; substring matching must not treat word tails as commands.
+    expect(classify('Bash', { command: 'echo "material-builder skill + schema" > notes.md' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'echo this gate is overkill sometimes' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'cat skills/material-builder.md' }, VARIANT1).tier).toBe('allow')
+  })
+  test('real kill / pkill / killall still confirm', () => {
+    expect(classify('Bash', { command: 'kill 1234' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'pkill -f gateway' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'cd /x && kill -9 99' }, VARIANT1).tier).toBe('confirm')
+  })
+  test('token-start applies to other word rules too: mydocker/unsudo do not confirm', () => {
+    expect(classify('Bash', { command: 'echo mydocker test' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'echo unsudo ish' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'docker ps' }, VARIANT1).tier).toBe('confirm')
+  })
+})
+
+describe('git-exec-surface is segment-scoped (live FP 2026-06-09)', () => {
+  test('`git show X | grep -c` does NOT confirm — the -c belongs to grep', () => {
+    const v = classify('Bash', { command: 'git show origin/main:file.ts | grep -c "MARKER"' }, VARIANT1)
+    expect(v.matchedRule ?? '').not.toContain('git-exec-surface')
+    expect(v.tier).toBe('allow')
+  })
+  test('`git log | wc -c` and `git diff; grep -c x f` do not confirm', () => {
+    expect(classify('Bash', { command: 'git log --oneline | wc -c' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'git diff --stat; grep -c x file' }, VARIANT1).tier).toBe('allow')
+  })
+  test('real git -c still confirms, including -c hidden behind a quoted pipe (anti-evasion)', () => {
+    expect(classify('Bash', { command: 'git -c core.sshcommand=evil push origin main' }, VARIANT1).matchedRule).toContain('git-exec-surface')
+    // The quoted | must NOT split the segment — the -c stays attributed to git.
+    expect(classify('Bash', { command: 'git --work-tree="a|b" -c core.sshcommand=evil push' }, VARIANT1).matchedRule).toContain('git-exec-surface')
+  })
+  test('unbalanced quoting falls back to the conservative whole-string scan', () => {
+    const v = classify('Bash', { command: 'git show "unterminated | grep -c x' }, VARIANT1)
+    expect(v.matchedRule ?? '').toContain('git-exec-surface')
+  })
+  test('hooks-path writes and GIT_ env indirection confirm regardless of segmentation', () => {
+    expect(classify('Bash', { command: 'echo x > .git/hooks/pre-push | cat' }, VARIANT1).matchedRule).toContain('git-exec-surface')
+    // `git push` substring rule fires first here — what matters is it confirms.
+    expect(classify('Bash', { command: 'GIT_SSH_COMMAND=evil git push' }, VARIANT1).tier).toBe('confirm')
+    // With git push overridden, the env indirection must still confirm via the surface.
+    const overridden = { ...VARIANT1, confirm_overrides: { builtin_rules: ['git push'] } }
+    expect(classify('Bash', { command: 'GIT_SSH_COMMAND=evil git push' }, overridden).matchedRule).toContain('git-exec-surface')
+  })
 })
 
 describe('Variant 1 — smooth autonomy', () => {

--- a/plugin/tests/security/permission-policy.test.ts
+++ b/plugin/tests/security/permission-policy.test.ts
@@ -133,6 +133,15 @@ describe('git-exec-surface is segment-scoped (live FP 2026-06-09)', () => {
     // The quoted | must NOT split the segment — the -c stays attributed to git.
     expect(classify('Bash', { command: 'git --work-tree="a|b" -c core.sshcommand=evil push' }, VARIANT1).matchedRule).toContain('git-exec-surface')
   })
+  test('shell indirection → whole-command scan, wrapper-fn -c still confirms (Codex Critical)', () => {
+    // A wrapper routes argv into git; the per-segment narrowing must NOT apply
+    // when indirection is present — it falls back to the whole-command scan,
+    // which catches the git…-c ordering across the wrapper.
+    expect(classify('Bash', { command: 'g(){ git "$@"; }; g -c core.sshcommand=evil fetch origin' }, VARIANT1).matchedRule).toContain('git-exec-surface')
+  })
+  test('indirection does not over-block a benign $() with no config flag', () => {
+    expect(classify('Bash', { command: 'B=$(git rev-parse --abbrev-ref HEAD); echo $B' }, VARIANT1).tier).toBe('allow')
+  })
   test('unbalanced quoting falls back to the conservative whole-string scan', () => {
     const v = classify('Bash', { command: 'git show "unterminated | grep -c x' }, VARIANT1)
     expect(v.matchedRule ?? '').toContain('git-exec-surface')


### PR DESCRIPTION
Два живых FP, поднимавших confirm-карточку вождю на безобидных командах:
1. `kill ` срабатывал внутри `skill`/`overkill` — token-start lookbehind для слово-правил.
2. git-exec-surface ловил `git show X | grep -c Y` (флаг grep) — per-segment quote-aware scan.

Double review Codex high: нашёл Critical (индирекция `g(){ git "\$@"; }; g -c evil` протаскивала флаг в не-git сегмент). Закрыт вторым коммитом: при наличии `\$`/backtick — fall back на whole-command scan (≥ прежнего поведения), FP без индирекции остаётся подавленным. 110 тестов зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)