### PR TITLE
Мультичат: голосовые доносят транскрипт до чат-сессии

### DIFF
--- a/plugin/src/chats/hooks/multichat-entrypoint.sh
+++ b/plugin/src/chats/hooks/multichat-entrypoint.sh
@@ -107,11 +107,21 @@ wait_claude_ready() {
 prompt_fingerprint() {
   printf '%s' "$1" | python3 -c '
 import sys
-for line in sys.stdin.read().splitlines():
-    line = line.strip()
-    if len(line) >= 4:
+lines = [l.strip() for l in sys.stdin.read().splitlines()]
+# Prefer the stable speaker line over whatever happens to come first: a
+# leading <media .../> descriptor can be very long (voice transcript
+# attribute) and tmux may wrap it differently than our 60-char slice,
+# producing a false "not submitted". The [from @user] line is short and
+# always rendered verbatim.
+for line in lines:
+    if line.startswith("[from @") and len(line) >= 4:
         sys.stdout.write(line[:60])
         break
+else:
+    for line in lines:
+        if len(line) >= 4:
+            sys.stdout.write(line[:60])
+            break
 ' || true
 }
 
@@ -186,6 +196,8 @@ submit_prompt() {
 
 # Parse one JSON file into a single prompt string. Reads the file path
 # from $INBOX_FILE so nothing user-controlled is interpolated into shell.
+# Exit codes: 0 = prompt on stdout; 1 = parse failure; 3 = nothing to
+# deliver (no text, no media, no reply context) — caller must NOT submit.
 build_prompt() {
   INBOX_FILE="$1" python3 - <<'PYEOF'
 import json
@@ -206,27 +218,52 @@ if not isinstance(d, dict):
           file=sys.stderr)
     sys.exit(1)
 
-parts = []
-
-reply_context = d.get('reply_context')
-if isinstance(reply_context, str) and reply_context:
-    parts.append(reply_context)
-
 text = d.get('text', '') or ''
 user = d.get('user', '') or ''
-if user:
-    parts.append(f'[from @{user}] {text}')
-else:
-    parts.append(text)
 
-media_paths = d.get('media_paths') or []
-if isinstance(media_paths, list):
-    for p in media_paths:
-        if isinstance(p, str) and p:
-            parts.append(f'[media: {p}]')
+reply_context = d.get('reply_context')
+if not (isinstance(reply_context, str) and reply_context):
+    reply_context = None
+
+raw_descriptors = d.get('media_descriptors') or []
+descriptors = [m for m in raw_descriptors
+               if isinstance(m, str) and m.strip()] \
+    if isinstance(raw_descriptors, list) else []
+
+raw_paths = d.get('media_paths') or []
+media_paths = [p for p in raw_paths if isinstance(p, str) and p] \
+    if isinstance(raw_paths, list) else []
+
+# Skip-empty contract: with no payload on ANY channel there is nothing
+# for the model to act on — submitting would paste an attribution-only
+# prompt the verify loop may never confirm (the 2026-06-11 incident:
+# voice messages arrived with empty text before transcripts were
+# carried, and the watcher burned 5 attempts on a no-op submit).
+if not text.strip() and reply_context is None \
+        and not descriptors and not media_paths:
+    sys.exit(3)
+
+parts = []
+
+if reply_context is not None:
+    parts.append(reply_context)
+
+# Media descriptors go ABOVE the speaker line — parity with the DM
+# path's buildChannelContent (media first, then text). The speaker
+# attribution stays adjacent to the text it labels.
+parts.extend(descriptors)
+
+if user:
+    parts.append(f'[from @{user}] {text}' if text else f'[from @{user}]')
+else:
+    if text:
+        parts.append(text)
+
+for p in media_paths:
+    parts.append(f'[media: {p}]')
 
 # Two-newline join so the model sees explicit paragraph breaks between
-# the reply context, the main text, and the media descriptors.
+# the reply context, the media descriptors, and the main text.
 sys.stdout.write('\n\n'.join(parts))
 PYEOF
 }
@@ -235,11 +272,17 @@ PYEOF
 # NOTE: We deliberately do NOT recurse into .processed/ — `find -maxdepth 1`
 # plus the leading-dot exclusion handled by the *.json glob keeps us safe.
 process_inbox() {
-  local f msg_text
+  local f msg_text rc
   while IFS= read -r -d '' f; do
     [[ -f "$f" ]] || continue
-    msg_text="$(build_prompt "$f" || true)"
-    if [[ -n "$msg_text" ]]; then
+    rc=0
+    msg_text="$(build_prompt "$f")" || rc=$?
+    if [[ "$rc" -eq 3 ]]; then
+      # Nothing to deliver (no text / media / reply context) — never
+      # paste an empty prompt into the composer. Keep the file for
+      # triage under a distinct prefix.
+      mv "$f" "${PROCESSED}/skipped-empty-$(basename "$f")"
+    elif [[ "$rc" -eq 0 && -n "$msg_text" ]]; then
       if submit_prompt "$msg_text"; then
         mv "$f" "${PROCESSED}/$(basename "$f")"
       else

--- a/plugin/src/chats/hooks/multichat-entrypoint.sh
+++ b/plugin/src/chats/hooks/multichat-entrypoint.sh
@@ -108,20 +108,35 @@ prompt_fingerprint() {
   printf '%s' "$1" | python3 -c '
 import sys
 lines = [l.strip() for l in sys.stdin.read().splitlines()]
-# Prefer the stable speaker line over whatever happens to come first: a
-# leading <media .../> descriptor can be very long (voice transcript
-# attribute) and tmux may wrap it differently than our 60-char slice,
-# producing a false "not submitted". The [from @user] line is short and
-# always rendered verbatim.
-for line in lines:
-    if line.startswith("[from @") and len(line) >= 4:
-        sys.stdout.write(line[:60])
-        break
+# Selection order (build_prompt renders reply_context -> descriptors ->
+# speaker line -> media paths):
+#   1. The LAST "[from @" line, if long enough to be distinctive. Last,
+#      not first: reply_context precedes the current message and a
+#      quoted body may itself contain a "[from @old]" line — picking it
+#      would verify the wrong text (false submit confirmation).
+#   2. A "<media " descriptor line. Its head carries the per-message
+#      file_id, so a caption-less voice note (bare attribution shorter
+#      than the threshold — identical across every voice note from the
+#      same user) still gets a unique fingerprint. The first 60 chars
+#      sit on one visual pane row even after tmux wraps the long tail.
+#   3. The bare speaker line, then any line >= 4 chars (legacy fallback).
+speaker = next(
+    (l for l in reversed(lines) if l.startswith("[from @") and len(l) >= 4),
+    None,
+)
+if speaker is not None and len(speaker) >= 20:
+    sys.stdout.write(speaker[:60])
 else:
-    for line in lines:
-        if len(line) >= 4:
-            sys.stdout.write(line[:60])
-            break
+    descriptor = next((l for l in lines if l.startswith("<media ")), None)
+    if descriptor is not None:
+        sys.stdout.write(descriptor[:60])
+    elif speaker is not None:
+        sys.stdout.write(speaker[:60])
+    else:
+        for line in lines:
+            if len(line) >= 4:
+                sys.stdout.write(line[:60])
+                break
 ' || true
 }
 
@@ -222,7 +237,11 @@ text = d.get('text', '') or ''
 user = d.get('user', '') or ''
 
 reply_context = d.get('reply_context')
-if not (isinstance(reply_context, str) and reply_context):
+if isinstance(reply_context, str):
+    # strip() so whitespace-only context cannot defeat the skip-empty
+    # contract below (Codex review, 2026-06-11).
+    reply_context = reply_context.strip() or None
+else:
     reply_context = None
 
 raw_descriptors = d.get('media_descriptors') or []
@@ -248,9 +267,10 @@ parts = []
 if reply_context is not None:
     parts.append(reply_context)
 
-# Media descriptors go ABOVE the speaker line — parity with the DM
-# path's buildChannelContent (media first, then text). The speaker
-# attribution stays adjacent to the text it labels.
+# Media descriptors go ABOVE the speaker line, matching the DM path
+# (buildChannelContent renders media before text). Note the residual
+# divergence: DM puts reply metadata LAST, this path renders
+# reply_context FIRST (pre-existing ordering, kept as-is).
 parts.extend(descriptors)
 
 if user:

--- a/plugin/src/router/inbox-bridge.ts
+++ b/plugin/src/router/inbox-bridge.ts
@@ -65,6 +65,11 @@ export type InboundMessage = {
   user: string
   reply_context?: string
   media_paths?: string[]
+  // Rendered `<media ... />` descriptor tags (one physical line each —
+  // renderMediaDescriptor guarantees it). This is how voice transcripts
+  // reach the per-chat session: parity with the DM path, where
+  // buildChannelContent puts the same strings above the user text.
+  media_descriptors?: string[]
   timestamp: string
   // Telegram message_id (stringified) of the triggering message — the one
   // that summoned the bot (an @mention or reply-to-bot in a group). The

--- a/plugin/src/telegram/handlers.ts
+++ b/plugin/src/telegram/handlers.ts
@@ -502,6 +502,10 @@ async function gateAndNotify(
       timestamp: new Date().toISOString(),
       ...(replyContext !== undefined ? { reply_context: replyContext } : {}),
       ...(mediaPaths.length > 0 ? { media_paths: mediaPaths } : {}),
+      // Rendered descriptors carry what `text` cannot — notably the voice
+      // transcript. Dropping them here was the 2026-06-11 bug: group voice
+      // messages reached the per-chat session as empty text.
+      ...(renderedMedia.length > 0 ? { media_descriptors: renderedMedia } : {}),
       ...(ctx.message?.message_id !== undefined
         ? { message_id: String(ctx.message.message_id) }
         : {}),

--- a/plugin/src/telegram/media.ts
+++ b/plugin/src/telegram/media.ts
@@ -186,7 +186,13 @@ export function renderMediaDescriptor(media: MediaDescriptor): string {
   }
 
   parts.push(' />')
-  return parts.join('')
+  // Single-physical-line invariant: escapeHtmlAttr neutralizes quotes/<>
+  // but passes CR/LF/tabs through, and a Groq transcript can contain
+  // them. The multichat watcher pastes prompts line-oriented into a tmux
+  // composer and fingerprints the first line — a descriptor split across
+  // lines would corrupt both. Collapse all control chars to one space.
+  // eslint-disable-next-line no-control-regex
+  return parts.join('').replace(/[\u0000-\u001f]+/g, ' ')
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/plugin/src/telegram/media.ts
+++ b/plugin/src/telegram/media.ts
@@ -192,7 +192,7 @@ export function renderMediaDescriptor(media: MediaDescriptor): string {
   // composer and fingerprints the first line — a descriptor split across
   // lines would corrupt both. Collapse all control chars to one space.
   // eslint-disable-next-line no-control-regex
-  return parts.join('').replace(/[\u0000-\u001f]+/g, ' ')
+  return parts.join('').replace(/[\u0000-\u001f\u007f-\u009f]+/g, ' ')
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/plugin/tests/chats/multichat-entrypoint-media.test.ts
+++ b/plugin/tests/chats/multichat-entrypoint-media.test.ts
@@ -1,0 +1,210 @@
+// Tests for build_prompt media_descriptors support, the skip-empty
+// contract and the speaker-line fingerprint preference in
+// src/chats/hooks/multichat-entrypoint.sh (fix 2026-06-11).
+//
+// Production bug: voice messages reached the per-chat inbox with empty
+// `text` and no media payload (transcript dropped on the TS side); the
+// watcher then submitted an effectively empty prompt and could not
+// confirm it. The fix carries rendered descriptors in
+// `media_descriptors`, renders them into the prompt (reply_context →
+// media → speaker line), skips messages with no payload at all, and
+// fingerprints the stable `[from @user]` line instead of a long
+// descriptor line that tmux may wrap.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { spawnSync } from 'child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const SCRIPT = join(
+  import.meta.dir,
+  '..',
+  '..',
+  'src',
+  'chats',
+  'hooks',
+  'multichat-entrypoint.sh',
+)
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'entrypoint-media-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function runHelpers(
+  snippet: string,
+  extraEnv: Record<string, string> = {},
+): { code: number; stdout: string; stderr: string } {
+  const res = spawnSync(
+    'bash',
+    [
+      '-c',
+      `set -uo pipefail
+MULTICHAT_ENTRYPOINT_TEST_ONLY=1 source "${SCRIPT}"
+PANE='%1'
+CHAT_ID='test-chat'
+${snippet}`,
+    ],
+    {
+      env: {
+        ...process.env,
+        ...extraEnv,
+      },
+      encoding: 'utf8',
+      timeout: 15_000,
+    },
+  )
+  return {
+    code: res.status ?? -1,
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? '',
+  }
+}
+
+function writeInboxJson(name: string, payload: unknown): string {
+  const p = join(dir, name)
+  writeFileSync(p, JSON.stringify(payload))
+  return p
+}
+
+const VOICE_DESCRIPTOR =
+  '<media kind="voice" file_id="abc" mime="audio/ogg" size="37410" duration_sec="10" transcript="Проверь воркшоп, вождь ждёт" transcription_status="ok" />'
+
+describe('build_prompt — media_descriptors', () => {
+  test('voice descriptor lands between reply_context and the speaker line', () => {
+    const f = writeInboxJson('msg.json', {
+      text: '',
+      user: 'dashieshiev',
+      chat_id: '-1',
+      user_id: '1',
+      timestamp: 'x',
+      reply_context: '<untrusted_metadata type="telegram_reply">ctx</untrusted_metadata>',
+      media_descriptors: [VOICE_DESCRIPTOR],
+    })
+    const res = runHelpers(`build_prompt '${f}'`)
+    expect(res.code).toBe(0)
+    const parts = res.stdout.split('\n\n')
+    expect(parts[0]).toContain('untrusted_metadata')
+    expect(parts[1]).toBe(VOICE_DESCRIPTOR)
+    expect(parts[2]).toContain('[from @dashieshiev]')
+  })
+
+  test('descriptor without reply_context still renders before speaker line', () => {
+    const f = writeInboxJson('msg.json', {
+      text: 'и текст тоже',
+      user: 'dashieshiev',
+      media_descriptors: [VOICE_DESCRIPTOR],
+    })
+    const res = runHelpers(`build_prompt '${f}'`)
+    expect(res.code).toBe(0)
+    const parts = res.stdout.split('\n\n')
+    expect(parts[0]).toBe(VOICE_DESCRIPTOR)
+    expect(parts[1]).toBe('[from @dashieshiev] и текст тоже')
+  })
+
+  test('non-string entries in media_descriptors are ignored', () => {
+    const f = writeInboxJson('msg.json', {
+      text: 'привет',
+      user: 'u',
+      media_descriptors: [42, null, VOICE_DESCRIPTOR],
+    })
+    const res = runHelpers(`build_prompt '${f}'`)
+    expect(res.code).toBe(0)
+    expect(res.stdout).toContain(VOICE_DESCRIPTOR)
+    expect(res.stdout).not.toContain('42')
+  })
+})
+
+describe('build_prompt — skip-empty contract', () => {
+  test('no text, no media, no reply_context → exit 3, empty stdout', () => {
+    const f = writeInboxJson('msg.json', {
+      text: '',
+      user: 'dashieshiev',
+      chat_id: '-1',
+    })
+    const res = runHelpers(`rc=0; build_prompt '${f}' || rc=$?; echo "rc=$rc" >&2`)
+    expect(res.stdout).toBe('')
+    expect(res.stderr).toContain('rc=3')
+  })
+
+  test('whitespace-only text with no other payload → exit 3', () => {
+    const f = writeInboxJson('msg.json', { text: '   ', user: 'u' })
+    const res = runHelpers(`rc=0; build_prompt '${f}' || rc=$?; echo "rc=$rc" >&2`)
+    expect(res.stdout).toBe('')
+    expect(res.stderr).toContain('rc=3')
+  })
+
+  test('empty text WITH media descriptor is NOT skipped', () => {
+    const f = writeInboxJson('msg.json', {
+      text: '',
+      user: 'u',
+      media_descriptors: [VOICE_DESCRIPTOR],
+    })
+    const res = runHelpers(`rc=0; build_prompt '${f}' || rc=$?; echo "rc=$rc" >&2`)
+    expect(res.stderr).toContain('rc=0')
+    expect(res.stdout).toContain('transcript=')
+    // Speaker attribution survives even with empty text.
+    expect(res.stdout).toContain('[from @u]')
+  })
+
+  test('empty text WITH reply_context only is NOT skipped (status quo)', () => {
+    const f = writeInboxJson('msg.json', {
+      text: '',
+      user: 'u',
+      reply_context: 'ctx-not-empty',
+    })
+    const res = runHelpers(`rc=0; build_prompt '${f}' || rc=$?; echo "rc=$rc" >&2`)
+    expect(res.stderr).toContain('rc=0')
+    expect(res.stdout).toContain('ctx-not-empty')
+  })
+})
+
+describe('process_inbox — skipped-empty files', () => {
+  test('empty message moves to .processed/skipped-empty-*, no tmux calls', () => {
+    // Stub tmux that records calls — none expected.
+    const binDir = join(dir, 'bin')
+    spawnSync('mkdir', ['-p', binDir])
+    writeFileSync(
+      join(binDir, 'tmux'),
+      `#!/usr/bin/env bash\necho "$@" >> "${dir}/tmux.log"\nexit 0\n`,
+    )
+    spawnSync('chmod', ['755', join(binDir, 'tmux')])
+
+    const inbox = join(dir, 'inbox')
+    const processed = join(inbox, '.processed')
+    spawnSync('mkdir', ['-p', processed])
+    writeFileSync(
+      join(inbox, '100-aaaa.json'),
+      JSON.stringify({ text: '', user: 'u' }),
+    )
+
+    const res = runHelpers(
+      `INBOX='${inbox}'; PROCESSED='${processed}'; process_inbox; ls "${processed}"`,
+      { PATH: `${binDir}:${process.env['PATH'] ?? ''}` },
+    )
+    expect(res.code).toBe(0)
+    expect(res.stdout).toContain('skipped-empty-100-aaaa.json')
+    // No paste/submit attempted for an empty message.
+    expect(res.stdout).not.toContain('submit-unconfirmed')
+  })
+})
+
+describe('prompt_fingerprint — speaker-line preference', () => {
+  test('prefers the [from @user] line over a long leading descriptor', () => {
+    const prompt = `${VOICE_DESCRIPTOR}\n[from @dashieshiev] Проверь воркшоп`
+    const res = runHelpers(`prompt_fingerprint "$(printf '%s' '${prompt.replace(/'/g, "'\\''")}')"`)
+    expect(res.code).toBe(0)
+    expect(res.stdout.startsWith('[from @dashieshiev]')).toBe(true)
+  })
+
+  test('falls back to first long-enough line when no speaker line exists', () => {
+    const res = runHelpers(`prompt_fingerprint 'обычный текст без атрибуции достаточно длинный'`)
+    expect(res.stdout.startsWith('обычный текст')).toBe(true)
+  })
+})

--- a/plugin/tests/chats/multichat-entrypoint-media.test.ts
+++ b/plugin/tests/chats/multichat-entrypoint-media.test.ts
@@ -208,3 +208,46 @@ describe('prompt_fingerprint — speaker-line preference', () => {
     expect(res.stdout.startsWith('обычный текст')).toBe(true)
   })
 })
+
+describe('build_prompt — whitespace-only reply_context (Codex finding 2)', () => {
+  test('reply_context of spaces with no other payload → exit 3', () => {
+    const f = writeInboxJson('msg.json', {
+      text: '',
+      user: 'u',
+      reply_context: '   ',
+    })
+    const res = runHelpers(`rc=0; build_prompt '${f}' || rc=$?; echo "rc=$rc" >&2`)
+    expect(res.stdout).toBe('')
+    expect(res.stderr).toContain('rc=3')
+  })
+})
+
+describe('prompt_fingerprint — reply-context steal (Codex finding 1)', () => {
+  test('quoted [from @old] inside reply_context does not steal the fingerprint', () => {
+    const prompt = [
+      '<untrusted_metadata type="telegram_reply">',
+      '[from @old_user] цитата прошлого сообщения достаточно длинная',
+      '</untrusted_metadata>',
+      '',
+      VOICE_DESCRIPTOR,
+      '',
+      '[from @dashieshiev] Проверь воркшоп немедленно',
+    ].join('\n')
+    const res = runHelpers(
+      `prompt_fingerprint "$(printf '%s' '${prompt.replace(/'/g, "'\\''")}')"`,
+    )
+    expect(res.code).toBe(0)
+    expect(res.stdout.startsWith('[from @dashieshiev]')).toBe(true)
+  })
+
+  test('bare short speaker line falls back to unique descriptor head', () => {
+    // Caption-less voice note: "[from @u]" is identical across messages —
+    // the descriptor head (carrying file_id) must win instead.
+    const prompt = `${VOICE_DESCRIPTOR}\n\n[from @u]`
+    const res = runHelpers(
+      `prompt_fingerprint "$(printf '%s' '${prompt.replace(/'/g, "'\\''")}')"`,
+    )
+    expect(res.code).toBe(0)
+    expect(res.stdout.startsWith('<media kind="voice" file_id="abc"')).toBe(true)
+  })
+})

--- a/plugin/tests/telegram/handlers.voice-multichat.test.ts
+++ b/plugin/tests/telegram/handlers.voice-multichat.test.ts
@@ -1,0 +1,256 @@
+// Multichat voice transcript delivery (fix 2026-06-11).
+//
+// Production bug: a voice message in a multichat group produced an
+// InboundMessage with empty `text` and NO media payload — the rendered
+// media descriptors (which carry the Groq transcript) were dropped on
+// the router path, so the per-chat session received nothing to read.
+// The DM path renders descriptors via buildChannelContent; the router
+// path must carry the same strings in `media_descriptors`.
+
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type { Context } from 'grammy'
+
+import { handleInboundVoice } from '../../src/telegram/handlers.js'
+import type { HandlerDeps } from '../../src/telegram/handlers.js'
+import type {
+  ChatPolicy,
+  MultichatPolicy,
+} from '../../src/chats/policy-loader.js'
+import type { AppConfig, StatePaths } from '../../src/config.js'
+import { createLogger } from '../../src/log.js'
+import type { TelegramApi } from '../../src/channel/tools.js'
+import type { BotIdentity } from '../../src/prompt/build.js'
+import type { MultichatRouter } from '../../src/router/multichat-router.js'
+import type { InboundMessage } from '../../src/router/inbox-bridge.js'
+import { renderMediaDescriptor } from '../../src/telegram/media.js'
+
+const silentLog = createLogger('test', {
+  stream: { write: () => true } as unknown as NodeJS.WritableStream,
+})
+
+const WARCHIEF_USER_ID = 164795011
+const ALLOWED_GROUP_CHAT_ID = -1003784643974
+const BOT_ID = 8507713167
+
+function makeConfig(): AppConfig {
+  return {
+    bot_id: BOT_ID,
+    dm_only: true,
+    allowed_user_ids: [WARCHIEF_USER_ID],
+    allowed_chat_ids: [WARCHIEF_USER_ID],
+    status: {
+      enabled: false,
+      interval_ms: 700,
+      ttl_ms: 300_000,
+      delete_on_complete: true,
+      suppress_typing_bubble: false,
+    },
+    album: { flush_ms: 2000 },
+    voice: { provider: 'groq', language: 'ru', model: 'whisper-large-v3-turbo' },
+    webhook: { enabled: false, host: '127.0.0.1', port: 0 },
+    permission_relay: { enabled: false, allowed_user_ids: [], bash_only_proof: true },
+    commands: { help: true, status: true, stop: true, reset: true, new: true },
+    memory: {
+      enabled: false,
+      source_tag: 'tg',
+      max_hot_bytes: 20480,
+      trim_keep_lines: 600,
+      buffer_ttl_ms: 5 * 60 * 1000,
+      buffer_max_entries: 100,
+    },
+    progress: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      recent_buffer: 10,
+      session_ttl_ms: 600000,
+    },
+    task_mirror: {
+      enabled: true,
+      edit_throttle_ms: 3000,
+      session_ttl_ms: 600000,
+      collapse_completed_after: 5,
+    },
+    watcher: {
+      enabled: true,
+      debounce_ms: 10_000,
+      busy_threshold_ms: 30_000,
+    },
+  } as unknown as AppConfig
+}
+
+function makeStatePaths(): StatePaths {
+  const root = mkdtempSync(join(tmpdir(), 'dashi-voice-mc-test-'))
+  return {
+    root,
+    env: join(root, '.env'),
+    config: join(root, 'config.json'),
+    allowlist: join(root, 'allowlist.json'),
+    pid: join(root, 'bot.pid'),
+    lock: join(root, 'bot.lock'),
+    updateOffset: join(root, 'update-offset'),
+    inbox: join(root, 'inbox'),
+    sessionIds: join(root, 'session-ids'),
+    deadLetterUpdates: join(root, 'dead-letter', 'updates'),
+    deadLetterWebhook: join(root, 'dead-letter', 'webhook'),
+    logs: {
+      server: join(root, 'logs', 'server.log'),
+      telegram: join(root, 'logs', 'telegram.log'),
+      permissions: join(root, 'logs', 'permissions.jsonl'),
+      webhook: join(root, 'logs', 'webhook.log'),
+      ask_user_question: join(root, 'logs', 'ask-user-question.jsonl'),
+      permission_gate: join(root, 'logs', 'permission-gate.jsonl'),
+    },
+  }
+}
+
+function makePolicy(): MultichatPolicy {
+  const groupChatPolicy: ChatPolicy = {
+    mode: 'public',
+    streaming: 'off',
+    tmux_mirror: false,
+    edit_message_progress: false,
+    delivery: 'final_only',
+    persona_file: 'thrall.md',
+    handoff_file: 'handoff.md',
+    system_reminder: '',
+    idle_ttl_ms: 1_800_000,
+    max_queue_depth: 1,
+  }
+  const chats: Record<string, ChatPolicy> = {
+    [String(ALLOWED_GROUP_CHAT_ID)]: groupChatPolicy,
+  }
+  return {
+    version: 1,
+    allowlist: {
+      chats: Object.keys(chats),
+      users: [String(WARCHIEF_USER_ID)],
+    },
+    mention_allowlist: [String(WARCHIEF_USER_ID)],
+    chats,
+  }
+}
+
+function makeTelegramApi(): TelegramApi {
+  const noop = async (): Promise<never> => {
+    throw new Error('unexpected api call in voice-multichat test')
+  }
+  return {
+    sendMessage: (async () => ({ message_id: 1 })) as unknown as TelegramApi['sendMessage'],
+    editMessageText: noop as unknown as TelegramApi['editMessageText'],
+    setMessageReaction: async () => undefined,
+    sendChatAction: async () => undefined,
+    sendDocument: noop as unknown as TelegramApi['sendDocument'],
+    sendPhoto: noop as unknown as TelegramApi['sendPhoto'],
+    downloadFile: noop as unknown as TelegramApi['downloadFile'],
+    deleteMessage: noop as unknown as TelegramApi['deleteMessage'],
+  }
+}
+
+function makeRouterSpy(): { router: MultichatRouter; calls: InboundMessage[] } {
+  const calls: InboundMessage[] = []
+  const router = {
+    dispatch: async (msg: InboundMessage) => {
+      calls.push(msg)
+    },
+  } as unknown as MultichatRouter
+  return { router, calls }
+}
+
+function makeDeps(router: MultichatRouter): { deps: HandlerDeps; statePaths: StatePaths } {
+  const statePaths = makeStatePaths()
+  const bot: BotIdentity = { id: BOT_ID, username: 'canarybot' }
+  const deps: HandlerDeps = {
+    server: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      notification: async () => undefined,
+    } as any,
+    config: makeConfig(),
+    statePaths,
+    telegramApi: makeTelegramApi(),
+    log: silentLog,
+    bot,
+    botApi: { api: {} } as unknown as HandlerDeps['botApi'],
+    botToken: 'fake-token',
+    env: {}, // no GROQ_API_KEY → transcription_status="missing_key", no download
+    policy: makePolicy(),
+    router,
+  }
+  return { deps, statePaths }
+}
+
+// Voice message in the allowed group, replying to a bot message — the
+// reply-to-bot satisfies the addressing gate (a voice note has no text
+// to carry an @mention; this is exactly how the warchief talks to the
+// bot in the intensive group).
+function makeGroupVoiceCtx(): Context {
+  return {
+    chat: { id: ALLOWED_GROUP_CHAT_ID, type: 'supergroup' as const },
+    from: { id: WARCHIEF_USER_ID, is_bot: false, username: 'dashieshiev' },
+    me: { id: BOT_ID, username: 'canarybot' },
+    message: {
+      message_id: 1793,
+      date: 1700000000,
+      voice: {
+        file_id: 'voice-file-id-1',
+        duration: 10,
+        mime_type: 'audio/ogg',
+        file_size: 37410,
+      },
+      chat: { id: ALLOWED_GROUP_CHAT_ID, type: 'supergroup' as const },
+      from: { id: WARCHIEF_USER_ID, is_bot: false, username: 'dashieshiev' },
+      reply_to_message: {
+        message_id: 1792,
+        date: 1700000000,
+        text: 'bot speaking',
+        from: { id: BOT_ID, is_bot: true, username: 'canarybot' },
+      },
+    },
+  } as unknown as Context
+}
+
+describe('multichat voice → media descriptors reach the per-chat session', () => {
+  test('group voice dispatches InboundMessage with media_descriptors', async () => {
+    const { router, calls } = makeRouterSpy()
+    const { deps, statePaths } = makeDeps(router)
+
+    await handleInboundVoice(makeGroupVoiceCtx(), deps)
+
+    expect(calls.length).toBe(1)
+    const msg = calls[0]!
+    // Voice has no caption — text stays empty; the payload must live in
+    // media_descriptors instead of being silently dropped.
+    expect(msg.text).toBe('')
+    expect(msg.media_descriptors).toBeDefined()
+    expect(msg.media_descriptors!.length).toBe(1)
+    const d = msg.media_descriptors![0]!
+    expect(d.startsWith('<media kind="voice"')).toBe(true)
+    expect(d).toContain('transcription_status="missing_key"')
+    // Single physical line — the tmux watcher pastes line-oriented.
+    expect(d.includes('\n')).toBe(false)
+    rmSync(statePaths.root, { recursive: true, force: true })
+  })
+})
+
+describe('renderMediaDescriptor — single-line invariant', () => {
+  test('transcript with newlines/control chars renders as one line', () => {
+    const rendered = renderMediaDescriptor({
+      kind: 'voice',
+      fileId: 'f1',
+      mime: 'audio/ogg',
+      size: 1000,
+      durationSec: 3,
+      transcript: 'первая строка\nвторая строка\r\nтретья\tтаббип',
+      transcriptionStatus: 'ok',
+    })
+    expect(rendered.includes('\n')).toBe(false)
+    expect(rendered.includes('\r')).toBe(false)
+    expect(rendered).toContain('первая строка')
+    expect(rendered).toContain('вторая строка')
+    // Tag shape survives sanitization.
+    expect(rendered.startsWith('<media kind="voice"')).toBe(true)
+    expect(rendered.endsWith('/>')).toBe(true)
+  })
+})

--- a/plugin/tests/telegram/handlers.voice-multichat.test.ts
+++ b/plugin/tests/telegram/handlers.voice-multichat.test.ts
@@ -254,3 +254,33 @@ describe('renderMediaDescriptor — single-line invariant', () => {
     expect(rendered.endsWith('/>')).toBe(true)
   })
 })
+
+// Integration slice (Codex finding 3): the field must survive the real
+// inbox write — the bash watcher reads the JSON file, not the TS object.
+import { writeToInbox, ensureChatStateDirs } from '../../src/router/inbox-bridge.js'
+import { readFileSync } from 'fs'
+
+describe('writeToInbox persists media_descriptors to the JSON file', () => {
+  test('round-trip: descriptor string lands in the on-disk JSON', async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), 'dashi-inbox-rt-'))
+    const chatId = '-1003784643974'
+    await ensureChatStateDirs(chatId, stateDir)
+    const descriptor =
+      '<media kind="voice" file_id="f1" transcript="привет" transcription_status="ok" />'
+    const path = await writeToInbox(
+      chatId,
+      {
+        text: '',
+        chat_id: chatId,
+        user_id: '164795011',
+        user: 'dashieshiev',
+        timestamp: new Date().toISOString(),
+        media_descriptors: [descriptor],
+      },
+      stateDir,
+    )
+    const onDisk = JSON.parse(readFileSync(path, 'utf8'))
+    expect(onDisk.media_descriptors).toEqual([descriptor])
+    rmSync(stateDir, { recursive: true, force: true })
+  })
+})


### PR DESCRIPTION
## Баг (прод, 2026-06-11, чат интенсива)
Голосовые в мультичат-группе приходили в per-chat inbox с пустым `text` — rendered media-дескрипторы (включая транскрипт Groq) выбрасывались на роутер-пути. Агент в группе «не видел» голосовые; пустой prompt дополнительно ломал submit-confirm у watcher (submit not confirmed after 5 attempts).

## Фикс
- `InboundMessage.media_descriptors`: rendered `<media .../>` строки доезжают до per-chat сессии (handlers → inbox-bridge → entrypoint) — паритет с DM-путём (`buildChannelContent`)
- `renderMediaDescriptor`: однострочный инвариант — control chars (включая DEL/C1) схлопываются в пробел; заодно закрывает bracketed-paste escape (`ESC[201~`) из стороннего Groq-вывода в bypassPermissions-сессию
- `build_prompt`: дескрипторы между reply_context и speaker line; skip-empty contract (exit 3 → `.processed/skipped-empty-*`) — пустые сообщения не сабмитятся
- `prompt_fingerprint`: последняя `[from @user]` строка (цитата не крадёт подтверждение); короткая bare-атрибуция уступает уникальной голове дескриптора

## Ревью
- Codex GPT-5.5 план: APPROVE-WITH-CHANGES (6 пунктов — все учтены)
- Codex GPT-5.5 код: FIX-FIRST → 3 finding'а закрыты вторым коммитом
- Fable subagent код: SHIP (+4 замечания закрыты; album-path follow-up — см. ниже)

## Тесты
16 новых, 1598/1598 зелёные, tsc clean.

## Follow-up (не в этом PR)
Album-путь (`dispatchAlbum`) роняет дескрипторы так же — Fable IMPORTANT #1; зеркальный 3-строчный фикс + тест отдельным PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)