### PR TITLE
Permission gate: verb-aware systemctl — read-only и упоминания без карточки

### DIFF
--- a/plugin/docs/permission-policy.example.yaml
+++ b/plugin/docs/permission-policy.example.yaml
@@ -15,8 +15,9 @@
 # .env, *.pem, *.key, .ssh, .aws, gcloud, /proc/*/environ, and catastrophic
 # shell (rm -rf /, fork bombs, mkfs, dd to a disk). You cannot un-deny those.
 # A built-in confirm ALWAYS fires for sudo, git push, rm -rf, curl|sh,
-# base64 -d|sh, systemctl, kill/pkill, docker, npm publish, package installs —
-# unless you explicitly allow-list the exact form below.
+# base64 -d|sh, mutating systemctl (verb-aware: status/cat/show/list-* flow,
+# start/stop/restart/enable/… confirm), kill/pkill, docker, npm publish,
+# package installs — unless you explicitly allow-list the exact form below.
 
 version: 1
 

--- a/plugin/src/security/permission-policy.ts
+++ b/plugin/src/security/permission-policy.ts
@@ -203,7 +203,6 @@ const BUILTIN_CONFIRM_BASH: readonly string[] = [
   'git clean -',
   'chmod -r',
   'chown -r',
-  'systemctl',
   'kill ',
   'pkill',
   'docker ',
@@ -511,6 +510,85 @@ function gitExecSurface(rawCommand: string): boolean {
   // Indirection-free, balanced: the flag can only belong to git if a
   // git-bearing segment literally carries it.
   return segs.some((s) => /\bgit\b/i.test(s) && gitFlagPresent(s))
+}
+
+// ── systemctl: verb-aware confirm (live FPs 2026-06-10) ─────────────────
+//
+// The blanket `systemctl` substring rule fired on `systemctl cat <unit>`
+// (read-only diagnostics) and even on `grep -rn "systemctl" src/` (the word
+// as a search pattern) — both raised real confirm cards. Only MUTATING
+// systemd operations need the owner's tap; reads and mere mentions must
+// flow. Like gitExecSurface this check is non-overridable: a mutating
+// systemctl (service stop/restart — including the agent's own comms
+// channel) always reaches the owner.
+//
+// Per `systemctl` token occurrence we look at the first non-flag token that
+// follows — systemd's subcommand position (flags that take a DETACHED value,
+// `-H host` / `--root /mnt`, consume that value so it can't be mistaken for
+// the verb — Fable review 2026-06-10: `systemctl -H root@host restart x`
+// must not slip through as a "mention"):
+//   * read-only verb (status/cat/show/list-*/is-*…) → safe;
+//   * `$`/backtick verb (variable indirection)       → confirm (fail-safe);
+//   * any other verb-shaped word — mutating OR unknown → confirm (fail-safe
+//     for future/unknown verbs);
+//   * not verb-shaped (a path, a number, a pattern tail) → if flags were
+//     skipped to get here this is invocation-shaped, confirm; otherwise a
+//     textual mention (`grep -rn "systemctl" src/`), safe. A real invocation
+//     needs a verb to mutate anything (`systemctl` alone just lists units).
+// Occurrences are OR'ed — a read-only hit cannot mask a mutating sibling.
+// Accepted residuals under the agent-mistake threat model (mirrors the
+// gitExecSurface note): a verb arriving through a pipe
+// (`echo "restart foo" | xargs systemctl`) is not resolved here, and a
+// flagless non-verb-shaped first argument (`systemctl ./restart`) reads as
+// a mention — systemd itself rejects such argv, so nothing mutates.
+//
+// MIGRATION (2026-06-10): the literal 'systemctl' entry left
+// BUILTIN_CONFIRM_BASH, so a confirm_overrides list naming it now fails
+// schema validation — delete that override; the verb-aware rule is
+// non-overridable by design (like gitExecSurface).
+const SYSTEMCTL_READONLY_VERBS = new Set([
+  'status', 'cat', 'show', 'help',
+  'is-active', 'is-enabled', 'is-failed', 'is-system-running',
+  'list-units', 'list-unit-files', 'list-dependencies', 'list-timers',
+  'list-sockets', 'list-jobs', 'list-machines', 'list-paths', 'list-automounts',
+  'get-default', 'show-environment',
+])
+// Flags whose value is a SEPARATE token. Lowercased command collapses
+// `-H` (--host) into `-h` (help) — treating `-h` as value-taking is safe in
+// both readings (bare `systemctl -h` just ends with no verb → allow).
+const SYSTEMCTL_VALUE_FLAGS = new Set([
+  '-h', '-m', '-p', '-t', '-n', '-o', '-s',
+  '--host', '--machine', '--root', '--property', '--type', '--lines',
+  '--output', '--signal', '--kill-who', '--state', '--job-mode',
+])
+const SYSTEMCTL_FLAG_RE = /^--?[a-z0-9-]+(=.*)?$/
+const SYSTEMCTL_VERB_SHAPED_RE = /^[a-z][a-z-]*$/
+
+function systemctlMutation(commandLower: string): boolean {
+  if (!commandLower.includes('systemctl')) return false
+  const tokens = commandLower.split(/[\s"'`;|&()<>\\]+/).filter((t) => t.length > 0)
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i] as string
+    if (t !== 'systemctl' && !t.endsWith('/systemctl')) continue
+    let j = i + 1
+    let sawFlag = false
+    while (j < tokens.length) {
+      const tok = tokens[j] as string
+      if (SYSTEMCTL_VALUE_FLAGS.has(tok)) { sawFlag = true; j += 2; continue }
+      if (SYSTEMCTL_FLAG_RE.test(tok)) { sawFlag = true; j++; continue }
+      break
+    }
+    const verb = tokens[j]
+    if (verb === undefined) continue // bare systemctl lists units — read-only
+    if (verb.startsWith('$')) return true // variable verb — cannot prove safe
+    if (SYSTEMCTL_READONLY_VERBS.has(verb)) continue
+    if (SYSTEMCTL_VERB_SHAPED_RE.test(verb)) return true // mutating or unknown
+    // Not verb-shaped. Flags between `systemctl` and here prove invocation
+    // shape (a mention carries no systemctl flags) — fail safe to confirm.
+    if (sawFlag) return true
+    // Otherwise a mention (path / number / pattern tail), not a call.
+  }
+  return false
 }
 
 const INTERPRETER_RE = /\b(sh|bash|zsh|ksh|dash|fish|python[0-9.]*|perl|ruby|node|php)\b/
@@ -832,6 +910,11 @@ export function classifyToolCall(input: ClassifyInput): PermissionVerdict {
     // case-sensitive `-c` check distinguishes `git -C` from `git -c`.
     if (gitExecSurface(rawCommand!)) {
       return { tier: 'confirm', reason: 'git config/hook execution surface needs confirmation', matchedRule: 'builtin:confirm_bash:git-exec-surface' }
+    }
+    // Non-overridable: mutating systemd operations (verb-aware — read-only
+    // verbs and textual mentions of "systemctl" flow through).
+    if (systemctlMutation(commandLower)) {
+      return { tier: 'confirm', reason: 'mutating systemctl needs confirmation', matchedRule: 'builtin:confirm_bash:systemctl-mutation' }
     }
   }
 

--- a/plugin/tests/security/permission-policy.test.ts
+++ b/plugin/tests/security/permission-policy.test.ts
@@ -118,6 +118,73 @@ describe('built-in confirm bash (interpreter/exfil evasion)', () => {
   })
 })
 
+describe('systemctl is verb-aware — read-only verbs and mentions do not confirm (live FP 2026-06-10)', () => {
+  test('read-only systemctl verbs auto-allow', () => {
+    // `systemctl cat channel-thrall.service` raised a real confirm card while
+    // diagnosing a service — reading a unit file mutates nothing.
+    expect(classify('Bash', { command: 'systemctl cat channel-thrall.service' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'systemctl status nginx' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'systemctl show -p MainPID foo.service' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'systemctl list-units --failed' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'systemctl is-active dashi-worker' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'systemctl --user is-enabled foo' }, VARIANT1).tier).toBe('allow')
+  })
+  test('mentioning systemctl in a grep pattern / text does not confirm', () => {
+    // `grep -rn "systemctl" src/security/` raised a real confirm card — the
+    // word appeared as a search pattern, not as an invocation.
+    expect(classify('Bash', { command: 'grep -rn "systemctl" src/security/' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'echo systemctl' }, VARIANT1).tier).toBe('allow')
+  })
+  test('mutating systemctl verbs confirm, local and remote', () => {
+    expect(classify('Bash', { command: 'systemctl restart dashi-brain-swarm-worker' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'systemctl daemon-reload' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'systemctl enable --now foo' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'systemctl --user restart foo' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: "ssh root@65.109.137.239 'systemctl restart worker'" }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'systemctl stop gateway && echo done' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: '/usr/bin/systemctl kill foo' }, VARIANT1).tier).toBe('confirm')
+  })
+  test('unknown or indirect systemctl verbs fail safe to confirm', () => {
+    expect(classify('Bash', { command: 'systemctl frobnicate x' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'v=restart; systemctl $v foo' }, VARIANT1).tier).toBe('confirm')
+  })
+  test('a read-only verb cannot mask a mutating sibling occurrence', () => {
+    expect(
+      classify('Bash', { command: 'systemctl cat foo.service && systemctl restart foo' }, VARIANT1).tier,
+    ).toBe('confirm')
+  })
+  test('detached flag values cannot displace the verb (Fable review 2026-06-10)', () => {
+    // `-H host` / `--root /mnt` put a non-verb token in verb position; the
+    // mutating verb after it must still confirm — these are remote/offline
+    // service mutations, the exact thing the gate exists for.
+    expect(classify('Bash', { command: 'systemctl -H root@65.109.137.239 restart worker' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'systemctl -H my.host.example restart worker' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'systemctl -M mycontainer.raw restart worker' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'systemctl --root /mnt enable foo' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'systemctl -o cat restart foo' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'systemctl -n 50 restart foo' }, VARIANT1).tier).toBe('confirm')
+  })
+  test('unknown flag with a path value still fails safe — flags prove invocation shape', () => {
+    expect(classify('Bash', { command: 'systemctl --future-flag /some/path restart x' }, VARIANT1).tier).toBe('confirm')
+  })
+  test('bare systemctl and bare help flag stay read-only', () => {
+    expect(classify('Bash', { command: 'systemctl' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'systemctl -h' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'systemctl -H root@host status worker' }, VARIANT1).tier).toBe('allow')
+  })
+  test('quoted verbs resolve through tokenization', () => {
+    expect(classify('Bash', { command: "systemctl 'restart' foo" }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'backslash does not hide it: \\systemctl restart foo' }, VARIANT1).tier).toBe('confirm')
+  })
+  test('attached/equals flag forms and wrappers still confirm (Codex review 2026-06-10)', () => {
+    expect(classify('Bash', { command: 'systemctl --root=/mnt enable foo' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'systemctl -proot restart x' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'sudo systemctl restart nginx' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'SYSTEMD_PAGER=cat systemctl restart worker' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'systemctl \\\n  restart worker' }, VARIANT1).tier).toBe('confirm')
+  })
+})
+
 describe('git -C (change-dir) is NOT git -c (config) — case-sensitive (live FP 2026-06-10)', () => {
   test('`git -C <dir> …` auto-allows — uppercase -C must not trip the -c surface', () => {
     expect(classify('Bash', { command: 'git -C /home/x/repo log --oneline -1' }, VARIANT1).tier).toBe('allow')


### PR DESCRIPTION
## Проблема
Живые false positives 2026-06-10 (жалоба владельца «спрашивай только то, что реально опасно»):
- `systemctl cat channel-thrall.service` — read-only диагностика подняла карточку;
- `grep -rn "systemctl" src/` — слово как поисковый паттерн подняло карточку.

## Фикс
Blanket-правило `systemctl` из BUILTIN_CONFIRM_BASH заменено на verb-aware `systemctlMutation()` (non-overridable, по образцу git-exec-surface):
- read-only глаголы (status/cat/show/list-*/is-*/get-default/show-environment/help) — allow;
- мутирующие, неизвестные и `$`-глаголы — confirm (fail-safe);
- detached-value флаги (`-H host`, `--root /mnt`) поглощают значение — verb-позиция не сдвигается;
- non-verb token после флагов — confirm (флаги доказывают invocation shape), без флагов — текстовое упоминание, allow;
- вхождения OR'ятся: read-only сосед не маскирует мутирующее.

## Ревью
- Fable (свежая сессия): нашёл detached-flag-value bypass (`systemctl -H root@host restart` уходил в allow) — закрыт + 6 регрессионных тестов.
- Codex GPT-5.5: FIX-список (тесты --root=/mnt, -proot, env-prefix, multiline; migration note про confirm_overrides) — всё внесено.

## Тесты
123 pass в permission-policy.test.ts (+15 новых), 1453 полный набор, tsc clean.

## Migration
`confirm_overrides.builtin_rules: ["systemctl"]` теперь падает на schema-валидации — удалить override, правило non-overridable by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)