### PR TITLE
fix: preserve text_link URLs on inbound + stop double-escaping HTML entities

### DIFF
--- a/plugin/src/format/html.ts
+++ b/plugin/src/format/html.ts
@@ -331,8 +331,13 @@ export function markdownToTelegramHtml(text: string): string {
   work = stashSafeTags(work, tagStore)
 
   // 5. Escape remaining raw text.
+  //   Bare `&` is escaped, but NOT one that already begins a valid HTML
+  //   entity (named/decimal/hex) — else agent-emitted `&lt;` / `&amp;` gets
+  //   double-escaped to `&amp;lt;` and the warchief sees a literal `&lt;`
+  //   in chat (2026-06-13). escapeHtml() keeps its unconditional behaviour:
+  //   it wraps raw user content where a literal `&lt;` is the right output.
   work = work
-    .replace(/&/g, '&amp;')
+    .replace(/&(?!(?:[a-zA-Z][a-zA-Z0-9]*|#\d+|#x[0-9a-fA-F]+);)/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
 

--- a/plugin/src/telegram/entities.ts
+++ b/plugin/src/telegram/entities.ts
@@ -1,0 +1,51 @@
+// Reconstruct Markdown links from Telegram message entities so the agent
+// receives the URL behind a hyperlink, not just its visible label.
+//
+// Telegram delivers hyperlinks out-of-band: `entities` (for a text message)
+// and `caption_entities` (for media captions). A `text_link` entity carries
+// the target in `.url` and covers the substring [offset, offset+length)
+// measured in UTF-16 code units — which match JS string indexing. The raw
+// `text`/`caption` field holds only the visible label, so without this a
+// forwarded `[читать](https://…)` reaches Claude as bare `читать` and the
+// link is lost.
+
+export interface MessageEntityLike {
+  type: string
+  offset: number
+  length: number
+  url?: string
+}
+
+export interface EntityCarrier {
+  text?: string
+  caption?: string
+  entities?: readonly MessageEntityLike[]
+  caption_entities?: readonly MessageEntityLike[]
+}
+
+/**
+ * Return the message's text (or caption) with `text_link` hyperlinks
+ * re-expanded to Markdown `[label](url)`. Non-link entities and messages
+ * without link entities are returned unchanged. Safe on `undefined`.
+ */
+export function textWithEntities(msg: EntityCarrier | undefined): string {
+  if (!msg) return ''
+  const base = msg.text ?? msg.caption ?? ''
+  const entities = msg.text !== undefined ? msg.entities : msg.caption_entities
+  if (!base || !entities || entities.length === 0) return base
+
+  const links = entities
+    .filter(
+      (e): e is MessageEntityLike & { url: string } =>
+        e.type === 'text_link' && typeof e.url === 'string' && e.url.length > 0,
+    )
+    // Splice right-to-left so earlier offsets stay valid as we mutate.
+    .sort((a, b) => b.offset - a.offset)
+
+  let out = base
+  for (const e of links) {
+    const label = out.slice(e.offset, e.offset + e.length)
+    out = out.slice(0, e.offset) + `[${label}](${e.url})` + out.slice(e.offset + e.length)
+  }
+  return out
+}

--- a/plugin/src/telegram/handlers.ts
+++ b/plugin/src/telegram/handlers.ts
@@ -27,6 +27,7 @@ import type { InboundMessage } from '../router/inbox-bridge.js'
 import { sendChannelNotification, type ChannelEvent } from '../channel/notify.js'
 import { gateTelegramMessage, type GateInput } from './gate.js'
 import { isAddressedToBot } from './addressing.js'
+import { textWithEntities } from './entities.js'
 import {
   buildChannelContent,
   type BotIdentity,
@@ -667,7 +668,7 @@ async function tryRouteToAlbumBuffer(
 
   const descriptors = await buildDescriptors()
   const rendered = descriptors.map(renderMediaDescriptor)
-  const caption = (ctx.message?.caption ?? '').trim()
+  const caption = textWithEntities(ctx.message).trim()
   const reply = ctx.message?.reply_to_message
     ? adaptReply(ctx.message.reply_to_message)
     : undefined
@@ -1145,7 +1146,7 @@ export async function handleInboundText(ctx: Context, deps: HandlerDeps): Promis
   maybeTriggerWatcher(ctx, deps)
   maybeBumpMirror(ctx, deps)
 
-  await gateAndNotify(ctx, deps, () => text, undefined, 'text')
+  await gateAndNotify(ctx, deps, () => textWithEntities(ctx.message), undefined, 'text')
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -1183,7 +1184,7 @@ export async function handleInboundPhoto(ctx: Context, deps: HandlerDeps): Promi
     return [md]
   }
   if (await tryRouteToAlbumBuffer(ctx, deps, buildPhoto, 'photo')) return
-  await gateAndNotify(ctx, deps, () => ctx.message?.caption ?? '', buildPhoto, 'photo')
+  await gateAndNotify(ctx, deps, () => textWithEntities(ctx.message), buildPhoto, 'photo')
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -1207,7 +1208,7 @@ export async function handleInboundDocument(ctx: Context, deps: HandlerDeps): Pr
     return [md]
   }
   if (await tryRouteToAlbumBuffer(ctx, deps, buildDoc, 'document')) return
-  await gateAndNotify(ctx, deps, () => ctx.message?.caption ?? '', buildDoc, 'document')
+  await gateAndNotify(ctx, deps, () => textWithEntities(ctx.message), buildDoc, 'document')
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -1221,7 +1222,7 @@ export async function handleInboundVoice(ctx: Context, deps: HandlerDeps): Promi
   await gateAndNotify(
     ctx,
     deps,
-    () => ctx.message?.caption ?? '',
+    () => textWithEntities(ctx.message),
     async () => {
       const voice = ctx.message?.voice
       if (!voice) return []
@@ -1286,7 +1287,7 @@ export async function handleInboundAudio(ctx: Context, deps: HandlerDeps): Promi
     return [md]
   }
   if (await tryRouteToAlbumBuffer(ctx, deps, buildAudio, 'audio')) return
-  await gateAndNotify(ctx, deps, () => ctx.message?.caption ?? '', buildAudio, 'audio')
+  await gateAndNotify(ctx, deps, () => textWithEntities(ctx.message), buildAudio, 'audio')
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -1312,7 +1313,7 @@ export async function handleInboundVideo(ctx: Context, deps: HandlerDeps): Promi
     return [md]
   }
   if (await tryRouteToAlbumBuffer(ctx, deps, buildVideo, 'video')) return
-  await gateAndNotify(ctx, deps, () => ctx.message?.caption ?? '', buildVideo, 'video')
+  await gateAndNotify(ctx, deps, () => textWithEntities(ctx.message), buildVideo, 'video')
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/plugin/tests/format/html.test.ts
+++ b/plugin/tests/format/html.test.ts
@@ -185,3 +185,16 @@ describe('isTelegramHtmlParseError', () => {
     expect(isTelegramHtmlParseError(42)).toBe(false)
   })
 })
+
+describe('markdownToTelegramHtml — entity double-escape (2026-06-13)', () => {
+  test('preserves already-valid HTML entities instead of double-escaping', () => {
+    expect(markdownToTelegramHtml('4 &lt; 5 и a &gt; b')).toBe('4 &lt; 5 и a &gt; b')
+    expect(markdownToTelegramHtml('Tom &amp; Jerry')).toBe('Tom &amp; Jerry')
+    expect(markdownToTelegramHtml('&#39;quote&#39;')).toBe('&#39;quote&#39;')
+  })
+
+  test('still escapes a bare ampersand and bare angle brackets', () => {
+    expect(markdownToTelegramHtml('R&D and AT&T')).toBe('R&amp;D and AT&amp;T')
+    expect(markdownToTelegramHtml('a < b и c > d')).toBe('a &lt; b и c &gt; d')
+  })
+})

--- a/plugin/tests/telegram/entities.test.ts
+++ b/plugin/tests/telegram/entities.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test'
+
+import { textWithEntities } from '../../src/telegram/entities.js'
+
+describe('textWithEntities', () => {
+  test('returns empty string for undefined message', () => {
+    expect(textWithEntities(undefined)).toBe('')
+  })
+
+  test('returns text unchanged when there are no entities', () => {
+    expect(textWithEntities({ text: 'hello world' })).toBe('hello world')
+  })
+
+  test('expands a single text_link into a Markdown link', () => {
+    const msg = {
+      text: 'see here',
+      entities: [{ type: 'text_link', offset: 4, length: 4, url: 'https://example.com/x' }],
+    }
+    expect(textWithEntities(msg)).toBe('see [here](https://example.com/x)')
+  })
+
+  test('ignores non-link entities (bold etc.)', () => {
+    const msg = {
+      text: 'bold text',
+      entities: [{ type: 'bold', offset: 0, length: 4 }],
+    }
+    expect(textWithEntities(msg)).toBe('bold text')
+  })
+
+  test('expands multiple text_links with correct offsets', () => {
+    const msg = {
+      text: 'a B c D',
+      entities: [
+        { type: 'text_link', offset: 2, length: 1, url: 'https://one' },
+        { type: 'text_link', offset: 6, length: 1, url: 'https://two' },
+      ],
+    }
+    expect(textWithEntities(msg)).toBe('a [B](https://one) c [D](https://two)')
+  })
+
+  test('uses caption + caption_entities for media messages', () => {
+    const msg = {
+      caption: 'photo link',
+      caption_entities: [{ type: 'text_link', offset: 6, length: 4, url: 'https://img' }],
+    }
+    expect(textWithEntities(msg)).toBe('photo [link](https://img)')
+  })
+})


### PR DESCRIPTION
Two independent, self-contained fixes for Telegram ⇄ agent message fidelity. Both were reproduced on a live deployment before fixing.

## 1. Inbound hyperlinks lose their URL (`text_link` / `caption_entities`)

`telegram/handlers.ts` builds the text forwarded to the agent from `message.text` / `message.caption` only — it never reads `entities` / `caption_entities`. Telegram delivers a hyperlink's target out-of-band in a `text_link` entity's `.url`, so a forwarded post whose visible text *is* a link reached the agent as bare label text and the URL was silently dropped.

New `src/telegram/entities.ts` exports `textWithEntities()`, which re-expands `text_link` entities to Markdown `[label](url)` (UTF-16 offsets, spliced right-to-left so earlier offsets stay valid). It is wired into every inbound closure in `handlers.ts` (text + photo/document/voice/audio/video captions + buffered-album caption). The raw `text` used for command / permission-reply / AskUserQuestion parsing is intentionally left untouched, so those still match verbatim.

## 2. Already-valid HTML entities get double-escaped (`markdownToTelegramHtml`)

The escape pass ran `.replace(/&/g, '&amp;')` unconditionally, so an agent-emitted `&lt;` / `&amp;` became `&amp;lt;` / `&amp;amp;` and the user saw a literal `&lt;` in chat. Fixed with a negative lookahead that skips an `&` already beginning a valid named/decimal/hex entity:

```
.replace(/&(?!(?:[a-zA-Z][a-zA-Z0-9]*|#\d+|#x[0-9a-fA-F]+);)/g, '&amp;')
```

A bare `&` (e.g. `R&D`, `AT&T`) is still escaped. `escapeHtml()` keeps its unconditional behaviour — it wraps raw user content where a literal `&lt;` is the right output — so its existing contract/tests are unchanged.

## Tests

- `tests/telegram/entities.test.ts` — 6 cases (single / multiple `text_link`, non-link entities ignored, caption path, undefined input).
- `tests/format/html.test.ts` — entity-preservation + bare-escape cases.
- Full suite green on this base: `bun test` → 1672 pass / 0 fail; `tsc --noEmit` clean.

Both fixes additionally verified end-to-end on a live bot (forwarded post with hidden URLs revealed; agent-emitted entities render as symbols, not literals).