### PR TITLE
Канал /keys: панель кнопок для подтверждения нативных диалогов (auth по Telegram ID)

### DIFF
--- a/plugin/src/commands/keys.ts
+++ b/plugin/src/commands/keys.ts
@@ -29,10 +29,21 @@ const execFileAsync = promisify(execFile)
 // Exported so the /keys inline-button panel (telegram/keys-panel-ui.ts)
 // derives its accepted token set from THIS list — a single whitelist
 // shared by the `/key` text command and the tap keypad.
-export const LITERAL_TOKENS = new Set([
+//
+// The canonical lists are frozen and the live `Set`/`Record` are built from
+// them, then themselves frozen, so a future importer can't mutate at runtime
+// what `/key` (and the kkey panel) accept. A `Set` would otherwise expose
+// .add/.delete and a plain `Record` is mutable by reference — both would let
+// imported code widen the keystroke whitelist (a pane-injection security
+// surface). `parseKeyTokens` and the panel resolve the EXACT same token set.
+
+// Canonical literal-token list (readonly tuple, frozen). Digits 0-9 + y/n.
+const LITERAL_TOKEN_LIST = Object.freeze([
   '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'y', 'n',
-])
-export const NAMED_TOKENS: Record<string, string> = {
+] as const)
+
+// Canonical named-token map (frozen). lower-case token → tmux key name.
+const NAMED_TOKEN_ENTRIES = Object.freeze({
   enter: 'Enter',
   esc: 'Escape',
   escape: 'Escape',
@@ -42,7 +53,17 @@ export const NAMED_TOKENS: Record<string, string> = {
   down: 'Down',
   left: 'Left',
   right: 'Right',
-}
+} as const)
+
+// Immutable Set: a `ReadonlySet` view forbids .add/.delete at the type level,
+// and freezing the underlying object hard-stops mutation at runtime.
+export const LITERAL_TOKENS: ReadonlySet<string> = Object.freeze(
+  new Set<string>(LITERAL_TOKEN_LIST),
+)
+// Immutable Record: Readonly at the type level, frozen at runtime so an
+// importer can neither reassign nor add named tokens.
+export const NAMED_TOKENS: Readonly<Record<string, string>> =
+  Object.freeze({ ...NAMED_TOKEN_ENTRIES })
 
 export const MAX_KEY_TOKENS = 5
 

--- a/plugin/src/commands/keys.ts
+++ b/plugin/src/commands/keys.ts
@@ -27,23 +27,45 @@ const execFileAsync = promisify(execFile)
 // Literal characters are sent with `send-keys -l` (no name lookup);
 // named keys are sent without -l so tmux resolves Enter/Escape/arrows.
 // Exported so the /keys inline-button panel (telegram/keys-panel-ui.ts)
-// derives its accepted token set from THIS list — a single whitelist
+// derives its accepted token set from THESE structures — a single whitelist
 // shared by the `/key` text command and the tap keypad.
 //
-// The canonical lists are frozen and the live `Set`/`Record` are built from
-// them, then themselves frozen, so a future importer can't mutate at runtime
-// what `/key` (and the kkey panel) accept. A `Set` would otherwise expose
-// .add/.delete and a plain `Record` is mutable by reference — both would let
-// imported code widen the keystroke whitelist (a pane-injection security
-// surface). `parseKeyTokens` and the panel resolve the EXACT same token set.
+// RUNTIME TAMPER-RESISTANCE (the whole point — this is a pane-injection
+// security surface):
+//   - `LITERAL_TOKEN_LIST` is a `Object.freeze`d array. Freezing an ARRAY
+//     genuinely blocks `push`/index-assignment/`length` mutation at runtime,
+//     so its `.includes()` membership cannot be widened — this is the single
+//     source of truth literal-token validation checks against.
+//   - `NAMED_TOKENS` is a `Object.freeze`d plain object. Freezing an object
+//     blocks adding/reassigning own properties at runtime, so `t in
+//     NAMED_TOKENS` cannot be widened either.
+//   - We deliberately do NOT export a `Set` of literal tokens. A `Set`'s
+//     contents live in internal slots, so `Object.freeze(new Set(...))` does
+//     NOT stop `.add('rm')` — an importer could cast the `ReadonlySet` back to
+//     `Set` and widen the injectable keystroke set. The frozen array + the
+//     `isLiteralToken` predicate below close that hole.
 
-// Canonical literal-token list (readonly tuple, frozen). Digits 0-9 + y/n.
-const LITERAL_TOKEN_LIST = Object.freeze([
+// Canonical literal-token list (readonly tuple, frozen at runtime). Digits
+// 0-9 + y/n. SINGLE SOURCE OF TRUTH — literal-token validation and the panel
+// both derive from this exact frozen array.
+export const LITERAL_TOKEN_LIST = Object.freeze([
   '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'y', 'n',
 ] as const)
 
-// Canonical named-token map (frozen). lower-case token → tmux key name.
-const NAMED_TOKEN_ENTRIES = Object.freeze({
+// Immutable literal-token predicate. Membership is checked against the FROZEN
+// `LITERAL_TOKEN_LIST` (whose `.includes` cannot be widened at runtime), so
+// there is no mutable `Set` an importer could cast-and-`.add()` to inject a
+// new keystroke. The function itself is frozen so it cannot be monkey-patched.
+export const isLiteralToken: (t: string) => boolean = Object.freeze(
+  (t: string): boolean => (LITERAL_TOKEN_LIST as readonly string[]).includes(t),
+)
+
+// Canonical named-token map (frozen at runtime). lower-case token → tmux key
+// name. `esc` and `escape` are intentional ALIASES for the same Escape key —
+// the /keys panel surfaces `esc` only (both parse identically). Freezing a
+// plain object hard-stops adding/reassigning own properties, so `t in
+// NAMED_TOKENS` is genuinely immutable at runtime.
+export const NAMED_TOKENS: Readonly<Record<string, string>> = Object.freeze({
   enter: 'Enter',
   esc: 'Escape',
   escape: 'Escape',
@@ -54,16 +76,6 @@ const NAMED_TOKEN_ENTRIES = Object.freeze({
   left: 'Left',
   right: 'Right',
 } as const)
-
-// Immutable Set: a `ReadonlySet` view forbids .add/.delete at the type level,
-// and freezing the underlying object hard-stops mutation at runtime.
-export const LITERAL_TOKENS: ReadonlySet<string> = Object.freeze(
-  new Set<string>(LITERAL_TOKEN_LIST),
-)
-// Immutable Record: Readonly at the type level, frozen at runtime so an
-// importer can neither reassign nor add named tokens.
-export const NAMED_TOKENS: Readonly<Record<string, string>> =
-  Object.freeze({ ...NAMED_TOKEN_ENTRIES })
 
 export const MAX_KEY_TOKENS = 5
 
@@ -84,7 +96,9 @@ export function parseKeyTokens(args: string): ParsedKeys | { error: string } {
   }
   const steps: ParsedKeys['steps'] = []
   for (const t of tokens) {
-    if (LITERAL_TOKENS.has(t)) {
+    // Validate against the FROZEN list (not a mutable Set) so a runtime
+    // `(structure as Set).add('rm')` cannot widen the injectable keystrokes.
+    if (isLiteralToken(t)) {
       steps.push({ literal: true, key: t })
     } else if (t in NAMED_TOKENS) {
       steps.push({ literal: false, key: NAMED_TOKENS[t]! })

--- a/plugin/src/commands/keys.ts
+++ b/plugin/src/commands/keys.ts
@@ -26,10 +26,13 @@ const execFileAsync = promisify(execFile)
 
 // Literal characters are sent with `send-keys -l` (no name lookup);
 // named keys are sent without -l so tmux resolves Enter/Escape/arrows.
-const LITERAL_TOKENS = new Set([
+// Exported so the /keys inline-button panel (telegram/keys-panel-ui.ts)
+// derives its accepted token set from THIS list — a single whitelist
+// shared by the `/key` text command and the tap keypad.
+export const LITERAL_TOKENS = new Set([
   '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'y', 'n',
 ])
-const NAMED_TOKENS: Record<string, string> = {
+export const NAMED_TOKENS: Record<string, string> = {
   enter: 'Enter',
   esc: 'Escape',
   escape: 'Escape',

--- a/plugin/src/commands/keys.ts
+++ b/plugin/src/commands/keys.ts
@@ -37,8 +37,10 @@ const execFileAsync = promisify(execFile)
 //     so its `.includes()` membership cannot be widened — this is the single
 //     source of truth literal-token validation checks against.
 //   - `NAMED_TOKENS` is a `Object.freeze`d plain object. Freezing an object
-//     blocks adding/reassigning own properties at runtime, so `t in
-//     NAMED_TOKENS` cannot be widened either.
+//     blocks adding/reassigning own properties at runtime, so its own keys
+//     cannot be widened. Membership is checked with `Object.hasOwn` (NOT a
+//     bare `t in NAMED_TOKENS`) so a polluted `Object.prototype` cannot smuggle
+//     an un-whitelisted token through the prototype chain.
 //   - We deliberately do NOT export a `Set` of literal tokens. A `Set`'s
 //     contents live in internal slots, so `Object.freeze(new Set(...))` does
 //     NOT stop `.add('rm')` — an importer could cast the `ReadonlySet` back to
@@ -63,8 +65,9 @@ export const isLiteralToken: (t: string) => boolean = Object.freeze(
 // Canonical named-token map (frozen at runtime). lower-case token → tmux key
 // name. `esc` and `escape` are intentional ALIASES for the same Escape key —
 // the /keys panel surfaces `esc` only (both parse identically). Freezing a
-// plain object hard-stops adding/reassigning own properties, so `t in
-// NAMED_TOKENS` is genuinely immutable at runtime.
+// plain object hard-stops adding/reassigning own properties; membership is
+// tested with `Object.hasOwn` (not a prototype-walking `in`) so the frozen own
+// keys are the genuine, immutable whitelist at runtime.
 export const NAMED_TOKENS: Readonly<Record<string, string>> = Object.freeze({
   enter: 'Enter',
   esc: 'Escape',
@@ -100,7 +103,11 @@ export function parseKeyTokens(args: string): ParsedKeys | { error: string } {
     // `(structure as Set).add('rm')` cannot widen the injectable keystrokes.
     if (isLiteralToken(t)) {
       steps.push({ literal: true, key: t })
-    } else if (t in NAMED_TOKENS) {
+    } else if (Object.hasOwn(NAMED_TOKENS, t)) {
+      // OWN-property check (not `t in NAMED_TOKENS`): a bare `in` walks the
+      // prototype chain, so `Object.prototype.rm = 'Enter'` would make
+      // `parseKeyTokens('rm')` accept an un-whitelisted token (prototype
+      // pollution). `Object.hasOwn` only sees the frozen own keys, closing it.
       steps.push({ literal: false, key: NAMED_TOKENS[t]! })
     } else {
       return { error: `неизвестная клавиша: ${t} — разрешены цифры, y/n, enter, esc, tab, space, стрелки` }

--- a/plugin/src/commands/oob.ts
+++ b/plugin/src/commands/oob.ts
@@ -26,12 +26,13 @@
 
 import type { AppConfig } from '../config.js'
 import type { Logger } from '../log.js'
-import type { TelegramApi } from '../channel/tools.js'
+import type { TelegramApi, InlineKeyboardLike } from '../channel/tools.js'
 import { sendChannelNotification, type ChannelEvent } from '../channel/notify.js'
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { parseKeyTokens, sendKeys, parseCcCommand, sendSlashCommand, sendNamedKey, type KeysExec, type TmuxKeysTarget } from './keys.js'
+import { buildKeysKeyboard, KEYS_PANEL_HEADER } from '../telegram/keys-panel-ui.js'
 
-export type OobCommandName = 'help' | 'status' | 'stop' | 'reset' | 'new' | 'mirror' | 'key' | 'cc'
+export type OobCommandName = 'help' | 'status' | 'stop' | 'reset' | 'new' | 'mirror' | 'key' | 'keys' | 'cc'
 
 const KNOWN_COMMANDS = new Set<OobCommandName>([
   'help',
@@ -41,6 +42,7 @@ const KNOWN_COMMANDS = new Set<OobCommandName>([
   'new',
   'mirror',
   'key',
+  'keys',
   'cc',
 ])
 
@@ -152,7 +154,11 @@ export interface OobResult {
   handled: true
   command: OobCommandName
   notifyChannel?: { content: string; meta: Record<string, string> }
-  replyToTelegram?: { text: string; parseMode?: 'HTML' }
+  // `inlineKeyboard` (optional, additive) attaches a reply_markup keypad to
+  // the Telegram reply — used by /keys to render the tap panel. Mirrors how
+  // the permission gate sends its Allow/Deny keyboard. Existing replies omit
+  // it and Telegram sends a plain message.
+  replyToTelegram?: { text: string; parseMode?: 'HTML'; inlineKeyboard?: InlineKeyboardLike }
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -170,6 +176,7 @@ function helpText(): string {
     + '<code>/new force</code> — начать новую сессию (подтверди флагом <code>force</code>)\n'
     + '<code>/mirror on|off|status</code> — управлять зеркалом терминала (tmux, обновляется в реальном времени)\n'
     + '<code>/key 1|2|3|y|n|enter|esc…</code> — нажать клавишу в терминале агента (ответить на диалог)\n'
+    + '<code>/keys</code> — панель кнопок: тап = нажатие в сессии (ответить на нативный диалог Claude Code)\n'
     + '<code>/cc &lt;команда&gt;</code> — встроенная команда Claude Code: <code>/cc compact</code>, <code>/cc model opus</code>, <code>/cc context</code>\n\n'
     + '<i>примечание: /stop — best-effort: плагин передаёт сигнал остановки через '
     + 'канал, но не может гарантировать прерывание посреди вызова инструмента.</i>'
@@ -190,6 +197,7 @@ export const BOT_COMMANDS: ReadonlyArray<BotCommandSpec> = [
   { command: 'new', description: 'начать новую сессию (нужен force)' },
   { command: 'mirror', description: 'зеркало терминала: on | off | status' },
   { command: 'key', description: 'нажать клавишу в терминале: 1 | 2 | y | n | enter | esc' },
+  { command: 'keys', description: 'панель кнопок для подтверждений (нажатия в сессию)' },
   { command: 'cc', description: 'встроенная команда Claude Code: compact | model | context …' },
 ]
 
@@ -522,6 +530,33 @@ export async function handleOobCommand(
       }
     }
 
+    case 'keys': {
+      // Render the one-tap keypad. The buttons inject the SAME whitelisted
+      // keystrokes /key does — their `kkey:` callbacks are dispatched in
+      // server.ts with the same fail-closed allowlist auth. We only need a
+      // resolvable pane to make the panel useful; if none, explain like /key.
+      if (!ctx.tmuxKeys) {
+        return {
+          handled: true,
+          command: 'keys',
+          replyToTelegram: {
+            text: '<b>/keys</b> — недоступно: плагин не знает tmux-pane сессии (нет tmux-конфига).',
+            parseMode: 'HTML',
+          },
+        }
+      }
+      ctx.log.info('oob /keys', { chat_id: ctx.chatId })
+      return {
+        handled: true,
+        command: 'keys',
+        replyToTelegram: {
+          text: KEYS_PANEL_HEADER,
+          parseMode: 'HTML',
+          inlineKeyboard: buildKeysKeyboard(),
+        },
+      }
+    }
+
     case 'cc': {
       // Passthrough to Claude Code's OWN slash commands (/compact, /model,
       // /context, custom skills…) by typing them into the agent pane.
@@ -577,6 +612,9 @@ export async function executeOobResult(
       await ctx.telegramApi.sendMessage(ctx.chatId, result.replyToTelegram.text, {
         ...(result.replyToTelegram.parseMode !== undefined
           ? { parse_mode: result.replyToTelegram.parseMode }
+          : {}),
+        ...(result.replyToTelegram.inlineKeyboard !== undefined
+          ? { reply_markup: result.replyToTelegram.inlineKeyboard }
           : {}),
       })
     } catch (err) {

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -695,7 +695,10 @@ bot.on('callback_query:data', async ctx => {
       await handleKkeyCallback(
         {
           callbackQuery: { data },
-          from: { id: ctx.from.id },
+          // Pass the id straight through (may be undefined for a malformed
+          // update). The handler treats a missing/non-number id as
+          // unauthorized — fail-closed, never trusts the caller's identity.
+          from: { id: ctx.from?.id },
           answerCallbackQuery: async arg => {
             await ctx.answerCallbackQuery(arg)
           },
@@ -710,6 +713,16 @@ bot.on('callback_query:data', async ctx => {
       log.error('kkey callback_query handler threw', {
         error: err instanceof Error ? err.message : String(err),
       })
+      // Best-effort: clear the Telegram spinner even when the handler threw
+      // before it could answer (otherwise the user sees a hanging spinner).
+      // A failure of THIS call is itself swallowed — never rethrow.
+      try {
+        await ctx.answerCallbackQuery({ text: 'ошибка' })
+      } catch (ackErr) {
+        log.warn('kkey error-ack answerCallbackQuery failed', {
+          error: ackErr instanceof Error ? ackErr.message : String(ackErr),
+        })
+      }
     }
     return
   }

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -68,6 +68,7 @@ import { createPermissionGateUi } from './telegram/permission-gate-ui.js'
 import { TelegramPoller, tokenLock } from './telegram/poller.js'
 import { describePidHolder, readLockHolder } from './telegram/pid-inspect.js'
 import { BOT_COMMANDS } from './commands/oob.js'
+import { handleKkeyCallback } from './telegram/keys-panel-ui.js'
 import { startWebhookServer, type WebhookServerHandle } from './webhook/server.js'
 import {
   handleInboundAudio,
@@ -675,6 +676,38 @@ bot.on('callback_query:data', async ctx => {
       })
     } catch (err) {
       log.error('pgate callback_query handler threw', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+    return
+  }
+  // /keys keypad (kkey:*) — one-tap keystroke injection into the agent pane.
+  // Dispatched on its own prefix so it never collides with pgate:/ask:/perm:.
+  // Auth is fail-closed against config.allowed_user_ids — the SAME allowlist
+  // that guards the sibling `/key` OOB text command (handlers.ts OOB gate).
+  // We use allowed_user_ids (not the permission_gate set) because these
+  // buttons ARE /key: a tap injects one whitelisted keystroke, identical to
+  // typing `/key <token>`, so the authorization surface must match /key's.
+  // The handler never mutates the keyboard message — the warchief taps it
+  // repeatedly across a multi-step dialog.
+  if (data.startsWith('kkey:')) {
+    try {
+      await handleKkeyCallback(
+        {
+          callbackQuery: { data },
+          from: { id: ctx.from.id },
+          answerCallbackQuery: async arg => {
+            await ctx.answerCallbackQuery(arg)
+          },
+        },
+        {
+          allowedUserIds: config.allowed_user_ids,
+          log,
+          ...(tmuxKeysTarget !== undefined ? { tmuxKeysTarget } : {}),
+        },
+      )
+    } catch (err) {
+      log.error('kkey callback_query handler threw', {
         error: err instanceof Error ? err.message : String(err),
       })
     }

--- a/plugin/src/telegram/keys-panel-ui.ts
+++ b/plugin/src/telegram/keys-panel-ui.ts
@@ -58,12 +58,17 @@ export function parseKkeyCallback(data: string): string | null {
   return token
 }
 
-// Build the 3-row keypad. Labels are human-friendly (✓ y, ⏎ enter, arrows);
-// callback_data carries the raw whitelist token the handler injects.
+// Build the 5-row keypad. Labels are human-friendly (✓ y, ⏎ enter, arrows);
+// callback_data carries the raw whitelist token the handler injects. The
+// panel exposes the FULL /key whitelist (no UI/parser mismatch) — Claude Code
+// dialogs literally say "Tab to amend", so omitting tab/space/0/6-9 would
+// limit live recovery.
 //
 // Row1: dialog option selectors 1-5
-// Row2: yes/no + confirm/cancel
-// Row3: arrow navigation
+// Row2: dialog option selectors 6-9 + 0
+// Row3: yes/no + confirm/cancel
+// Row4: arrow navigation
+// Row5: tab / space (Claude Code "Tab to amend", whitespace)
 export function buildKeysKeyboard(): InlineKeyboardLike {
   return {
     inline_keyboard: [
@@ -73,6 +78,13 @@ export function buildKeysKeyboard(): InlineKeyboardLike {
         { text: '3', callback_data: `${KKEY_PREFIX}3` },
         { text: '4', callback_data: `${KKEY_PREFIX}4` },
         { text: '5', callback_data: `${KKEY_PREFIX}5` },
+      ],
+      [
+        { text: '6', callback_data: `${KKEY_PREFIX}6` },
+        { text: '7', callback_data: `${KKEY_PREFIX}7` },
+        { text: '8', callback_data: `${KKEY_PREFIX}8` },
+        { text: '9', callback_data: `${KKEY_PREFIX}9` },
+        { text: '0', callback_data: `${KKEY_PREFIX}0` },
       ],
       [
         { text: '✓ y', callback_data: `${KKEY_PREFIX}y` },
@@ -85,6 +97,10 @@ export function buildKeysKeyboard(): InlineKeyboardLike {
         { text: '↓ down', callback_data: `${KKEY_PREFIX}down` },
         { text: '← left', callback_data: `${KKEY_PREFIX}left` },
         { text: '→ right', callback_data: `${KKEY_PREFIX}right` },
+      ],
+      [
+        { text: '⇥ tab', callback_data: `${KKEY_PREFIX}tab` },
+        { text: '␣ space', callback_data: `${KKEY_PREFIX}space` },
       ],
     ],
   }
@@ -99,14 +115,23 @@ export const KEYS_PANEL_HEADER =
 // ─────────────────────────────────────────────────────────────────────
 // Callback handler (extracted from server.ts so it is unit-testable in
 // isolation, mirroring permission-gate-ui.ts's handlePgateCallback). The
-// security model is the same: parse → fail-closed auth → pane check →
-// inject. A reject at ANY step toasts and sends NO keystroke.
+// security model: fail-closed auth FIRST → parse token → pane check →
+// inject. A reject at ANY step toasts and sends NO keystroke. Auth precedes
+// parsing so a non-allowed caller can never learn token validity.
 // ─────────────────────────────────────────────────────────────────────
 
 // Structural subset of grammY's callback_query Context the handler needs.
+// `from` (and its `id`) is optional: grammY callback contexts almost always
+// carry a sender, but a malformed/replayed update can omit it. A missing or
+// non-number id is treated as unauthorized (fail-closed) — see
+// handleKkeyCallback's auth-first gate.
 export interface KkeyCallbackContext {
   callbackQuery: { data: string }
-  from: { id: number }
+  // `id?: number | undefined` (explicit `| undefined`) so a caller may pass
+  // `{ id: ctx.from?.id }` directly under exactOptionalPropertyTypes — a
+  // malformed update yields `undefined`, which the handler rejects as
+  // unauthorized.
+  from?: { id?: number | undefined }
   answerCallbackQuery(arg: { text: string }): Promise<void>
 }
 
@@ -133,15 +158,24 @@ export async function handleKkeyCallback(
   ctx: KkeyCallbackContext,
   deps: KkeyCallbackDeps,
 ): Promise<boolean> {
+  // AUTH FIRST — the strict first decision, before parsing the token or
+  // touching the pane. A non-allowed (or missing/non-number id) caller must
+  // get ONLY «не авторизовано» and learn nothing about token validity or
+  // pane state. Parsing first would leak which tokens are valid (a malformed
+  // `kkey:rm` would surface «неизвестная клавиша») and break uniform
+  // fail-closed behaviour. A missing id is treated as unauthorized.
+  const fromId = ctx.from?.id
+  if (typeof fromId !== 'number' || !deps.allowedUserIds.includes(fromId)) {
+    deps.log.warn('kkey unauthorized tap', {
+      user_id: fromId,
+      data: ctx.callbackQuery.data,
+    })
+    await ctx.answerCallbackQuery({ text: 'не авторизовано' })
+    return true
+  }
   const token = parseKkeyCallback(ctx.callbackQuery.data)
   if (token === null) {
     await ctx.answerCallbackQuery({ text: 'неизвестная клавиша' })
-    return true
-  }
-  // Fail-closed auth: only an allowed user id may drive the session.
-  if (!deps.allowedUserIds.includes(ctx.from.id)) {
-    deps.log.warn('kkey unauthorized tap', { user_id: ctx.from.id, token })
-    await ctx.answerCallbackQuery({ text: 'не авторизовано' })
     return true
   }
   if (deps.tmuxKeysTarget === undefined) {

--- a/plugin/src/telegram/keys-panel-ui.ts
+++ b/plugin/src/telegram/keys-panel-ui.ts
@@ -20,7 +20,7 @@
 // run a command). See server.ts bot.on('callback_query:data') for the wiring.
 
 import {
-  LITERAL_TOKENS,
+  LITERAL_TOKEN_LIST,
   NAMED_TOKENS,
   parseKeyTokens,
   sendKeys,
@@ -35,10 +35,20 @@ export const KKEY_PREFIX = 'kkey:'
 
 // The closed set of tokens a `kkey:` callback may carry === the keys.ts
 // whitelist (digits 0-9, y, n, enter, esc/escape, tab, space, arrows).
-// Reusing keys.ts's sets keeps a single source of truth: extending the
-// whitelist there extends what the panel accepts, no duplicate list.
+// Derived from keys.ts's FROZEN canonical structures (the literal array +
+// the frozen named-token map) so there is a single source of truth: extending
+// the whitelist there extends what the panel accepts, no duplicate list. We
+// build this local lookup from the frozen sources rather than importing a
+// mutable Set — keys.ts no longer exports one (a cast-and-`.add` Set would be
+// a runtime pane-injection hole).
+//
+// NOTE on `esc`/`escape`: NAMED_TOKENS maps BOTH to the Escape key — they are
+// intentional aliases. parseKkeyCallback therefore accepts a `kkey:escape`
+// callback too, but the rendered keypad (buildKeysKeyboard) intentionally
+// surfaces `esc` ONLY: one Escape button is the complete capability, a second
+// `escape` button would be redundant.
 const ALLOWED_TOKENS: ReadonlySet<string> = new Set<string>([
-  ...LITERAL_TOKENS,
+  ...LITERAL_TOKEN_LIST,
   ...Object.keys(NAMED_TOKENS),
 ])
 

--- a/plugin/src/telegram/keys-panel-ui.ts
+++ b/plugin/src/telegram/keys-panel-ui.ts
@@ -1,0 +1,166 @@
+// /keys panel — one-tap inline-button keypad for answering Claude Code's
+// NATIVE terminal dialogs (permission rules, model switch, trust prompts)
+// from Telegram. The buttons are a graphical front-end to the SAME
+// keystroke injection that `/key` performs: a tap presses ONE whitelisted
+// key in the agent's tmux pane.
+//
+// Callback data uses the `kkey:` prefix so it never collides with the other
+// inline flows sharing bot.on('callback_query:data'):
+//   * `pgate:*` — permission-gate Allow/Deny (telegram/permission-gate-ui.ts)
+//   * `ask:*`   — AskUserQuestion (telegram/ask-user-question.ts)
+//   * `perm:*`  — headless MCP permission relay (channel/permissions.ts)
+//
+//   kkey:<token>   where <token> is ONE entry of the /key whitelist.
+//
+// Security: a tap is honoured ONLY for a user id in the same allow-list that
+// guards the sibling `/key` OOB command (config.allowed_user_ids). Anyone
+// else gets an answerCallbackQuery toast and NO keystroke is sent. The token
+// set is the exact keys.ts whitelist — there is no way to inject arbitrary
+// text into the pane (so a pane that dropped to a shell can't be driven to
+// run a command). See server.ts bot.on('callback_query:data') for the wiring.
+
+import {
+  LITERAL_TOKENS,
+  NAMED_TOKENS,
+  parseKeyTokens,
+  sendKeys,
+  type KeysExec,
+  type TmuxKeysTarget,
+} from '../commands/keys.js'
+import type { InlineKeyboardLike } from '../channel/tools.js'
+import type { Logger } from '../log.js'
+
+// The callback prefix. Distinct from pgate:/ask:/perm: by construction.
+export const KKEY_PREFIX = 'kkey:'
+
+// The closed set of tokens a `kkey:` callback may carry === the keys.ts
+// whitelist (digits 0-9, y, n, enter, esc/escape, tab, space, arrows).
+// Reusing keys.ts's sets keeps a single source of truth: extending the
+// whitelist there extends what the panel accepts, no duplicate list.
+const ALLOWED_TOKENS: ReadonlySet<string> = new Set<string>([
+  ...LITERAL_TOKENS,
+  ...Object.keys(NAMED_TOKENS),
+])
+
+// Parse a `kkey:<token>` callback_data string. Returns the validated token
+// (lower-cased, single entry of the whitelist) or null for anything else —
+// a non-kkey prefix, an empty token, a multi-token payload, or a token
+// outside the whitelist. Null callers answer the callback with a toast and
+// send NO keystroke (fail-closed).
+export function parseKkeyCallback(data: string): string | null {
+  if (typeof data !== 'string') return null
+  if (!data.startsWith(KKEY_PREFIX)) return null
+  const token = data.slice(KKEY_PREFIX.length)
+  // Single token only — reject embedded separators / whitespace / sequences
+  // (e.g. `1;2`, `1 enter`). The pane-injection layer takes one key per tap.
+  if (token.length === 0) return null
+  if (!ALLOWED_TOKENS.has(token)) return null
+  return token
+}
+
+// Build the 3-row keypad. Labels are human-friendly (✓ y, ⏎ enter, arrows);
+// callback_data carries the raw whitelist token the handler injects.
+//
+// Row1: dialog option selectors 1-5
+// Row2: yes/no + confirm/cancel
+// Row3: arrow navigation
+export function buildKeysKeyboard(): InlineKeyboardLike {
+  return {
+    inline_keyboard: [
+      [
+        { text: '1', callback_data: `${KKEY_PREFIX}1` },
+        { text: '2', callback_data: `${KKEY_PREFIX}2` },
+        { text: '3', callback_data: `${KKEY_PREFIX}3` },
+        { text: '4', callback_data: `${KKEY_PREFIX}4` },
+        { text: '5', callback_data: `${KKEY_PREFIX}5` },
+      ],
+      [
+        { text: '✓ y', callback_data: `${KKEY_PREFIX}y` },
+        { text: '✗ n', callback_data: `${KKEY_PREFIX}n` },
+        { text: '⏎ enter', callback_data: `${KKEY_PREFIX}enter` },
+        { text: '⎋ esc', callback_data: `${KKEY_PREFIX}esc` },
+      ],
+      [
+        { text: '↑ up', callback_data: `${KKEY_PREFIX}up` },
+        { text: '↓ down', callback_data: `${KKEY_PREFIX}down` },
+        { text: '← left', callback_data: `${KKEY_PREFIX}left` },
+        { text: '→ right', callback_data: `${KKEY_PREFIX}right` },
+      ],
+    ],
+  }
+}
+
+// Header text rendered above the keypad. HTML parse mode.
+export const KEYS_PANEL_HEADER =
+  '<b>Управление сессией</b> — тап = нажатие в моей сессии. '
+  + 'Для диалога Claude Code: 1/2/3 = выбор пункта, y/n = да/нет, '
+  + '⏎ подтвердить, ⎋ отмена.'
+
+// ─────────────────────────────────────────────────────────────────────
+// Callback handler (extracted from server.ts so it is unit-testable in
+// isolation, mirroring permission-gate-ui.ts's handlePgateCallback). The
+// security model is the same: parse → fail-closed auth → pane check →
+// inject. A reject at ANY step toasts and sends NO keystroke.
+// ─────────────────────────────────────────────────────────────────────
+
+// Structural subset of grammY's callback_query Context the handler needs.
+export interface KkeyCallbackContext {
+  callbackQuery: { data: string }
+  from: { id: number }
+  answerCallbackQuery(arg: { text: string }): Promise<void>
+}
+
+export interface KkeyCallbackDeps {
+  // The SAME allowlist that guards the sibling `/key` OOB text command
+  // (config.allowed_user_ids). A tap is honoured only for a user id in
+  // this set — fail-closed for everyone else.
+  allowedUserIds: readonly number[]
+  // The resolved agent pane. Undefined when the plugin can't resolve a
+  // pane (no tmux config / no $TMUX env) — a tap then toasts «pane
+  // недоступен» and sends nothing.
+  tmuxKeysTarget?: TmuxKeysTarget
+  log: Logger
+  // Injected for tests; defaults to the real tmux exec inside sendKeys.
+  exec?: KeysExec
+}
+
+// Dispatch a `kkey:*` callback. Always answers the callback query (so the
+// Telegram spinner clears) and returns true when it consumed the event.
+// NEVER injects a keystroke for a non-allowed user id (the warchief's hard
+// requirement). Does NOT mutate the keyboard message — the warchief taps it
+// repeatedly across a multi-step dialog.
+export async function handleKkeyCallback(
+  ctx: KkeyCallbackContext,
+  deps: KkeyCallbackDeps,
+): Promise<boolean> {
+  const token = parseKkeyCallback(ctx.callbackQuery.data)
+  if (token === null) {
+    await ctx.answerCallbackQuery({ text: 'неизвестная клавиша' })
+    return true
+  }
+  // Fail-closed auth: only an allowed user id may drive the session.
+  if (!deps.allowedUserIds.includes(ctx.from.id)) {
+    deps.log.warn('kkey unauthorized tap', { user_id: ctx.from.id, token })
+    await ctx.answerCallbackQuery({ text: 'не авторизовано' })
+    return true
+  }
+  if (deps.tmuxKeysTarget === undefined) {
+    await ctx.answerCallbackQuery({ text: 'pane недоступен' })
+    return true
+  }
+  const parsedKeys = parseKeyTokens(token)
+  if ('error' in parsedKeys) {
+    // Unreachable: parseKkeyCallback already validated the token against the
+    // same whitelist. Handle defensively so an unexpected reject toasts and
+    // still sends nothing.
+    await ctx.answerCallbackQuery({ text: 'неизвестная клавиша' })
+    return true
+  }
+  const sent = await sendKeys(deps.tmuxKeysTarget, parsedKeys, deps.exec)
+  if (sent.ok) {
+    await ctx.answerCallbackQuery({ text: `нажато: ${token}` })
+  } else {
+    await ctx.answerCallbackQuery({ text: `ошибка: ${sent.error.slice(0, 180)}` })
+  }
+  return true
+}

--- a/plugin/tests/commands/oob.test.ts
+++ b/plugin/tests/commands/oob.test.ts
@@ -474,7 +474,7 @@ describe('/keys command', () => {
     expect(res.replyToTelegram?.text).toContain('Управление сессией')
     const kb = res.replyToTelegram?.inlineKeyboard
     expect(kb).toBeDefined()
-    expect(kb!.inline_keyboard.length).toBe(3)
+    expect(kb!.inline_keyboard.length).toBe(5)
     expect(kb!.inline_keyboard[0]!.map((b) => b.callback_data)).toEqual([
       'kkey:1', 'kkey:2', 'kkey:3', 'kkey:4', 'kkey:5',
     ])

--- a/plugin/tests/commands/oob.test.ts
+++ b/plugin/tests/commands/oob.test.ts
@@ -441,3 +441,55 @@ describe('/key command', () => {
     expect(res.replyToTelegram?.text).toContain('неизвестная клавиша')
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────
+// /keys — inline-button keypad panel (2026-06-13).
+// ─────────────────────────────────────────────────────────────────────
+
+describe('/keys command', () => {
+  test('parses as a known command', () => {
+    const p = parseOobCommand('/keys')
+    expect(p?.name).toBe('keys')
+    expect(p?.args).toBe('')
+  })
+
+  test('without tmuxKeys ctx replies «недоступно», no keyboard, no channel notify', async () => {
+    const parsed = parseOobCommand('/keys')
+    if (!parsed) throw new Error('parse failed')
+    const res = await handleOobCommand(parsed, makeCtx())
+    expect(res.command).toBe('keys')
+    expect(res.replyToTelegram?.text).toContain('недоступно')
+    expect(res.replyToTelegram?.inlineKeyboard).toBeUndefined()
+    expect(res.notifyChannel).toBeUndefined()
+  })
+
+  test('with tmuxKeys ctx replies with the keypad and never wakes Claude', async () => {
+    const parsed = parseOobCommand('/keys')
+    if (!parsed) throw new Error('parse failed')
+    const ctx = makeCtx()
+    ctx.tmuxKeys = { target: { paneTarget: '%1', socketPath: '/tmp/s' } }
+    const res = await handleOobCommand(parsed, ctx)
+    expect(res.command).toBe('keys')
+    expect(res.replyToTelegram?.parseMode).toBe('HTML')
+    expect(res.replyToTelegram?.text).toContain('Управление сессией')
+    const kb = res.replyToTelegram?.inlineKeyboard
+    expect(kb).toBeDefined()
+    expect(kb!.inline_keyboard.length).toBe(3)
+    expect(kb!.inline_keyboard[0]!.map((b) => b.callback_data)).toEqual([
+      'kkey:1', 'kkey:2', 'kkey:3', 'kkey:4', 'kkey:5',
+    ])
+    expect(res.notifyChannel).toBeUndefined()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// /help lists /keys (autocomplete + help parity).
+// ─────────────────────────────────────────────────────────────────────
+
+describe('/help lists /keys', () => {
+  test('help text mentions /keys', async () => {
+    const parsed = parseOobCommand('/help')!
+    const result = await handleOobCommand(parsed, makeCtx())
+    expect(result.replyToTelegram!.text).toContain('/keys')
+  })
+})

--- a/plugin/tests/telegram/keys-panel.test.ts
+++ b/plugin/tests/telegram/keys-panel.test.ts
@@ -10,8 +10,10 @@ import {
   type KkeyCallbackDeps,
 } from '../../src/telegram/keys-panel-ui.js'
 import {
-  LITERAL_TOKENS,
+  LITERAL_TOKEN_LIST,
   NAMED_TOKENS,
+  isLiteralToken,
+  parseKeyTokens,
   type KeysExec,
   type TmuxKeysTarget,
 } from '../../src/commands/keys.js'
@@ -65,6 +67,61 @@ describe('parseKkeyCallback', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────
+// Runtime tamper-resistance of the literal-token whitelist (LOW #1).
+// A malicious in-process import must NOT be able to widen the set of
+// keystrokes /key (and the kkey panel) will inject into the tmux pane.
+// ─────────────────────────────────────────────────────────────────────
+
+describe('literal-token whitelist is tamper-proof at runtime', () => {
+  test('frozen LITERAL_TOKEN_LIST cannot be widened, and validation stays closed', () => {
+    // Sanity: the canonical structure is frozen.
+    expect(Object.isFrozen(LITERAL_TOKEN_LIST)).toBe(true)
+    expect(Object.isFrozen(isLiteralToken)).toBe(true)
+
+    // Baseline behaviour BEFORE any mutation attempt.
+    expect(isLiteralToken('1')).toBe(true)
+    expect(isLiteralToken('rm')).toBe(false)
+    expect('error' in parseKeyTokens('1')).toBe(false)
+    expect('error' in parseKeyTokens('rm')).toBe(true)
+
+    // Attempt every plausible runtime widening of the literal whitelist.
+    // (a) cast the readonly array to a mutable array and push.
+    try {
+      ;(LITERAL_TOKEN_LIST as unknown as string[]).push('rm')
+    } catch {
+      /* frozen array throws in strict mode — that is the point */
+    }
+    // (b) index-assign past the end.
+    try {
+      ;(LITERAL_TOKEN_LIST as unknown as string[])[100] = 'rm'
+    } catch {
+      /* frozen array index write is rejected */
+    }
+    // (c) cast the predicate to a Set-like and try .add — there is no Set,
+    //     so this is a no-op; the predicate stays frozen.
+    try {
+      ;(isLiteralToken as unknown as { add?: (t: string) => void }).add?.('rm')
+    } catch {
+      /* no-op / rejected */
+    }
+
+    // PROOF: a malicious mutation could not widen the injectable keystroke
+    // set. `rm` is STILL rejected, and a legitimate literal is STILL accepted.
+    expect(isLiteralToken('rm')).toBe(false)
+    expect(isLiteralToken('1')).toBe(true)
+    expect((LITERAL_TOKEN_LIST as readonly string[]).includes('rm')).toBe(false)
+
+    const rejected = parseKeyTokens('rm')
+    expect('error' in rejected).toBe(true)
+    const accepted = parseKeyTokens('1')
+    expect('error' in accepted).toBe(false)
+    if (!('error' in accepted)) {
+      expect(accepted.steps).toEqual([{ literal: true, key: '1' }])
+    }
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
 // buildKeysKeyboard
 // ─────────────────────────────────────────────────────────────────────
 
@@ -87,7 +144,7 @@ describe('buildKeysKeyboard', () => {
       kb.inline_keyboard.flat().map((b) => b.callback_data!.slice(KKEY_PREFIX.length)),
     )
     const whitelist = new Set([
-      ...LITERAL_TOKENS,
+      ...LITERAL_TOKEN_LIST,
       ...Object.keys(NAMED_TOKENS),
     ])
     // 'escape' is an alias of 'esc' — the panel exposes 'esc' only. Every

--- a/plugin/tests/telegram/keys-panel.test.ts
+++ b/plugin/tests/telegram/keys-panel.test.ts
@@ -9,7 +9,12 @@ import {
   type KkeyCallbackContext,
   type KkeyCallbackDeps,
 } from '../../src/telegram/keys-panel-ui.js'
-import type { KeysExec, TmuxKeysTarget } from '../../src/commands/keys.js'
+import {
+  LITERAL_TOKENS,
+  NAMED_TOKENS,
+  type KeysExec,
+  type TmuxKeysTarget,
+} from '../../src/commands/keys.js'
 import type { Logger } from '../../src/log.js'
 
 function makeLogger(): Logger {
@@ -64,14 +69,37 @@ describe('parseKkeyCallback', () => {
 // ─────────────────────────────────────────────────────────────────────
 
 describe('buildKeysKeyboard', () => {
-  test('produces 3 rows with the expected callback_data values', () => {
+  test('produces the full 5-row layout with all whitelisted tokens', () => {
     const kb = buildKeysKeyboard()
-    expect(kb.inline_keyboard.length).toBe(3)
+    expect(kb.inline_keyboard.length).toBe(5)
 
     const cb = (row: number) => kb.inline_keyboard[row]!.map((b) => b.callback_data)
     expect(cb(0)).toEqual(['kkey:1', 'kkey:2', 'kkey:3', 'kkey:4', 'kkey:5'])
-    expect(cb(1)).toEqual(['kkey:y', 'kkey:n', 'kkey:enter', 'kkey:esc'])
-    expect(cb(2)).toEqual(['kkey:up', 'kkey:down', 'kkey:left', 'kkey:right'])
+    expect(cb(1)).toEqual(['kkey:6', 'kkey:7', 'kkey:8', 'kkey:9', 'kkey:0'])
+    expect(cb(2)).toEqual(['kkey:y', 'kkey:n', 'kkey:enter', 'kkey:esc'])
+    expect(cb(3)).toEqual(['kkey:up', 'kkey:down', 'kkey:left', 'kkey:right'])
+    expect(cb(4)).toEqual(['kkey:tab', 'kkey:space'])
+  })
+
+  test('panel coverage = full /key whitelist (no UI/parser mismatch)', () => {
+    const kb = buildKeysKeyboard()
+    const panelTokens = new Set(
+      kb.inline_keyboard.flat().map((b) => b.callback_data!.slice(KKEY_PREFIX.length)),
+    )
+    const whitelist = new Set([
+      ...LITERAL_TOKENS,
+      ...Object.keys(NAMED_TOKENS),
+    ])
+    // 'escape' is an alias of 'esc' — the panel exposes 'esc' only. Every
+    // OTHER whitelisted token must have a button, and every button token must
+    // be in the whitelist.
+    for (const tok of whitelist) {
+      if (tok === 'escape') continue
+      expect(panelTokens.has(tok)).toBe(true)
+    }
+    for (const tok of panelTokens) {
+      expect(whitelist.has(tok)).toBe(true)
+    }
   })
 
   test('every callback_data parses back to a whitelisted token', () => {
@@ -206,5 +234,71 @@ describe('handleKkeyCallback — auth gate', () => {
     expect(calls.length).toBe(0)
     // A non-allowed user must not even learn whether a pane exists.
     expect(toasts).toEqual(['не авторизовано'])
+  })
+
+  test('AUTH FIRST: non-allowed + MALFORMED token (kkey:rm) → «не авторизовано» (NOT «неизвестная клавиша»), 0 sendKeys', async () => {
+    // The critical auth-first proof: a non-allowed caller replaying malformed
+    // callback data must NOT learn token validity. If parse ran first this
+    // would be «неизвестная клавиша», leaking that `rm` is not a valid token.
+    const { ctx, toasts } = makeCtx('kkey:rm', NON_ALLOWED_ID)
+    const { deps, calls } = makeDeps()
+    const consumed = await handleKkeyCallback(ctx, deps)
+    expect(consumed).toBe(true)
+    expect(toasts).toEqual(['не авторизовано'])
+    expect(calls.length).toBe(0)
+  })
+
+  test('missing/undefined from id → «не авторизовано», 0 sendKeys', async () => {
+    const toasts: string[] = []
+    // No `from` at all — a malformed/replayed update. Must fail-closed.
+    const ctx: KkeyCallbackContext = {
+      callbackQuery: { data: 'kkey:2' },
+      answerCallbackQuery: async (arg) => {
+        toasts.push(arg.text)
+      },
+    }
+    const { deps, calls } = makeDeps()
+    const consumed = await handleKkeyCallback(ctx, deps)
+    expect(consumed).toBe(true)
+    expect(toasts).toEqual(['не авторизовано'])
+    expect(calls.length).toBe(0)
+  })
+
+  test('from present but id undefined → «не авторизовано», 0 sendKeys', async () => {
+    const toasts: string[] = []
+    const ctx: KkeyCallbackContext = {
+      callbackQuery: { data: 'kkey:2' },
+      from: { id: undefined },
+      answerCallbackQuery: async (arg) => {
+        toasts.push(arg.text)
+      },
+    }
+    const { deps, calls } = makeDeps()
+    await handleKkeyCallback(ctx, deps)
+    expect(toasts).toEqual(['не авторизовано'])
+    expect(calls.length).toBe(0)
+  })
+
+  test('handler throw (exec throws unexpectedly) → spinner still cleared via the caller catch (no hanging spinner)', async () => {
+    // A raw-throwing exec propagates out of sendKeys/handleKkeyCallback (the
+    // handler does not swallow it). The server.ts kkey branch wraps the call
+    // in try/catch and answers «ошибка» so the Telegram spinner never hangs.
+    // We replicate that wrapper here to prove the end-to-end no-hanging-spinner
+    // invariant the security review required.
+    const { ctx, toasts } = makeCtx('kkey:2', ALLOWED_ID)
+    const throwingExec: KeysExec = async () => {
+      throw new Error('exec blew up')
+    }
+    const { deps } = makeDeps({ exec: throwingExec })
+    let threw = false
+    try {
+      await handleKkeyCallback(ctx, deps)
+    } catch {
+      threw = true
+      // Mirror server.ts: best-effort spinner clear on a handler throw.
+      await ctx.answerCallbackQuery({ text: 'ошибка' })
+    }
+    expect(threw).toBe(true)
+    expect(toasts).toEqual(['ошибка'])
   })
 })

--- a/plugin/tests/telegram/keys-panel.test.ts
+++ b/plugin/tests/telegram/keys-panel.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  buildKeysKeyboard,
+  handleKkeyCallback,
+  parseKkeyCallback,
+  KEYS_PANEL_HEADER,
+  KKEY_PREFIX,
+  type KkeyCallbackContext,
+  type KkeyCallbackDeps,
+} from '../../src/telegram/keys-panel-ui.js'
+import type { KeysExec, TmuxKeysTarget } from '../../src/commands/keys.js'
+import type { Logger } from '../../src/log.js'
+
+function makeLogger(): Logger {
+  return { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// parseKkeyCallback
+// ─────────────────────────────────────────────────────────────────────
+
+describe('parseKkeyCallback', () => {
+  test('accepts each whitelisted literal token', () => {
+    for (const t of ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'y', 'n']) {
+      expect(parseKkeyCallback(`${KKEY_PREFIX}${t}`)).toBe(t)
+    }
+  })
+
+  test('accepts each whitelisted named token', () => {
+    for (const t of ['enter', 'esc', 'escape', 'tab', 'space', 'up', 'down', 'left', 'right']) {
+      expect(parseKkeyCallback(`${KKEY_PREFIX}${t}`)).toBe(t)
+    }
+  })
+
+  test('rejects a non-whitelisted token (kkey:rm)', () => {
+    expect(parseKkeyCallback('kkey:rm')).toBeNull()
+  })
+
+  test('rejects an empty token (kkey:)', () => {
+    expect(parseKkeyCallback('kkey:')).toBeNull()
+  })
+
+  test('rejects a multi-token / sequence payload (kkey:1;2)', () => {
+    expect(parseKkeyCallback('kkey:1;2')).toBeNull()
+    expect(parseKkeyCallback('kkey:1 enter')).toBeNull()
+    expect(parseKkeyCallback('kkey:1,2')).toBeNull()
+  })
+
+  test('rejects non-kkey callback data', () => {
+    expect(parseKkeyCallback('pgate:allow:abcde')).toBeNull()
+    expect(parseKkeyCallback('ask:foo')).toBeNull()
+    expect(parseKkeyCallback('perm:allow')).toBeNull()
+    expect(parseKkeyCallback('1')).toBeNull()
+  })
+
+  test('rejects an empty string', () => {
+    expect(parseKkeyCallback('')).toBeNull()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// buildKeysKeyboard
+// ─────────────────────────────────────────────────────────────────────
+
+describe('buildKeysKeyboard', () => {
+  test('produces 3 rows with the expected callback_data values', () => {
+    const kb = buildKeysKeyboard()
+    expect(kb.inline_keyboard.length).toBe(3)
+
+    const cb = (row: number) => kb.inline_keyboard[row]!.map((b) => b.callback_data)
+    expect(cb(0)).toEqual(['kkey:1', 'kkey:2', 'kkey:3', 'kkey:4', 'kkey:5'])
+    expect(cb(1)).toEqual(['kkey:y', 'kkey:n', 'kkey:enter', 'kkey:esc'])
+    expect(cb(2)).toEqual(['kkey:up', 'kkey:down', 'kkey:left', 'kkey:right'])
+  })
+
+  test('every callback_data parses back to a whitelisted token', () => {
+    const kb = buildKeysKeyboard()
+    for (const row of kb.inline_keyboard) {
+      for (const btn of row) {
+        expect(btn.callback_data).toBeDefined()
+        expect(parseKkeyCallback(btn.callback_data!)).not.toBeNull()
+      }
+    }
+  })
+
+  test('header is HTML and explains the keypad in Russian', () => {
+    expect(KEYS_PANEL_HEADER).toContain('Управление сессией')
+    expect(KEYS_PANEL_HEADER).toContain('<b>')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// handleKkeyCallback — AUTH gate (the critical security test) + dispatch.
+// ─────────────────────────────────────────────────────────────────────
+
+const ALLOWED_ID = 164795011
+const NON_ALLOWED_ID = 999999
+
+function makeCtx(data: string, fromId: number): {
+  ctx: KkeyCallbackContext
+  toasts: string[]
+} {
+  const toasts: string[] = []
+  const ctx: KkeyCallbackContext = {
+    callbackQuery: { data },
+    from: { id: fromId },
+    answerCallbackQuery: async (arg) => {
+      toasts.push(arg.text)
+    },
+  }
+  return { ctx, toasts }
+}
+
+// `noPane: true` builds deps WITHOUT a resolvable pane (the key is omitted,
+// not set to undefined — exactOptionalPropertyTypes rejects explicit
+// undefined). Other overrides merge on top.
+function makeDeps(
+  overrides: Partial<KkeyCallbackDeps> & { noPane?: boolean } = {},
+): {
+  deps: KkeyCallbackDeps
+  calls: string[][]
+} {
+  const calls: string[][] = []
+  const exec: KeysExec = async (args) => {
+    calls.push([...args])
+    return { exitCode: 0, stderr: '' }
+  }
+  const target: TmuxKeysTarget = { paneTarget: '%1', socketPath: '/tmp/s' }
+  const { noPane, ...rest } = overrides
+  const deps: KkeyCallbackDeps = {
+    allowedUserIds: [ALLOWED_ID],
+    log: makeLogger(),
+    exec,
+    ...(noPane ? {} : { tmuxKeysTarget: target }),
+    ...rest,
+  }
+  return { deps, calls }
+}
+
+describe('handleKkeyCallback — auth gate', () => {
+  test('NON-allowed user: toasts «не авторизовано» and NEVER sends a keystroke', async () => {
+    const { ctx, toasts } = makeCtx('kkey:2', NON_ALLOWED_ID)
+    const { deps, calls } = makeDeps()
+    const consumed = await handleKkeyCallback(ctx, deps)
+    expect(consumed).toBe(true)
+    // The critical assertion: the exec/sendKeys mock got ZERO calls.
+    expect(calls.length).toBe(0)
+    expect(toasts).toEqual(['не авторизовано'])
+  })
+
+  test('ALLOWED user: sendKeys called once with the parsed token', async () => {
+    const { ctx, toasts } = makeCtx('kkey:2', ALLOWED_ID)
+    const { deps, calls } = makeDeps()
+    const consumed = await handleKkeyCallback(ctx, deps)
+    expect(consumed).toBe(true)
+    // Exactly one send-keys invocation, carrying the literal token «2».
+    expect(calls).toEqual([['-S', '/tmp/s', 'send-keys', '-t', '%1', '-l', '2']])
+    expect(toasts).toEqual(['нажато: 2'])
+  })
+
+  test('ALLOWED user, named token (enter): sent without -l', async () => {
+    const { ctx, toasts } = makeCtx('kkey:enter', ALLOWED_ID)
+    const { deps, calls } = makeDeps()
+    await handleKkeyCallback(ctx, deps)
+    expect(calls).toEqual([['-S', '/tmp/s', 'send-keys', '-t', '%1', 'Enter']])
+    expect(toasts).toEqual(['нажато: enter'])
+  })
+
+  test('non-whitelisted token: toasts «неизвестная клавиша», no keystroke', async () => {
+    const { ctx, toasts } = makeCtx('kkey:rm', ALLOWED_ID)
+    const { deps, calls } = makeDeps()
+    await handleKkeyCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    expect(toasts).toEqual(['неизвестная клавиша'])
+  })
+
+  test('no resolvable pane: toasts «pane недоступен», no keystroke', async () => {
+    const { ctx, toasts } = makeCtx('kkey:2', ALLOWED_ID)
+    // Omit tmuxKeysTarget entirely.
+    const { deps, calls } = makeDeps({ noPane: true })
+    await handleKkeyCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    expect(toasts).toEqual(['pane недоступен'])
+  })
+
+  test('tmux failure: toasts an error, never throws', async () => {
+    const { ctx, toasts } = makeCtx('kkey:2', ALLOWED_ID)
+    const calls: string[][] = []
+    const failingExec: KeysExec = async (args) => {
+      calls.push([...args])
+      return { exitCode: 1, stderr: 'no such pane' }
+    }
+    const { deps } = makeDeps({ exec: failingExec })
+    const consumed = await handleKkeyCallback(ctx, deps)
+    expect(consumed).toBe(true)
+    expect(calls.length).toBe(1)
+    expect(toasts[0]).toContain('ошибка')
+    expect(toasts[0]).toContain('no such pane')
+  })
+
+  test('auth check runs BEFORE pane check (non-allowed + no pane → не авторизовано)', async () => {
+    const { ctx, toasts } = makeCtx('kkey:2', NON_ALLOWED_ID)
+    const { deps, calls } = makeDeps({ noPane: true })
+    await handleKkeyCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    // A non-allowed user must not even learn whether a pane exists.
+    expect(toasts).toEqual(['не авторизовано'])
+  })
+})

--- a/plugin/tests/telegram/keys-panel.test.ts
+++ b/plugin/tests/telegram/keys-panel.test.ts
@@ -119,6 +119,50 @@ describe('literal-token whitelist is tamper-proof at runtime', () => {
       expect(accepted.steps).toEqual([{ literal: true, key: '1' }])
     }
   })
+
+  // LOW #3 (fix-loop): named-token membership must be an OWN-property check
+  // (Object.hasOwn), not a prototype-walking `t in NAMED_TOKENS`. A polluted
+  // Object.prototype must NOT smuggle an un-whitelisted token into the pane.
+  test('prototype pollution cannot widen the named-token whitelist', () => {
+    // Save a clean baseline so we can prove behaviour is unchanged AFTER the
+    // pollution is removed too.
+    expect('error' in parseKeyTokens('rm')).toBe(true)
+    expect('error' in parseKeyTokens('enter')).toBe(false)
+
+    try {
+      // (a) classic prototype pollution: a non-own key reachable via the chain.
+      ;(Object.prototype as unknown as Record<string, string>).rm = 'Enter'
+      // (b) literal-style pollution of another plausible attacker token.
+      ;(Object.prototype as unknown as Record<string, string>).reboot = 'Escape'
+
+      // `rm` IS now visible via `'rm' in NAMED_TOKENS` (prototype chain) — that
+      // is exactly the hole. Object.hasOwn must still reject it.
+      expect('rm' in NAMED_TOKENS).toBe(true) // proves the pollution is live
+      expect(Object.hasOwn(NAMED_TOKENS, 'rm')).toBe(false)
+
+      // PROOF: parseKeyTokens STILL rejects the polluted tokens (no step
+      // produced), so no un-whitelisted keystroke can reach the tmux pane.
+      const polluted = parseKeyTokens('rm')
+      expect('error' in polluted).toBe(true)
+      expect('error' in parseKeyTokens('reboot')).toBe(true)
+
+      // And a legitimate named token STILL parses to its real Escape/Enter key.
+      const enter = parseKeyTokens('enter')
+      expect('error' in enter).toBe(false)
+      if (!('error' in enter)) {
+        expect(enter.steps).toEqual([{ literal: false, key: 'Enter' }])
+      }
+    } finally {
+      // Remove the pollution so it cannot leak into any other test.
+      delete (Object.prototype as unknown as Record<string, string>).rm
+      delete (Object.prototype as unknown as Record<string, string>).reboot
+    }
+
+    // Clean-state sanity AFTER cleanup: chain is no longer polluted.
+    expect('rm' in NAMED_TOKENS).toBe(false)
+    expect('error' in parseKeyTokens('rm')).toBe(true)
+    expect('error' in parseKeyTokens('enter')).toBe(false)
+  })
 })
 
 // ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Что
Новая OOB-команда **/keys** — присылает в Telegram inline-панель кнопок, тап по которой отправляет ОДНО whitelisted-нажатие в tmux-pane сессии агента. Решает кейс вождя: отвечать на нативные диалоги Claude Code (напр. «Permission rule Bash(rm:*) requires confirmation → 1. Yes / 2. Yes don't ask / 3. No») одним тапом вместо набора `/key 1`.

Панель (callback_data `kkey:<token>`):
- [1][2][3][4][5] · [6][7][8][9][0]
- [✓ y][✗ n][⏎ enter][⎋ esc]
- [↑][↓][←][→] · [⇥ tab][␣ space]

## Безопасность (hard-требование вождя)
Кнопки и их callbacks работают ТОЛЬКО для Telegram-id из `config.allowed_user_ids`, **fail-closed**:
- auth — СТРОГО первое решение в `handleKkeyCallback` (до парсинга токена/проверки pane); неавторизованный/без id видит только «не авторизовано», нажатие не уходит, валидность токенов не утекает.
- whitelist неизменяем в рантайме: literal-токены через `Object.freeze`-массив + frozen-предикат; named-токены через `Object.hasOwn` (защита от prototype pollution). Расширить набор инжектируемых клавиш в рантайме нельзя.
- callback-префикс `kkey:` не коллизирует с `pgate:`/`ask:`/`perm:`; `answerCallbackQuery` на каждом пути (включая throw) — нет висящего спиннера.
- `/keys` за тем же OOB-гейтом, что `/key` (private chat + allow-list); reply_markup в группы не уходит.

## Ревью
Двойное ревью Codex GPT-5.5 + Opus, 3 круга fix-loop:
- Codex поймал: auth не строго первым, спиннер-edge-кейсы, мутабельный Set-whitelist, prototype pollution — все закрыты.
- Финал: **оба APPROVE, 0 findings.**

## Тесты
`bun run typecheck` чист; фич-тесты `tests/telegram/keys-panel.test.ts` + `tests/commands/oob.test.ts` (+keys.test.ts) — 69 pass, 0 fail (auth-first, отказ чужому = 0 нажатий, whitelist tamper-proof, prototype-pollution регресс). 2 фейла в полном прогоне (`hooks-sentinel` webhook/PyYAML) — pre-existing на origin/main, вне scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)