### PR TITLE
Прогресс-карточка: вернул многословный формат как было до плагина

### DIFF
--- a/plugin/src/status/activity-renderer.ts
+++ b/plugin/src/status/activity-renderer.ts
@@ -165,7 +165,13 @@ export function humanizeTool(toolName: string, toolInput: ToolInput): string | n
     case 'Agent': {
       const sub = strField(toolInput, 'subagent_type') || '?'
       const label = SUBAGENT_LABELS[sub] ?? `running ${sub}`
-      return `<b>${escapeHtml(label)}</b>`
+      const labelHtml = `<b>${escapeHtml(label)}</b>`
+      // gateway.py:_render_dispatches — a running subagent showed its task
+      // description ("> exploring structure -- Find UIS client …") so the
+      // operator sees WHAT the agent was dispatched to do, not just its
+      // label. Restored 2026-06-14 (operator-preferred verbose card).
+      const desc = strField(toolInput, 'description').slice(0, 60)
+      return desc ? `${labelHtml} -- ${escapeHtml(desc)}` : labelHtml
     }
     case 'Bash': {
       const cmd = strField(toolInput, 'command').trim()
@@ -276,9 +282,11 @@ export function renderActivityBlock(
     const total = snapshot.calls.length
     const window = Math.min(ACTIVITY_WINDOW, total)
     const recent = snapshot.calls.slice(total - window)
-    if (total > recent.length) {
-      lines.push(escapeHtml(`▸ ... +${total - recent.length} earlier`))
-    }
+    // gateway.py:_render_activity — header carries the running total ("steps
+    // (N total):"); the last `window` calls follow. The total count is what
+    // replaces the older "+N earlier" collapse line. Restored 2026-06-14
+    // (operator-preferred verbose card).
+    lines.push(escapeHtml(`steps (${total} total):`))
     for (const call of recent) {
       if (call.humanized) {
         // Humanized string is already HTML-safe: inner identifiers were

--- a/plugin/src/status/progress-reporter.ts
+++ b/plugin/src/status/progress-reporter.ts
@@ -93,16 +93,16 @@ interface ChatProgressEntry {
 // inline tags (<b>, <code>, <pre>) are rendered.
 const HTML_OPTS = { parse_mode: 'HTML' as const }
 
-// Tools that should never appear in the rolling activity card. Reads, greps,
-// globs, and deferred-tool lookups are bookkeeping; the dashi-channel MCP
-// reply tools are the channel itself (mirroring them would recurse), and
-// gbrain-recall is background context fetching the warchief does not need to
-// see. Bash/Edit/Write/WebFetch/WebSearch/Agent and gbrain mutations
-// (memory/swarm/tasks) keep flowing through.
+// Tools that should never appear in the rolling activity card. Deferred-tool
+// lookups (ToolSearch) are pure bookkeeping; the dashi-channel MCP reply tools
+// are the channel itself (mirroring them would recurse), and gbrain-recall is
+// background context fetching the operator does not need to see.
+//
+// NB: Read/Grep/Glob are intentionally NOT skipped — the operator's preferred
+// verbose card (gateway era) listed reads and globs alongside Bash/Edit. They
+// were un-filtered 2026-06-14 to restore that density. Bash/Edit/Write/
+// WebFetch/WebSearch/Agent and gbrain mutations always flow through.
 const NOISY_TOOL_NAMES: ReadonlySet<string> = new Set([
-  'Read',
-  'Grep',
-  'Glob',
   'ToolSearch',
 ])
 const NOISY_TOOL_PREFIXES: ReadonlyArray<string> = [

--- a/plugin/tests/status/activity-renderer.test.ts
+++ b/plugin/tests/status/activity-renderer.test.ts
@@ -177,6 +177,21 @@ describe('humanizeTool', () => {
     expect(humanizeTool('Agent', { subagent_type: 'mystery' })).toBe('<b>running mystery</b>')
   })
 
+  test('Agent appends task description when present', () => {
+    expect(
+      humanizeTool('Agent', {
+        subagent_type: 'Explore',
+        description: 'Find UIS client and check call history',
+      }),
+    ).toBe('<b>exploring structure</b> -- Find UIS client and check call history')
+  })
+
+  test('Agent escapes HTML in description', () => {
+    expect(humanizeTool('Agent', { subagent_type: 'mystery', description: '<b>x</b>' })).toBe(
+      '<b>running mystery</b> -- &lt;b&gt;x&lt;/b&gt;',
+    )
+  })
+
   test('TodoWrite and unknown tools return null', () => {
     expect(humanizeTool('TodoWrite', { todos: [] })).toBeNull()
     expect(humanizeTool('Hypothetical', {})).toBeNull()
@@ -221,7 +236,7 @@ describe('renderActivityBlock', () => {
     expect(out).toContain('▸ bash bun test')
   })
 
-  test('rolling overflow shows +N earlier', () => {
+  test('rolling overflow shows steps (N total) header and last window', () => {
     const snap: ActivitySnapshot = {
       startedAtMs: baseStart,
       calls: [
@@ -238,8 +253,11 @@ describe('renderActivityBlock', () => {
     }
     const out = renderActivityBlock(snap, baseStart + 25_000)
     expect(out).toContain('working -- 25s')
-    expect(out).toContain('+3 earlier')
+    // Header carries the running total; the older "+N earlier" line is gone.
+    expect(out).toContain('steps (8 total):')
+    expect(out).not.toContain('earlier')
     expect(out).toContain('▸ bash eight')
+    // Only the last window (5) renders; older calls are implied by the total.
     expect(out).not.toContain('bash one')
   })
 

--- a/plugin/tests/status/status-manager.test.ts
+++ b/plugin/tests/status/status-manager.test.ts
@@ -612,8 +612,8 @@ describe('StatusManager.recordActivityByChatId', () => {
     expect(last.text).not.toMatch(/subagent-1[^0-9]/)
     expect(last.text).toContain('subagent-11')
     expect(last.text).toContain('subagent-10')
-    // Renderer window is 5 → "+N earlier" line appears (10 retained, 5 shown).
-    expect(last.text).toContain('earlier')
+    // Renderer header carries the buffered total (10 retained, 5 shown).
+    expect(last.text).toContain('steps (10 total):')
   })
 
   test('Visibility failure during lazy-open is swallowed', async () => {
@@ -698,8 +698,8 @@ describe('StatusManager.recordActivityByChatId', () => {
     await mgr.recordActivityByChatId('164795011', { kind: 'reasoning' })
     const last = api.calls.filter((c) => c.kind === 'edit').pop()!
     // Buffer kept the last 10 (cmd-02..cmd-11). Renderer window is 5 →
-    // show cmd-07..cmd-11 + a `+5 earlier` line (10 buffered − 5 shown).
-    expect(last.text).toContain('+5 earlier')
+    // show cmd-07..cmd-11 under a `steps (10 total):` header (no +N line).
+    expect(last.text).toContain('steps (10 total):')
     expect(last.text).toContain('cmd-11')
     expect(last.text).toContain('cmd-07')
     // cmd-00 and cmd-01 evicted; cmd-02..cmd-06 in the +5 collapse.


### PR DESCRIPTION
Регрессия с переезда gateway->plugin. Восстановил три вещи в карточке активности (общий renderActivityBlock для StatusManager и ProgressReporter):

- заголовок «steps (N total):» вместо строки «▸ ... +N earlier» (общий total теперь несёт число скрытых шагов)
- сабагент показывает описание задачи: «exploring structure -- Find UIS client …» (порт gateway.py:_render_dispatches)
- сняли noise-фильтр с Read/Grep/Glob — карточка снова плотная, как в старом формате; ToolSearch и dashi-channel/gbrain-recall остаются скрыты

Тесты обновлены под новый формат (status + activity-renderer), весь набор зелёный (1666), typecheck чист.