### PR TITLE
Команды на send-keys: /stop /reset /new реально работают + мост /cc к встроенным командам Claude Code

### DIFF
--- a/plugin/src/commands/keys.ts
+++ b/plugin/src/commands/keys.ts
@@ -151,6 +151,12 @@ export function parseCcCommand(args: string): ParsedCc | { error: string } {
   if (trimmed.length === 0) {
     return { error: 'usage: /cc <команда> [аргументы] — напр. /cc compact, /cc model opus' }
   }
+  // Explicit newline reject (Codex/Fable review): the charset already excludes
+  // \r\n, but a bare-anchored regex CAN match before a trailing newline in JS,
+  // so reject up front to make the single-line invariant obvious and robust.
+  if (/[\r\n]/.test(trimmed)) {
+    return { error: 'аргументы не должны содержать переводов строки' }
+  }
   const wsIdx = trimmed.search(/\s/)
   const rawName = wsIdx === -1 ? trimmed : trimmed.slice(0, wsIdx)
   const name = rawName.toLowerCase().replace(/^\//, '')

--- a/plugin/src/commands/keys.ts
+++ b/plugin/src/commands/keys.ts
@@ -127,3 +127,87 @@ export async function sendKeys(
   }
   return { ok: true }
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// /cc — passthrough to Claude Code's own slash commands (/compact, /clear,
+// /model, /context, custom skills, …) by typing them into the agent pane.
+// ─────────────────────────────────────────────────────────────────────
+
+// Slash-command NAME: a leading letter then letters/digits/colon/dash.
+// Colon allows plugin-namespaced commands (e.g. superpowers:brainstorm).
+export const SLASH_NAME_RE = /^[a-z][a-z0-9:-]{0,40}$/
+// ARGS: a deliberately narrow set — alphanumerics, space, and a few path/flag
+// punctuation marks. NO shell metacharacters ($ ` ; | & > < ( ) { } " ' \\),
+// so even if the pane were at a shell prompt the text can't compose a command.
+export const SLASH_ARGS_RE = /^[A-Za-z0-9 ._:/@=-]{0,200}$/
+
+export interface ParsedCc {
+  name: string
+  rest: string
+}
+
+export function parseCcCommand(args: string): ParsedCc | { error: string } {
+  const trimmed = args.trim()
+  if (trimmed.length === 0) {
+    return { error: 'usage: /cc <команда> [аргументы] — напр. /cc compact, /cc model opus' }
+  }
+  const wsIdx = trimmed.search(/\s/)
+  const rawName = wsIdx === -1 ? trimmed : trimmed.slice(0, wsIdx)
+  const name = rawName.toLowerCase().replace(/^\//, '')
+  const rest = wsIdx === -1 ? '' : trimmed.slice(wsIdx + 1).trim()
+  if (!SLASH_NAME_RE.test(name)) {
+    return { error: `недопустимое имя команды: ${rawName}` }
+  }
+  if (!SLASH_ARGS_RE.test(rest)) {
+    return { error: 'аргументы содержат недопустимые символы (разрешены буквы, цифры, . _ : / @ = -)' }
+  }
+  return { name, rest }
+}
+
+// Type `/<name> [rest]` into the pane and submit with Enter. Clears the input
+// line first (C-u) so a leftover draft can't corrupt the command — the same
+// hygiene used when driving another agent's pane by hand.
+export async function sendSlashCommand(
+  target: TmuxKeysTarget,
+  parsed: ParsedCc,
+  exec: KeysExec = defaultKeysExec,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const socketArgs = target.socketPath
+    ? ['-S', target.socketPath]
+    : target.socketName
+      ? ['-L', target.socketName]
+      : []
+  const text = parsed.rest ? `/${parsed.name} ${parsed.rest}` : `/${parsed.name}`
+  // `text` always starts with '/', so it can never be parsed as a tmux flag.
+  const steps: Array<readonly string[]> = [
+    [...socketArgs, 'send-keys', '-t', target.paneTarget, 'C-u'],
+    [...socketArgs, 'send-keys', '-t', target.paneTarget, '-l', text],
+    [...socketArgs, 'send-keys', '-t', target.paneTarget, 'Enter'],
+  ]
+  for (const args of steps) {
+    const res = await exec(args)
+    if (res.exitCode !== 0) {
+      return { ok: false, error: res.stderr.slice(0, 200) || `tmux exited ${res.exitCode}` }
+    }
+  }
+  return { ok: true }
+}
+
+// Send a single named key (Escape, Enter, …) to the pane — used by /stop to
+// interrupt Claude, and reusable by other control commands.
+export async function sendNamedKey(
+  target: TmuxKeysTarget,
+  key: string,
+  exec: KeysExec = defaultKeysExec,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const socketArgs = target.socketPath
+    ? ['-S', target.socketPath]
+    : target.socketName
+      ? ['-L', target.socketName]
+      : []
+  const res = await exec([...socketArgs, 'send-keys', '-t', target.paneTarget, key])
+  if (res.exitCode !== 0) {
+    return { ok: false, error: res.stderr.slice(0, 200) || `tmux exited ${res.exitCode}` }
+  }
+  return { ok: true }
+}

--- a/plugin/src/commands/oob.ts
+++ b/plugin/src/commands/oob.ts
@@ -29,9 +29,9 @@ import type { Logger } from '../log.js'
 import type { TelegramApi } from '../channel/tools.js'
 import { sendChannelNotification, type ChannelEvent } from '../channel/notify.js'
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js'
-import { parseKeyTokens, sendKeys, type KeysExec, type TmuxKeysTarget } from './keys.js'
+import { parseKeyTokens, sendKeys, parseCcCommand, sendSlashCommand, sendNamedKey, type KeysExec, type TmuxKeysTarget } from './keys.js'
 
-export type OobCommandName = 'help' | 'status' | 'stop' | 'reset' | 'new' | 'mirror' | 'key'
+export type OobCommandName = 'help' | 'status' | 'stop' | 'reset' | 'new' | 'mirror' | 'key' | 'cc'
 
 const KNOWN_COMMANDS = new Set<OobCommandName>([
   'help',
@@ -41,6 +41,7 @@ const KNOWN_COMMANDS = new Set<OobCommandName>([
   'new',
   'mirror',
   'key',
+  'cc',
 ])
 
 // Sub-actions for /mirror. We accept the bare command (= same as `status`),
@@ -168,7 +169,8 @@ function helpText(): string {
     + '<code>/reset force</code> — сбросить состояние сессии (подтверди флагом <code>force</code>)\n'
     + '<code>/new force</code> — начать новую сессию (подтверди флагом <code>force</code>)\n'
     + '<code>/mirror on|off|status</code> — управлять зеркалом терминала (tmux, обновляется в реальном времени)\n'
-    + '<code>/key 1|2|3|y|n|enter|esc…</code> — нажать клавишу в терминале агента (ответить на диалог)\n\n'
+    + '<code>/key 1|2|3|y|n|enter|esc…</code> — нажать клавишу в терминале агента (ответить на диалог)\n'
+    + '<code>/cc &lt;команда&gt;</code> — встроенная команда Claude Code: <code>/cc compact</code>, <code>/cc model opus</code>, <code>/cc context</code>\n\n'
     + '<i>примечание: /stop — best-effort: плагин передаёт сигнал остановки через '
     + 'канал, но не может гарантировать прерывание посреди вызова инструмента.</i>'
   )
@@ -188,6 +190,7 @@ export const BOT_COMMANDS: ReadonlyArray<BotCommandSpec> = [
   { command: 'new', description: 'начать новую сессию (нужен force)' },
   { command: 'mirror', description: 'зеркало терминала: on | off | status' },
   { command: 'key', description: 'нажать клавишу в терминале: 1 | 2 | y | n | enter | esc' },
+  { command: 'cc', description: 'встроенная команда Claude Code: compact | model | context …' },
 ]
 
 function statusText(ctx: OobContext): string {
@@ -283,6 +286,21 @@ export async function handleOobCommand(
           })
         }
       }
+      // Real interrupt: Escape stops Claude's current generation/tool. Falls
+      // back to the channel-notification signal when no pane is resolvable.
+      if (ctx.tmuxKeys) {
+        const sent = await sendNamedKey(ctx.tmuxKeys.target, 'Escape', ctx.tmuxKeys.exec)
+        return {
+          handled: true,
+          command: 'stop',
+          replyToTelegram: {
+            text: sent.ok
+              ? '<b>stop</b> — Escape отправлен в сессию (прерывание).'
+              : `<b>stop</b> — tmux ошибка: <code>${escapeHtml(sent.error)}</code>`,
+            parseMode: 'HTML',
+          },
+        }
+      }
       return {
         handled: true,
         command: 'stop',
@@ -309,6 +327,21 @@ export async function handleOobCommand(
         }
       }
       ctx.log.info('oob /reset force', { chat_id: ctx.chatId })
+      // Real reset: type Claude Code's own /clear into the pane. Fallback to
+      // the (best-effort) channel signal when no pane is resolvable.
+      if (ctx.tmuxKeys) {
+        const sent = await sendSlashCommand(ctx.tmuxKeys.target, { name: 'clear', rest: '' }, ctx.tmuxKeys.exec)
+        return {
+          handled: true,
+          command: 'reset',
+          replyToTelegram: {
+            text: sent.ok
+              ? '<b>сессия сброшена</b> — отправил <code>/clear</code> в сессию.'
+              : `<b>reset</b> — tmux ошибка: <code>${escapeHtml(sent.error)}</code>`,
+            parseMode: 'HTML',
+          },
+        }
+      }
       return {
         handled: true,
         command: 'reset',
@@ -332,6 +365,20 @@ export async function handleOobCommand(
         }
       }
       ctx.log.info('oob /new force', { chat_id: ctx.chatId })
+      // Claude Code has no separate «new session» — /clear IS the reset.
+      if (ctx.tmuxKeys) {
+        const sent = await sendSlashCommand(ctx.tmuxKeys.target, { name: 'clear', rest: '' }, ctx.tmuxKeys.exec)
+        return {
+          handled: true,
+          command: 'new',
+          replyToTelegram: {
+            text: sent.ok
+              ? '<b>новая сессия</b> — отправил <code>/clear</code> в сессию.'
+              : `<b>new</b> — tmux ошибка: <code>${escapeHtml(sent.error)}</code>`,
+            parseMode: 'HTML',
+          },
+        }
+      }
       return {
         handled: true,
         command: 'new',
@@ -470,6 +517,42 @@ export async function handleOobCommand(
         command: 'key',
         replyToTelegram: {
           text: `<b>нажато:</b> <code>${escapeHtml(parsed.args.trim().toLowerCase())}</code>`,
+          parseMode: 'HTML',
+        },
+      }
+    }
+
+    case 'cc': {
+      // Passthrough to Claude Code's OWN slash commands (/compact, /model,
+      // /context, custom skills…) by typing them into the agent pane.
+      if (!ctx.tmuxKeys) {
+        return {
+          handled: true,
+          command: 'cc',
+          replyToTelegram: {
+            text: '<b>/cc</b> — недоступно: плагин не знает tmux-pane сессии.',
+            parseMode: 'HTML',
+          },
+        }
+      }
+      const cc = parseCcCommand(parsed.args)
+      if ('error' in cc) {
+        return {
+          handled: true,
+          command: 'cc',
+          replyToTelegram: { text: escapeHtml(cc.error), parseMode: 'HTML' },
+        }
+      }
+      ctx.log.info('oob /cc', { chat_id: ctx.chatId, name: cc.name })
+      const sent = await sendSlashCommand(ctx.tmuxKeys.target, cc, ctx.tmuxKeys.exec)
+      const shown = cc.rest ? `/${cc.name} ${cc.rest}` : `/${cc.name}`
+      return {
+        handled: true,
+        command: 'cc',
+        replyToTelegram: {
+          text: sent.ok
+            ? `<b>отправлено в сессию:</b> <code>${escapeHtml(shown)}</code>`
+            : `<b>/cc</b> — tmux ошибка: <code>${escapeHtml(sent.error)}</code>`,
           parseMode: 'HTML',
         },
       }

--- a/plugin/tests/commands/keys.test.ts
+++ b/plugin/tests/commands/keys.test.ts
@@ -155,3 +155,12 @@ describe('sendNamedKey', () => {
     expect(calls).toEqual([['-L', 'sk', 'send-keys', '-t', '%3', 'Escape']])
   })
 })
+
+describe('parseCcCommand newline guard', () => {
+  test('any carriage return or newline is rejected', () => {
+    for (const bad of ['compact\n; rm', 'compact\nrm -rf /', 'a\rb', 'model\nopus']) {
+      const r = parseCcCommand(bad)
+      expect('error' in r).toBe(true)
+    }
+  })
+})

--- a/plugin/tests/commands/keys.test.ts
+++ b/plugin/tests/commands/keys.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, test } from 'bun:test'
 import {
   MAX_KEY_TOKENS,
   parseKeyTokens,
+  parseCcCommand,
   sendKeys,
+  sendSlashCommand,
   type KeysExec,
 } from '../../src/commands/keys.js'
 
@@ -84,5 +86,72 @@ describe('sendKeys', () => {
     expect(res.ok).toBe(false)
     expect(!res.ok && res.error).toContain('no such pane')
     expect(calls.length).toBe(1) // second step never attempted
+  })
+})
+
+describe('parseCcCommand', () => {
+  test('name only and name+args parse', () => {
+    const r = parseCcCommand('compact')
+    expect('name' in r && r.name).toBe('compact')
+    const r2 = parseCcCommand('model opus')
+    expect('name' in r2 && r2.name).toBe('model')
+    expect('name' in r2 && r2.rest).toBe('opus')
+    // leading slash is tolerated
+    const r3 = parseCcCommand('/context')
+    expect('name' in r3 && r3.name).toBe('context')
+    // namespaced skill command
+    const r4 = parseCcCommand('superpowers:brainstorm')
+    expect('name' in r4 && r4.name).toBe('superpowers:brainstorm')
+  })
+
+  test('shell metacharacters in args are rejected', () => {
+    for (const bad of ['model $(reboot)', 'x; rm -rf /', 'a | sh', 'a `id`', 'a && b', 'a > /etc/x', "a'b", 'a"b', 'a\\b']) {
+      const r = parseCcCommand(bad)
+      expect('error' in r).toBe(true)
+    }
+  })
+
+  test('bad command names rejected', () => {
+    for (const bad of ['', '1abc', '-x', 'A'.repeat(50), 'a!b', 'имя']) {
+      const r = parseCcCommand(bad)
+      expect('error' in r).toBe(true)
+    }
+  })
+})
+
+describe('sendSlashCommand', () => {
+  test('clears line, types literal starting with /, submits Enter', async () => {
+    const calls: string[][] = []
+    const exec = async (args: readonly string[]) => {
+      calls.push([...args])
+      return { exitCode: 0, stderr: '' }
+    }
+    const r = await sendSlashCommand({ paneTarget: '%2', socketPath: '/tmp/s' }, { name: 'compact', rest: '' }, exec)
+    expect(r.ok).toBe(true)
+    expect(calls).toEqual([
+      ['-S', '/tmp/s', 'send-keys', '-t', '%2', 'C-u'],
+      ['-S', '/tmp/s', 'send-keys', '-t', '%2', '-l', '/compact'],
+      ['-S', '/tmp/s', 'send-keys', '-t', '%2', 'Enter'],
+    ])
+    // literal always begins with '/', never a leading dash → no tmux flag risk
+    expect(calls[1]![6]!.startsWith('/')).toBe(true)
+  })
+
+  test('args are appended after a space', async () => {
+    const calls: string[][] = []
+    const exec = async (args: readonly string[]) => { calls.push([...args]); return { exitCode: 0, stderr: '' } }
+    await sendSlashCommand({ paneTarget: '%2' }, { name: 'model', rest: 'opus' }, exec)
+    expect(calls[1]).toEqual(['send-keys', '-t', '%2', '-l', '/model opus'])
+  })
+})
+
+import { sendNamedKey } from '../../src/commands/keys.js'
+describe('sendNamedKey', () => {
+  test('sends a single named key', async () => {
+    const calls: string[][] = []
+    const exec = async (args: readonly string[]) => { calls.push([...args]); return { exitCode: 0, stderr: '' } }
+    const r = await sendNamedKey({ paneTarget: '%3', socketName: 'sk' }, 'Escape', exec)
+    expect(r.ok).toBe(true)
+    expect(calls).toEqual([['-L', 'sk', 'send-keys', '-t', '%3', 'Escape']])
   })
 })


### PR DESCRIPTION
По запросу вождя (2026-06-12): /reset force, /new force, /compact фактически были no-op — плагин слал сигнал в канал, но Claude Code не имеет внешнего API управления сессией. Решение — печатать реальные команды в pane через tmux send-keys (инфраструктура из PR #79).

**Изменения:**
- /stop → Escape в pane = реальное прерывание генерации/тула
- /reset force, /new force → печатают /clear = реальный сброс контекста
- НОВАЯ /cc <команда> — мост к встроенным командам Claude Code: /cc compact (сжатие контекста), /cc model opus, /cc context, /cc cost, кастомные скиллы (включая ultra-режимы)
- Все с fallback на старый channel-signal когда pane не резолвится

**Безопасность:** имя команды по строгому шаблону (буквы/цифры/двоеточие/дефис), args без shell-метасимволов ($ ` ; | & и т.д. отвергаются — тесты), Ctrl+U чистит строку перед вводом, литерал всегда начинается с / (не флаг tmux). execFile без shell. Только DM+allowlist (OOB-гейт).

tsc clean, 1799 tests pass (+13 новых).

🤖 Generated with [Claude Code](https://claude.com/claude-code)