### PR TITLE
Мультичат: отправка файлов (sendDocument через outbox, токен на сервере)

### DIFF
--- a/plugin/src/chats/hooks/session-start.sh
+++ b/plugin/src/chats/hooks/session-start.sh
@@ -129,6 +129,17 @@ parts = [persona.rstrip()]
 if reminder:
     parts.append('---')
     parts.append(reminder.strip())
+# Capability note (all chats): how to attach a file from a multichat session,
+# which has no reply tool. The Stop hook turns the marker into an outbox
+# attachment and the router sends it AFTER the text. Secrets are refused.
+parts.append('---')
+parts.append(
+    'Отправка файла в чат: в этой сессии нет reply-инструмента, поэтому чтобы '
+    'прикрепить файл, добавь в текст ответа маркер [[file: /абсолютный/путь]] '
+    '(можно несколько). Файл уйдёт после текста. НЕ читай токен и не дёргай '
+    'Telegram API напрямую. Секреты (.env, ключи, *.pem/*.key, secrets/) '
+    'отправлять нельзя — они будут отклонены.'
+)
 additional_context = '\n\n'.join(parts)
 
 payload = {

--- a/plugin/src/chats/hooks/stop-to-outbox.py
+++ b/plugin/src/chats/hooks/stop-to-outbox.py
@@ -79,6 +79,13 @@ TAIL_BYTES = 1024 * 1024
 # / wrong-chat writes from a malformed env value.
 _CHAT_ID_RE = re.compile(r"-?\d+")
 
+# Attachment marker the multichat agent writes in its reply to send a file —
+# `[[file: /abs/path]]`. The capture is the path; the router validates it
+# authoritatively (secret denylist + size cap) before sending. We never read or
+# shell out to the path here, so a marker can never leak file content via the
+# hook. Newlines excluded so a marker stays single-line.
+_FILE_MARKER_RE = re.compile(r"\[\[file:\s*([^\]\n]+?)\s*\]\]")
+
 logging.basicConfig(stream=sys.stderr, level=logging.INFO)
 logger = logging.getLogger("stop-to-outbox")
 
@@ -384,11 +391,26 @@ def main() -> int:
         _debug_log(hook_state_dir, "no_text", session_id=session_id, reason="tool_only_turn")
         return 0
     assistant_text, assistant_uuid = extracted
-    if not assistant_text.strip():
+
+    # Attachment markers. A multichat session has no reply tool, so it signals
+    # files with `[[file: /abs/path]]` in its reply text. Extract the paths and
+    # strip the markers from the visible text. The ROUTER validates each path
+    # authoritatively (secret denylist + size cap) before sending — this hook
+    # only collects paths and never reads/opens/shells out to the files.
+    attach_files = [m.strip() for m in _FILE_MARKER_RE.findall(assistant_text) if m.strip()]
+    if attach_files:
+        assistant_text = _FILE_MARKER_RE.sub("", assistant_text).strip()
+
+    # Nothing to deliver: neither visible text nor any attachment.
+    if not assistant_text.strip() and not attach_files:
         _debug_log(hook_state_dir, "no_text", session_id=session_id, reason="blank")
         return 0
 
-    assistant_hash = hashlib.sha256(assistant_text.encode("utf-8")).hexdigest()
+    # Dedupe basis folds in the files so a re-fire of the same turn dedupes; the
+    # transcript uuid below is the primary discriminator either way.
+    assistant_hash = hashlib.sha256(
+        "\x00".join([assistant_text, *attach_files]).encode("utf-8")
+    ).hexdigest()
     # Dedupe discriminator: the transcript line's uuid uniquely identifies the
     # turn, so two DIFFERENT turns with identical text (e.g. "Готово." twice)
     # are NOT suppressed. Fall back to the text hash only when the transcript
@@ -418,7 +440,6 @@ def main() -> int:
 
     now_iso = datetime.now(timezone.utc).isoformat()
     message: dict[str, Any] = {
-        "text": assistant_text,
         "chat_id": chat_id,  # strictly from env, never from transcript
         "timestamp": now_iso,
         # 'auto' (2026-06-05): the router converts markdown -> Telegram HTML
@@ -427,6 +448,13 @@ def main() -> int:
         # group chats (no parse_mode at all).
         "format": "auto",
     }
+    # text is omitted entirely for a file-only reply (OutboxMessage.text is
+    # min(1) optional — an empty string would fail the schema); attachments are
+    # added when the reply carried `[[file:…]]` markers.
+    if assistant_text.strip():
+        message["text"] = assistant_text
+    if attach_files:
+        message["files"] = attach_files
 
     final_path = outbox_dir / build_filename()
     try:

--- a/plugin/src/chats/hooks/stop-to-outbox.py
+++ b/plugin/src/chats/hooks/stop-to-outbox.py
@@ -83,8 +83,9 @@ _CHAT_ID_RE = re.compile(r"-?\d+")
 # `[[file: /abs/path]]`. The capture is the path; the router validates it
 # authoritatively (secret denylist + size cap) before sending. We never read or
 # shell out to the path here, so a marker can never leak file content via the
-# hook. Newlines excluded so a marker stays single-line.
-_FILE_MARKER_RE = re.compile(r"\[\[file:\s*([^\]\n]+?)\s*\]\]")
+# hook. Single-line only: [ \t]* (NOT \s*, which would swallow a newline before
+# the path) plus a newline-free capture keep a marker on one line.
+_FILE_MARKER_RE = re.compile(r"\[\[file:[ \t]*([^\]\n]+?)[ \t]*\]\]")
 
 logging.basicConfig(stream=sys.stderr, level=logging.INFO)
 logger = logging.getLogger("stop-to-outbox")

--- a/plugin/src/router/inbox-bridge.ts
+++ b/plugin/src/router/inbox-bridge.ts
@@ -114,13 +114,25 @@ export const OutboxMessageFormatSchema = z
   .default('html')
 export type OutboxMessageFormat = z.infer<typeof OutboxMessageFormatSchema>
 
-export const OutboxMessageSchema = z.object({
-  text: z.string().min(1),
-  chat_id: z.string().min(1),
-  reply_to: z.string().optional(),
-  timestamp: z.string().min(1),
-  format: OutboxMessageFormatSchema,
-})
+export const OutboxMessageSchema = z
+  .object({
+    // Optional when `files` is present (a file-only reply has no text body);
+    // the refine below still requires at least one of text/files so an empty
+    // message can never be claimed/sent.
+    text: z.string().min(1).optional(),
+    chat_id: z.string().min(1),
+    reply_to: z.string().optional(),
+    timestamp: z.string().min(1),
+    format: OutboxMessageFormatSchema,
+    // Absolute paths of attachments to send AFTER the text. The router
+    // validates each path server-side (workspace-confined + secret denylist +
+    // size cap) before sending — the writer/session never holds the bot token.
+    files: z.array(z.string().min(1)).optional(),
+  })
+  .refine(
+    (m) => (m.text !== undefined && m.text.length > 0) || (m.files !== undefined && m.files.length > 0),
+    { message: 'OutboxMessage must carry text or files' },
+  )
 export type OutboxMessage = z.infer<typeof OutboxMessageSchema>
 
 const INBOX_SUBDIR = 'inbox'

--- a/plugin/src/router/inbox-bridge.ts
+++ b/plugin/src/router/inbox-bridge.ts
@@ -124,9 +124,10 @@ export const OutboxMessageSchema = z
     reply_to: z.string().optional(),
     timestamp: z.string().min(1),
     format: OutboxMessageFormatSchema,
-    // Absolute paths of attachments to send AFTER the text. The router
-    // validates each path server-side (workspace-confined + secret denylist +
-    // size cap) before sending — the writer/session never holds the bot token.
+    // Absolute paths of attachments to send AFTER the text. The router checks
+    // each path server-side (secret denylist on path AND realpath + symlink
+    // reject + size cap; NOT workspace-confined, per owner) before sending — the
+    // writer/session never holds the bot token.
     files: z.array(z.string().min(1)).optional(),
   })
   .refine(

--- a/plugin/src/router/multichat-router.ts
+++ b/plugin/src/router/multichat-router.ts
@@ -25,12 +25,13 @@
 //   does not keep the process alive when server.ts shuts down without
 //   an explicit stop() — defence in depth.
 
-import { readdir, unlink } from 'node:fs/promises'
-import { join } from 'node:path'
+import { readdir, stat, unlink } from 'node:fs/promises'
+import { basename, join } from 'node:path'
 
 import type { TelegramApi } from '../channel/tools.js'
 import { splitMessage } from '../format/chunk.js'
 import { markdownToTelegramHtml } from '../format/html.js'
+import { isPhotoExtension, MAX_ATTACHMENT_BYTES } from '../security/paths.js'
 import type { Logger } from '../log.js'
 import {
   assertValidChatId,
@@ -56,6 +57,13 @@ import type { TmuxSessionPool } from './tmux-session-pool.js'
 export interface MultichatTelegramApi {
   sendMessage: TelegramApi['sendMessage']
   sendChatAction: TelegramApi['sendChatAction']
+  // Outbox attachments (parity with the launcher reply tool). Optional so the
+  // many existing router test fixtures (text-only) need no change; production
+  // (server.ts) always wires both. When absent, file sends are skipped. The
+  // router checks each path (secret denylist + size cap) before calling these;
+  // the bot token stays inside the safe-wrapped API.
+  sendDocument?: TelegramApi['sendDocument']
+  sendPhoto?: TelegramApi['sendPhoto']
 }
 
 export interface RouterDeps {
@@ -95,6 +103,19 @@ function parseMessageId(raw: string): number | undefined {
   const n = Number(raw)
   if (!Number.isSafeInteger(n) || n <= 0) return undefined
   return n
+}
+
+// The ONLY hard limit on multichat attachments (warchief 2026-06-10: «только
+// секреты не слать, всё остальное можно»). Matches secret material by path so a
+// public-group session — or a prompt injected by a group member — cannot exfil
+// credentials via sendDocument. Deliberately narrow (env files, private-key
+// extensions, a `secrets/` segment, ssh keys, service-account json) so it does
+// NOT over-block ordinary files that merely contain a word like "token".
+const SECRET_ATTACHMENT_RE =
+  /(?:^|\/)\.env(?:\.[^/]*)?$|(?:^|\/)\.?secrets?\/|\.(?:pem|key|p12|pfx|asc|gpg|ppk|jks|keystore)$|(?:^|\/)\.ssh\/|(?:^|\/)id_(?:rsa|ed25519|ecdsa|dsa)$|(?:^|\/)\.(?:npmrc|netrc|pgpass)$|(?:^|\/)sa-[\w-]*\.json$|\.secret$/i
+
+export function isSecretAttachmentPath(filePath: string): boolean {
+  return SECRET_ATTACHMENT_RE.test(filePath)
 }
 
 // Per-chat outbox loop bookkeeping. fs.watch is intentionally NOT used
@@ -801,71 +822,83 @@ export class MultichatRouter {
     // the same 4000-char boundary so a long group answer doesn't trip
     // Telegram's 4096 cap. safe-telegram-api still validates/redacts
     // each chunk on the way out.
-    let text = message.text
-    if (message.format === 'auto') {
-      text = markdownToTelegramHtml(text)
-      opts.parse_mode = 'HTML'
-    } else if (message.format === 'html') {
-      opts.parse_mode = 'HTML'
-    } else if (message.format === 'markdown') {
-      opts.parse_mode = 'MarkdownV2'
-    }
-    // format === 'text' → omit parse_mode entirely.
-    //
-    // Partial-delivery policy for multi-chunk sends (Codex review
-    // 2026-06-05, MED #1): if chunk 0 fails, nothing reached the user —
-    // dead-letter the claim like any single-message failure (operator
-    // retry is safe). If a LATER chunk fails, the head of the answer is
-    // already user-visible — retrying the whole payload would duplicate
-    // it, so we log `partial_delivery` and CONFIRM the claim instead
-    // (same «never duplicate the user-visible message» stance as the
-    // confirm-failure path below).
-    let sentChunks = 0
-    try {
-      const chunks = message.format === 'auto' ? splitMessage(text) : [text]
-      for (let i = 0; i < chunks.length; i++) {
-        // reply_to threads only the first chunk — mirrors the reply
-        // tool's chunking contract (no quote-spam on long answers).
-        const chunkOpts = i === 0 ? opts : { ...opts }
-        if (i > 0) delete chunkOpts.reply_to_message_id
-        await this.telegramApi.sendMessage(chatId, chunks[i] as string, chunkOpts)
-        sentChunks++
+    // text is optional (a file-only reply has none — schema requires text OR
+    // files). format === 'text' → omit parse_mode entirely.
+    const body = message.text ?? ''
+    if (body.length > 0) {
+      let text = body
+      if (message.format === 'auto') {
+        text = markdownToTelegramHtml(body)
+        opts.parse_mode = 'HTML'
+      } else if (message.format === 'html') {
+        opts.parse_mode = 'HTML'
+      } else if (message.format === 'markdown') {
+        opts.parse_mode = 'MarkdownV2'
       }
-    } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err)
-      if (sentChunks > 0) {
-        this.logger.error('router.outbox.partial_delivery', {
+      // Partial-delivery policy for multi-chunk sends (Codex review
+      // 2026-06-05, MED #1): if chunk 0 fails, nothing reached the user —
+      // dead-letter the claim like any single-message failure (operator
+      // retry is safe). If a LATER chunk fails, the head of the answer is
+      // already user-visible — retrying the whole payload would duplicate
+      // it, so we log `partial_delivery` and CONFIRM the claim instead
+      // (same «never duplicate the user-visible message» stance as the
+      // confirm-failure path below).
+      let sentChunks = 0
+      try {
+        const chunks = message.format === 'auto' ? splitMessage(text) : [text]
+        for (let i = 0; i < chunks.length; i++) {
+          // reply_to threads only the first chunk — mirrors the reply
+          // tool's chunking contract (no quote-spam on long answers).
+          const chunkOpts = i === 0 ? opts : { ...opts }
+          if (i > 0) delete chunkOpts.reply_to_message_id
+          await this.telegramApi.sendMessage(chatId, chunks[i] as string, chunkOpts)
+          sentChunks++
+        }
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err)
+        if (sentChunks > 0) {
+          this.logger.error('router.outbox.partial_delivery', {
+            chat_id: chatId,
+            original: claim.originalName,
+            sent_chunks: sentChunks,
+            error: reason,
+          })
+          await confirmOutboxClaim(claim).catch((confirmErr: unknown) => {
+            this.logger.warn('router.outbox.confirm_failed', {
+              chat_id: chatId,
+              original: claim.originalName,
+              error:
+                confirmErr instanceof Error
+                  ? confirmErr.message
+                  : String(confirmErr),
+            })
+          })
+          return
+        }
+        this.logger.warn('router.outbox.send_failed', {
           chat_id: chatId,
-          original: claim.originalName,
-          sent_chunks: sentChunks,
           error: reason,
+          original: claim.originalName,
         })
-        await confirmOutboxClaim(claim).catch((confirmErr: unknown) => {
-          this.logger.warn('router.outbox.confirm_failed', {
+        await rejectOutboxClaim(claim, { reason }).catch((rejectErr: unknown) => {
+          this.logger.error('router.outbox.dead_letter_failed', {
             chat_id: chatId,
             original: claim.originalName,
             error:
-              confirmErr instanceof Error
-                ? confirmErr.message
-                : String(confirmErr),
+              rejectErr instanceof Error ? rejectErr.message : String(rejectErr),
           })
         })
         return
       }
-      this.logger.warn('router.outbox.send_failed', {
-        chat_id: chatId,
-        error: reason,
-        original: claim.originalName,
-      })
-      await rejectOutboxClaim(claim, { reason }).catch((rejectErr: unknown) => {
-        this.logger.error('router.outbox.dead_letter_failed', {
-          chat_id: chatId,
-          original: claim.originalName,
-          error:
-            rejectErr instanceof Error ? rejectErr.message : String(rejectErr),
-        })
-      })
-      return
+    }
+
+    // Attachments (best-effort, sent AFTER the text). Each path is checked
+    // server-side (NOT a secret + exists + not a dir + size cap) before the
+    // token-holding API is touched. A rejected/failed attachment is logged and
+    // skipped — it never undoes an already-sent text reply, and a secret/size
+    // rejection is permanent so we do NOT dead-letter/retry the claim.
+    if (message.files !== undefined && message.files.length > 0) {
+      await this.sendOutboxFiles(chatId, message.files, claim.originalName)
     }
     await confirmOutboxClaim(claim).catch((confirmErr: unknown) => {
       // Confirm failure means the file lingers in processing/ but the
@@ -879,6 +912,76 @@ export class MultichatRouter {
           confirmErr instanceof Error ? confirmErr.message : String(confirmErr),
       })
     })
+  }
+
+  /**
+   * Send outbox attachments AFTER the text. Best-effort and independent: each
+   * file is validated (NOT a secret, exists, regular file, ≤ MAX_ATTACHMENT_BYTES)
+   * then sent through the token-holding safe API; a rejected/failed file is
+   * logged and skipped so it never undoes an already-sent text reply. Per the
+   * warchief the ONLY hard limit is the secret denylist — any other file (any
+   * path) is allowed. Photos go via sendPhoto (inline preview), the rest via
+   * sendDocument.
+   */
+  private async sendOutboxFiles(
+    chatId: string,
+    files: string[],
+    origin: string,
+  ): Promise<void> {
+    const sendDoc = this.telegramApi.sendDocument
+    const sendImg = this.telegramApi.sendPhoto
+    if (sendDoc === undefined || sendImg === undefined) {
+      this.logger.warn('router.outbox.file_unsupported', {
+        chat_id: chatId,
+        original: origin,
+        count: files.length,
+      })
+      return
+    }
+    for (const filePath of files) {
+      try {
+        if (isSecretAttachmentPath(filePath)) {
+          this.logger.warn('router.outbox.file_rejected_secret', {
+            chat_id: chatId,
+            original: origin,
+            file: basename(filePath),
+          })
+          continue
+        }
+        const st = await stat(filePath)
+        if (!st.isFile()) {
+          this.logger.warn('router.outbox.file_rejected', {
+            chat_id: chatId,
+            original: origin,
+            file: basename(filePath),
+            reason: 'not_a_file',
+          })
+          continue
+        }
+        if (st.size > MAX_ATTACHMENT_BYTES) {
+          this.logger.warn('router.outbox.file_rejected', {
+            chat_id: chatId,
+            original: origin,
+            file: basename(filePath),
+            reason: 'too_large',
+            size: st.size,
+          })
+          continue
+        }
+        if (isPhotoExtension(filePath)) {
+          await sendImg(chatId, filePath, {})
+        } else {
+          await sendDoc(chatId, filePath, {})
+        }
+      } catch (err) {
+        this.logger.warn('router.outbox.file_send_failed', {
+          chat_id: chatId,
+          original: origin,
+          file: basename(filePath),
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
   }
 }
 

--- a/plugin/src/router/multichat-router.ts
+++ b/plugin/src/router/multichat-router.ts
@@ -25,7 +25,7 @@
 //   does not keep the process alive when server.ts shuts down without
 //   an explicit stop() — defence in depth.
 
-import { readdir, stat, unlink } from 'node:fs/promises'
+import { lstat, readdir, realpath, unlink } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 
 import type { TelegramApi } from '../channel/tools.js'
@@ -106,16 +106,35 @@ function parseMessageId(raw: string): number | undefined {
 }
 
 // The ONLY hard limit on multichat attachments (warchief 2026-06-10: «только
-// секреты не слать, всё остальное можно»). Matches secret material by path so a
-// public-group session — or a prompt injected by a group member — cannot exfil
-// credentials via sendDocument. Deliberately narrow (env files, private-key
-// extensions, a `secrets/` segment, ssh keys, service-account json) so it does
-// NOT over-block ordinary files that merely contain a word like "token".
-const SECRET_ATTACHMENT_RE =
-  /(?:^|\/)\.env(?:\.[^/]*)?$|(?:^|\/)\.?secrets?\/|\.(?:pem|key|p12|pfx|asc|gpg|ppk|jks|keystore)$|(?:^|\/)\.ssh\/|(?:^|\/)id_(?:rsa|ed25519|ecdsa|dsa)$|(?:^|\/)\.(?:npmrc|netrc|pgpass)$|(?:^|\/)sa-[\w-]*\.json$|\.secret$/i
+// секреты не слать, всё остальное можно» — deny secrets by path, allow every
+// other file; NO workspace confinement). This is the exfil gate for a session
+// that may live in a PUBLIC group: a group member's prompt injection must not be
+// able to attach a credential file. The check runs server-side, on BOTH the
+// raw path AND its realpath (a non-secret-named symlink can resolve into a
+// secret — see sendOutboxFiles). Covers the real credential STORES, not just a
+// casual word, so it neither under-blocks (Codex/automated review HIGH) nor
+// over-blocks ordinary files named e.g. "token-economy.md".
+const SECRET_ATTACHMENT_PATTERNS: RegExp[] = [
+  /\.env$|\.envrc$|\.env\.[^/]*$/i, //                          env files (.env, prod.env, .env.production, .envrc)
+  /\.(?:pem|key|p12|pfx|asc|gpg|ppk|jks|keystore|kdbx)(?:\.(?:bak|old|orig|txt|save|[0-9]+))?$/i, // private-key material (+ backups)
+  /(?:^|\/)\.?secrets?(?:\.d)?\//i, //                          a secrets/ directory
+  /(?:^|\/)\.ssh\//i, //                                        ssh dir
+  /(?:^|\/)id_(?:rsa|ed25519|ecdsa|dsa)(?:\.[^/]*)?$/i, //      ssh private keys (+ .pub/.bak)
+  /(?:^|\/)\.(?:npmrc|netrc|pgpass|pypirc|git-credentials)$/i,
+  /(?:^|\/)\.(?:aws|kube|gnupg|codex)\//i, //                   credential-store dirs
+  /(?:^|\/)\.docker\/config\.json$/i,
+  /(?:^|\/)\.config\/(?:gcloud|gh)\//i,
+  /(?:^|\/)\.cargo\/credentials/i,
+  /(?:^|\/)\.gem\/credentials$/i,
+  /(?:^|\/)\.(?:claude|credentials)\.json$/i, //                .claude.json / .credentials.json
+  /(?:^|\/)sa-[\w-]*\.json$/i,
+  /(?:^|\/)(?:service[_-]?account|firebase-adminsdk)[\w.-]*\.json$/i,
+  /(?:^|\/)(?:credentials?|auth|secret|token|apikey|api[_-]?key)\.(?:json|ya?ml|toml|txt|ini|env)$/i,
+  /\.secrets?$/i,
+]
 
 export function isSecretAttachmentPath(filePath: string): boolean {
-  return SECRET_ATTACHMENT_RE.test(filePath)
+  return SECRET_ATTACHMENT_PATTERNS.some((re) => re.test(filePath))
 }
 
 // Per-chat outbox loop bookkeeping. fs.watch is intentionally NOT used
@@ -948,8 +967,19 @@ export class MultichatRouter {
           })
           continue
         }
-        const st = await stat(filePath)
-        if (!st.isFile()) {
+        // lstat (does NOT follow symlinks) so a symlink named like an innocuous
+        // file cannot smuggle a secret target past the name-based denylist.
+        const ls = await lstat(filePath)
+        if (ls.isSymbolicLink()) {
+          this.logger.warn('router.outbox.file_rejected', {
+            chat_id: chatId,
+            original: origin,
+            file: basename(filePath),
+            reason: 'symlink',
+          })
+          continue
+        }
+        if (!ls.isFile()) {
           this.logger.warn('router.outbox.file_rejected', {
             chat_id: chatId,
             original: origin,
@@ -958,13 +988,28 @@ export class MultichatRouter {
           })
           continue
         }
-        if (st.size > MAX_ATTACHMENT_BYTES) {
+        if (ls.size > MAX_ATTACHMENT_BYTES) {
           this.logger.warn('router.outbox.file_rejected', {
             chat_id: chatId,
             original: origin,
             file: basename(filePath),
             reason: 'too_large',
-            size: st.size,
+            size: ls.size,
+          })
+          continue
+        }
+        // Re-check the CANONICAL path: a symlinked PARENT directory could route
+        // an innocuous-looking path into a secret store. realpath resolves all
+        // links; if the real target is a secret, refuse. (Residual: a TOCTOU
+        // swap after this check, or the agent copying a secret to an innocuous
+        // name, is active-agent malice the owner accepted — its Bash is gated.)
+        const realPath = await realpath(filePath)
+        if (isSecretAttachmentPath(realPath)) {
+          this.logger.warn('router.outbox.file_rejected_secret', {
+            chat_id: chatId,
+            original: origin,
+            file: basename(filePath),
+            reason: 'resolved_to_secret',
           })
           continue
         }

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -823,6 +823,12 @@ if (
           telegramApi.sendMessage(chatId, text, opts),
         sendChatAction: (chatId, action) =>
           telegramApi.sendChatAction(chatId, action),
+        // Outbox attachments — the safe-wrapped API holds the token; the
+        // router validates each path before calling this.
+        sendDocument: (chatId, filePath, opts) =>
+          telegramApi.sendDocument(chatId, filePath, opts),
+        sendPhoto: (chatId, filePath, opts) =>
+          telegramApi.sendPhoto(chatId, filePath, opts),
       },
       logger: log,
     })

--- a/plugin/tests/chats/stop-to-outbox.test.ts
+++ b/plugin/tests/chats/stop-to-outbox.test.ts
@@ -682,3 +682,65 @@ describe('stop-to-outbox.py — transcript-flush race (extended-thinking)', () =
     expect(listOutboxJson().length).toBe(0)
   })
 })
+
+describe('attachment markers ([[file: …]])', () => {
+  const baseEnv = () => ({ CHAT_ID, MULTICHAT_STATE_DIR: stateDir })
+
+  test('extracts a [[file: …]] marker into files[] and strips it from text', () => {
+    const transcript = writeTranscript([
+      userLine('скинь презентацию'),
+      assistantLine([
+        { type: 'text', text: 'Вот файл. [[file: /home/openclaw/x/present.html]] Готово.' },
+      ]),
+    ])
+    const r = run(baseEnv(), { transcript_path: transcript, session_id: 's1' })
+    expect(r.code).toBe(0)
+    const files = listOutboxJson()
+    expect(files.length).toBe(1)
+    const msg = readOutboxPayload(files[0] as string)
+    expect(msg.files).toEqual(['/home/openclaw/x/present.html'])
+    // marker removed from the visible text
+    expect(String(msg.text)).not.toContain('[[file:')
+    expect(String(msg.text)).toContain('Вот файл.')
+    expect(String(msg.text)).toContain('Готово.')
+  })
+
+  test('file-only reply (text is only the marker) omits text, keeps files', () => {
+    const transcript = writeTranscript([
+      userLine('файл'),
+      assistantLine([{ type: 'text', text: '[[file: /tmp/a.pdf]]' }]),
+    ])
+    const r = run(baseEnv(), { transcript_path: transcript, session_id: 's1' })
+    expect(r.code).toBe(0)
+    const files = listOutboxJson()
+    expect(files.length).toBe(1)
+    const msg = readOutboxPayload(files[0] as string)
+    expect(msg.files).toEqual(['/tmp/a.pdf'])
+    expect(msg.text).toBeUndefined()
+  })
+
+  test('multiple markers collect into files[] in order', () => {
+    const transcript = writeTranscript([
+      userLine('два файла'),
+      assistantLine([
+        { type: 'text', text: 'Оба тут [[file: /tmp/1.png]] и [[file: /tmp/2.txt]].' },
+      ]),
+    ])
+    const r = run(baseEnv(), { transcript_path: transcript, session_id: 's1' })
+    expect(r.code).toBe(0)
+    const msg = readOutboxPayload(listOutboxJson()[0] as string)
+    expect(msg.files).toEqual(['/tmp/1.png', '/tmp/2.txt'])
+  })
+
+  test('no marker → no files key (unchanged text-only behaviour)', () => {
+    const transcript = writeTranscript([
+      userLine('привет'),
+      assistantLine([{ type: 'text', text: 'Здравствуй, вождь.' }]),
+    ])
+    const r = run(baseEnv(), { transcript_path: transcript, session_id: 's1' })
+    expect(r.code).toBe(0)
+    const msg = readOutboxPayload(listOutboxJson()[0] as string)
+    expect(msg.files).toBeUndefined()
+    expect(msg.text).toBe('Здравствуй, вождь.')
+  })
+})

--- a/plugin/tests/router/secret-attachment-denylist.test.ts
+++ b/plugin/tests/router/secret-attachment-denylist.test.ts
@@ -1,0 +1,42 @@
+// The ONLY hard limit on multichat attachments: secret material must never be
+// sendable to a (public) chat, while ordinary files are allowed (warchief
+// 2026-06-10). Guards the file-exfil surface of the multichat file-send.
+import { describe, expect, test } from 'bun:test'
+import { isSecretAttachmentPath } from '../../src/router/multichat-router.js'
+
+describe('isSecretAttachmentPath', () => {
+  test('BLOCKS secret material', () => {
+    for (const p of [
+      '/home/openclaw/.claude-lab/thrall/secrets/socialdata.env',
+      '/home/openclaw/app/.env',
+      '/home/openclaw/app/.env.production',
+      '/etc/ssl/private/server.key',
+      '/home/x/cert.pem',
+      '/home/x/keystore.p12',
+      '/home/x/.ssh/id_rsa',
+      '/home/x/id_ed25519',
+      '/home/x/.npmrc',
+      '/home/x/.netrc',
+      '/home/openclaw/.secrets/firebase/sa-thrall.json',
+      '/var/run/sa-gbrain.json',
+      '/tmp/api.secret',
+    ]) {
+      expect(isSecretAttachmentPath(p)).toBe(true)
+    }
+  })
+
+  test('ALLOWS ordinary files (any path, any common type)', () => {
+    for (const p of [
+      '/home/openclaw/.claude-lab/thrall/.claude/skills/present/present-gbrain.html',
+      '/tmp/report.pdf',
+      '/home/x/cover.png',
+      '/home/x/cowork-1.txt',
+      '/home/x/diagram.svg',
+      '/home/x/data.json',
+      '/home/x/token-economy-lesson.html',
+      '/home/x/credentials-explained.md',
+    ]) {
+      expect(isSecretAttachmentPath(p)).toBe(false)
+    }
+  })
+})

--- a/plugin/tests/router/secret-attachment-denylist.test.ts
+++ b/plugin/tests/router/secret-attachment-denylist.test.ts
@@ -1,24 +1,45 @@
 // The ONLY hard limit on multichat attachments: secret material must never be
 // sendable to a (public) chat, while ordinary files are allowed (warchief
-// 2026-06-10). Guards the file-exfil surface of the multichat file-send.
+// 2026-06-10). Guards the file-exfil surface. The denylist was widened after
+// Codex + the automated commit review flagged missing credential stores.
 import { describe, expect, test } from 'bun:test'
 import { isSecretAttachmentPath } from '../../src/router/multichat-router.js'
 
 describe('isSecretAttachmentPath', () => {
-  test('BLOCKS secret material', () => {
+  test('BLOCKS secret material (path-based)', () => {
     for (const p of [
       '/home/openclaw/.claude-lab/thrall/secrets/socialdata.env',
       '/home/openclaw/app/.env',
       '/home/openclaw/app/.env.production',
+      '/home/x/prod.env',
+      '/home/x/.envrc',
       '/etc/ssl/private/server.key',
       '/home/x/cert.pem',
+      '/home/x/private.key.bak',
       '/home/x/keystore.p12',
       '/home/x/.ssh/id_rsa',
       '/home/x/id_ed25519',
+      '/home/x/id_rsa.bak',
       '/home/x/.npmrc',
       '/home/x/.netrc',
+      '/home/x/.git-credentials',
+      '/home/x/.aws/credentials',
+      '/home/x/.kube/config',
+      '/home/x/.docker/config.json',
+      '/home/x/.config/gcloud/application_default_credentials.json',
+      '/home/x/.config/gh/hosts.yml',
+      '/home/x/.gnupg/secring.gpg',
+      '/home/x/.codex/auth.json',
+      '/home/x/.claude.json',
+      '/home/x/.credentials.json',
+      '/home/x/.cargo/credentials.toml',
       '/home/openclaw/.secrets/firebase/sa-thrall.json',
       '/var/run/sa-gbrain.json',
+      '/home/x/service-account.json',
+      '/home/x/firebase-adminsdk-abc.json',
+      '/home/x/credentials.json',
+      '/home/x/auth.yaml',
+      '/home/x/secret.json',
       '/tmp/api.secret',
     ]) {
       expect(isSecretAttachmentPath(p)).toBe(true)
@@ -33,8 +54,8 @@ describe('isSecretAttachmentPath', () => {
       '/home/x/cowork-1.txt',
       '/home/x/diagram.svg',
       '/home/x/data.json',
+      '/home/x/lesson.md',
       '/home/x/token-economy-lesson.html',
-      '/home/x/credentials-explained.md',
     ]) {
       expect(isSecretAttachmentPath(p)).toBe(false)
     }


### PR DESCRIPTION
## Проблема
Мультичат-сессии отдают ответ через `Stop-hook -> outbox -> router`, и этот путь умел только ТЕКСТ. Когда сессия в чате воркшопа попыталась прислать презентацию, она полезла в сырой `curl + ${TELEGRAM_BOT_TOKEN}` -> гейт жёстко отбил (секреты hard-denied). Итог: текст готов, файл не ушёл, сессия зависла.

## Решение (токен остаётся на сервере)
- **OutboxMessage**: `+files[]`; `text` стал optional, refine требует text ИЛИ files.
- **Stop-hook** (`stop-to-outbox.py`): парсит маркер `[[file: /abs/path]]` из ответа агента, кладёт пути в `files`, вырезает маркер из видимого текста. Хук НЕ читает/не открывает файлы.
- **Router** (`multichat-router`): после текста шлёт каждый файл через `sendDocument`/`sendPhoto` (safe API держит токен). Валидация на сервере.
- **server.ts**: адаптер прокидывает `sendDocument`/`sendPhoto` (опциональны -> старые тест-моки не трогаются).
- **session-start.sh**: инжектит подсказку про маркер во все мультичат-сессии.

## Безопасность (по слову вождя: «только секреты не слать, всё остальное можно»)
Единственный жёсткий лимит — denylist на секрет-файлы (env-файлы, private-key расширения, секрет-каталог, ssh-ключи, service-account json) + проверка существует/не-каталог/<=50MB. БЕЗ workspace-ограничения — любой обычный файл (любой путь) разрешён. Это закрывает exfil-поверхность (публичная группа / инъекция не сольёт секрет через sendDocument), но не мешает нормальной работе.

## Тесты
- 4 на маркер-извлечение: extract+strip / file-only (text опускается) / multiple / none (текст-only без изменений).
- 2 на denylist: блокирует секреты, разрешает обычные файлы (любой путь/тип).
- 1582 pass, tsc чисто.

## Дальше
Двойное ревью (Codex+Fable, фокус на exfil-поверхности) -> merge -> рестарт мультичат-сессии -> e2e (отправить безопасный файл, не внутреннюю презентацию в публичную группу).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
