### PR TITLE
Канал: постоянное напоминание агентам отвечать через Telegram

### DIFF
--- a/plugin/CLAUDE.md
+++ b/plugin/CLAUDE.md
@@ -1,0 +1,38 @@
+# Jarvis Channel Runtime — how you reach the user
+
+This Claude Code session is **not** a normal terminal. It runs inside a tmux
+session bridged to **Telegram** by the `dashi-channel` MCP server. Inbound
+Telegram messages are injected into this session; that is how the user talks to
+you.
+
+**The user reads Telegram. They do NOT read this terminal, your transcript, or
+your ordinary assistant final message.** If you only "answer" in the terminal,
+the user sees nothing.
+
+## The one rule
+
+In a **direct chat**, every reply, question, confirmation, status update, or
+final answer meant for the user MUST be sent with the reply tool before you end
+the turn:
+
+```
+mcp__dashi-channel__reply({ chat_id, text })   // chat_id comes from the inbound <channel> tag
+```
+
+Never end a turn that owes the user a response without calling `reply`. A Stop
+hook auto-forwards your final text as a backup, but it cannot deliver a mid-turn
+question and may lose formatting — call `reply` explicitly, do not rely on the
+fallback.
+
+## Public group / multichat chats
+
+For group/supergroup chats the channel **outbox** path delivers your final text
+automatically — do not manually re-send it (that double-posts). The invariant
+still holds: terminal-only text is never visible to the user, so put anything
+they must see into the turn's delivered output.
+
+## Reminders
+
+A UserPromptSubmit hook re-states this on every turn — heed it. This file and
+that hook are the durable form of the channel discipline; the MCP server states
+it only once at session start.

--- a/plugin/scripts/channel-reminder.ts
+++ b/plugin/scripts/channel-reminder.ts
@@ -70,10 +70,14 @@ export function renderContext(text: string): string {
 if (import.meta.main) {
   // We do not even need to read stdin: the reminder is independent of the
   // prompt body, and reading it would only risk echoing private content.
+  // Set exitCode and let the process terminate naturally — calling
+  // process.exit() right after an async stdout write can truncate the
+  // payload before the stream flushes (Codex review). The payload is one
+  // short line, but natural termination is the safe pattern.
   try {
     process.stdout.write(renderContext(reminderForChat(process.env.CHAT_ID)))
   } catch {
     // Never gate the turn on a reminder failure.
   }
-  process.exit(0)
+  process.exitCode = 0
 }

--- a/plugin/scripts/channel-reminder.ts
+++ b/plugin/scripts/channel-reminder.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env bun
+// channel-reminder.ts — UserPromptSubmit hook that re-injects the Telegram
+// bridge invariant on EVERY warchief turn.
+//
+// Why this exists (2026-06-12): agents run as long-lived `claude … server:
+// dashi-channel` sessions. The dashi-channel MCP server states the reply
+// discipline once at session start ("the sender reads Telegram, not this
+// terminal"), and plugin/CLAUDE.md repeats it as a durable invariant — but
+// over a long session both fade, and agents end turns with terminal-only
+// text the warchief never sees. A UserPromptSubmit hook fires on every
+// inbound prompt, so emitting the reminder here re-grounds the model each
+// turn instead of relying on start-of-session context alone.
+//
+// Output contract: a single JSON object on stdout carrying
+// `hookSpecificOutput.additionalContext` — Claude Code prepends that string
+// to the turn as context. It is NEVER sent to Telegram; the only way it
+// reaches the chat is if the model parrots it, so the text stays terse.
+//
+// Hard invariants (shared with the other dashi hooks):
+//   * Exit code 0 in EVERY path — a non-zero hook blocks the model; a
+//     missing reminder must never gate the turn.
+//   * stdout carries ONLY the JSON envelope (no logs, no secrets) — anything
+//     else on stdout becomes additional model context.
+//   * No file reads/writes; configuration is env-only.
+//
+// Env:
+//   CHAT_ID   the Telegram chat id this session serves. Negative ids are
+//             groups/supergroups (multichat); anything else is treated as a
+//             direct chat with the warchief. Absent → DM-safe generic.
+
+const DM_REMINDER =
+  'Telegram bridge: the sender reads Telegram, not this terminal — terminal/transcript text never reaches them. ' +
+  'Every reply, question, confirmation, status update, or final answer for this chat MUST go through the ' +
+  'mcp__dashi-channel__reply tool (pass chat_id) before you end the turn. Do not end a turn that owes the sender ' +
+  'a response without calling reply.'
+
+const GROUP_REMINDER =
+  'Telegram bridge: this turn comes from a public/multichat group — the sender reads Telegram, not this terminal. ' +
+  'Final text is delivered by the channel outbox path, so do not assume terminal-only text is visible, but also do ' +
+  'not force a manual reply call where the group outbox already handles delivery.'
+
+// Generic, DM-safe wording for the case where CHAT_ID is unset — it states
+// the invariant without asserting a specific delivery path.
+const GENERIC_REMINDER =
+  'Telegram bridge: the sender reads Telegram, not this terminal. Anything meant for them must be delivered through ' +
+  'the channel (the mcp__dashi-channel__reply tool in a direct chat); terminal-only text is not visible to the sender.'
+
+/**
+ * Pick the reminder for a chat id. Negative id → group; a present non-negative
+ * id → DM; absent/blank → generic DM-safe.
+ */
+export function reminderForChat(chatId: string | undefined): string {
+  const trimmed = (chatId ?? '').trim()
+  if (trimmed === '') return GENERIC_REMINDER
+  if (trimmed.startsWith('-')) return GROUP_REMINDER
+  return DM_REMINDER
+}
+
+/** The exact stdout envelope Claude Code reads for UserPromptSubmit context. */
+export function renderContext(text: string): string {
+  return JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'UserPromptSubmit',
+      additionalContext: text,
+    },
+  })
+}
+
+// Side-effecting entrypoint — skipped when imported by tests.
+if (import.meta.main) {
+  // We do not even need to read stdin: the reminder is independent of the
+  // prompt body, and reading it would only risk echoing private content.
+  try {
+    process.stdout.write(renderContext(reminderForChat(process.env.CHAT_ID)))
+  } catch {
+    // Never gate the turn on a reminder failure.
+  }
+  process.exit(0)
+}

--- a/plugin/scripts/patch-claude-settings.ts
+++ b/plugin/scripts/patch-claude-settings.ts
@@ -28,6 +28,13 @@ const MARKER = 'dashi-channel-hook'
 // installs/updates alongside the notification-mirror hook without either
 // clobbering the other. Only added when --permission-gate-helper is given.
 const GATE_MARKER = 'dashi-permission-gate-hook'
+// Channel-reminder UserPromptSubmit hook (2026-06-12). Distinct marker so it
+// installs/updates alongside the notification-mirror hook. Re-injects the
+// Telegram-bridge reply discipline on every turn (the MCP server states it
+// only once at session start; agents forget over a long session). On-by-
+// default: parseArgs defaults --reminder-helper to the sibling script, so a
+// plain install wires it without an opt-in flag.
+const REMINDER_MARKER = 'dashi-channel-reminder-hook'
 // Substring of the dashi helper script path used to identify *markerless*
 // legacy entries — re-running install over a settings file that was
 // hand-edited (no marker but pointing at our post-hook.ts) used to leave
@@ -60,6 +67,9 @@ export interface PatchOptions {
   readonly permissionGateHelperPath?: string
   /** Optional explicit policy path for the gate hook (TELEGRAM_PERMISSION_POLICY_PATH). */
   readonly policyPath?: string
+  /** When set, register the channel-reminder UserPromptSubmit hook pointing at
+   *  this helper (scripts/channel-reminder.ts). Defaulted by the CLI. */
+  readonly reminderHelperPath?: string
 }
 
 interface HookEntry {
@@ -137,6 +147,20 @@ function buildGateEntry(opts: PatchOptions): HookEntry {
   }
 }
 
+// UserPromptSubmit command for the channel-reminder hook. The hook reads
+// CHAT_ID from env to pick the DM vs group reminder. No token, no webhook —
+// it emits additionalContext to stdout and never makes a network call.
+function buildReminderCommand(opts: PatchOptions): string {
+  return `CHAT_ID=${sq(opts.chatId)} bun ${sq(opts.reminderHelperPath!)}`
+}
+
+function buildReminderEntry(opts: PatchOptions): HookEntry {
+  return {
+    marker: REMINDER_MARKER,
+    hooks: [{ type: 'command', command: buildReminderCommand(opts) }],
+  }
+}
+
 // True if an entry's command string points at our helper script, even if
 // the marker was hand-stripped or never present. Survives different
 // absolute prefixes (e.g. user moved the plugin between dirs) by matching
@@ -162,13 +186,24 @@ export function applyPatch(settings: SettingsShape, opts: PatchOptions): Setting
     // markerless notification entry, OR the gate marker (re-added below for
     // PreToolUse). Unrelated entries survive untouched.
     const filtered = existing.filter(
-      (e) => !e || (e.marker !== MARKER && e.marker !== GATE_MARKER && !isLegacyDashiEntry(e)),
+      (e) =>
+        !e ||
+        (e.marker !== MARKER &&
+          e.marker !== GATE_MARKER &&
+          e.marker !== REMINDER_MARKER &&
+          !isLegacyDashiEntry(e)),
     )
     const rebuilt = [...filtered, next]
     // The gate hook lives on PreToolUse only, and is registered FIRST so its
     // deny verdict is evaluated before the notification mirror runs.
     if (event === 'PreToolUse' && withGate) {
       rebuilt.unshift(buildGateEntry(opts))
+    }
+    // The channel-reminder hook lives on UserPromptSubmit only. Appended after
+    // the mirror entry — both run; the mirror emits no stdout, the reminder
+    // emits additionalContext, so order is immaterial.
+    if (event === 'UserPromptSubmit' && opts.reminderHelperPath !== undefined) {
+      rebuilt.push(buildReminderEntry(opts))
     }
     hooks[event] = rebuilt
   }
@@ -183,6 +218,8 @@ function parseArgs(argv: ReadonlyArray<string>): PatchOptions {
   let helperPath = ''
   let permissionGateHelperPath: string | undefined
   let policyPath: string | undefined
+  let reminderHelperPath: string | undefined
+  let noReminder = false
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
     const next = argv[i + 1]
@@ -193,6 +230,8 @@ function parseArgs(argv: ReadonlyArray<string>): PatchOptions {
     if (a === '--helper' && next) { helperPath = next; i++; continue }
     if (a === '--permission-gate-helper' && next) { permissionGateHelperPath = next; i++; continue }
     if (a === '--policy-path' && next) { policyPath = next; i++; continue }
+    if (a === '--reminder-helper' && next) { reminderHelperPath = next; i++; continue }
+    if (a === '--no-reminder') { noReminder = true; continue }
   }
   if (!settingsPath || !chatId || !webhookUrl) {
     process.stderr.write(
@@ -200,12 +239,19 @@ function parseArgs(argv: ReadonlyArray<string>): PatchOptions {
     )
     process.exit(2)
   }
+  const scriptDir = dirname(fileURLToPath(import.meta.url))
   if (!helperPath) {
     // Default to sibling post-hook.ts. `import.meta.dir` is a Bun extension;
     // resolve via `fileURLToPath(import.meta.url)` so the script also works
     // when invoked under plain Node (review M5).
-    const scriptDir = dirname(fileURLToPath(import.meta.url))
     helperPath = pathResolve(scriptDir, 'post-hook.ts')
+  }
+  // Channel reminder is on by default (sibling channel-reminder.ts) unless
+  // explicitly disabled with --no-reminder. This keeps the durable invariant
+  // in plugin/CLAUDE.md ("a hook re-states this every turn") true on every
+  // agent without a manual settings.json edit.
+  if (!noReminder && !reminderHelperPath) {
+    reminderHelperPath = pathResolve(scriptDir, 'channel-reminder.ts')
   }
   const opts: PatchOptions = {
     settingsPath,
@@ -215,6 +261,7 @@ function parseArgs(argv: ReadonlyArray<string>): PatchOptions {
     ...(agentId ? { agentId } : {}),
     ...(permissionGateHelperPath ? { permissionGateHelperPath } : {}),
     ...(policyPath ? { policyPath } : {}),
+    ...(reminderHelperPath ? { reminderHelperPath } : {}),
   }
   return opts
 }

--- a/plugin/tests/hooks/install-hooks.test.ts
+++ b/plugin/tests/hooks/install-hooks.test.ts
@@ -360,3 +360,45 @@ function countPluginEntries(parsed: Record<string, unknown>): number {
   }
   return total
 }
+
+describe('applyPatch (pure) — channel reminder', () => {
+  test('registers the reminder hook on UserPromptSubmit only when reminderHelperPath set', () => {
+    const out = applyPatch({}, {
+      settingsPath: '/tmp/x',
+      chatId: '164795011',
+      webhookUrl: 'http://127.0.0.1:8093/hooks/agent',
+      helperPath: '/p/scripts/post-hook.ts',
+      reminderHelperPath: '/p/scripts/channel-reminder.ts',
+    }) as { hooks: Record<string, Array<{ marker?: string; hooks?: Array<{ command?: string }> }>> }
+    const ups = out.hooks.UserPromptSubmit ?? []
+    const reminder = ups.find((e) => e.marker === 'dashi-channel-reminder-hook')
+    expect(reminder).toBeDefined()
+    expect(reminder!.hooks?.[0]?.command).toContain('channel-reminder.ts')
+    expect(reminder!.hooks?.[0]?.command).toContain("CHAT_ID='164795011'")
+    // Reminder must NOT appear on other events.
+    for (const ev of ['SessionStart', 'PreToolUse', 'PostToolUse', 'Stop']) {
+      expect((out.hooks[ev] ?? []).find((e) => e.marker === 'dashi-channel-reminder-hook')).toBeUndefined()
+    }
+  })
+
+  test('absent reminderHelperPath → no reminder entry (back-compat)', () => {
+    const out = applyPatch({}, {
+      settingsPath: '/tmp/x',
+      chatId: '1',
+      webhookUrl: 'http://x',
+      helperPath: '/p/post-hook.ts',
+    }) as { hooks: Record<string, Array<{ marker?: string }>> }
+    expect((out.hooks.UserPromptSubmit ?? []).find((e) => e.marker === 'dashi-channel-reminder-hook')).toBeUndefined()
+  })
+
+  test('re-run replaces the reminder entry rather than duplicating', () => {
+    const opts = {
+      settingsPath: '/tmp/x', chatId: '1', webhookUrl: 'http://x',
+      helperPath: '/p/post-hook.ts', reminderHelperPath: '/p/channel-reminder.ts',
+    }
+    let s: Record<string, unknown> = applyPatch({}, opts)
+    s = applyPatch(s, opts)
+    const ups = (s as { hooks: Record<string, Array<{ marker?: string }>> }).hooks.UserPromptSubmit ?? []
+    expect(ups.filter((e) => e.marker === 'dashi-channel-reminder-hook').length).toBe(1)
+  })
+})

--- a/plugin/tests/scripts/channel-reminder.test.ts
+++ b/plugin/tests/scripts/channel-reminder.test.ts
@@ -43,3 +43,45 @@ describe('renderContext', () => {
     expect(renderContext(reminderForChat('164795011')).includes('\n')).toBe(false)
   })
 })
+
+// Integration: run the hook as a real process and assert the executable
+// contract (Codex/Fable review): exit 0, stdout = valid envelope only,
+// stderr empty, private stdin never echoed, CHAT_ID never leaked.
+import { spawnSync } from 'child_process'
+import { join } from 'path'
+
+const HOOK = join(import.meta.dir, '..', '..', 'scripts', 'channel-reminder.ts')
+
+function runHook(chatId: string | undefined, stdin: string) {
+  const env = { ...process.env }
+  if (chatId === undefined) delete env.CHAT_ID
+  else env.CHAT_ID = chatId
+  return spawnSync('bun', [HOOK], { input: stdin, encoding: 'utf8', env })
+}
+
+describe('channel-reminder.ts — process contract', () => {
+  test('DM: exit 0, stdout is the envelope only, stderr empty, no stdin/CHAT_ID leak', () => {
+    const secret = 'PRIVATE-PROMPT-BODY-do-not-echo'
+    const r = runHook('164795011', secret)
+    expect(r.status).toBe(0)
+    expect(r.stderr).toBe('')
+    const parsed = JSON.parse(r.stdout)
+    expect(parsed.hookSpecificOutput.hookEventName).toBe('UserPromptSubmit')
+    expect(parsed.hookSpecificOutput.additionalContext).toContain('mcp__dashi-channel__reply')
+    expect(r.stdout).not.toContain(secret)
+    expect(r.stdout).not.toContain('164795011')
+  })
+
+  test('group CHAT_ID → outbox-aware envelope, exit 0', () => {
+    const r = runHook('-1003784643974', 'hi')
+    expect(r.status).toBe(0)
+    const parsed = JSON.parse(r.stdout)
+    expect(parsed.hookSpecificOutput.additionalContext).toContain('outbox')
+  })
+
+  test('absent CHAT_ID → exit 0, generic envelope', () => {
+    const r = runHook(undefined, 'hi')
+    expect(r.status).toBe(0)
+    expect(JSON.parse(r.stdout).hookSpecificOutput.additionalContext).toContain('Telegram')
+  })
+})

--- a/plugin/tests/scripts/channel-reminder.test.ts
+++ b/plugin/tests/scripts/channel-reminder.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test'
+
+import { reminderForChat, renderContext } from '../../scripts/channel-reminder.js'
+
+describe('reminderForChat', () => {
+  test('positive (DM) chat id → strict reply-tool reminder', () => {
+    const r = reminderForChat('164795011')
+    expect(r).toContain('mcp__dashi-channel__reply')
+    expect(r).toContain('MUST')
+  })
+
+  test('negative (group) chat id → outbox-aware reminder, no forced reply', () => {
+    const r = reminderForChat('-1003784643974')
+    expect(r).toContain('public/multichat')
+    expect(r).toContain('outbox')
+    // Must NOT order a manual reply call in groups (the outbox delivers).
+    expect(r).not.toContain('MUST go through')
+  })
+
+  test('absent chat id → generic DM-safe reminder', () => {
+    const r = reminderForChat(undefined)
+    expect(r).toContain('Telegram')
+    expect(r).toContain('reply tool')
+  })
+
+  test('blank/whitespace chat id → generic', () => {
+    expect(reminderForChat('   ')).toBe(reminderForChat(undefined))
+  })
+})
+
+describe('renderContext', () => {
+  test('emits the exact UserPromptSubmit additionalContext envelope', () => {
+    const out = JSON.parse(renderContext('hello'))
+    expect(out).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'UserPromptSubmit',
+        additionalContext: 'hello',
+      },
+    })
+  })
+
+  test('is single-line JSON (safe as sole stdout)', () => {
+    expect(renderContext(reminderForChat('164795011')).includes('\n')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Проблема (вождь, 2026-06-12)
Агенты в длинной tmux-сессии забывают, что общаются с вождём через MCP-бридж dashi-channel на Telegram, и завершают ход терминальным текстом, которого вождь не видит. MCP-сервер даёт правило про reply один раз на старте — за диалог выветривается.

## Фикс (Codex GPT-5.5 дизайн + двойное ревью Codex+Fable)
- **plugin/CLAUDE.md** (новый): durable-инвариант в cwd сессии, грузится всем агентам поверх их CLAUDE.md. Терминал не виден вождю; в DM отвечать только через `mcp__dashi-channel__reply`; в группах — outbox-путь, не дублировать.
- **scripts/channel-reminder.ts** (новый): UserPromptSubmit-хук, реинжектит правило на КАЖДЫЙ ход через `additionalContext`. Ветвление по знаку CHAT_ID: DM-строгий / групповой / generic. Exit 0 всегда, stdout только JSON-конверт, секреты/stdin не светятся.
- **patch-claude-settings.ts**: ставит reminder на UserPromptSubmit ПО УМОЛЧАНИЮ (маркер dashi-channel-reminder-hook, `--no-reminder` для отключения) — хук не «спящий», обещание CLAUDE.md истинно на всех агентах, re-run идемпотентен.

## Ревью
- Codex GPT-5.5 дизайн: рекомендация принята целиком.
- Codex GPT-5.5 код: SHIP (envelope сверен с доками Claude Code) + 2 находки закрыты.
- Fable subagent: SHIP + IMPORTANT (авто-регистрация) закрыт.

## Тесты
13 новых (3 ветви reminder, форма envelope, single-line, spawn-контракт, регистрация в патчере, идемпотентность, back-compat). 1610/1610 зелёные, tsc clean.

## Активация
Хук-скрипт и CLAUDE.md раскатываются git-pull'ом; патчер регистрирует хук в settings.json каждого агента; активируется рестартом сессий (хуки live-reload, но CLAUDE.md и новые хуки — со старта сессии).

🤖 Generated with [Claude Code](https://claude.com/claude-code)