### PR TITLE
Канал /keys + /cc: backspace/clear, удаление /key, панель команд /cc

### DIFF
--- a/plugin/src/commands/keys.ts
+++ b/plugin/src/commands/keys.ts
@@ -78,6 +78,13 @@ export const NAMED_TOKENS: Readonly<Record<string, string>> = Object.freeze({
   down: 'Down',
   left: 'Left',
   right: 'Right',
+  // Input-field editing for the /keys panel. `backspace` deletes ONE char to
+  // the left; `clear` (Ctrl-U) erases the whole input line at once. Both are
+  // control keys — they can only DELETE in the input field, never inject text,
+  // so they don't widen the pane-injection surface. C-u is the same line-clear
+  // already used by sendSlashCommand below.
+  backspace: 'BSpace',
+  clear: 'C-u',
 } as const)
 
 export const MAX_KEY_TOKENS = 5
@@ -92,7 +99,7 @@ export interface ParsedKeys {
 export function parseKeyTokens(args: string): ParsedKeys | { error: string } {
   const tokens = args.trim().toLowerCase().split(/\s+/).filter((t) => t.length > 0)
   if (tokens.length === 0) {
-    return { error: 'usage: /key <1-9|0|y|n|enter|esc|tab|space|up|down|left|right> …' }
+    return { error: 'нет клавиши: <1-9|0|y|n|enter|esc|tab|space|up|down|left|right|backspace|clear> …' }
   }
   if (tokens.length > MAX_KEY_TOKENS) {
     return { error: `слишком много нажатий за раз (максимум ${MAX_KEY_TOKENS})` }
@@ -110,7 +117,7 @@ export function parseKeyTokens(args: string): ParsedKeys | { error: string } {
       // pollution). `Object.hasOwn` only sees the frozen own keys, closing it.
       steps.push({ literal: false, key: NAMED_TOKENS[t]! })
     } else {
-      return { error: `неизвестная клавиша: ${t} — разрешены цифры, y/n, enter, esc, tab, space, стрелки` }
+      return { error: `неизвестная клавиша: ${t} — разрешены цифры, y/n, enter, esc, tab, space, стрелки, backspace, clear` }
     }
   }
   return { steps }

--- a/plugin/src/commands/oob.ts
+++ b/plugin/src/commands/oob.ts
@@ -29,10 +29,11 @@ import type { Logger } from '../log.js'
 import type { TelegramApi, InlineKeyboardLike } from '../channel/tools.js'
 import { sendChannelNotification, type ChannelEvent } from '../channel/notify.js'
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js'
-import { parseKeyTokens, sendKeys, parseCcCommand, sendSlashCommand, sendNamedKey, type KeysExec, type TmuxKeysTarget } from './keys.js'
+import { parseCcCommand, sendSlashCommand, sendNamedKey, type KeysExec, type TmuxKeysTarget } from './keys.js'
 import { buildKeysKeyboard, KEYS_PANEL_HEADER } from '../telegram/keys-panel-ui.js'
+import { buildCcKeyboard, CC_PANEL_HEADER } from '../telegram/cc-panel-ui.js'
 
-export type OobCommandName = 'help' | 'status' | 'stop' | 'reset' | 'new' | 'mirror' | 'key' | 'keys' | 'cc'
+export type OobCommandName = 'help' | 'status' | 'stop' | 'reset' | 'new' | 'mirror' | 'keys' | 'cc'
 
 const KNOWN_COMMANDS = new Set<OobCommandName>([
   'help',
@@ -41,7 +42,6 @@ const KNOWN_COMMANDS = new Set<OobCommandName>([
   'reset',
   'new',
   'mirror',
-  'key',
   'keys',
   'cc',
 ])
@@ -175,9 +175,8 @@ function helpText(): string {
     + '<code>/reset force</code> — сбросить состояние сессии (подтверди флагом <code>force</code>)\n'
     + '<code>/new force</code> — начать новую сессию (подтверди флагом <code>force</code>)\n'
     + '<code>/mirror on|off|status</code> — управлять зеркалом терминала (tmux, обновляется в реальном времени)\n'
-    + '<code>/key 1|2|3|y|n|enter|esc…</code> — нажать клавишу в терминале агента (ответить на диалог)\n'
-    + '<code>/keys</code> — панель кнопок: тап = нажатие в сессии (ответить на нативный диалог Claude Code)\n'
-    + '<code>/cc &lt;команда&gt;</code> — встроенная команда Claude Code: <code>/cc compact</code>, <code>/cc model opus</code>, <code>/cc context</code>\n\n'
+    + '<code>/keys</code> — панель кнопок: тап = нажатие в сессии (ответить на нативный диалог Claude Code; есть ⌫ backspace и 🧹 clear)\n'
+    + '<code>/cc</code> — панель команд Claude Code (тап = выполнить); либо <code>/cc &lt;команда&gt;</code>: <code>/cc compact</code>, <code>/cc model opus</code>\n\n'
     + '<i>примечание: /stop — best-effort: плагин передаёт сигнал остановки через '
     + 'канал, но не может гарантировать прерывание посреди вызова инструмента.</i>'
   )
@@ -196,9 +195,8 @@ export const BOT_COMMANDS: ReadonlyArray<BotCommandSpec> = [
   { command: 'reset', description: 'сбросить сессию (нужен force)' },
   { command: 'new', description: 'начать новую сессию (нужен force)' },
   { command: 'mirror', description: 'зеркало терминала: on | off | status' },
-  { command: 'key', description: 'нажать клавишу в терминале: 1 | 2 | y | n | enter | esc' },
   { command: 'keys', description: 'панель кнопок для подтверждений (нажатия в сессию)' },
-  { command: 'cc', description: 'встроенная команда Claude Code: compact | model | context …' },
+  { command: 'cc', description: 'панель команд Claude Code (тап) или /cc <команда>' },
 ]
 
 function statusText(ctx: OobContext): string {
@@ -487,49 +485,6 @@ export async function handleOobCommand(
       }
     }
 
-    case 'key': {
-      // Deterministic dialog answers: press whitelisted keys in the agent's
-      // pane. Reached only via the DM+allowlist OOB gate in handlers.ts.
-      if (!ctx.tmuxKeys) {
-        return {
-          handled: true,
-          command: 'key',
-          replyToTelegram: {
-            text: '<b>/key</b> — недоступно: плагин не знает tmux-pane сессии (нет tmux-конфига).',
-            parseMode: 'HTML',
-          },
-        }
-      }
-      const parsedKeys = parseKeyTokens(parsed.args)
-      if ('error' in parsedKeys) {
-        return {
-          handled: true,
-          command: 'key',
-          replyToTelegram: { text: escapeHtml(parsedKeys.error), parseMode: 'HTML' },
-        }
-      }
-      ctx.log.info('oob /key', { chat_id: ctx.chatId, keys: parsed.args.trim() })
-      const sent = await sendKeys(ctx.tmuxKeys.target, parsedKeys, ctx.tmuxKeys.exec)
-      if (!sent.ok) {
-        return {
-          handled: true,
-          command: 'key',
-          replyToTelegram: {
-            text: `<b>/key</b> — tmux ошибка: <code>${escapeHtml(sent.error)}</code>`,
-            parseMode: 'HTML',
-          },
-        }
-      }
-      return {
-        handled: true,
-        command: 'key',
-        replyToTelegram: {
-          text: `<b>нажато:</b> <code>${escapeHtml(parsed.args.trim().toLowerCase())}</code>`,
-          parseMode: 'HTML',
-        },
-      }
-    }
-
     case 'keys': {
       // Render the one-tap keypad. The buttons inject the SAME whitelisted
       // keystrokes /key does — their `kkey:` callbacks are dispatched in
@@ -567,6 +522,21 @@ export async function handleOobCommand(
           replyToTelegram: {
             text: '<b>/cc</b> — недоступно: плагин не знает tmux-pane сессии.',
             parseMode: 'HTML',
+          },
+        }
+      }
+      // Bare `/cc` (no args) → render the one-tap command panel. The buttons
+      // run the SAME passthrough `/cc <command>` does — their `ccmd:` callbacks
+      // are dispatched in server.ts with the same fail-closed allowlist auth.
+      if (parsed.args.trim() === '') {
+        ctx.log.info('oob /cc panel', { chat_id: ctx.chatId })
+        return {
+          handled: true,
+          command: 'cc',
+          replyToTelegram: {
+            text: CC_PANEL_HEADER,
+            parseMode: 'HTML',
+            inlineKeyboard: buildCcKeyboard(),
           },
         }
       }

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -69,6 +69,7 @@ import { TelegramPoller, tokenLock } from './telegram/poller.js'
 import { describePidHolder, readLockHolder } from './telegram/pid-inspect.js'
 import { BOT_COMMANDS } from './commands/oob.js'
 import { handleKkeyCallback } from './telegram/keys-panel-ui.js'
+import { handleCcmdCallback } from './telegram/cc-panel-ui.js'
 import { startWebhookServer, type WebhookServerHandle } from './webhook/server.js'
 import {
   handleInboundAudio,
@@ -720,6 +721,41 @@ bot.on('callback_query:data', async ctx => {
         await ctx.answerCallbackQuery({ text: 'ошибка' })
       } catch (ackErr) {
         log.warn('kkey error-ack answerCallbackQuery failed', {
+          error: ackErr instanceof Error ? ackErr.message : String(ackErr),
+        })
+      }
+    }
+    return
+  }
+  // /cc command panel (ccmd:*) — one-tap run of a whitelisted Claude Code
+  // slash command in the agent pane. Same fail-closed allowlist auth as kkey:
+  // (config.allowed_user_ids === the /cc OOB command's gate). A tap types
+  // `/<name>` into the pane and submits — identical to typing `/cc <name>`.
+  // Never mutates the keyboard message — the warchief taps it repeatedly.
+  if (data.startsWith('ccmd:')) {
+    try {
+      await handleCcmdCallback(
+        {
+          callbackQuery: { data },
+          from: { id: ctx.from?.id },
+          answerCallbackQuery: async arg => {
+            await ctx.answerCallbackQuery(arg)
+          },
+        },
+        {
+          allowedUserIds: config.allowed_user_ids,
+          log,
+          ...(tmuxKeysTarget !== undefined ? { tmuxKeysTarget } : {}),
+        },
+      )
+    } catch (err) {
+      log.error('ccmd callback_query handler threw', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      try {
+        await ctx.answerCallbackQuery({ text: 'ошибка' })
+      } catch (ackErr) {
+        log.warn('ccmd error-ack answerCallbackQuery failed', {
           error: ackErr instanceof Error ? ackErr.message : String(ackErr),
         })
       }

--- a/plugin/src/telegram/cc-panel-ui.ts
+++ b/plugin/src/telegram/cc-panel-ui.ts
@@ -1,0 +1,147 @@
+// /cc panel — one-tap inline-button keypad for running the MOST COMMON
+// Claude Code slash commands (/compact, /clear, /model, …) in the agent's
+// tmux pane from Telegram. It is the graphical front-end to the SAME
+// passthrough `/cc <command>` performs: a tap types `/<name>` into the pane
+// and submits with Enter (via sendSlashCommand, which C-u clears the input
+// line first so a leftover draft can't corrupt the command).
+//
+// Callback data uses the `ccmd:` prefix so it never collides with the other
+// inline flows sharing bot.on('callback_query:data'):
+//   * `kkey:*`  — /keys keystroke keypad (telegram/keys-panel-ui.ts)
+//   * `pgate:*` — permission-gate Allow/Deny
+//   * `ask:*`   — AskUserQuestion
+//   * `perm:*`  — headless MCP permission relay
+//
+//   ccmd:<name>   where <name> is ONE entry of the CLOSED command whitelist
+//                 below (argless, popular Claude Code commands only).
+//
+// Security: a tap is honoured ONLY for a user id in the same allow-list that
+// guards the sibling `/cc` OOB command (config.allowed_user_ids). Anyone else
+// gets an answerCallbackQuery toast and NOTHING is typed. The command set is a
+// FROZEN whitelist — there is no way to type arbitrary text into the pane, so
+// a pane that dropped to a shell can't be driven to run a shell command.
+
+import { sendSlashCommand, type KeysExec, type TmuxKeysTarget } from '../commands/keys.js'
+import type { InlineKeyboardLike } from '../channel/tools.js'
+import type { Logger } from '../log.js'
+
+// The callback prefix. Distinct from kkey:/pgate:/ask:/perm: by construction.
+export const CCMD_PREFIX = 'ccmd:'
+
+// Closed, frozen whitelist of the popular Claude Code slash commands the panel
+// exposes. name = the command typed (no leading slash, no args); label = the
+// button text; desc = one-line explanation rendered in the header. Argless on
+// purpose: a tap is a fixed command, not a macro. `model` opens Claude Code's
+// interactive model picker — drive the selection afterwards with the /keys
+// arrows + ⏎. Object.freeze (deep) so the set can't be widened at runtime.
+export interface CcCommandSpec {
+  readonly name: string
+  readonly label: string
+  readonly desc: string
+}
+export const CC_PANEL_COMMANDS: readonly CcCommandSpec[] = Object.freeze([
+  Object.freeze({ name: 'compact', label: '🗜 compact', desc: 'сжать контекст (освободить место)' }),
+  Object.freeze({ name: 'context', label: '📊 context', desc: 'показать расход контекста' }),
+  Object.freeze({ name: 'cost', label: '💰 cost', desc: 'стоимость токенов сессии' }),
+  Object.freeze({ name: 'status', label: 'ℹ️ status', desc: 'статус Claude Code' }),
+  Object.freeze({ name: 'model', label: '🧠 model', desc: 'выбрать модель (дальше стрелки /keys + ⏎)' }),
+  Object.freeze({ name: 'resume', label: '⏯ resume', desc: 'список/возобновить сессии' }),
+  Object.freeze({ name: 'export', label: '📤 export', desc: 'экспорт диалога' }),
+  Object.freeze({ name: 'clear', label: '🧹 clear', desc: 'очистить диалог — НОВЫЙ контекст (необратимо)' }),
+] as const)
+
+// Membership lookup built from the frozen specs — single source of truth.
+const ALLOWED_CCMD: ReadonlySet<string> = new Set<string>(
+  CC_PANEL_COMMANDS.map((c) => c.name),
+)
+
+// Parse a `ccmd:<name>` callback_data string. Returns the validated command
+// name (one entry of the frozen whitelist) or null for anything else — a
+// non-ccmd prefix, an empty name, or a name outside the whitelist. Null
+// callers answer the callback with a toast and type NOTHING (fail-closed).
+export function parseCcmdCallback(data: string): string | null {
+  if (typeof data !== 'string') return null
+  if (!data.startsWith(CCMD_PREFIX)) return null
+  const name = data.slice(CCMD_PREFIX.length)
+  if (name.length === 0) return null
+  if (!ALLOWED_CCMD.has(name)) return null
+  return name
+}
+
+// Build the keypad: two commands per row, in the CC_PANEL_COMMANDS order.
+export function buildCcKeyboard(): InlineKeyboardLike {
+  const rows: Array<Array<{ text: string; callback_data: string }>> = []
+  for (let i = 0; i < CC_PANEL_COMMANDS.length; i += 2) {
+    const row = CC_PANEL_COMMANDS.slice(i, i + 2).map((c) => ({
+      text: c.label,
+      callback_data: `${CCMD_PREFIX}${c.name}`,
+    }))
+    rows.push(row)
+  }
+  return { inline_keyboard: rows }
+}
+
+// Header text rendered above the keypad. HTML parse mode. Lists each command
+// with its explanation so the warchief knows what every button does.
+export const CC_PANEL_HEADER =
+  '<b>Команды Claude Code</b> — тап = выполнить в моей сессии.\n'
+  + CC_PANEL_COMMANDS.map((c) => `<code>/${c.name}</code> — ${c.desc}`).join('\n')
+
+// ─────────────────────────────────────────────────────────────────────
+// Callback handler — mirrors handleKkeyCallback. Security model: fail-closed
+// auth FIRST → parse name → pane check → run. A reject at ANY step toasts and
+// types NOTHING. Auth precedes parsing so a non-allowed caller can never learn
+// which commands are valid.
+// ─────────────────────────────────────────────────────────────────────
+
+export interface CcmdCallbackContext {
+  callbackQuery: { data: string }
+  from?: { id?: number | undefined }
+  answerCallbackQuery(arg: { text: string }): Promise<void>
+}
+
+export interface CcmdCallbackDeps {
+  allowedUserIds: readonly number[]
+  tmuxKeysTarget?: TmuxKeysTarget
+  log: Logger
+  exec?: KeysExec
+}
+
+// Dispatch a `ccmd:*` callback. Always answers the callback query and returns
+// true when it consumed the event. NEVER types a command for a non-allowed
+// user id. Does NOT mutate the keyboard message (the warchief taps it
+// repeatedly).
+export async function handleCcmdCallback(
+  ctx: CcmdCallbackContext,
+  deps: CcmdCallbackDeps,
+): Promise<boolean> {
+  // AUTH FIRST — before parsing the name or touching the pane. A non-allowed
+  // (or missing/non-number id) caller gets ONLY «не авторизовано» and learns
+  // nothing about command validity or pane state.
+  const fromId = ctx.from?.id
+  if (typeof fromId !== 'number' || !deps.allowedUserIds.includes(fromId)) {
+    deps.log.warn('ccmd unauthorized tap', {
+      user_id: fromId,
+      data: ctx.callbackQuery.data,
+    })
+    await ctx.answerCallbackQuery({ text: 'не авторизовано' })
+    return true
+  }
+  const name = parseCcmdCallback(ctx.callbackQuery.data)
+  if (name === null) {
+    await ctx.answerCallbackQuery({ text: 'неизвестная команда' })
+    return true
+  }
+  if (deps.tmuxKeysTarget === undefined) {
+    await ctx.answerCallbackQuery({ text: 'pane недоступен' })
+    return true
+  }
+  // rest is always '' — the panel runs argless commands only.
+  const sent = await sendSlashCommand(deps.tmuxKeysTarget, { name, rest: '' }, deps.exec)
+  if (sent.ok) {
+    await ctx.answerCallbackQuery({ text: `выполнено: /${name}` })
+  } else {
+    await ctx.answerCallbackQuery({ text: `ошибка: ${sent.error.slice(0, 180)}` })
+  }
+  return true
+}

--- a/plugin/src/telegram/keys-panel-ui.ts
+++ b/plugin/src/telegram/keys-panel-ui.ts
@@ -78,7 +78,7 @@ export function parseKkeyCallback(data: string): string | null {
 // Row2: dialog option selectors 6-9 + 0
 // Row3: yes/no + confirm/cancel
 // Row4: arrow navigation
-// Row5: tab / space (Claude Code "Tab to amend", whitespace)
+// Row5: tab / space + input editing — backspace (one char), clear (whole line, C-u)
 export function buildKeysKeyboard(): InlineKeyboardLike {
   return {
     inline_keyboard: [
@@ -111,6 +111,8 @@ export function buildKeysKeyboard(): InlineKeyboardLike {
       [
         { text: '⇥ tab', callback_data: `${KKEY_PREFIX}tab` },
         { text: '␣ space', callback_data: `${KKEY_PREFIX}space` },
+        { text: '⌫ backspace', callback_data: `${KKEY_PREFIX}backspace` },
+        { text: '🧹 clear', callback_data: `${KKEY_PREFIX}clear` },
       ],
     ],
   }
@@ -120,7 +122,7 @@ export function buildKeysKeyboard(): InlineKeyboardLike {
 export const KEYS_PANEL_HEADER =
   '<b>Управление сессией</b> — тап = нажатие в моей сессии. '
   + 'Для диалога Claude Code: 1/2/3 = выбор пункта, y/n = да/нет, '
-  + '⏎ подтвердить, ⎋ отмена.'
+  + '⏎ подтвердить, ⎋ отмена. ⌫ стереть символ, 🧹 очистить ввод.'
 
 // ─────────────────────────────────────────────────────────────────────
 // Callback handler (extracted from server.ts so it is unit-testable in

--- a/plugin/tests/commands/keys.test.ts
+++ b/plugin/tests/commands/keys.test.ts
@@ -22,9 +22,16 @@ describe('parseKeyTokens', () => {
     expect('steps' in r3 && r3.steps).toEqual([{ literal: false, key: 'Escape' }])
   })
 
-  test('empty args -> usage error', () => {
+  test('backspace and clear map to BSpace and C-u (input editing)', () => {
+    const rb = parseKeyTokens('backspace')
+    expect('steps' in rb && rb.steps).toEqual([{ literal: false, key: 'BSpace' }])
+    const rc = parseKeyTokens('clear')
+    expect('steps' in rc && rc.steps).toEqual([{ literal: false, key: 'C-u' }])
+  })
+
+  test('empty args -> no-key error', () => {
     const r = parseKeyTokens('   ')
-    expect('error' in r && r.error).toContain('usage')
+    expect('error' in r && r.error).toContain('нет клавиши')
   })
 
   test('arbitrary text is rejected (no shell injection surface)', () => {

--- a/plugin/tests/commands/oob.test.ts
+++ b/plugin/tests/commands/oob.test.ts
@@ -386,46 +386,20 @@ describe('/mirror command', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────
-// /key — deterministic dialog answers (2026-06-12).
+// /key was removed 2026-06-14 (redundant: the /keys tap panel covers it).
+// /cc gained a bare-command button panel (2026-06-14).
 // ─────────────────────────────────────────────────────────────────────
 
-describe('/key command', () => {
-  test('parses as known command with args', () => {
+describe('/key removed', () => {
+  test('/key is no longer a known OOB command', () => {
     const p = parseOobCommand('/key 2 enter')
-    expect(p?.name).toBe('key')
-    expect(p?.args).toBe('2 enter')
+    expect(p).toBeNull()
   })
+})
 
-  test('without tmuxKeys ctx replies "недоступно"', async () => {
-    const parsed = parseOobCommand('/key 2')
-    if (!parsed) throw new Error('parse failed')
-    const ctx = makeCtx()
-    const res = await handleOobCommand(parsed, ctx)
-    expect(res.command).toBe('key')
-    expect(res.replyToTelegram?.text).toContain('недоступно')
-    expect(res.notifyChannel).toBeUndefined()
-  })
-
-  test('sends whitelisted keys via injected exec and confirms', async () => {
-    const parsed = parseOobCommand('/key 2')
-    if (!parsed) throw new Error('parse failed')
-    const calls: string[][] = []
-    const ctx = makeCtx()
-    ctx.tmuxKeys = {
-      target: { paneTarget: '%1', socketPath: '/tmp/s' },
-      exec: async (args) => {
-        calls.push([...args])
-        return { exitCode: 0, stderr: '' }
-      },
-    }
-    const res = await handleOobCommand(parsed, ctx)
-    expect(calls).toEqual([['-S', '/tmp/s', 'send-keys', '-t', '%1', '-l', '2']])
-    expect(res.replyToTelegram?.text).toContain('нажато')
-    expect(res.notifyChannel).toBeUndefined() // never wakes Claude
-  })
-
-  test('rejects non-whitelisted token without touching tmux', async () => {
-    const parsed = parseOobCommand('/key rm')
+describe('/cc panel', () => {
+  test('bare /cc renders the command keyboard (no keystroke sent)', async () => {
+    const parsed = parseOobCommand('/cc')
     if (!parsed) throw new Error('parse failed')
     const calls: string[][] = []
     const ctx = makeCtx()
@@ -437,59 +411,26 @@ describe('/key command', () => {
       },
     }
     const res = await handleOobCommand(parsed, ctx)
-    expect(calls.length).toBe(0)
-    expect(res.replyToTelegram?.text).toContain('неизвестная клавиша')
-  })
-})
-
-// ─────────────────────────────────────────────────────────────────────
-// /keys — inline-button keypad panel (2026-06-13).
-// ─────────────────────────────────────────────────────────────────────
-
-describe('/keys command', () => {
-  test('parses as a known command', () => {
-    const p = parseOobCommand('/keys')
-    expect(p?.name).toBe('keys')
-    expect(p?.args).toBe('')
-  })
-
-  test('without tmuxKeys ctx replies «недоступно», no keyboard, no channel notify', async () => {
-    const parsed = parseOobCommand('/keys')
-    if (!parsed) throw new Error('parse failed')
-    const res = await handleOobCommand(parsed, makeCtx())
-    expect(res.command).toBe('keys')
-    expect(res.replyToTelegram?.text).toContain('недоступно')
-    expect(res.replyToTelegram?.inlineKeyboard).toBeUndefined()
+    expect(res.command).toBe('cc')
+    expect(res.replyToTelegram?.inlineKeyboard).toBeDefined()
+    expect(calls.length).toBe(0) // rendering the panel sends nothing
     expect(res.notifyChannel).toBeUndefined()
   })
 
-  test('with tmuxKeys ctx replies with the keypad and never wakes Claude', async () => {
-    const parsed = parseOobCommand('/keys')
+  test('/cc <command> still types the command into the pane', async () => {
+    const parsed = parseOobCommand('/cc compact')
     if (!parsed) throw new Error('parse failed')
+    const calls: string[][] = []
     const ctx = makeCtx()
-    ctx.tmuxKeys = { target: { paneTarget: '%1', socketPath: '/tmp/s' } }
+    ctx.tmuxKeys = {
+      target: { paneTarget: '%1', socketPath: '/tmp/s' },
+      exec: async (args) => {
+        calls.push([...args])
+        return { exitCode: 0, stderr: '' }
+      },
+    }
     const res = await handleOobCommand(parsed, ctx)
-    expect(res.command).toBe('keys')
-    expect(res.replyToTelegram?.parseMode).toBe('HTML')
-    expect(res.replyToTelegram?.text).toContain('Управление сессией')
-    const kb = res.replyToTelegram?.inlineKeyboard
-    expect(kb).toBeDefined()
-    expect(kb!.inline_keyboard.length).toBe(5)
-    expect(kb!.inline_keyboard[0]!.map((b) => b.callback_data)).toEqual([
-      'kkey:1', 'kkey:2', 'kkey:3', 'kkey:4', 'kkey:5',
-    ])
-    expect(res.notifyChannel).toBeUndefined()
-  })
-})
-
-// ─────────────────────────────────────────────────────────────────────
-// /help lists /keys (autocomplete + help parity).
-// ─────────────────────────────────────────────────────────────────────
-
-describe('/help lists /keys', () => {
-  test('help text mentions /keys', async () => {
-    const parsed = parseOobCommand('/help')!
-    const result = await handleOobCommand(parsed, makeCtx())
-    expect(result.replyToTelegram!.text).toContain('/keys')
+    expect(res.command).toBe('cc')
+    expect(calls.some((c) => c.includes('/compact'))).toBe(true)
   })
 })

--- a/plugin/tests/telegram/cc-panel-ui.test.ts
+++ b/plugin/tests/telegram/cc-panel-ui.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  CC_PANEL_COMMANDS,
+  CCMD_PREFIX,
+  buildCcKeyboard,
+  handleCcmdCallback,
+  parseCcmdCallback,
+  type CcmdCallbackContext,
+  type CcmdCallbackDeps,
+} from '../../src/telegram/cc-panel-ui.js'
+import type { Logger } from '../../src/log.js'
+
+const log = { info() {}, warn() {}, error() {}, debug() {} } as unknown as Logger
+const ALLOWED = [164795011]
+const PANE = { paneTarget: '%1', socketPath: '/tmp/s' }
+
+function makeCtx(data: string, fromId: number | undefined): {
+  ctx: CcmdCallbackContext
+  answers: string[]
+} {
+  const answers: string[] = []
+  const ctx: CcmdCallbackContext = {
+    callbackQuery: { data },
+    from: { id: fromId },
+    answerCallbackQuery: async (arg) => {
+      answers.push(arg.text)
+    },
+  }
+  return { ctx, answers }
+}
+
+function capturingExec(): { calls: string[][]; deps: CcmdCallbackDeps } {
+  const calls: string[][] = []
+  const deps: CcmdCallbackDeps = {
+    allowedUserIds: ALLOWED,
+    tmuxKeysTarget: PANE,
+    log,
+    exec: async (args) => {
+      calls.push([...args])
+      return { exitCode: 0, stderr: '' }
+    },
+  }
+  return { calls, deps }
+}
+
+describe('parseCcmdCallback', () => {
+  test('accepts a whitelisted command', () => {
+    expect(parseCcmdCallback(`${CCMD_PREFIX}compact`)).toBe('compact')
+    expect(parseCcmdCallback(`${CCMD_PREFIX}model`)).toBe('model')
+  })
+
+  test('rejects unknown command, wrong prefix, empty, non-string', () => {
+    expect(parseCcmdCallback(`${CCMD_PREFIX}rm`)).toBeNull()
+    expect(parseCcmdCallback(`${CCMD_PREFIX}compact extra`)).toBeNull()
+    expect(parseCcmdCallback('kkey:1')).toBeNull()
+    expect(parseCcmdCallback(`${CCMD_PREFIX}`)).toBeNull()
+    expect(parseCcmdCallback(`${CCMD_PREFIX}__proto__`)).toBeNull()
+    expect(parseCcmdCallback(`${CCMD_PREFIX}constructor`)).toBeNull()
+    expect(parseCcmdCallback(`${CCMD_PREFIX}toString`)).toBeNull()
+    expect(parseCcmdCallback(`${CCMD_PREFIX}Compact`)).toBeNull()
+    expect(parseCcmdCallback(`${CCMD_PREFIX}compact `)).toBeNull()
+    // @ts-expect-error runtime guard for non-string
+    expect(parseCcmdCallback(undefined)).toBeNull()
+  })
+})
+
+describe('buildCcKeyboard', () => {
+  test('exposes exactly the whitelisted commands as ccmd: callbacks', () => {
+    const kb = buildCcKeyboard()
+    const datas = kb.inline_keyboard.flat().map((b) => b.callback_data)
+    expect(datas.sort()).toEqual(
+      CC_PANEL_COMMANDS.map((c) => `${CCMD_PREFIX}${c.name}`).sort(),
+    )
+  })
+})
+
+describe('handleCcmdCallback', () => {
+  test('unauthorized user id: toast, NO command typed', async () => {
+    const { calls, deps } = capturingExec()
+    const { ctx, answers } = makeCtx(`${CCMD_PREFIX}compact`, 999)
+    await handleCcmdCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    expect(answers[0]).toContain('не авторизовано')
+  })
+
+  test('missing id is unauthorized (fail-closed)', async () => {
+    const { calls, deps } = capturingExec()
+    const { ctx, answers } = makeCtx(`${CCMD_PREFIX}compact`, undefined)
+    await handleCcmdCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    expect(answers[0]).toContain('не авторизовано')
+  })
+
+  test('authorized + valid command types /<name> into pane', async () => {
+    const { calls, deps } = capturingExec()
+    const { ctx, answers } = makeCtx(`${CCMD_PREFIX}compact`, ALLOWED[0]!)
+    await handleCcmdCallback(ctx, deps)
+    // sendSlashCommand: C-u clear, then literal text, then Enter
+    expect(calls.some((c) => c.includes('/compact'))).toBe(true)
+    expect(calls.some((c) => c.includes('C-u'))).toBe(true)
+    expect(answers[0]).toContain('выполнено')
+  })
+
+  test('authorized + unknown command: toast, NO command typed', async () => {
+    const { calls, deps } = capturingExec()
+    const { ctx, answers } = makeCtx(`${CCMD_PREFIX}reboot`, ALLOWED[0]!)
+    await handleCcmdCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    expect(answers[0]).toContain('неизвестная команда')
+  })
+
+  test('no pane resolvable: toast, NO command typed', async () => {
+    const calls: string[][] = []
+    const deps: CcmdCallbackDeps = {
+      allowedUserIds: ALLOWED,
+      log,
+      exec: async (args) => {
+        calls.push([...args])
+        return { exitCode: 0, stderr: '' }
+      },
+    }
+    const { ctx, answers } = makeCtx(`${CCMD_PREFIX}compact`, ALLOWED[0]!)
+    await handleCcmdCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    expect(answers[0]).toContain('pane недоступен')
+  })
+})

--- a/plugin/tests/telegram/keys-panel.test.ts
+++ b/plugin/tests/telegram/keys-panel.test.ts
@@ -179,7 +179,7 @@ describe('buildKeysKeyboard', () => {
     expect(cb(1)).toEqual(['kkey:6', 'kkey:7', 'kkey:8', 'kkey:9', 'kkey:0'])
     expect(cb(2)).toEqual(['kkey:y', 'kkey:n', 'kkey:enter', 'kkey:esc'])
     expect(cb(3)).toEqual(['kkey:up', 'kkey:down', 'kkey:left', 'kkey:right'])
-    expect(cb(4)).toEqual(['kkey:tab', 'kkey:space'])
+    expect(cb(4)).toEqual(['kkey:tab', 'kkey:space', 'kkey:backspace', 'kkey:clear'])
   })
 
   test('panel coverage = full /key whitelist (no UI/parser mismatch)', () => {


### PR DESCRIPTION
## Что
- **/keys**: кнопки **⌫ backspace** и **🧹 clear** (BSpace / C-u) — удаление в поле ввода (по запросу вождя).
- **Убрана команда /key** — дубль панели /keys. Модуль `keys.ts` оставлен (его использует панель).
- **Новая панель /cc**: bare `/cc` рендерит кнопки популярных команд Claude Code (compact/context/cost/status/model/resume/export/clear) с пояснением каждой; тап выполняет через `sendSlashCommand`. `/cc <команда>` работает как раньше.
- `server.ts`: диспетчер `ccmd:` (зеркало `kkey:`), fail-closed auth по `allowed_user_ids`.
- `/help` + меню команд обновлены.

## Безопасность
Та же модель, что у /keys: closed FROZEN whitelist, auth-FIRST, изоляция префиксов (kkey:/ccmd:/pgate:/ask:/perm:), `sendSlashCommand` печатает только `/<name>` без shell-метасимволов. backspace/clear — только удаление, не инжект текста.

## Тесты
backspace/clear parse, /key-removed, bare-/cc-панель, ccmd auth/whitelist/edge (proto/constructor/case/trailing). tsc чист; 1658 pass / 2 fail (обе — окружение: PyYAML не установлен + флэки-таймаут ask_user_question, к PR не относятся).

## Ревью
Двойное: **Codex GPT-5.5 APPROVE-WITH-NITS** + **Opus** (нашёл блокер — stale assertion в keys-panel.test.ts:182, исправлен; ниты закрыты).

🤖 Generated with [Claude Code](https://claude.com/claude-code)