### PR TITLE
Telegram Rich Messages (Bot API 10.1) — M1: DM sendRichMessage + transparent fallback

### DIFF
--- a/plugin/src/channel/tools.ts
+++ b/plugin/src/channel/tools.ts
@@ -34,6 +34,11 @@ import {
 } from '../format/html.js'
 import { splitMessage } from '../format/chunk.js'
 import { assertSendableFile, isPhotoExtension } from '../security/paths.js'
+import {
+  buildRichMessagePayload,
+  contentFitsRichLimits,
+} from '../format/rich.js'
+import type { RichLatch } from '../safety/rich-latch.js'
 
 // ─────────────────────────────────────────────────────────────────────
 // MCP request/response types we touch. We narrow rather than import deep
@@ -101,6 +106,18 @@ export interface SendDocumentOpts {
   caption?: string
 }
 
+// Options for the rich-message send. Threading only for M1; M3/M4 extend.
+export interface SendRichMessageOpts {
+  reply_to_message_id?: number
+}
+
+// Result of a rich send. Either Telegram accepted it (we got a message_id)
+// or the layered wrapper decided to fall back to the HTML path. `fallback`
+// is the signal the reply tool reads to decide whether to also run the HTML
+// chunk path — exactly one of the two ships, so a message is never lost or
+// duplicated.
+export type SendRichMessageResult = { message_id: number } | { fallback: true }
+
 export interface DownloadResult {
   path: string
   mime?: string
@@ -122,6 +139,17 @@ export type ChatAction =
 
 export interface TelegramApi {
   sendMessage(chatId: string, text: string, opts: SendMessageOpts): Promise<{ message_id: number }>
+  // Telegram Bot API 10.1 Rich Messages: ship RAW markdown that Telegram
+  // renders server-side (tables/math/headings/task-lists/<details>/footnotes,
+  // up to 32768 bytes). The result is either a message_id (sent) or
+  // { fallback: true } (caller must use the HTML path instead). Implemented
+  // via grammY's raw escape hatch; redaction runs in the safe wrapper BEFORE
+  // the raw send — never call this from outside the layered chain.
+  sendRichMessage(
+    chatId: string,
+    rawMarkdown: string,
+    opts: SendRichMessageOpts,
+  ): Promise<SendRichMessageResult>
   editMessageText(chatId: string, messageId: number, text: string, opts: EditOpts): Promise<void>
   setMessageReaction(chatId: string, messageId: number, emoji: string): Promise<void>
   sendChatAction(chatId: string, action: ChatAction): Promise<void>
@@ -130,6 +158,20 @@ export interface TelegramApi {
   downloadFile(fileId: string, destDir: string): Promise<DownloadResult>
   deleteMessage(chatId: string, messageId: number): Promise<void>
 }
+
+// grammY ^1.21.0 has no typed `sendRichMessage` on its RawApi (the method is
+// newer than the bundled types). We reach it through the raw escape hatch
+// `bot.api.raw`, narrowed to a typed function rather than `any`: the body is
+// the RichMessageBody buildRichMessagePayload produces, and the response is
+// the small shape we read message_id from (defensively — Telegram nests it
+// under `result`, grammY usually unwraps to the top level).
+interface RawSendRichResponse {
+  message_id?: number
+  result?: { message_id?: number }
+}
+type RawSendRichMessageFn = (
+  body: Record<string, unknown>,
+) => Promise<RawSendRichResponse>
 
 // Thin wrapper around grammY bot.api. Keeps the rest of the system free of
 // grammy-specific quirks (reply_parameters vs reply_to_message_id, etc).
@@ -148,6 +190,29 @@ export function createTelegramApi(bot: Bot, token: string): TelegramApi {
       }
       const sent = await bot.api.sendMessage(chatId, text, other)
       return { message_id: sent.message_id }
+    },
+    async sendRichMessage(chatId, rawMarkdown, opts) {
+      // Build the raw-api body (chat_id + markdown + reply_parameters) and
+      // dispatch through grammY's untyped raw escape hatch. The safe wrapper
+      // already redacted `rawMarkdown`; this layer only transports it.
+      const body = buildRichMessagePayload(rawMarkdown, {
+        chat_id: chatId,
+        ...(opts.reply_to_message_id !== undefined
+          ? { reply_to_message_id: opts.reply_to_message_id }
+          : {}),
+      })
+      // `bot.api.raw` is typed to known methods only; cast through unknown to
+      // a typed function for the (still-untyped-in-grammY) sendRichMessage.
+      const rawApi = bot.api.raw as unknown as Record<string, unknown>
+      const sendRich = rawApi.sendRichMessage as RawSendRichMessageFn
+      const res = await sendRich(body as unknown as Record<string, unknown>)
+      // Parse message_id defensively: top-level (grammY-unwrapped) first,
+      // then nested under `result` (raw Bot API envelope).
+      const messageId = res.message_id ?? res.result?.message_id
+      if (typeof messageId !== 'number') {
+        throw new Error('sendRichMessage returned no message_id')
+      }
+      return { message_id: messageId }
     },
     async editMessageText(chatId, messageId, text, opts) {
       const other: Record<string, unknown> = {}
@@ -329,6 +394,20 @@ export interface ToolDeps {
   // H4 fix (2026-05-23): when multichat is enabled, the policy is the
   // authoritative outbound allowlist. Omitted in legacy DM-only mode.
   policy?: MultichatPolicy
+  // M1 rich messages (2026-06-14): session-scoped capability latch shared
+  // with the safe-telegram-api wrapper. The reply handler reads
+  // `sendDisabled` to skip rich attempts cheaply once a capability error has
+  // latched it off. Optional so existing test fixtures that omit it keep the
+  // legacy HTML-only behaviour (rich is then never attempted).
+  richLatch?: RichLatch
+}
+
+// DM detection: a Telegram DM chat.id equals the user's id and is positive.
+// Groups/supergroups/channels are negative. M1 ships rich messages to DMs
+// only (groups are M4). Non-numeric / NaN ids fail closed (not a DM).
+export function isDmChat(chatId: string): boolean {
+  const n = Number(chatId)
+  return Number.isFinite(n) && n > 0
 }
 
 function toolError(name: string, message: string): CallToolResult {
@@ -377,7 +456,46 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
 
         const sentIds: number[] = []
 
-        if (args.format === 'html') {
+        // ── M1 Rich Messages (Bot API 10.1) ─────────────────────────────
+        // Attempt a single RAW-markdown rich send when ALL conditions hold.
+        // On success we push the id and SKIP the HTML/text+chunk path. On a
+        // transparent `{ fallback: true }` we fall through to the existing
+        // HTML path UNCHANGED — exactly one path ships, so the reply is
+        // never lost or duplicated. A `transient` error re-throws from the
+        // safe wrapper (caught by the outer try) so we never silently
+        // swallow then resend.
+        const richLatch = deps.richLatch
+        const richEligible =
+          config.richMessages.enabled &&
+          args.format !== 'text' &&
+          args.format !== 'markdownv2' &&
+          richLatch !== undefined &&
+          !richLatch.sendDisabled &&
+          !config.richMessages.perChatOptOut.includes(args.chat_id) &&
+          files.length === 0 &&
+          contentFitsRichLimits(args.text) &&
+          isDmChat(args.chat_id)
+
+        let richSent = false
+        if (richEligible) {
+          const richOpts: SendRichMessageOpts = {}
+          if (replyToId !== undefined) richOpts.reply_to_message_id = replyToId
+          const res = await telegramApi.sendRichMessage(args.chat_id, args.text, richOpts)
+          if ('message_id' in res) {
+            sentIds.push(res.message_id)
+            richSent = true
+          }
+          // else res.fallback === true → fall through to the HTML path below.
+        }
+
+        if (richSent) {
+          // Rich shipped the whole body — nothing else to send for text.
+          // (Attachments are impossible here: richEligible required
+          // files.length === 0.)
+        } else if (args.format === 'html' || args.format === 'rich') {
+          // HTML path (also the fallback for 'rich'): when rich was skipped
+          // (disabled / non-DM / oversize / opted-out / has files) or fell
+          // back transparently, render markdown → validated Telegram HTML.
           // Convert markdown → Telegram HTML, then chunk at 4000 chars so we
           // never exceed Telegram's 4096 sendMessage cap. reply_to applies
           // only to the first chunk so a long answer doesn't quote-spam the

--- a/plugin/src/channel/tools.ts
+++ b/plugin/src/channel/tools.ts
@@ -323,10 +323,10 @@ const TOOL_DEFINITIONS: ToolDefinition[] = [
         },
         format: {
           type: 'string',
-          enum: ['text', 'markdownv2', 'html'],
+          enum: ['text', 'markdownv2', 'html', 'rich'],
           default: 'html',
           description:
-            "Rendering mode. Default: 'html' — markdown (**bold**, *italic*, `code`, ```fenced```, [text](url), tables, # headings) is auto-converted to Telegram's HTML subset and auto-chunked at 4000 chars. Plain `<`, `>`, `&` in regular text are safe — they get auto-escaped before sending. On parse error the chunk re-sends as plain text so the reply still ships. Use 'text' only to bypass markdown conversion entirely (e.g. sending pre-built Telegram entity strings verbatim). 'markdownv2' passes raw — caller escapes per Telegram rules.",
+            "Rendering mode. Default: 'html' — markdown (**bold**, *italic*, `code`, ```fenced```, [text](url), tables, # headings) is auto-converted to Telegram's HTML subset and auto-chunked at 4000 chars. Plain `<`, `>`, `&` in regular text are safe — they get auto-escaped before sending. On parse error the chunk re-sends as plain text so the reply still ships. Use 'text' only to bypass markdown conversion entirely (e.g. sending pre-built Telegram entity strings verbatim). 'markdownv2' passes raw — caller escapes per Telegram rules. 'rich' is never required: DM replies auto-upgrade to Telegram's native markdown rendering when available; the explicit value just forces the same gate.",
         },
       },
       required: ['chat_id', 'text'],

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -295,6 +295,24 @@ export const AppConfigSchema = z.object({
     timeout_ms: z.number().int().positive().default(120_000),
     allowed_user_ids: z.array(z.number().int().positive()).optional(),
   }).default({}),
+  // Rich Messages (M1, Bot API 10.1, 2026-06-14). When enabled, a DM reply
+  // whose body fits 32768 bytes ships as a single RAW-markdown rich message
+  // (Telegram renders tables/math/headings/task-lists/<details>/footnotes)
+  // with a TRANSPARENT fallback to the HTML path on any rejection. Default
+  // ON: the fallback makes it safe to enable everywhere — a build without the
+  // method latches off after one call and behaves exactly like before.
+  //
+  // `perChatOptOut` holds chat_ids (as strings, matching the inbound
+  // <channel chat_id="…">) that should NEVER receive rich messages — they
+  // always take the HTML path. Use it to pin a specific chat to the legacy
+  // rendering while the feature rolls out.
+  //
+  // Kill switch: set env TELEGRAM_RICH_MESSAGES to a falsy value (0/false/
+  // no/off) to force enabled=false fleet-wide without editing config.json.
+  richMessages: z.object({
+    enabled: z.boolean().default(true),
+    perChatOptOut: z.array(z.string()).default([]),
+  }).default({}),
 })
 export type AppConfig = z.infer<typeof AppConfigSchema>
 
@@ -366,6 +384,19 @@ export const RuntimeEnvSchema = z.object({
   TELEGRAM_ASK_USER_QUESTION_TIMEOUT_MS: z.coerce.number().int().positive().optional(),
   TELEGRAM_ASK_USER_QUESTION_ALLOWED_USER_IDS: z.string().optional(), // CSV
   TELEGRAM_ASK_USER_QUESTION_MAX_PREVIEW_CHARS: z.coerce.number().int().positive().optional(),
+  // Rich Messages (M1, 2026-06-14). Kill switch: a falsy value
+  // (0/false/no/off, case-insensitive) forces richMessages.enabled=false;
+  // anything else (1/true/yes/on …) forces it true. Unset = config.json /
+  // schema default (true). Parsed to a boolean here; layered onto the
+  // richMessages block in loadConfig.
+  TELEGRAM_RICH_MESSAGES: z
+    .string()
+    .transform((v) => !/^(0|false|no|off)$/i.test(v.trim()))
+    .optional(),
+  // CSV of chat_ids that always take the HTML path (never rich). Mirrors the
+  // CSV chat-id parsing used for the allowlist; stored as strings to match
+  // the inbound <channel chat_id="…"> form the reply tool compares against.
+  TELEGRAM_RICH_MESSAGES_PER_CHAT_OPT_OUT: z.string().optional(), // CSV
 })
 export type RuntimeEnv = z.infer<typeof RuntimeEnvSchema>
 
@@ -538,6 +569,22 @@ export function loadConfig(env: NodeJS.ProcessEnv): AppConfig {
     askUserQuestion.max_preview_chars = parsedEnv.TELEGRAM_ASK_USER_QUESTION_MAX_PREVIEW_CHARS
   }
   if (Object.keys(askUserQuestion).length > 0) merged.ask_user_question = askUserQuestion
+
+  // Rich Messages env overrides (M1, 2026-06-14). Same layering pattern: take
+  // the config.json sub-object if present, layer env on top, emit only when
+  // something is set so Zod applies schema defaults cleanly otherwise.
+  const richMessages = (merged.richMessages && typeof merged.richMessages === 'object'
+    ? merged.richMessages
+    : {}) as Record<string, unknown>
+  if (parsedEnv.TELEGRAM_RICH_MESSAGES !== undefined) {
+    richMessages.enabled = parsedEnv.TELEGRAM_RICH_MESSAGES
+  }
+  if (parsedEnv.TELEGRAM_RICH_MESSAGES_PER_CHAT_OPT_OUT !== undefined) {
+    // Chat ids stay as strings (matching the inbound <channel chat_id="…">).
+    // Reuse parseCsvChatIds for validation, then stringify each entry.
+    richMessages.perChatOptOut = parseCsvChatIds(parsedEnv.TELEGRAM_RICH_MESSAGES_PER_CHAT_OPT_OUT).map(String)
+  }
+  if (Object.keys(richMessages).length > 0) merged.richMessages = richMessages
 
   try {
     return AppConfigSchema.parse(merged)

--- a/plugin/src/format/rich.ts
+++ b/plugin/src/format/rich.ts
@@ -1,0 +1,169 @@
+// Telegram Bot API 10.1 "Rich Messages" — pure helpers (no I/O).
+//
+// Rich Messages let Telegram render RAW markdown server-side: tables, math,
+// headings, task-lists, <details>, footnotes — far beyond the HTML subset
+// markdownToTelegramHtml targets. The cap is 32768 bytes (vs 4096 for a
+// normal sendMessage), so a long structured answer ships as ONE message
+// instead of being chunked + lossily HTML-converted.
+//
+// This module is deliberately side-effect-free: it only classifies errors,
+// checks length limits, and builds the raw-api request body. The actual
+// send (and the transparent HTML fallback) lives in the safe-telegram-api
+// wrapper + the reply tool, so redaction and rate-limiting still apply.
+//
+// Layering reminder: the rich method is a new TelegramApi method so it flows
+// through safeTelegramApi (redaction) → rateLimitedTelegramApi (429 queue)
+// → rawTelegramApi (grammY raw escape hatch). NEVER call the raw send
+// directly from the reply tool — that would bypass secret redaction.
+
+// Telegram Bot API 10.1 rich-message body cap. Telegram measures this in
+// UTF-8 bytes, not JS code-units; contentFitsRichLimits() below compares
+// byte length so a Cyrillic/emoji-heavy answer is gated correctly.
+export const RICH_MESSAGE_MAX_CHARS = 32768
+
+/**
+ * True when `text` fits inside a single rich message. Telegram counts the
+ * body in UTF-8 bytes, so we measure bytes — not `text.length` (which counts
+ * UTF-16 code units and would let a Cyrillic payload sneak past the cap).
+ * Boundary: exactly RICH_MESSAGE_MAX_CHARS bytes fits; one more does not.
+ */
+export function contentFitsRichLimits(text: string): boolean {
+  return Buffer.byteLength(text, 'utf8') <= RICH_MESSAGE_MAX_CHARS
+}
+
+// Error classification for the rich send path. Drives the transparent
+// fallback in safe-telegram-api:
+//   - capability : Telegram (or this grammY build) doesn't know the method.
+//                  Latch it OFF for the session and fall back to HTML.
+//   - parser     : Telegram's markdown parser rejected the body (400). One-off
+//                  fall back to HTML (which DOES validate) — do NOT latch.
+//   - oversize   : body too large (400 about size). Fall back to HTML chunking.
+//   - transient  : anything else (network, 5xx, 429). Re-throw — the
+//                  rate-limit wrapper handles 429; other transients surface so
+//                  we never silently swallow then double-send.
+export type RichErrorClass = 'capability' | 'parser' | 'oversize' | 'transient'
+
+// Pull an HTTP-ish status code out of the many shapes an error can take:
+// grammY's GrammyError (`error_code`), a fetch Response-ish (`status`), or a
+// plain object carrying either. Returns undefined when no numeric code found.
+function extractStatusCode(err: unknown): number | undefined {
+  if (typeof err !== 'object' || err === null) return undefined
+  const e = err as Record<string, unknown>
+  if (typeof e.error_code === 'number') return e.error_code
+  if (typeof e.status === 'number') return e.status
+  if (typeof e.statusCode === 'number') return e.statusCode
+  return undefined
+}
+
+// Lowercased human-readable message for substring sniffing. grammY's
+// GrammyError exposes `.description`; native errors expose `.message`.
+function extractMessage(err: unknown): string {
+  if (typeof err === 'string') return err.toLowerCase()
+  if (typeof err !== 'object' || err === null) return ''
+  const e = err as Record<string, unknown>
+  const parts: string[] = []
+  if (typeof e.description === 'string') parts.push(e.description)
+  if (typeof e.message === 'string') parts.push(e.message)
+  return parts.join(' ').toLowerCase()
+}
+
+/**
+ * Classify a rich-send failure so the caller can decide fallback vs latch
+ * vs re-throw. See RichErrorClass for the policy each class drives.
+ *
+ * capability — HTTP 404, or message mentioning "method not found",
+ *   "unsupported", "not implemented". Telegram returns 404 for unknown
+ *   methods; an older grammY/local build can surface "not found"/"unsupported".
+ * parser — a 400 BadRequest that is NOT about size. Markdown the parser
+ *   rejected; one-off fall back to the HTML path.
+ * oversize — a 400 mentioning the body being too large ("too long",
+ *   "message is too long", "too large", "entities too long").
+ * transient — everything else (network, 5xx, 429, unknown). Re-thrown.
+ */
+export function richErrorClass(err: unknown): RichErrorClass {
+  const code = extractStatusCode(err)
+  const msg = extractMessage(err)
+
+  // Capability: explicit 404, or a message that names the method as unknown.
+  // Checked first because some transports report unknown-method as 400 with a
+  // "method not found" description rather than 404.
+  if (
+    code === 404 ||
+    msg.includes('method not found') ||
+    msg.includes('not implemented') ||
+    msg.includes('unsupported') ||
+    msg.includes('method is not supported')
+  ) {
+    return 'capability'
+  }
+
+  if (code === 400) {
+    // Oversize is a 400 sub-case — sniff the size wording first so we don't
+    // misclassify it as a generic parser error (both fall back, but the
+    // distinction is useful for logs/metrics and matches the spec contract).
+    if (
+      msg.includes('too long') ||
+      msg.includes('too large') ||
+      msg.includes('message is too long') ||
+      msg.includes('entities too long')
+    ) {
+      return 'oversize'
+    }
+    return 'parser'
+  }
+
+  // 5xx, 429, network errors, or anything we can't read — treat as transient
+  // and let the caller re-throw (the rate-limit wrapper owns 429 retries).
+  return 'transient'
+}
+
+// Options accepted by buildRichMessagePayload. Mirrors the subset of the
+// rich-message body we set today (chat target + threading via
+// reply_parameters). Kept minimal — M3/M4 can extend (streaming drafts,
+// group threads).
+export interface BuildRichMessageOpts {
+  chat_id: string
+  reply_to_message_id?: number
+}
+
+// Shape of the raw-api body handed to grammY's
+// `bot.api.raw.sendRichMessage(...)`. grammY raw bodies are plain objects
+// keyed by the Bot API param names. We model the fields we set; `[key:
+// string]` would invite typos, so we keep it explicit + optional.
+//
+// Wire format confirmed against the shipped Hermes reference
+// (gateway/platforms/telegram.py `_rich_message_payload`/`_try_send_rich`):
+// sendRichMessage takes a top-level `rich_message` InputRichMessage object
+// whose raw markdown lives in its `markdown` field — NOT a flat top-level
+// `markdown`. i.e. `sendRichMessage(chat_id, rich_message={markdown}, reply_parameters?)`.
+export interface InputRichMessage {
+  markdown: string
+}
+export interface RichMessageBody {
+  chat_id: string
+  rich_message: InputRichMessage
+  reply_parameters?: { message_id: number }
+}
+
+/**
+ * Build the raw-api request body for sendRichMessage. Pure: no redaction,
+ * no I/O. Redaction runs on `rawMarkdown` in the safe wrapper BEFORE this
+ * body reaches the transport, so do not pre-process the text here.
+ *
+ * grammY raw bodies use Bot-API param names directly — threading is
+ * `reply_parameters: { message_id }` (same convention createTelegramApi
+ * uses for sendMessage), not the legacy `reply_to_message_id`.
+ */
+export function buildRichMessagePayload(
+  rawMarkdown: string,
+  opts: BuildRichMessageOpts,
+): RichMessageBody {
+  const body: RichMessageBody = {
+    chat_id: opts.chat_id,
+    rich_message: { markdown: rawMarkdown },
+  }
+  if (opts.reply_to_message_id !== undefined) {
+    body.reply_parameters = { message_id: opts.reply_to_message_id }
+  }
+  return body
+}

--- a/plugin/src/safety/rate-limited-telegram-api.ts
+++ b/plugin/src/safety/rate-limited-telegram-api.ts
@@ -33,6 +33,8 @@ import type {
   EditOpts,
   SendDocumentOpts,
   SendMessageOpts,
+  SendRichMessageOpts,
+  SendRichMessageResult,
   TelegramApi,
 } from '../channel/tools.js'
 
@@ -236,6 +238,18 @@ export function createRateLimitedTelegramApi(
       sendOpts: SendMessageOpts,
     ): Promise<{ message_id: number }> {
       return enqueueSend(chatId, () => raw.sendMessage(chatId, text, sendOpts))
+    },
+
+    // Rich messages consume the same per-chat send budget as a normal
+    // sendMessage (one outbound bubble), so they route through the identical
+    // FIFO + token-bucket + 429-retry path. Ordering with sibling sends to
+    // the same chat is preserved.
+    async sendRichMessage(
+      chatId: string,
+      rawMarkdown: string,
+      richOpts: SendRichMessageOpts,
+    ): Promise<SendRichMessageResult> {
+      return enqueueSend(chatId, () => raw.sendRichMessage(chatId, rawMarkdown, richOpts))
     },
 
     async editMessageText(

--- a/plugin/src/safety/rich-latch.ts
+++ b/plugin/src/safety/rich-latch.ts
@@ -1,0 +1,40 @@
+// Rich-message capability latch.
+//
+// A tiny per-process holder of two kill-switches:
+//   - sendDisabled  : flipped ON when a rich send fails with a `capability`
+//                     class error (Telegram / this grammY build can't do
+//                     sendRichMessage). Once latched, the safe wrapper
+//                     short-circuits every subsequent rich attempt to the
+//                     HTML fallback WITHOUT hitting Telegram again — so a
+//                     missing method costs exactly one failed call per
+//                     session, not one per reply.
+//   - draftDisabled : reserved for M3 (streaming rich drafts). Declared now
+//                     so the latch shape is stable; M1 never sets it.
+//
+// Process-local, mutable, not persisted: a restart re-probes capability,
+// which is correct — Telegram may roll the method out between restarts.
+
+export interface RichLatch {
+  sendDisabled: boolean
+  draftDisabled: boolean
+  setSendDisabled(value: boolean): void
+  setDraftDisabled(value: boolean): void
+}
+
+/**
+ * Create a fresh rich latch with both switches OFF. One instance per
+ * process is shared by the safe-telegram-api wrapper (writer on capability
+ * failure) and the reply tool (reader to skip rich attempts cheaply).
+ */
+export function createRichLatch(): RichLatch {
+  return {
+    sendDisabled: false,
+    draftDisabled: false,
+    setSendDisabled(value: boolean): void {
+      this.sendDisabled = value
+    },
+    setDraftDisabled(value: boolean): void {
+      this.draftDisabled = value
+    },
+  }
+}

--- a/plugin/src/safety/safe-telegram-api.ts
+++ b/plugin/src/safety/safe-telegram-api.ts
@@ -160,19 +160,21 @@ export function createSafeTelegramApi(
       rawMarkdown: string,
       opts: SendRichMessageOpts,
     ): Promise<SendRichMessageResult> {
-      // Redact FIRST — secrets must be stripped from the raw markdown before
-      // it leaves the process, exactly like the sendMessage path. We do NOT
-      // run validateTelegramHtml here: the body is markdown, not HTML, and
-      // the validator would corrupt it. Telegram's server-side parser is the
-      // safety net — a bad body comes back as a 400 we classify and fall
-      // back from.
-      const redacted = redactSecrets(rawMarkdown, extraSecrets)
-
       // Latch already tripped (or no latch wired) → don't even attempt the
       // send; report fallback so the caller uses the validated HTML path.
+      // Checked before redaction: a latched-off session would otherwise pay
+      // a full redaction pass on up-to-32KB text for every skipped call.
       if (richLatch === undefined || richLatch.sendDisabled) {
         return { fallback: true }
       }
+
+      // Redact BEFORE the raw call — secrets must be stripped from the raw
+      // markdown before it leaves the process, exactly like the sendMessage
+      // path. We do NOT run validateTelegramHtml here: the body is markdown,
+      // not HTML, and the validator would corrupt it. Telegram's server-side
+      // parser is the safety net — a bad body comes back as a 400 we
+      // classify and fall back from.
+      const redacted = redactSecrets(rawMarkdown, extraSecrets)
 
       try {
         return await raw.sendRichMessage(chatId, redacted, opts)

--- a/plugin/src/safety/safe-telegram-api.ts
+++ b/plugin/src/safety/safe-telegram-api.ts
@@ -26,10 +26,14 @@ import type {
   InlineKeyboardLike,
   SendDocumentOpts,
   SendMessageOpts,
+  SendRichMessageOpts,
+  SendRichMessageResult,
   TelegramApi,
 } from '../channel/tools.js'
 import { redactSecrets } from './redact.js'
 import { validateTelegramHtml } from './html-validator.js'
+import { richErrorClass } from '../format/rich.js'
+import type { RichLatch } from './rich-latch.js'
 
 /**
  * Walk an inline keyboard and redact every button's `text` and `url`
@@ -99,11 +103,19 @@ function redactReplyMarkup(
  * @param extraSecrets  Optional list of exact-substring secrets to mask
  *                      (e.g. webhook token, Groq key). Passed through to
  *                      redactSecrets on every send.
+ * @param richLatch     Optional M1 rich-message capability latch. When the
+ *                      rich send fails with a `capability` error we flip
+ *                      `sendDisabled` so subsequent rich attempts short-
+ *                      circuit to fallback without hitting Telegram. When
+ *                      omitted, sendRichMessage always reports `{ fallback }`
+ *                      (the layered chain then uses the HTML path) so a
+ *                      mis-wired build degrades safely instead of crashing.
  */
 export function createSafeTelegramApi(
   raw: TelegramApi,
   log: Logger,
   extraSecrets?: ReadonlyArray<string>,
+  richLatch?: RichLatch,
 ): TelegramApi {
   const sanitize = (
     text: string,
@@ -140,6 +152,55 @@ export function createSafeTelegramApi(
         safeOpts.reply_markup = redactReplyMarkup(safeOpts.reply_markup, extraSecrets)
       }
       return raw.sendMessage(chatId, safeText, safeOpts)
+    },
+
+    async sendRichMessage(
+      chatId: string,
+      rawMarkdown: string,
+      opts: SendRichMessageOpts,
+    ): Promise<SendRichMessageResult> {
+      // Redact FIRST — secrets must be stripped from the raw markdown before
+      // it leaves the process, exactly like the sendMessage path. We do NOT
+      // run validateTelegramHtml here: the body is markdown, not HTML, and
+      // the validator would corrupt it. Telegram's server-side parser is the
+      // safety net — a bad body comes back as a 400 we classify and fall
+      // back from.
+      const redacted = redactSecrets(rawMarkdown, extraSecrets)
+
+      // Latch already tripped (or no latch wired) → don't even attempt the
+      // send; report fallback so the caller uses the validated HTML path.
+      if (richLatch === undefined || richLatch.sendDisabled) {
+        return { fallback: true }
+      }
+
+      try {
+        return await raw.sendRichMessage(chatId, redacted, opts)
+      } catch (err) {
+        const cls = richErrorClass(err)
+        if (cls === 'capability') {
+          // Telegram / this build can't do rich messages. Latch OFF for the
+          // session so we pay this failed call at most once, then fall back.
+          richLatch.sendDisabled = true
+          log.warn('rich message capability error — latching off, falling back to HTML', {
+            error: err instanceof Error ? err.message : String(err),
+          })
+          return { fallback: true }
+        }
+        if (cls === 'parser' || cls === 'oversize') {
+          // One-off body problem; the HTML path validates + chunks, so fall
+          // back without latching (other messages may be fine).
+          log.warn('rich message rejected — falling back to HTML', {
+            class: cls,
+            error: err instanceof Error ? err.message : String(err),
+          })
+          return { fallback: true }
+        }
+        // transient (network / 5xx / 429) — surface it. We must NOT fall back
+        // here: the rate-limit wrapper owns 429 retries, and swallowing a
+        // transient then sending via HTML risks a duplicate if the rich send
+        // actually landed. Re-throw so the reply tool's outer try reports it.
+        throw err
+      }
     },
 
     async editMessageText(chatId: string, messageId: number, text: string, opts: EditOpts): Promise<void> {

--- a/plugin/src/schemas.ts
+++ b/plugin/src/schemas.ts
@@ -22,7 +22,14 @@ export const ReplyArgsSchema = z.object({
   // text without markdown markers passes through unchanged. Pass 'text'
   // explicitly only when the caller needs a literal `<` / `>` / `&` in
   // the body (rare). Inspired by openclaw/extensions/telegram (MIT).
-  format: z.enum(['text', 'markdownv2', 'html']).default('html'),
+  //
+  // 'rich' (M1, Bot API 10.1): ship RAW markdown that Telegram renders
+  // server-side (tables/math/headings/task-lists/<details>/footnotes). It is
+  // NOT required to request it — when `richMessages.enabled` is on, an 'html'
+  // (the default) reply to a DM is auto-upgraded to rich with a transparent
+  // HTML fallback. The explicit 'rich' value is reserved for forcing the rich
+  // attempt; behaviourally it joins the same auto-upgrade gate as 'html'.
+  format: z.enum(['text', 'markdownv2', 'html', 'rich']).default('html'),
 })
 export type ReplyArgs = z.infer<typeof ReplyArgsSchema>
 

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -38,6 +38,7 @@ import {
 } from './channel/tools.js'
 import { createSafeTelegramApi } from './safety/safe-telegram-api.js'
 import { createRateLimitedTelegramApi } from './safety/rate-limited-telegram-api.js'
+import { createRichLatch } from './safety/rich-latch.js'
 import { redactSecrets } from './safety/redact.js'
 import { StatusManager } from './status/status-manager.js'
 import { ProgressReporter } from './status/progress-reporter.js'
@@ -425,7 +426,13 @@ const rateLimitedTelegramApi = createRateLimitedTelegramApi(rawTelegramApi, log)
 // accidentally tries to ship the token (e.g. error message including a
 // URL-with-token from grammy) gets it scrubbed before the bytes leave us.
 const apiSecrets: string[] = [...logSecrets, env.TELEGRAM_BOT_TOKEN]
-const telegramApi = createSafeTelegramApi(rateLimitedTelegramApi, log, apiSecrets)
+// M1 Rich Messages (2026-06-14): one process-scoped capability latch shared
+// between the safe wrapper (flips sendDisabled on a `capability` error) and
+// the reply tool (reads sendDisabled to skip rich attempts cheaply). A
+// restart re-probes capability, which is correct — Telegram may roll the
+// method out between restarts.
+const richLatch = createRichLatch()
+const telegramApi = createSafeTelegramApi(rateLimitedTelegramApi, log, apiSecrets, richLatch)
 
 const mcp = new Server(
   { name: 'dashi-channel', version: '1.0.0' },
@@ -578,6 +585,9 @@ const toolDeps: ToolDeps = {
   telegramApi,
   log,
   statusManager,
+  // M1 Rich Messages: the reply tool reads richLatch.sendDisabled to skip
+  // rich attempts once a capability error has latched it off.
+  richLatch,
   // H4 fix (2026-05-23): outbound assertAllowedChat now consults the
   // multichat policy when present. Falls back to legacy config-only
   // behaviour when multichat is disabled or policy load failed.

--- a/plugin/tests/channel/permissions.test.ts
+++ b/plugin/tests/channel/permissions.test.ts
@@ -92,6 +92,7 @@ function mkConfig(allowedIds: number[] = [164795011]): AppConfig {
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     permission_gate: { enabled: false, timeout_ms: 120_000 },
+    richMessages: { enabled: false, perChatOptOut: [] },
   }
 }
 

--- a/plugin/tests/channel/tools.guest.test.ts
+++ b/plugin/tests/channel/tools.guest.test.ts
@@ -208,6 +208,32 @@ describe('reply tool — guest path', () => {
     expect(registry.claim('gq-1').kind).toBe('consumed')
   })
 
+  test("format 'rich' degrades to HTML rendering — answerGuestQuery gets rendered body, never sendRichMessage", async () => {
+    const stub = makeStubApi()
+    const registry = new GuestQueryRegistry()
+    registered(registry, 'gq-rich')
+    const deps = makeDeps({ api: stub.api, registry })
+
+    // answerGuestQuery has no rich_message payload: 'rich' must render the
+    // same HTML subset as the default path (sendRichMessage stub throws, so
+    // any rich attempt fails this test loudly).
+    const result = await callTool(
+      replyReq({
+        chat_id: '-100987',
+        guest_query_id: 'gq-rich',
+        text: '**жирный** ответ',
+        format: 'rich',
+      }),
+      deps,
+    )
+
+    expect(result.isError).toBeUndefined()
+    expect(stub.guestCalls.length).toBe(1)
+    expect(stub.guestCalls[0]!.text).toContain('<b>жирный</b>')
+    expect(stub.guestCalls[0]!.opts.parse_mode).toBe('HTML')
+    expect(stub.sendMessageCalls).toBe(0)
+  })
+
   test('unknown guest query → tool error, no API call', async () => {
     const stub = makeStubApi()
     const deps = makeDeps({ api: stub.api, registry: new GuestQueryRegistry() })

--- a/plugin/tests/channel/tools.test.ts
+++ b/plugin/tests/channel/tools.test.ts
@@ -23,6 +23,9 @@ const silentLog = createLogger('test', { stream: { write: () => true } as unknow
 function makeStubApi(overrides: Partial<TelegramApi> = {}): TelegramApi {
   return {
     sendMessage: async (_chatId: string, _text: string, _opts: SendMessageOpts) => ({ message_id: 1 }),
+    // Default rich stub reports fallback so legacy reply tests (richMessages
+    // disabled in makeConfig) never accidentally exercise the rich path.
+    sendRichMessage: async () => ({ fallback: true as const }),
     editMessageText: async (_chatId: string, _messageId: number, _text: string, _opts: EditOpts) => {
       /* noop */
     },
@@ -86,6 +89,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     permission_gate: { enabled: false, timeout_ms: 120_000 },
+    richMessages: { enabled: false, perChatOptOut: [] },
     ...overrides,
   }
 }
@@ -377,6 +381,28 @@ describe('callTool', () => {
       deps,
     )
     expect(result.isError).toBeUndefined()
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('reply format=rich accepts new enum value (falls back to HTML when richMessages disabled)', async () => {
+    // Schema regression: 'rich' must be a legal format value (M1). With the
+    // default makeConfig (richMessages.enabled=false) no rich send is
+    // attempted — the body renders via the validated HTML path, parse_mode=HTML.
+    const captured: Array<{ text: string; opts: SendMessageOpts }> = []
+    const api = makeStubApi({
+      sendMessage: async (_chatId, text, opts) => {
+        captured.push({ text, opts })
+        return { message_id: 700 + captured.length }
+      },
+    })
+    const deps = makeDeps({ telegramApi: api })
+    const result = await callTool(
+      callReq('reply', { chat_id: '164795011', text: '# Title', format: 'rich' }),
+      deps,
+    )
+    expect(result.isError).toBeUndefined()
+    expect(captured).toHaveLength(1)
+    expect(captured[0]?.opts.parse_mode).toBe('HTML')
     rmSync(deps.statePaths.root, { recursive: true, force: true })
   })
 

--- a/plugin/tests/commands/oob.test.ts
+++ b/plugin/tests/commands/oob.test.ts
@@ -54,6 +54,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     permission_gate: { enabled: false, timeout_ms: 120_000 },
+    richMessages: { enabled: false, perChatOptOut: [] },
     ...overrides,
   }
 }
@@ -79,6 +80,7 @@ function makeTelegramApi(): TelegramApi {
   }
   return {
     sendMessage: fail('sendMessage') as TelegramApi['sendMessage'],
+    sendRichMessage: fail('sendRichMessage') as unknown as TelegramApi['sendRichMessage'],
     editMessageText: fail('editMessageText') as TelegramApi['editMessageText'],
     setMessageReaction: fail(
       'setMessageReaction',

--- a/plugin/tests/config.test.ts
+++ b/plugin/tests/config.test.ts
@@ -465,6 +465,59 @@ describe('loadConfig', () => {
   })
 })
 
+describe('richMessages config (M1, 2026-06-14)', () => {
+  test('defaults: enabled=true, perChatOptOut=[]', () => {
+    const cfg = loadConfig(env())
+    expect(cfg.richMessages.enabled).toBe(true)
+    expect(cfg.richMessages.perChatOptOut).toEqual([])
+  })
+
+  test('config.json values are loaded when no env override', () => {
+    writeFileSync(
+      join(stateDir, 'config.json'),
+      JSON.stringify({ richMessages: { enabled: false, perChatOptOut: ['164795011'] } }),
+    )
+    const cfg = loadConfig(env())
+    expect(cfg.richMessages.enabled).toBe(false)
+    expect(cfg.richMessages.perChatOptOut).toEqual(['164795011'])
+  })
+
+  test('TELEGRAM_RICH_MESSAGES=0 kill-switch forces enabled=false', () => {
+    const cfg = loadConfig(env({ TELEGRAM_RICH_MESSAGES: '0' }))
+    expect(cfg.richMessages.enabled).toBe(false)
+  })
+
+  test('TELEGRAM_RICH_MESSAGES=false kill-switch forces enabled=false', () => {
+    const cfg = loadConfig(env({ TELEGRAM_RICH_MESSAGES: 'false' }))
+    expect(cfg.richMessages.enabled).toBe(false)
+  })
+
+  test('TELEGRAM_RICH_MESSAGES=1 forces enabled=true', () => {
+    writeFileSync(
+      join(stateDir, 'config.json'),
+      JSON.stringify({ richMessages: { enabled: false } }),
+    )
+    const cfg = loadConfig(env({ TELEGRAM_RICH_MESSAGES: '1' }))
+    expect(cfg.richMessages.enabled).toBe(true)
+  })
+
+  test('env kill-switch overrides config.json enabled=true', () => {
+    writeFileSync(
+      join(stateDir, 'config.json'),
+      JSON.stringify({ richMessages: { enabled: true } }),
+    )
+    const cfg = loadConfig(env({ TELEGRAM_RICH_MESSAGES: 'off' }))
+    expect(cfg.richMessages.enabled).toBe(false)
+  })
+
+  test('TELEGRAM_RICH_MESSAGES_PER_CHAT_OPT_OUT CSV parses to string ids', () => {
+    const cfg = loadConfig(
+      env({ TELEGRAM_RICH_MESSAGES_PER_CHAT_OPT_OUT: '164795011, -100123' }),
+    )
+    expect(cfg.richMessages.perChatOptOut).toEqual(['164795011', '-100123'])
+  })
+})
+
 describe('single progress surface defaults (2026-06-09 duplicate-windows fix)', () => {
   // Mac mini migration: ProgressReporter + StatusManager both defaulted ON,
   // so a fresh install with hooks registered rendered two «working/running»

--- a/plugin/tests/format/rich.test.ts
+++ b/plugin/tests/format/rich.test.ts
@@ -1,0 +1,140 @@
+// Unit tests for the pure rich-message helpers (no I/O).
+//   - richErrorClass: each classification branch
+//   - contentFitsRichLimits: boundary at RICH_MESSAGE_MAX_CHARS
+//   - buildRichMessagePayload: body shape
+
+import { describe, expect, test } from 'bun:test'
+import {
+  RICH_MESSAGE_MAX_CHARS,
+  buildRichMessagePayload,
+  contentFitsRichLimits,
+  richErrorClass,
+} from '../../src/format/rich.js'
+
+describe('RICH_MESSAGE_MAX_CHARS', () => {
+  test('is the Bot API 10.1 rich-message cap (32768)', () => {
+    expect(RICH_MESSAGE_MAX_CHARS).toBe(32768)
+  })
+})
+
+describe('richErrorClass', () => {
+  test('HTTP 404 → capability', () => {
+    expect(richErrorClass({ error_code: 404, description: 'Not Found' })).toBe('capability')
+  })
+
+  test('"method not found" message → capability', () => {
+    expect(richErrorClass(new Error('Bad Request: method not found'))).toBe('capability')
+  })
+
+  test('"unsupported" message → capability', () => {
+    expect(richErrorClass({ description: 'method is unsupported by this build' })).toBe('capability')
+  })
+
+  test('"not implemented" message → capability', () => {
+    expect(richErrorClass(new Error('sendRichMessage is not implemented'))).toBe('capability')
+  })
+
+  test('400 BadRequest (non-size) → parser', () => {
+    expect(
+      richErrorClass({ error_code: 400, description: "Bad Request: can't parse entities" }),
+    ).toBe('parser')
+  })
+
+  test('400 "message is too long" → oversize', () => {
+    expect(
+      richErrorClass({ error_code: 400, description: 'Bad Request: message is too long' }),
+    ).toBe('oversize')
+  })
+
+  test('400 "entities too long" → oversize', () => {
+    expect(
+      richErrorClass({ error_code: 400, description: 'Bad Request: entities too long' }),
+    ).toBe('oversize')
+  })
+
+  test('500 server error → transient', () => {
+    expect(richErrorClass({ error_code: 500, description: 'Internal Server Error' })).toBe('transient')
+  })
+
+  test('429 rate limit → transient (rate-limit wrapper owns retries)', () => {
+    expect(richErrorClass({ error_code: 429, parameters: { retry_after: 5 } })).toBe('transient')
+  })
+
+  test('network-ish error with no code → transient', () => {
+    expect(richErrorClass(new Error('fetch failed: ECONNRESET'))).toBe('transient')
+  })
+
+  test('null / non-object → transient', () => {
+    expect(richErrorClass(null)).toBe('transient')
+    expect(richErrorClass(undefined)).toBe('transient')
+    expect(richErrorClass(42)).toBe('transient')
+  })
+
+  test('reads `status` (fetch-Response shape) for 404 → capability', () => {
+    expect(richErrorClass({ status: 404 })).toBe('capability')
+  })
+})
+
+describe('contentFitsRichLimits', () => {
+  test('empty string fits', () => {
+    expect(contentFitsRichLimits('')).toBe(true)
+  })
+
+  test('exactly RICH_MESSAGE_MAX_CHARS bytes fits (boundary)', () => {
+    const atLimit = 'a'.repeat(RICH_MESSAGE_MAX_CHARS)
+    expect(Buffer.byteLength(atLimit, 'utf8')).toBe(RICH_MESSAGE_MAX_CHARS)
+    expect(contentFitsRichLimits(atLimit)).toBe(true)
+  })
+
+  test('one byte over the limit does NOT fit', () => {
+    const overLimit = 'a'.repeat(RICH_MESSAGE_MAX_CHARS + 1)
+    expect(contentFitsRichLimits(overLimit)).toBe(false)
+  })
+
+  test('measures UTF-8 bytes, not code units (Cyrillic counts double)', () => {
+    // Each Cyrillic char is 2 bytes in UTF-8. Half-the-cap+1 chars ⇒ over.
+    const halfPlusOne = 'я'.repeat(RICH_MESSAGE_MAX_CHARS / 2 + 1)
+    // .length (UTF-16 code units) is under the char cap …
+    expect(halfPlusOne.length).toBeLessThan(RICH_MESSAGE_MAX_CHARS)
+    // … but the byte length is over, so it must NOT fit.
+    expect(contentFitsRichLimits(halfPlusOne)).toBe(false)
+  })
+
+  test('Cyrillic payload exactly at the byte limit fits', () => {
+    const exactly = 'я'.repeat(RICH_MESSAGE_MAX_CHARS / 2)
+    expect(Buffer.byteLength(exactly, 'utf8')).toBe(RICH_MESSAGE_MAX_CHARS)
+    expect(contentFitsRichLimits(exactly)).toBe(true)
+  })
+})
+
+describe('buildRichMessagePayload', () => {
+  test('builds chat_id + markdown body without threading', () => {
+    const body = buildRichMessagePayload('# Title\n\n| a | b |', { chat_id: '164795011' })
+    expect(body).toEqual({
+      chat_id: '164795011',
+      rich_message: { markdown: '# Title\n\n| a | b |' },
+    })
+    // No reply_parameters when reply_to_message_id is omitted.
+    expect(body.reply_parameters).toBeUndefined()
+  })
+
+  test('adds reply_parameters when reply_to_message_id is set', () => {
+    const body = buildRichMessagePayload('hello', {
+      chat_id: '164795011',
+      reply_to_message_id: 777,
+    })
+    expect(body).toEqual({
+      chat_id: '164795011',
+      rich_message: { markdown: 'hello' },
+      reply_parameters: { message_id: 777 },
+    })
+  })
+
+  test('does not mutate / pre-process the markdown (redaction happens upstream)', () => {
+    const raw = 'secret token sk-abcdefghijklmnopqrstuvwxyz123456'
+    const body = buildRichMessagePayload(raw, { chat_id: '1' })
+    // Pure builder: passes the body through verbatim. Redaction is the safe
+    // wrapper's job, BEFORE this builder is reached.
+    expect(body.rich_message.markdown).toBe(raw)
+  })
+})

--- a/plugin/tests/prompt/media-prompt.test.ts
+++ b/plugin/tests/prompt/media-prompt.test.ts
@@ -62,6 +62,7 @@ const voiceConfig: AppConfig = {
   multichat: { enabled: false },
   ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
   permission_gate: { enabled: false, timeout_ms: 120_000 },
+  richMessages: { enabled: false, perChatOptOut: [] },
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/plugin/tests/safety/rate-limited-telegram-api.test.ts
+++ b/plugin/tests/safety/rate-limited-telegram-api.test.ts
@@ -109,6 +109,12 @@ function makeStubApi(clock: FakeClock): StubApi {
       calls.push({ method: 'sendMessage', chatId, text, opts, ts: clock.now() })
       return { message_id: calls.length }
     },
+    async sendRichMessage(_chatId, _rawMarkdown, _opts) {
+      // Pass-through stub; the rich path's own coverage lives in
+      // tests/safety/rich-path.test.ts. Routes through the same enqueue here.
+      maybeThrow('sendMessage')
+      return { message_id: calls.length + 1 }
+    },
     async editMessageText(chatId, messageId, text, opts) {
       maybeThrow('editMessageText')
       calls.push({ method: 'editMessageText', chatId, messageId, text, opts, ts: clock.now() })

--- a/plugin/tests/safety/rich-path.test.ts
+++ b/plugin/tests/safety/rich-path.test.ts
@@ -11,7 +11,7 @@
 // the real createSafeTelegramApi so redaction + classification run for real.
 
 import { describe, expect, test } from 'bun:test'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
@@ -378,16 +378,22 @@ describe("callTool('reply') rich gate", () => {
   })
 
   test('files present → rich skipped (text+attachment goes legacy path)', async () => {
-    // No workspace_root → attachment resolution rejects, but the point is that
-    // rich is never attempted when files are present. Assert no rich call.
-    const h = makeHarness({})
-    await callTool(
-      replyReq({ chat_id: PRINCE_DM, text: 'with file', files: ['/etc/hosts'] }),
+    // A VALID workspace file, so the reply runs the full send path instead of
+    // dying in attachment validation — proving the rich gate itself skips on
+    // files.length > 0 (Codex review 2026-07-04: the old /etc/hosts variant
+    // returned before ever reaching the gate).
+    const workspace = mkdtempSync(join(tmpdir(), 'dashi-rich-files-ws-'))
+    writeFileSync(join(workspace, 'report.txt'), 'attachment body')
+    const h = makeHarness({ config: { workspace_root: workspace } })
+    const result = await callTool(
+      replyReq({ chat_id: PRINCE_DM, text: 'with file', files: [join(workspace, 'report.txt')] }),
       h.deps,
     )
-    // Reply errors on the unresolved file (no workspace_root) — that's fine;
-    // the invariant under test is that the rich path was NOT taken.
+    expect(result.isError).toBeUndefined()
     expect(h.recorder.sendRich).toHaveLength(0)
+    // Text shipped through the legacy HTML chunk path.
+    expect(h.recorder.sendMessage).toHaveLength(1)
+    rmSync(workspace, { recursive: true, force: true })
     h.cleanup()
   })
 

--- a/plugin/tests/safety/rich-path.test.ts
+++ b/plugin/tests/safety/rich-path.test.ts
@@ -1,0 +1,419 @@
+// Integration tests for the M1 rich-message path.
+//
+// Two layers under test:
+//   1. createSafeTelegramApi.sendRichMessage — redaction BEFORE the raw send,
+//      error classification → fallback/latch/re-throw.
+//   2. callTool('reply', …) rich decision gate — when rich is attempted vs
+//      skipped, and the no-duplicate / no-loss invariant on every branch.
+//
+// We stub the INNER TelegramApi (the rate-limited layer) rather than grammY,
+// so the test is decoupled from transport. The reply path is driven through
+// the real createSafeTelegramApi so redaction + classification run for real.
+
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  callTool,
+  type CallToolRequest,
+  type DownloadResult,
+  type EditOpts,
+  type SendDocumentOpts,
+  type SendMessageOpts,
+  type SendRichMessageOpts,
+  type SendRichMessageResult,
+  type TelegramApi,
+  type ToolDeps,
+} from '../../src/channel/tools.js'
+import type { AppConfig, StatePaths } from '../../src/config.js'
+import { createLogger } from '../../src/log.js'
+import { createSafeTelegramApi } from '../../src/safety/safe-telegram-api.js'
+import { createRichLatch } from '../../src/safety/rich-latch.js'
+
+const silentLog = createLogger('test', {
+  stream: { write: () => true } as unknown as NodeJS.WritableStream,
+})
+
+const PRINCE_DM = '164795011' // positive id ⇒ DM
+const GROUP = '-1001234567890' // negative id ⇒ group (M1 must skip)
+
+// ─── Stub inner TelegramApi (records calls, programmable rich behaviour) ──
+
+interface Recorder {
+  sendMessage: Array<{ chatId: string; text: string; opts: SendMessageOpts }>
+  sendRich: Array<{ chatId: string; rawMarkdown: string; opts: SendRichMessageOpts }>
+}
+
+function makeInnerApi(
+  recorder: Recorder,
+  richBehaviour: () => Promise<SendRichMessageResult>,
+): TelegramApi {
+  let nextId = 1000
+  return {
+    async sendMessage(chatId, text, opts) {
+      recorder.sendMessage.push({ chatId, text, opts })
+      return { message_id: nextId++ }
+    },
+    async sendRichMessage(chatId, rawMarkdown, opts) {
+      recorder.sendRich.push({ chatId, rawMarkdown, opts })
+      return richBehaviour()
+    },
+    async editMessageText(_chatId, _messageId, _text, _opts: EditOpts) {},
+    async setMessageReaction(_chatId, _messageId, _emoji) {},
+    async sendChatAction() {},
+    async sendDocument(_chatId, _filePath, _opts: SendDocumentOpts) {
+      return { message_id: nextId++ }
+    },
+    async sendPhoto(_chatId, _filePath, _opts: SendDocumentOpts) {
+      return { message_id: nextId++ }
+    },
+    async downloadFile(_fileId, destDir): Promise<DownloadResult> {
+      return { path: join(destDir, 'x.bin'), size: 0 }
+    },
+    async deleteMessage(_chatId, _messageId) {},
+  }
+}
+
+function emptyRecorder(): Recorder {
+  return { sendMessage: [], sendRich: [] }
+}
+
+// ─── Config / deps fixtures ──────────────────────────────────────────────
+
+function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    bot_id: 8507713167,
+    dm_only: true,
+    allowed_user_ids: [164795011],
+    allowed_chat_ids: [164795011, -1001234567890],
+    status: { enabled: false, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true, suppress_typing_bubble: true },
+    album: { flush_ms: 2000 },
+    voice: { provider: 'groq', language: 'ru', model: 'whisper-large-v3-turbo' },
+    webhook: { enabled: false, host: '127.0.0.1', port: 0 },
+    permission_relay: { enabled: true, allowed_user_ids: [164795011], bash_only_proof: true },
+    commands: { help: true, status: true, stop: true, reset: true, new: true },
+    memory: {
+      enabled: false,
+      source_tag: 'tg',
+      max_hot_bytes: 20480,
+      trim_keep_lines: 600,
+      buffer_ttl_ms: 5 * 60 * 1000,
+      buffer_max_entries: 100,
+    },
+    progress: { enabled: false, edit_throttle_ms: 3000, recent_buffer: 10, session_ttl_ms: 600000 },
+    task_mirror: { enabled: false, edit_throttle_ms: 3000, session_ttl_ms: 600000, collapse_completed_after: 5 },
+    watcher: { enabled: false, debounce_ms: 10_000, busy_threshold_ms: 30_000 },
+    tmux_mirror: { enabled: false, pane_target: '', socket_name: '', poll_interval_ms: 5000, line_count: 50, hide_segments: [], mode: 'latest_inbound_only', max_lines: 14 },
+    multichat: { enabled: false },
+    ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
+    permission_gate: { enabled: false, timeout_ms: 120_000 },
+    richMessages: { enabled: true, perChatOptOut: [] },
+    ...overrides,
+  }
+}
+
+function makeStatePaths(): StatePaths {
+  const root = mkdtempSync(join(tmpdir(), 'dashi-rich-path-test-'))
+  return {
+    root,
+    env: join(root, '.env'),
+    config: join(root, 'config.json'),
+    allowlist: join(root, 'allowlist.json'),
+    pid: join(root, 'bot.pid'),
+    lock: join(root, 'bot.lock'),
+    updateOffset: join(root, 'update-offset'),
+    inbox: join(root, 'inbox'),
+    sessionIds: join(root, 'session-ids'),
+    deadLetterUpdates: join(root, 'dead-letter', 'updates'),
+    deadLetterWebhook: join(root, 'dead-letter', 'webhook'),
+    logs: {
+      server: join(root, 'logs', 'server.log'),
+      telegram: join(root, 'logs', 'telegram.log'),
+      permissions: join(root, 'logs', 'permissions.jsonl'),
+      webhook: join(root, 'logs', 'webhook.log'),
+      ask_user_question: join(root, 'logs', 'ask-user-question.jsonl'),
+      permission_gate: join(root, 'logs', 'permission-gate.jsonl'),
+    },
+  }
+}
+
+function makeStatusManager(): ToolDeps['statusManager'] {
+  return {
+    isActive: () => false,
+    activeChatIds: () => [],
+    start: async () => ({ chatId: '0', messageId: 0, startedAt: 0 }),
+    update: async () => {},
+    updateByChatId: async () => {},
+    complete: async () => {},
+    cancel: async () => {},
+  } as unknown as ToolDeps['statusManager']
+}
+
+interface Harness {
+  deps: ToolDeps
+  recorder: Recorder
+  latch: ReturnType<typeof createRichLatch>
+  cleanup: () => void
+}
+
+function makeHarness(opts: {
+  config?: Partial<AppConfig>
+  richBehaviour?: () => Promise<SendRichMessageResult>
+  extraSecrets?: string[]
+}): Harness {
+  const recorder = emptyRecorder()
+  const latch = createRichLatch()
+  const inner = makeInnerApi(
+    recorder,
+    opts.richBehaviour ?? (async () => ({ message_id: 5555 })),
+  )
+  // Real safe wrapper so redaction + classification run for real.
+  const telegramApi = createSafeTelegramApi(inner, silentLog, opts.extraSecrets, latch)
+  const statePaths = makeStatePaths()
+  const deps: ToolDeps = {
+    config: makeConfig(opts.config),
+    statePaths,
+    telegramApi,
+    log: silentLog,
+    statusManager: makeStatusManager(),
+    richLatch: latch,
+  }
+  return {
+    deps,
+    recorder,
+    latch,
+    cleanup: () => rmSync(statePaths.root, { recursive: true, force: true }),
+  }
+}
+
+function replyReq(args: Record<string, unknown>): CallToolRequest {
+  return { params: { name: 'reply', arguments: args } }
+}
+
+// ─── safe wrapper: redaction + classification ─────────────────────────────
+
+describe('safe-telegram-api.sendRichMessage', () => {
+  test('redacts a planted secret in raw markdown BEFORE the raw call', async () => {
+    const recorder = emptyRecorder()
+    const latch = createRichLatch()
+    const inner = makeInnerApi(recorder, async () => ({ message_id: 7 }))
+    const safe = createSafeTelegramApi(inner, silentLog, undefined, latch)
+
+    const res = await safe.sendRichMessage(
+      PRINCE_DM,
+      'token sk-abcdefghijklmnopqrstuvwxyz0123456789',
+      {},
+    )
+
+    expect(res).toEqual({ message_id: 7 })
+    expect(recorder.sendRich).toHaveLength(1)
+    // The raw layer must NOT have seen the secret.
+    expect(recorder.sendRich[0]?.rawMarkdown).not.toContain('sk-abcdefghijklmnopqrstuvwxyz')
+    expect(recorder.sendRich[0]?.rawMarkdown).toContain('[REDACTED]')
+  })
+
+  test('capability error → {fallback:true}, latch set, second call short-circuits', async () => {
+    const recorder = emptyRecorder()
+    const latch = createRichLatch()
+    const inner = makeInnerApi(recorder, async () => {
+      throw { error_code: 404, description: 'Not Found' }
+    })
+    const safe = createSafeTelegramApi(inner, silentLog, undefined, latch)
+
+    const first = await safe.sendRichMessage(PRINCE_DM, 'hi', {})
+    expect(first).toEqual({ fallback: true })
+    expect(latch.sendDisabled).toBe(true)
+    expect(recorder.sendRich).toHaveLength(1)
+
+    // Second call must short-circuit WITHOUT touching the raw layer again.
+    const second = await safe.sendRichMessage(PRINCE_DM, 'hi again', {})
+    expect(second).toEqual({ fallback: true })
+    expect(recorder.sendRich).toHaveLength(1) // unchanged — short-circuited
+  })
+
+  test('parser error → {fallback:true}, latch NOT set', async () => {
+    const recorder = emptyRecorder()
+    const latch = createRichLatch()
+    const inner = makeInnerApi(recorder, async () => {
+      throw { error_code: 400, description: "Bad Request: can't parse entities" }
+    })
+    const safe = createSafeTelegramApi(inner, silentLog, undefined, latch)
+
+    const res = await safe.sendRichMessage(PRINCE_DM, 'oops', {})
+    expect(res).toEqual({ fallback: true })
+    expect(latch.sendDisabled).toBe(false) // one-off; not latched
+  })
+
+  test('transient error → throws (no swallow, no resend), latch NOT set', async () => {
+    const recorder = emptyRecorder()
+    const latch = createRichLatch()
+    const inner = makeInnerApi(recorder, async () => {
+      throw { error_code: 500, description: 'Internal Server Error' }
+    })
+    const safe = createSafeTelegramApi(inner, silentLog, undefined, latch)
+
+    await expect(safe.sendRichMessage(PRINCE_DM, 'x', {})).rejects.toBeDefined()
+    expect(latch.sendDisabled).toBe(false)
+  })
+
+  test('no latch wired → always reports fallback without hitting raw', async () => {
+    const recorder = emptyRecorder()
+    const inner = makeInnerApi(recorder, async () => ({ message_id: 1 }))
+    const safe = createSafeTelegramApi(inner, silentLog, undefined, undefined)
+
+    const res = await safe.sendRichMessage(PRINCE_DM, 'x', {})
+    expect(res).toEqual({ fallback: true })
+    expect(recorder.sendRich).toHaveLength(0)
+  })
+})
+
+// ─── reply tool: rich decision gate + no-dup / no-loss invariant ──────────
+
+describe("callTool('reply') rich gate", () => {
+  test('happy path: one sendRichMessage, returns id, NO chunked sendMessage', async () => {
+    const h = makeHarness({ richBehaviour: async () => ({ message_id: 4242 }) })
+    const result = await callTool(replyReq({ chat_id: PRINCE_DM, text: '# Hi\n\n| a | b |' }), h.deps)
+
+    expect(result.isError).toBeUndefined()
+    expect(h.recorder.sendRich).toHaveLength(1)
+    expect(h.recorder.sendMessage).toHaveLength(0) // no chunking — no dup
+    expect(result.content[0]?.text).toContain('4242')
+    h.cleanup()
+  })
+
+  test('rich fallback → exactly ONE HTML send, no duplicate', async () => {
+    const h = makeHarness({ richBehaviour: async () => ({ fallback: true }) })
+    const result = await callTool(replyReq({ chat_id: PRINCE_DM, text: 'plain body' }), h.deps)
+
+    expect(result.isError).toBeUndefined()
+    expect(h.recorder.sendRich).toHaveLength(1) // attempted …
+    expect(h.recorder.sendMessage).toHaveLength(1) // … then HTML path, once
+    // HTML path uses parse_mode HTML.
+    expect(h.recorder.sendMessage[0]?.opts.parse_mode).toBe('HTML')
+    h.cleanup()
+  })
+
+  test('transient error during rich → throws up as tool error, NO HTML duplicate', async () => {
+    const h = makeHarness({
+      richBehaviour: async () => {
+        throw { error_code: 503, description: 'Service Unavailable' }
+      },
+    })
+    const result = await callTool(replyReq({ chat_id: PRINCE_DM, text: 'body' }), h.deps)
+
+    // The outer try in callTool turns the thrown transient into a tool error.
+    expect(result.isError).toBe(true)
+    // CRITICAL: no fallback HTML send happened — we must not double-send.
+    expect(h.recorder.sendMessage).toHaveLength(0)
+    h.cleanup()
+  })
+
+  test("format 'text' → rich NOT attempted, plain send", async () => {
+    const h = makeHarness({})
+    const result = await callTool(
+      replyReq({ chat_id: PRINCE_DM, text: 'verbatim', format: 'text' }),
+      h.deps,
+    )
+    expect(result.isError).toBeUndefined()
+    expect(h.recorder.sendRich).toHaveLength(0)
+    expect(h.recorder.sendMessage).toHaveLength(1)
+    expect(h.recorder.sendMessage[0]?.opts.parse_mode).toBeUndefined()
+    h.cleanup()
+  })
+
+  test("format 'markdownv2' → rich NOT attempted", async () => {
+    const h = makeHarness({})
+    const result = await callTool(
+      replyReq({ chat_id: PRINCE_DM, text: '*md*', format: 'markdownv2' }),
+      h.deps,
+    )
+    expect(result.isError).toBeUndefined()
+    expect(h.recorder.sendRich).toHaveLength(0)
+    expect(h.recorder.sendMessage).toHaveLength(1)
+    expect(h.recorder.sendMessage[0]?.opts.parse_mode).toBe('MarkdownV2')
+    h.cleanup()
+  })
+
+  test('> 32768 bytes → rich skipped, HTML path used', async () => {
+    const h = makeHarness({})
+    const huge = 'a'.repeat(32769)
+    const result = await callTool(replyReq({ chat_id: PRINCE_DM, text: huge }), h.deps)
+    expect(result.isError).toBeUndefined()
+    expect(h.recorder.sendRich).toHaveLength(0)
+    expect(h.recorder.sendMessage.length).toBeGreaterThanOrEqual(1) // chunked HTML
+    h.cleanup()
+  })
+
+  test('perChatOptOut chat → rich skipped', async () => {
+    const h = makeHarness({ config: { richMessages: { enabled: true, perChatOptOut: [PRINCE_DM] } } })
+    const result = await callTool(replyReq({ chat_id: PRINCE_DM, text: 'hi' }), h.deps)
+    expect(result.isError).toBeUndefined()
+    expect(h.recorder.sendRich).toHaveLength(0)
+    expect(h.recorder.sendMessage).toHaveLength(1)
+    h.cleanup()
+  })
+
+  test('richMessages.enabled=false → rich skipped', async () => {
+    const h = makeHarness({ config: { richMessages: { enabled: false, perChatOptOut: [] } } })
+    const result = await callTool(replyReq({ chat_id: PRINCE_DM, text: 'hi' }), h.deps)
+    expect(result.isError).toBeUndefined()
+    expect(h.recorder.sendRich).toHaveLength(0)
+    expect(h.recorder.sendMessage).toHaveLength(1)
+    h.cleanup()
+  })
+
+  test('latch already disabled → rich skipped (no raw call)', async () => {
+    const h = makeHarness({})
+    h.latch.sendDisabled = true
+    const result = await callTool(replyReq({ chat_id: PRINCE_DM, text: 'hi' }), h.deps)
+    expect(result.isError).toBeUndefined()
+    expect(h.recorder.sendRich).toHaveLength(0)
+    expect(h.recorder.sendMessage).toHaveLength(1)
+    h.cleanup()
+  })
+
+  test('files present → rich skipped (text+attachment goes legacy path)', async () => {
+    // No workspace_root → attachment resolution rejects, but the point is that
+    // rich is never attempted when files are present. Assert no rich call.
+    const h = makeHarness({})
+    await callTool(
+      replyReq({ chat_id: PRINCE_DM, text: 'with file', files: ['/etc/hosts'] }),
+      h.deps,
+    )
+    // Reply errors on the unresolved file (no workspace_root) — that's fine;
+    // the invariant under test is that the rich path was NOT taken.
+    expect(h.recorder.sendRich).toHaveLength(0)
+    h.cleanup()
+  })
+
+  test('group chat (negative id) → rich skipped (M1 DM-only), HTML used', async () => {
+    const h = makeHarness({})
+    const result = await callTool(replyReq({ chat_id: GROUP, text: '# heading' }), h.deps)
+    expect(result.isError).toBeUndefined()
+    expect(h.recorder.sendRich).toHaveLength(0)
+    expect(h.recorder.sendMessage.length).toBeGreaterThanOrEqual(1)
+    h.cleanup()
+  })
+
+  test('reply_to threads the rich message via reply_to_message_id', async () => {
+    const h = makeHarness({ richBehaviour: async () => ({ message_id: 11 }) })
+    await callTool(replyReq({ chat_id: PRINCE_DM, text: 'hi', reply_to: '321' }), h.deps)
+    expect(h.recorder.sendRich).toHaveLength(1)
+    expect(h.recorder.sendRich[0]?.opts.reply_to_message_id).toBe(321)
+    h.cleanup()
+  })
+
+  test('redaction end-to-end: secret in reply text never reaches raw rich call', async () => {
+    const h = makeHarness({ richBehaviour: async () => ({ message_id: 1 }) })
+    await callTool(
+      replyReq({ chat_id: PRINCE_DM, text: 'my key sk-abcdefghijklmnopqrstuvwxyz0123456789 ok' }),
+      h.deps,
+    )
+    expect(h.recorder.sendRich).toHaveLength(1)
+    expect(h.recorder.sendRich[0]?.rawMarkdown).not.toContain('sk-abcdefghijklmnopqrstuvwxyz')
+    expect(h.recorder.sendRich[0]?.rawMarkdown).toContain('[REDACTED]')
+    h.cleanup()
+  })
+})

--- a/plugin/tests/safety/safe-telegram-api.test.ts
+++ b/plugin/tests/safety/safe-telegram-api.test.ts
@@ -30,6 +30,9 @@ function makeStubApi(): { api: TelegramApi; calls: SentCall[] } {
       calls.push({ method: 'sendMessage', chatId, text, opts })
       return { message_id: 42 }
     },
+    async sendRichMessage(_chatId, _rawMarkdown, _opts) {
+      return { message_id: 99 }
+    },
     async editMessageText(chatId, messageId, text, opts) {
       calls.push({ method: 'editMessageText', chatId, messageId, text, opts })
     },

--- a/plugin/tests/security/paths.test.ts
+++ b/plugin/tests/security/paths.test.ts
@@ -75,6 +75,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     permission_gate: { enabled: false, timeout_ms: 120_000 },
+    richMessages: { enabled: false, perChatOptOut: [] },
     ...overrides,
   }
 }

--- a/plugin/tests/status/progress-reporter.test.ts
+++ b/plugin/tests/status/progress-reporter.test.ts
@@ -87,6 +87,7 @@ function makeConfig(overrides: Partial<AppConfig['progress']> = {}): AppConfig {
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     permission_gate: { enabled: false, timeout_ms: 120_000 },
+    richMessages: { enabled: false, perChatOptOut: [] },
   }
 }
 

--- a/plugin/tests/status/status-manager.multichat.test.ts
+++ b/plugin/tests/status/status-manager.multichat.test.ts
@@ -115,6 +115,7 @@ function makeConfig(): AppConfig {
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     permission_gate: { enabled: false, timeout_ms: 120_000 },
+    richMessages: { enabled: false, perChatOptOut: [] },
   }
 }
 

--- a/plugin/tests/status/status-manager.test.ts
+++ b/plugin/tests/status/status-manager.test.ts
@@ -64,6 +64,7 @@ function makeConfig(overrides: Partial<AppConfig['status']> = {}): AppConfig {
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     permission_gate: { enabled: false, timeout_ms: 120_000 },
+    richMessages: { enabled: false, perChatOptOut: [] },
   }
 }
 

--- a/plugin/tests/status/task-mirror.test.ts
+++ b/plugin/tests/status/task-mirror.test.ts
@@ -75,6 +75,7 @@ function makeConfig(overrides: Partial<AppConfig['task_mirror']> = {}): AppConfi
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     permission_gate: { enabled: false, timeout_ms: 120_000 },
+    richMessages: { enabled: false, perChatOptOut: [] },
   }
 }
 

--- a/plugin/tests/status/tmux-mirror.errors.test.ts
+++ b/plugin/tests/status/tmux-mirror.errors.test.ts
@@ -75,6 +75,9 @@ function makeStubApi(): {
       const id = nextMessageId++
       return { message_id: id }
     },
+    async sendRichMessage(_chatId, _rawMarkdown, _opts) {
+      return { fallback: true as const }
+    },
     async editMessageText(chatId, messageId, text, _opts: EditOpts) {
       ops.push({ method: 'editMessageText', chatId, messageId, text })
       if (editErrorQueue.length > 0) {

--- a/plugin/tests/status/tmux-mirror.test.ts
+++ b/plugin/tests/status/tmux-mirror.test.ts
@@ -49,6 +49,9 @@ function makeStubApi(initialMessageId = 100): {
       const id = nextMessageId++
       return { message_id: id }
     },
+    async sendRichMessage(_chatId, _rawMarkdown, _opts) {
+      return { fallback: true as const }
+    },
     async editMessageText(chatId, messageId, text, _opts: EditOpts) {
       if (editErrorQueue.length > 0) {
         const err = editErrorQueue.shift()

--- a/plugin/tests/telegram/ask-user-question.test.ts
+++ b/plugin/tests/telegram/ask-user-question.test.ts
@@ -71,6 +71,9 @@ function fakeTelegram(state: FakeTelegramSends, opts?: { editThrows?: boolean })
       state.nextMessageId += 1
       return { message_id: id }
     },
+    async sendRichMessage(_chatId, _rawMarkdown, _opts) {
+      return { fallback: true as const }
+    },
     async editMessageText(chatId, messageId, text, editOpts) {
       state.editCalls.push({ chatId, messageId, text, opts: editOpts })
       if (opts?.editThrows) throw new Error('edit refused for test')
@@ -928,6 +931,7 @@ function scriptedTelegram(state: FakeTelegramSends, sendErrors: Array<Error | nu
       const err = editErrors.shift() ?? null
       if (err) throw err
     },
+    async sendRichMessage(_c, _r, _o) { return { fallback: true as const } },
     async setMessageReaction(_c, _m, _e) { /* no-op */ },
     async sendChatAction(_c, _a) { /* no-op */ },
     async sendDocument(_c, _f, _o) { return { message_id: 0 } },

--- a/plugin/tests/telegram/gate.test.ts
+++ b/plugin/tests/telegram/gate.test.ts
@@ -51,6 +51,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     permission_gate: { enabled: false, timeout_ms: 120_000 },
+    richMessages: { enabled: false, perChatOptOut: [] },
     ...overrides,
   }
 }

--- a/plugin/tests/telegram/handlers.addressing.test.ts
+++ b/plugin/tests/telegram/handlers.addressing.test.ts
@@ -176,6 +176,7 @@ function makeTelegramApi(): {
   }
   const api: TelegramApi = {
     sendMessage: (async () => ({ message_id: 1 })) as unknown as TelegramApi['sendMessage'],
+    sendRichMessage: noop as unknown as TelegramApi['sendRichMessage'],
     editMessageText: noop as unknown as TelegramApi['editMessageText'],
     setMessageReaction: async (chatId, messageId, emoji) => {
       reactions.push({ chatId, messageId, emoji })

--- a/plugin/tests/telegram/handlers.album.test.ts
+++ b/plugin/tests/telegram/handlers.album.test.ts
@@ -159,6 +159,7 @@ function makeTelegramApi(): TelegramApi {
   }
   return {
     sendMessage: noop as unknown as TelegramApi['sendMessage'],
+    sendRichMessage: noop as unknown as TelegramApi['sendRichMessage'],
     editMessageText: noop as unknown as TelegramApi['editMessageText'],
     setMessageReaction: async () => undefined,
     sendChatAction: async () => undefined,

--- a/plugin/tests/telegram/handlers.test.ts
+++ b/plugin/tests/telegram/handlers.test.ts
@@ -79,6 +79,7 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     permission_gate: { enabled: false, timeout_ms: 120_000 },
+    richMessages: { enabled: false, perChatOptOut: [] },
     ...overrides,
   }
 }
@@ -160,6 +161,7 @@ function makeTelegramApi(): {
   }
   const api: TelegramApi = {
     sendMessage: noop as unknown as TelegramApi['sendMessage'],
+    sendRichMessage: noop as unknown as TelegramApi['sendRichMessage'],
     editMessageText: noop as unknown as TelegramApi['editMessageText'],
     setMessageReaction: async (chatId, messageId, emoji): Promise<void> => {
       reactions.push({ chatId, messageId, emoji })

--- a/plugin/tests/telegram/handlers.voice-multichat.test.ts
+++ b/plugin/tests/telegram/handlers.voice-multichat.test.ts
@@ -139,6 +139,7 @@ function makeTelegramApi(): TelegramApi {
   }
   return {
     sendMessage: (async () => ({ message_id: 1 })) as unknown as TelegramApi['sendMessage'],
+    sendRichMessage: noop as unknown as TelegramApi['sendRichMessage'],
     editMessageText: noop as unknown as TelegramApi['editMessageText'],
     setMessageReaction: async () => undefined,
     sendChatAction: async () => undefined,

--- a/plugin/tests/telegram/watcher.test.ts
+++ b/plugin/tests/telegram/watcher.test.ts
@@ -58,6 +58,7 @@ function makeConfig(overrides: Partial<AppConfig['watcher']> = {}): AppConfig {
     multichat: { enabled: false },
     ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
     permission_gate: { enabled: false, timeout_ms: 120_000 },
+    richMessages: { enabled: false, perChatOptOut: [] },
   }
 }
 
@@ -93,6 +94,7 @@ function makeFakeApi(): FakeApi {
       state.calls.push(entry)
       return { message_id: 999 }
     },
+    sendRichMessage: noop as unknown as TelegramApi['sendRichMessage'],
     editMessageText: noop as unknown as TelegramApi['editMessageText'],
     setMessageReaction: noop as unknown as TelegramApi['setMessageReaction'],
     sendChatAction: noop as unknown as TelegramApi['sendChatAction'],


### PR DESCRIPTION
## Что (M1)
Финальные ответы в ЛИЧКЕ уходят сырым markdown через **sendRichMessage** (Bot API 10.1) — Telegram нативно рендерит таблицы/формулы/чек-листы/`<details>`/сноски, до 32768 байт. Прозрачный откат на текущий HTML-путь при недоступности/ошибке. **Без потерь и без дублей.**

Стриминг-драфты (M3) и группы (M4) — отдельными фазами.

## Архитектура (план Opus + сверка с референсом Hermes)
- **rich-методы на уровне `TelegramApi`** (НЕ в reply-туле) → проходят редакцию секретов + rate-limit. Это ключевой инвариант: иначе сырой markdown ушёл бы мимо редакции.
- grammY 1.21 без типизации 10.1 → вызов через `bot.api.raw.sendRichMessage`. message_id парсится защитно.
- **Редакция секретов** на сыром markdown ДО raw-вызова; HTML-валидацию на rich-пути НЕ применяем (поломала бы markdown) — её роль берёт парсер Telegram + откат.
- Wire-формат `{ chat_id, rich_message: { markdown }, reply_parameters? }` — сверен с Hermes `_rich_message_payload`.
- **Откат:** capability(404/unsupported)→латч+HTML; parser/oversize→HTML; transient→прокидывается (НЕ ре-сенд → нет дублей).
- reply rich-гейт: личка (chat_id>0) + enabled + не-латч + не-opt-out + без файлов + ≤32KB.
- Конфиг `richMessages {enabled(def true), perChatOptOut}` + env-killswitch.

## Проверка
- `bun run typecheck` — чисто.
- `bun test` — 1709 pass; 2 fail = pre-existing PyYAML-env (hooks-sentinel.test, не связано). 47 новых тестов: редакция, fallback по каждому классу ошибок, no-dup на transient, 32KB, text/markdownv2 не-rich, opt-out, группы(skip), files(skip).

## Файлы
NEW: `src/format/rich.ts`, `src/safety/rich-latch.ts` + 2 теста. MODIFIED: `channel/tools.ts`, `safety/{safe,rate-limited}-telegram-api.ts`, `schemas.ts`, `config.ts`, `server.ts` + test-стабы.

🤖 Generated with [Claude Code](https://claude.com/claude-code)