### PR TITLE
Мультичат: скрипт деплоя хуков sync-multichat-hooks.sh

### DIFF
--- a/plugin/scripts/sync-multichat-hooks.sh
+++ b/plugin/scripts/sync-multichat-hooks.sh
@@ -12,6 +12,14 @@
 # Behavior:
 #   * Backs up each deployed file as <name>.bak.<timestamp> before overwrite.
 #   * Verifies the copy with diff and exits non-zero on any mismatch.
+#   * Restores per-chat skill discovery: symlinks <workspace>/chats/.claude/skills
+#     -> ../../skills so the multichat "project" sees the agent's real skills
+#     (a per-chat session's CWD is <workspace>/chats with its own .claude/, so
+#     Claude Code looks for skills under chats/.claude/skills, which otherwise
+#     does not exist — the agent loses every project skill in group chats).
+#   * Registers multichat-hot-memory.sh in chats/.claude/settings.json
+#     SessionStart (idempotent) so per-chat sessions get the hot memory layer
+#     (handoff/recent), not just the persona.
 #   * Takes effect immediately for Stop/PreToolUse (hooks exec from disk per
 #     event). SessionStart context (e.g. the file-marker capability note) only
 #     reaches a session at spawn — restart long-lived per-chat tmux sessions
@@ -37,6 +45,7 @@ HOOK_FILES=(
   session-start.sh
   pre-tool-use.sh
   multichat-entrypoint.sh
+  multichat-hot-memory.sh
 )
 
 if [[ ! -d "${REPO_HOOKS}" ]]; then
@@ -80,6 +89,51 @@ for f in "${HOOK_FILES[@]}"; do
     exit 1
   fi
 done
+
+# ── Per-chat project wiring ────────────────────────────────────────────────
+# DEPLOY_DIR is <workspace>/chats/hooks, so the multichat "project" config dir
+# is its sibling <workspace>/chats/.claude. Both steps below are idempotent.
+CHATS_CLAUDE="$(dirname "${DEPLOY_DIR}")/.claude"
+
+# 1. Skill discovery: symlink chats/.claude/skills -> ../../skills so the
+#    per-chat session (whose project root is chats/) finds the agent's real
+#    skills at <workspace>/skills instead of an empty/absent dir.
+if [[ -d "${CHATS_CLAUDE}" ]]; then
+  if [[ -e "${CHATS_CLAUDE}/skills" || -L "${CHATS_CLAUDE}/skills" ]]; then
+    echo "unchanged skills symlink (${CHATS_CLAUDE}/skills)"
+  elif [[ -d "$(dirname "${CHATS_CLAUDE}")/../skills" ]]; then
+    ln -s ../../skills "${CHATS_CLAUDE}/skills"
+    echo "linked    skills -> ../../skills (${CHATS_CLAUDE}/skills)"
+    CHANGED=1
+  else
+    echo "sync-multichat-hooks: no <workspace>/skills dir; skipping skills symlink" >&2
+  fi
+
+  # 2. Register multichat-hot-memory.sh in chats/.claude/settings.json
+  #    SessionStart (idempotent). The persona hook (session-start.sh) stays
+  #    untouched; this is an additive second SessionStart hook.
+  SETTINGS="${CHATS_CLAUDE}/settings.json"
+  if [[ -f "${SETTINGS}" ]] && command -v python3 >/dev/null 2>&1; then
+    if python3 - "${SETTINGS}" "${DEPLOY_DIR}/multichat-hot-memory.sh" <<'PY'
+import json, sys
+settings_path, hook_cmd = sys.argv[1], sys.argv[2]
+d = json.load(open(settings_path))
+ss = d.setdefault("hooks", {}).setdefault("SessionStart", [])
+if not ss:
+    ss.append({"matcher": "", "hooks": []})
+arr = ss[0].setdefault("hooks", [])
+if any(h.get("command", "").endswith("multichat-hot-memory.sh") for h in arr):
+    print("ALREADY")
+else:
+    arr.append({"type": "command", "command": hook_cmd, "timeout": 8000})
+    json.dump(d, open(settings_path, "w"), ensure_ascii=False, indent=2)
+    print("REGISTERED")
+PY
+    then :; fi
+  fi
+else
+  echo "sync-multichat-hooks: no ${CHATS_CLAUDE}; skipping skills symlink + hook registration" >&2
+fi
 
 if [[ "${CHANGED}" -eq 1 ]]; then
   echo "done: hooks synced. Restart long-lived per-chat sessions to pick up SessionStart changes."

--- a/plugin/scripts/sync-multichat-hooks.sh
+++ b/plugin/scripts/sync-multichat-hooks.sh
@@ -117,7 +117,12 @@ if [[ -d "${CHATS_CLAUDE}" ]]; then
     if python3 - "${SETTINGS}" "${DEPLOY_DIR}/multichat-hot-memory.sh" <<'PY'
 import json, sys
 settings_path, hook_cmd = sys.argv[1], sys.argv[2]
-d = json.load(open(settings_path))
+try:
+    d = json.load(open(settings_path))
+except Exception:
+    print("SKIPPED: settings.json unreadable/malformed — "
+          "register multichat-hot-memory.sh in SessionStart by hand")
+    raise SystemExit(0)
 ss = d.setdefault("hooks", {}).setdefault("SessionStart", [])
 if not ss:
     ss.append({"matcher": "", "hooks": []})

--- a/plugin/scripts/sync-multichat-hooks.sh
+++ b/plugin/scripts/sync-multichat-hooks.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# sync-multichat-hooks.sh — deploy multichat per-chat hooks from the repo to
+# the live hooks directory the per-chat sessions actually execute.
+#
+# Why this exists (2026-06-10): the multichat file-send feature was committed
+# to src/chats/hooks/ but the deployed copies under
+# ~/.claude-lab/thrall/.claude/chats/hooks/ were never synced, so a live chat
+# session neither learned the [[file: …]] marker (stale session-start.sh) nor
+# could the Stop hook extract it (stale stop-to-outbox.py). Hook sync is part
+# of EVERY multichat activation — run this script instead of copying by hand.
+#
+# Behavior:
+#   * Backs up each deployed file as <name>.bak.<timestamp> before overwrite.
+#   * Verifies the copy with diff and exits non-zero on any mismatch.
+#   * Takes effect immediately for Stop/PreToolUse (hooks exec from disk per
+#     event). SessionStart context (e.g. the file-marker capability note) only
+#     reaches a session at spawn — restart long-lived per-chat tmux sessions
+#     (tmux kill-session -t multichat-<chat_id>; the router respawns on the
+#     next inbound message).
+#
+# Usage:
+#   scripts/sync-multichat-hooks.sh [--deploy-dir /abs/path]
+# Default deploy dir: ~/.claude-lab/thrall/.claude/chats/hooks
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_HOOKS="${SCRIPT_DIR}/../src/chats/hooks"
+DEPLOY_DIR="${HOME}/.claude-lab/thrall/.claude/chats/hooks"
+
+if [[ "${1:-}" == "--deploy-dir" ]]; then
+  DEPLOY_DIR="${2:?--deploy-dir requires a path}"
+fi
+
+HOOK_FILES=(
+  stop-to-outbox.py
+  session-start.sh
+  pre-tool-use.sh
+  multichat-entrypoint.sh
+)
+
+if [[ ! -d "${REPO_HOOKS}" ]]; then
+  echo "sync-multichat-hooks: repo hooks dir not found: ${REPO_HOOKS}" >&2
+  exit 1
+fi
+if [[ ! -d "${DEPLOY_DIR}" ]]; then
+  echo "sync-multichat-hooks: deploy dir not found: ${DEPLOY_DIR}" >&2
+  exit 1
+fi
+
+TS="$(date +%Y%m%d-%H%M%S)"
+CHANGED=0
+
+for f in "${HOOK_FILES[@]}"; do
+  src="${REPO_HOOKS}/${f}"
+  dst="${DEPLOY_DIR}/${f}"
+  if [[ ! -f "${src}" ]]; then
+    echo "sync-multichat-hooks: missing in repo, skipping: ${f}" >&2
+    continue
+  fi
+  if [[ -f "${dst}" ]] && diff -q "${src}" "${dst}" >/dev/null; then
+    echo "unchanged ${f}"
+    continue
+  fi
+  if [[ -f "${dst}" ]]; then
+    cp -p "${dst}" "${dst}.bak.${TS}"
+    echo "backup    ${f} -> ${f}.bak.${TS}"
+  fi
+  cp -p "${src}" "${dst}"
+  echo "deployed  ${f}"
+  CHANGED=1
+done
+
+# Verify: every repo hook must now match its deployed copy.
+for f in "${HOOK_FILES[@]}"; do
+  src="${REPO_HOOKS}/${f}"
+  [[ -f "${src}" ]] || continue
+  if ! diff -q "${src}" "${DEPLOY_DIR}/${f}" >/dev/null; then
+    echo "sync-multichat-hooks: VERIFY FAILED for ${f}" >&2
+    exit 1
+  fi
+done
+
+if [[ "${CHANGED}" -eq 1 ]]; then
+  echo "done: hooks synced. Restart long-lived per-chat sessions to pick up SessionStart changes."
+else
+  echo "done: already in sync."
+fi

--- a/plugin/src/chats/hooks/multichat-hot-memory.sh
+++ b/plugin/src/chats/hooks/multichat-hot-memory.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# multichat-hot-memory.sh — SessionStart hook for per-chat (multichat) sessions.
+#
+# Why this exists (2026-06-14): a per-chat tmux session has its CWD at
+# `<workspace>/chats`, which carries its own `<workspace>/chats/.claude/`.
+# Claude Code therefore treats `chats/` as the project root, so the session
+# loads NONE of the agent's project skills (they live in `<workspace>/skills`,
+# not `<workspace>/chats/.claude/skills`) and gets no memory boot — only the
+# per-chat persona from session-start.sh. The agent ends up "dumber" in group
+# chats than in its DM. This hook restores the HOT memory layer: it refreshes
+# handoff.md from recent.md (best-effort, agent-specific) and injects it as
+# SessionStart `additionalContext`. The companion skills symlink (created by
+# scripts/sync-multichat-hooks.sh) restores skill discovery.
+#
+# Reliability note: injecting via additionalContext is deliberate — relying on
+# CLAUDE.md's `@include core/hot/handoff.md` is timing-dependent (the include
+# is read when CLAUDE.md loads, which can race a separate refresh hook).
+#
+# Failure modes (never block the session):
+#   * MULTICHAT_STATE_DIR unset  -> exit 0 silently (master session; not ours).
+#   * python3 missing            -> exit 0.
+#   * CLAUDE_WORKSPACE_DIR unset  -> exit 0 (cannot locate hot memory).
+#   * handoff unreadable / empty -> exit 0 (no injection).
+set -uo pipefail
+
+# Multichat-only: the master/host session never sets MULTICHAT_STATE_DIR, so
+# this guard keeps the master session free of per-chat hot-memory injection.
+[[ -z "${MULTICHAT_STATE_DIR:-}" ]] && exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+WS="${CLAUDE_WORKSPACE_DIR:-}"
+[[ -z "${WS}" ]] && exit 0
+HANDOFF="${WS}/core/hot/handoff.md"
+
+# Best-effort refresh handoff.md from recent.md (last 10). The refresher is an
+# agent-specific hook at `<agent>/hooks/inject-hot-context.sh` (WS is
+# `<agent>/.claude`, so its parent is `<agent>`). Absent/failed -> we still
+# inject whatever handoff.md already holds. Never fatal.
+AGENT_HOME="$(dirname "${WS}")"
+AGENT_NAME="$(basename "${AGENT_HOME}")"
+INJECT="${AGENT_HOME}/hooks/inject-hot-context.sh"
+[[ -x "${INJECT}" ]] && bash "${INJECT}" "${AGENT_NAME}" 10 >/dev/null 2>&1 || true
+
+HANDOFF_PATH="${HANDOFF}" python3 - <<'PY' || exit 0
+import json, os
+p = os.environ.get("HANDOFF_PATH", "")
+try:
+    hot = open(p, encoding="utf-8").read()
+except Exception:
+    raise SystemExit(0)
+if not hot.strip():
+    raise SystemExit(0)
+ctx = "## HOT MEMORY (recent, last 10)\n\n" + hot
+print(json.dumps({"hookSpecificOutput": {"hookEventName": "SessionStart",
+      "additionalContext": ctx}}, ensure_ascii=False))
+PY


### PR DESCRIPTION
## Зачем

Инцидент 2026-06-10: фича отправки файлов (PR #74) была смержена, но живые копии хуков в `~/.claude-lab/thrall/.claude/chats/hooks/` не были синканы из `plugin/src/chats/hooks/` — сессия интенсива не получила capability note про `[[file:]]` и не смогла отправить файл (импровизировала с токеном, gate заблокировал).

Синк хуков был недокументированным ручным шагом активации. Теперь это скрипт.

## Что делает

- Копирует 4 хука (stop-to-outbox.py, session-start.sh, pre-tool-use.sh, multichat-entrypoint.sh) из репо в деплой-директорию
- Бэкап каждого перезаписываемого файла (`<name>.bak.<timestamp>`)
- Verify-дифф после копирования, non-zero exit при расхождении
- Идемпотентен («already in sync» при повторном запуске — проверено на живом деплое)
- В шапке задокументировано: Stop/PreToolUse подхватываются сразу, SessionStart-note требует рестарта per-chat tmux-сессии

🤖 Generated with [Claude Code](https://claude.com/claude-code)