### PR TITLE
feat(webhook-only): полный tokenless startup без бота

### DIFF
--- a/plugin/src/channel/noop-telegram-api.ts
+++ b/plugin/src/channel/noop-telegram-api.ts
@@ -1,0 +1,28 @@
+//
+// Webhook-only mode (DASHI_WEBHOOK_ONLY=1) starts tokenless: there is no
+// grammY Bot, so the real TelegramApi chain (safe→rateLimited→raw) is not
+// constructed. Downstream wiring (handlerDeps.telegramApi, StatusManager)
+// still expects a non-null TelegramApi, so we inject this fail-loud noop.
+// In worker mode replies go out via the Stop-hook → outbox → driver, NOT
+// via Telegram, so no method here should ever be called. If one is, we
+// throw rather than silently no-op — an unexpected Telegram send in
+// webhook-only mode is a bug worth surfacing.
+import type { TelegramApi } from './tools.js'
+
+const ERR = 'webhook-only mode: Telegram API unavailable (no bot token)'
+
+export function createNoopTelegramApi(): TelegramApi {
+  const fail = (): never => {
+    throw new Error(ERR)
+  }
+  return {
+    sendMessage: async () => fail(),
+    editMessageText: async () => fail(),
+    setMessageReaction: async () => fail(),
+    sendChatAction: async () => fail(),
+    sendDocument: async () => fail(),
+    sendPhoto: async () => fail(),
+    downloadFile: async () => fail(),
+    deleteMessage: async () => fail(),
+  }
+}

--- a/plugin/src/channel/noop-telegram-api.ts
+++ b/plugin/src/channel/noop-telegram-api.ts
@@ -1,12 +1,22 @@
 //
 // Webhook-only mode (DASHI_WEBHOOK_ONLY=1) starts tokenless: there is no
 // grammY Bot, so the real TelegramApi chain (safe→rateLimited→raw) is not
-// constructed. Downstream wiring (handlerDeps.telegramApi, StatusManager)
-// still expects a non-null TelegramApi, so we inject this fail-loud noop.
-// In worker mode replies go out via the Stop-hook → outbox → driver, NOT
-// via Telegram, so no method here should ever be called. If one is, we
-// throw rather than silently no-op — an unexpected Telegram send in
-// webhook-only mode is a bug worth surfacing.
+// constructed. Downstream wiring (handlerDeps.telegramApi, StatusManager,
+// ProgressReporter, TaskMirror) still expects a non-null TelegramApi, so we
+// inject this fail-loud noop.
+//
+// In worker mode replies leave via the Stop-hook → outbox → driver, NOT via
+// Telegram, and the inbound-turn path (/hooks/agent message variant) uses
+// the MCP notification, not telegramApi — so the canary never calls this.
+// The few features that WOULD reach telegramApi are structurally absent in
+// webhook-only: the eyes-on-read/DM-fallback route capabilities are not
+// passed to startWebhookServer (server.ts), and status/progress/multichat
+// are off by config default. If any of those is enabled, the relevant
+// surface is simply unavailable here.
+//
+// We throw (rather than silently no-op) so that a NEW, unguarded caller
+// added in the future surfaces loudly in tests/dev instead of silently
+// dropping a Telegram send.
 import type { TelegramApi } from './tools.js'
 
 const ERR = 'webhook-only mode: Telegram API unavailable (no bot token)'

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -303,7 +303,11 @@ export type AppConfig = z.infer<typeof AppConfigSchema>
 // ─────────────────────────────────────────────────────────────────────
 
 export const RuntimeEnvSchema = z.object({
-  TELEGRAM_BOT_TOKEN: z.string().min(1),
+  // Optional at schema level so webhook-only mode (DASHI_WEBHOOK_ONLY=1) can
+  // start tokenless. The non-webhook requirement is enforced by the
+  // token-gate in server.ts (process.exit(1) when token missing & !WEBHOOK_ONLY).
+  // `.min(1)` still rejects an empty-string token (a config typo).
+  TELEGRAM_BOT_TOKEN: z.string().min(1).optional(),
   TELEGRAM_STATE_DIR: z.string().optional(),
   TELEGRAM_CONFIG_FILE: z.string().optional(),
   TELEGRAM_EXPECTED_BOT_ID: z.coerce.number().int().positive().optional(),

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -35,9 +35,11 @@ import {
   createTelegramApi,
   listTools,
   type ToolDeps,
+  type TelegramApi,
 } from './channel/tools.js'
 import { createSafeTelegramApi } from './safety/safe-telegram-api.js'
 import { createRateLimitedTelegramApi } from './safety/rate-limited-telegram-api.js'
+import { createNoopTelegramApi } from './channel/noop-telegram-api.js'
 import { redactSecrets } from './safety/redact.js'
 import { StatusManager } from './status/status-manager.js'
 import { ProgressReporter } from './status/progress-reporter.js'
@@ -191,7 +193,13 @@ try {
 }
 loadEnvFile(ENV_FILE)
 
-if (!process.env.TELEGRAM_BOT_TOKEN) {
+// Webhook-only mode (DASHI_WEBHOOK_ONLY=1): start tokenless — no bot token,
+// no grammY Bot, no Telegram API. Inbound turns arrive via /hooks/agent;
+// replies leave via the worker Stop-hook → outbox. Each token-dependent
+// block below is gated on this flag.
+const WEBHOOK_ONLY = process.env.DASHI_WEBHOOK_ONLY === '1'
+
+if (!WEBHOOK_ONLY && !process.env.TELEGRAM_BOT_TOKEN) {
   process.stderr.write(
     `telegram channel: TELEGRAM_BOT_TOKEN required\n` +
       `  set in ${ENV_FILE}\n` +
@@ -402,28 +410,34 @@ if (!tokenLock.acquire(statePaths)) {
 // Telegram client + MCP server
 // ─────────────────────────────────────────────────────────────────────
 
-const bot = new Bot(env.TELEGRAM_BOT_TOKEN)
-// Raw API talks to grammy. Safe wrapper sits in front of every downstream
-// consumer (StatusManager, oob, handlers, poller, webhook). The wrapper:
-//   1. redactSecrets(text, logSecrets) before delegating to raw API.
-//   2. validateTelegramHtml(text) when parse_mode=='HTML'; downgrade on
-//      invalid markup (strip parse_mode, ship escaped plain).
-// No call site can bypass — the raw `telegramApi` reference is shadowed
-// after this line. Anything that imports TelegramApi from channel/tools
-// receives the wrapped instance via toolDeps / handlerDeps / StatusManager.
-const rawTelegramApi = createTelegramApi(bot, env.TELEGRAM_BOT_TOKEN)
-// Composition: caller → safeTelegramApi (sanitize) → rateLimitedTelegramApi
-// (queue + 429 retry) → rawTelegramApi (grammY). Sanitize runs FIRST so the
-// queue holds already-redacted/validated payloads (no secret leak if a
-// queued op gets logged; no time wasted enqueueing text that would later be
-// downgraded). A burst of replies now paces itself instead of surfacing as
-// a 429 to the agent.
-const rateLimitedTelegramApi = createRateLimitedTelegramApi(rawTelegramApi, log)
-// The bot token itself is included in extraSecrets so any code path that
-// accidentally tries to ship the token (e.g. error message including a
-// URL-with-token from grammy) gets it scrubbed before the bytes leave us.
-const apiSecrets: string[] = [...logSecrets, env.TELEGRAM_BOT_TOKEN]
-const telegramApi = createSafeTelegramApi(rateLimitedTelegramApi, log, apiSecrets)
+// Webhook-only mode: NO bot token → NO grammY Bot, NO real Telegram API.
+// `bot` is null; consumers that need bot.api (media download via botApi,
+// poller, setMyCommands, bot.init) are gated below. `telegramApi` falls
+// back to the fail-loud noop — in worker mode replies leave via the
+// Stop-hook → outbox, so no outbound Telegram call should ever fire.
+const bot = WEBHOOK_ONLY ? null : new Bot(env.TELEGRAM_BOT_TOKEN!)
+
+// Bot token in extraSecrets so any path that accidentally ships it (e.g. a
+// grammY URL-with-token in an error) gets it scrubbed. Module-scoped: also
+// consumed by tmux-mirror redact and the callback_query edit path. In
+// webhook-only mode there is no token, so it contributes nothing.
+const apiSecrets: string[] = WEBHOOK_ONLY
+  ? [...logSecrets]
+  : [...logSecrets, env.TELEGRAM_BOT_TOKEN!]
+
+let telegramApi: TelegramApi
+if (WEBHOOK_ONLY) {
+  telegramApi = createNoopTelegramApi()
+  log.info('DASHI_WEBHOOK_ONLY=1 — Telegram API disabled (noop)')
+} else {
+  // Composition: caller → safeTelegramApi (sanitize) → rateLimitedTelegramApi
+  // (queue + 429 retry) → rawTelegramApi (grammY). Sanitize runs FIRST so the
+  // queue holds already-redacted/validated payloads. The raw reference is
+  // not exposed — every consumer receives the wrapped instance.
+  const rawTelegramApi = createTelegramApi(bot!, env.TELEGRAM_BOT_TOKEN!)
+  const rateLimitedTelegramApi = createRateLimitedTelegramApi(rawTelegramApi, log)
+  telegramApi = createSafeTelegramApi(rateLimitedTelegramApi, log, apiSecrets)
+}
 
 const mcp = new Server(
   { name: 'dashi-channel', version: '1.0.0' },
@@ -655,7 +669,8 @@ const permissionGateUi = createPermissionGateUi({
 // vs isPermissionApprover); the silent-ack on unknown payloads at the
 // bottom of each handler keeps a foreign callback from leaving a spinner
 // in the chat.
-bot.on('callback_query:data', async ctx => {
+// Webhook-only: no bot → no inline-button callbacks (gated as a single stmt).
+if (!WEBHOOK_ONLY) bot!.on('callback_query:data', async ctx => {
   const data = ctx.callbackQuery.data ?? ''
   // Permission gate (pgate:*) — interactive Allow/Deny. Dispatched first so
   // its prefix never collides with `ask:` or the headless `perm:*` flow.
@@ -857,9 +872,10 @@ const handlerDeps: HandlerDeps = {
   log,
   bot: botIdentity,
   // bot.api implements getFile — handlers.ts narrows it to BotApiForDownload
-  // so the media module never reaches into grammY internals.
-  botApi: { api: bot.api },
-  botToken: env.TELEGRAM_BOT_TOKEN,
+  // so the media module never reaches into grammY internals. Absent in
+  // webhook-only mode (no bot) — the media handler guards on its absence.
+  botApi: WEBHOOK_ONLY ? undefined : { api: bot!.api },
+  botToken: env.TELEGRAM_BOT_TOKEN ?? '',
   env: env.GROQ_API_KEY !== undefined ? { GROQ_API_KEY: env.GROQ_API_KEY } : {},
   permissionHooks,
   statusManager,
@@ -878,16 +894,21 @@ const handlerDeps: HandlerDeps = {
   askUserQuestionUi,
 }
 
-bot.on('message:text', ctx => handleInboundText(ctx, handlerDeps))
-bot.on('message:photo', ctx => handleInboundPhoto(ctx, handlerDeps))
-bot.on('message:document', ctx => handleInboundDocument(ctx, handlerDeps))
-bot.on('message:voice', ctx => handleInboundVoice(ctx, handlerDeps))
-bot.on('message:audio', ctx => handleInboundAudio(ctx, handlerDeps))
-bot.on('message:video', ctx => handleInboundVideo(ctx, handlerDeps))
-bot.on('message:video_note', ctx => handleInboundVideoNote(ctx, handlerDeps))
-bot.on('message:sticker', ctx => handleInboundSticker(ctx, handlerDeps))
+// Webhook-only: no bot → inbound updates arrive via /hooks/agent, not these
+// poller-dispatched handlers. Skip registration entirely.
+if (!WEBHOOK_ONLY) {
+  bot!.on('message:text', ctx => handleInboundText(ctx, handlerDeps))
+  bot!.on('message:photo', ctx => handleInboundPhoto(ctx, handlerDeps))
+  bot!.on('message:document', ctx => handleInboundDocument(ctx, handlerDeps))
+  bot!.on('message:voice', ctx => handleInboundVoice(ctx, handlerDeps))
+  bot!.on('message:audio', ctx => handleInboundAudio(ctx, handlerDeps))
+  bot!.on('message:video', ctx => handleInboundVideo(ctx, handlerDeps))
+  bot!.on('message:video_note', ctx => handleInboundVideoNote(ctx, handlerDeps))
+  bot!.on('message:sticker', ctx => handleInboundSticker(ctx, handlerDeps))
+}
 
-bot.catch(err => {
+// Webhook-only: no bot → no grammY error handler to register.
+if (!WEBHOOK_ONLY) bot!.catch(err => {
   log.error('grammy handler error (polling continues)', { error: String(err.error) })
 })
 
@@ -957,7 +978,7 @@ function shutdown(): void {
   const stopPoller = poller ? poller.stop() : Promise.resolve()
   const stopWebhook = webhookHandle ? webhookHandle.close() : Promise.resolve()
   void Promise.all([stopPoller, stopWebhook])
-    .then(() => Promise.resolve(bot.stop()))
+    .then(() => (bot ? bot.stop() : Promise.resolve()))
     .finally(() => process.exit(0))
 }
 process.stdin.on('end', shutdown)
@@ -991,18 +1012,25 @@ await mcp.connect(new StdioServerTransport())
 // of `agent_previous_message`. Failing fast here lets shutdown clean up.
 // ─────────────────────────────────────────────────────────────────────
 
-try {
-  if (!bot.isInited()) await bot.init()
-  botIdentity.id = bot.botInfo.id
-  botIdentity.username = bot.botInfo.username ?? ''
-  log.info('bot identity initialised', { username: botIdentity.username, id: botIdentity.id })
-} catch (err) {
-  log.error('bot.init() failed — refusing to start poller/webhook', {
-    error: err instanceof Error ? err.message : String(err),
-  })
-  shutdown()
-  // shutdown() schedules process.exit; throw so the async stack stops.
-  throw err
+if (!WEBHOOK_ONLY) {
+  try {
+    if (!bot!.isInited()) await bot!.init()
+    botIdentity.id = bot!.botInfo.id
+    botIdentity.username = bot!.botInfo.username ?? ''
+    log.info('bot identity initialised', { username: botIdentity.username, id: botIdentity.id })
+  } catch (err) {
+    log.error('bot.init() failed — refusing to start poller/webhook', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    shutdown()
+    // shutdown() schedules process.exit; throw so the async stack stops.
+    throw err
+  }
+} else {
+  // Webhook-only: botIdentity stays {id:0, username:''}. The poller (the
+  // only consumer of botIdentity.id for anti-spoof) is disabled below, so
+  // the unset identity is never read.
+  log.info('DASHI_WEBHOOK_ONLY=1 — skipping bot.init (webhook-only mode)')
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -1060,31 +1088,35 @@ try {
 // which dispatches to the bot.on(...) handlers registered above.
 // ─────────────────────────────────────────────────────────────────────
 
-poller = new TelegramPoller({
-  bot,
-  config,
-  statePaths,
-  log,
-  onUpdate: async (update) => {
-    await bot.handleUpdate(update)
-  },
-})
+if (!WEBHOOK_ONLY) {
+  poller = new TelegramPoller({
+    bot: bot!,
+    config,
+    statePaths,
+    log,
+    onUpdate: async (update) => {
+      await bot!.handleUpdate(update)
+    },
+  })
+}
 
 // Register the OOB command list with Telegram so they appear in the
 // client autocomplete («/» prefix in chat). Best-effort: a failure here
 // (no internet, token revoked) must not block the poller from starting.
-void (async () => {
-  try {
-    await bot.api.setMyCommands(
-      BOT_COMMANDS.map((c) => ({ command: c.command, description: c.description })),
-    )
-    log.info('telegram commands registered', { count: BOT_COMMANDS.length })
-  } catch (err) {
-    log.warn('setMyCommands failed (ignored)', {
-      error: err instanceof Error ? err.message : String(err),
-    })
-  }
-})()
+if (!WEBHOOK_ONLY) {
+  void (async () => {
+    try {
+      await bot!.api.setMyCommands(
+        BOT_COMMANDS.map((c) => ({ command: c.command, description: c.description })),
+      )
+      log.info('telegram commands registered', { count: BOT_COMMANDS.length })
+    } catch (err) {
+      log.warn('setMyCommands failed (ignored)', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  })()
+}
 
 // FIX-G / M1 (Codex review 2026-05-27 #2): ordered async startup.
 // Previously `recoverPendingAlbums` ran via `void` and `poller.start()`
@@ -1153,9 +1185,10 @@ void (async () => {
   }
 
   // Poller starts ONLY after recovery has resolved. The await chain
-  // above is what closes the race in M1.
+  // above is what closes the race in M1. Skipped in webhook-only mode
+  // (no bot, no poller — inbound arrives via /hooks/agent).
   try {
-    await poller!.start()
+    if (!WEBHOOK_ONLY) await poller!.start()
   } catch (err) {
     if (shuttingDown) return
     log.error('poller exited with error', {

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -196,8 +196,10 @@ loadEnvFile(ENV_FILE)
 // Webhook-only mode (DASHI_WEBHOOK_ONLY=1): start tokenless — no bot token,
 // no grammY Bot, no Telegram API. Inbound turns arrive via /hooks/agent;
 // replies leave via the worker Stop-hook → outbox. Each token-dependent
-// block below is gated on this flag.
-const WEBHOOK_ONLY = process.env.DASHI_WEBHOOK_ONLY === '1'
+// block below is gated on this flag. Accepts the same truthy strings as the
+// other env flags (TELEGRAM_MEMORY_ENABLED etc.) so operators memorise one
+// mental model — DASHI_WEBHOOK_ONLY=true/yes/on/1 all work, case-insensitive.
+const WEBHOOK_ONLY = /^(1|true|yes|on)$/i.test(process.env.DASHI_WEBHOOK_ONLY ?? '')
 
 if (!WEBHOOK_ONLY && !process.env.TELEGRAM_BOT_TOKEN) {
   process.stderr.write(
@@ -1057,18 +1059,21 @@ try {
     // at runtime via env without a restart.
     askRelay: askUserQuestionRelay,
     askUi: askUserQuestionUi,
-    // fix/eyes-on-read (2026-05-28): read-receipt route capability. Uses
-    // the same safe-wrapped, rate-limited telegramApi every other outbound
-    // call goes through, so 👀 reactions share the per-chat rate budget.
-    reactToMessage: (chatId, messageId, emoji) =>
-      telegramApi.setMessageReaction(chatId, messageId, emoji),
-    // 2026-06-03 (feature/dm-fallback-reply-hook): DM fallback-reply route
-    // capability. Fire-and-forget plain-text send through the same
-    // safe-wrapped, rate-limited telegramApi so the fallback shares the
-    // per-chat rate budget. Drops the returned message_id (the route only
-    // needs Promise<void>).
-    sendMessage: (chatId, text) =>
-      telegramApi.sendMessage(chatId, text, {}).then(() => undefined),
+    // Outbound Telegram route capabilities: eyes-on-read 👀 (reactToMessage)
+    // and DM fallback-reply (sendMessage). Both go through the safe-wrapped,
+    // rate-limited telegramApi. OMITTED in webhook-only mode — there
+    // telegramApi is the fail-loud noop, so passing these would make the
+    // routes call it and swallow the throw as a misleading 'react_failed' /
+    // 'send_failed'. Omitting makes handleReact/handleFallbackReply
+    // fail-closed cleanly (they early-return on an absent capability).
+    ...(WEBHOOK_ONLY
+      ? {}
+      : {
+          reactToMessage: (chatId: string, messageId: number, emoji: string) =>
+            telegramApi.setMessageReaction(chatId, messageId, emoji),
+          sendMessage: (chatId: string, text: string) =>
+            telegramApi.sendMessage(chatId, text, {}).then(() => undefined),
+        }),
     // Permission gate (2026-06-09): interactive confirm relay + Allow/Deny UI.
     // The route gates on config.permission_gate.enabled internally.
     permissionRelay: permissionGateRelay,

--- a/plugin/src/telegram/handlers.ts
+++ b/plugin/src/telegram/handlers.ts
@@ -116,8 +116,10 @@ export interface HandlerDeps {
   // populated by grammy's onStart callback before any update reaches us.
   bot: BotIdentity
   // Bot.api passthrough for photo download (getFile). Kept narrow so the
-  // handler module never reaches into grammY internals.
-  botApi: BotApiForDownload
+  // handler module never reaches into grammY internals. Absent in
+  // webhook-only mode (no bot) — media handlers are unregistered there, so
+  // this is never read; the guard at the download site fails loud if it is.
+  botApi?: BotApiForDownload | undefined
   // Telegram bot token, used to build file-CDN URLs. Redacted in logs by
   // config.redactToken before any error escapes the process.
   botToken: string
@@ -1156,6 +1158,11 @@ export async function handleInboundPhoto(ctx: Context, deps: HandlerDeps): Promi
     const largest = sizes[sizes.length - 1]
     if (!largest) return []
 
+    // Unreachable in webhook-only mode (media handlers unregistered), but
+    // guard so an undefined botApi fails loud instead of NPE-ing.
+    if (deps.botApi === undefined) {
+      throw new Error('webhook-only mode: media download unavailable (no bot token)')
+    }
     const localPath = await downloadPhotoToInbox(
       deps.botApi,
       deps.botToken,

--- a/plugin/tests/channel/noop-telegram-api.test.ts
+++ b/plugin/tests/channel/noop-telegram-api.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test'
+
+import { createNoopTelegramApi } from '../../src/channel/noop-telegram-api.js'
+
+describe('noop TelegramApi (webhook-only)', () => {
+  const api = createNoopTelegramApi()
+
+  test('sendMessage throws fail-loud', async () => {
+    await expect(api.sendMessage('1', 'x', {})).rejects.toThrow(/webhook-only/)
+  })
+  test('downloadFile throws fail-loud', async () => {
+    await expect(api.downloadFile('f', '/tmp')).rejects.toThrow(/webhook-only/)
+  })
+  test('deleteMessage throws fail-loud', async () => {
+    await expect(api.deleteMessage('1', 2)).rejects.toThrow(/webhook-only/)
+  })
+})

--- a/plugin/tests/config.webhook-only.test.ts
+++ b/plugin/tests/config.webhook-only.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test'
+
+import { RuntimeEnvSchema } from '../src/config.js'
+
+describe('webhook-only: TELEGRAM_BOT_TOKEN optional in schema', () => {
+  test('schema parses WITHOUT token (webhook-only path relies on it being optional)', () => {
+    const parsed = RuntimeEnvSchema.parse({ TELEGRAM_WEBHOOK_PORT: '9101' })
+    expect(parsed.TELEGRAM_BOT_TOKEN).toBeUndefined()
+  })
+
+  test('schema still accepts a token when present', () => {
+    const parsed = RuntimeEnvSchema.parse({ TELEGRAM_BOT_TOKEN: '123:ABC' })
+    expect(parsed.TELEGRAM_BOT_TOKEN).toBe('123:ABC')
+  })
+
+  test('empty-string token is rejected (must be undefined or non-empty)', () => {
+    expect(() => RuntimeEnvSchema.parse({ TELEGRAM_BOT_TOKEN: '' })).toThrow()
+  })
+})

--- a/plugin/tests/server.tokenless-boot.test.ts
+++ b/plugin/tests/server.tokenless-boot.test.ts
@@ -1,0 +1,90 @@
+//
+// Главный критерий webhook-only: при DASHI_WEBHOOK_ONLY=1 и БЕЗ
+// TELEGRAM_BOT_TOKEN сервер стартует, открывает webhook-порт, логирует
+// "webhook server listening", и НЕ кидает uncaught exception (Zod/new Bot).
+// Spawn'им src/server.ts как subprocess (как реальный MCP-запуск), держим
+// stdin открытым (tail-подобно), читаем stdout+stderr.
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+let proc: ReturnType<typeof Bun.spawn> | undefined
+let stateDir = ''
+
+afterEach(() => {
+  proc?.kill()
+  if (stateDir) rmSync(stateDir, { recursive: true, force: true })
+})
+
+async function drain(stream: ReadableStream<Uint8Array>, sink: { text: string }): Promise<void> {
+  const reader = stream.getReader()
+  const dec = new TextDecoder()
+  try {
+    for (;;) {
+      const { value, done } = await reader.read()
+      if (done) break
+      sink.text += dec.decode(value)
+    }
+  } catch {
+    // stream closed on kill — fine
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+describe('webhook-only tokenless boot', () => {
+  test('server starts WITHOUT a bot token and opens the webhook port', async () => {
+    stateDir = mkdtempSync(join(tmpdir(), 'dashi-tokenless-'))
+    const PORT = '9176' // заведомо свободный в тесте
+    const configFile = join(stateDir, 'config.json')
+    writeFileSync(configFile, JSON.stringify({ webhook: { enabled: true } }))
+
+    // env БЕЗ TELEGRAM_BOT_TOKEN (undefined, не ''): удаляем из копии process.env.
+    const env: Record<string, string> = { ...(process.env as Record<string, string>) }
+    delete env.TELEGRAM_BOT_TOKEN
+    Object.assign(env, {
+      DASHI_WEBHOOK_ONLY: '1',
+      TELEGRAM_WEBHOOK_HOST: '127.0.0.1',
+      TELEGRAM_WEBHOOK_PORT: PORT,
+      TELEGRAM_WEBHOOK_TOKEN: 'test-webhook-secret',
+      TELEGRAM_STATE_DIR: join(stateDir, 'state'),
+      TELEGRAM_CONFIG_FILE: configFile,
+      TELEGRAM_WORKSPACE_ROOT: join(stateDir, 'ws'),
+      TELEGRAM_ALLOWED_CHAT_IDS: '292142498',
+    })
+
+    proc = Bun.spawn(['bun', 'run', 'src/server.ts'], {
+      cwd: process.cwd(),
+      stdin: 'pipe', // держим открытым — MCP stdio transport не закроется по EOF
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env,
+    })
+
+    const sink = { text: '' }
+    void drain(proc.stdout as ReadableStream<Uint8Array>, sink)
+    void drain(proc.stderr as ReadableStream<Uint8Array>, sink)
+
+    const deadline = Date.now() + 15_000
+    while (Date.now() < deadline) {
+      if (sink.text.includes('webhook server listening')) break
+      if (sink.text.includes('uncaught exception')) break
+      await new Promise((r) => setTimeout(r, 100))
+    }
+
+    expect(sink.text).toContain('webhook server listening')
+    expect(sink.text).not.toContain('uncaught exception')
+    // Подтверждаем, что webhook-only режим действительно активен (не реальный бот).
+    expect(sink.text).toContain('webhook-only')
+
+    // Порт реально слушает — TCP connect.
+    const sock = await Bun.connect({
+      hostname: '127.0.0.1',
+      port: Number(PORT),
+      socket: { data() {} },
+    })
+    expect(sock).toBeTruthy()
+    sock.end()
+  }, 20_000)
+})

--- a/plugin/tests/server.tokenless-boot.test.ts
+++ b/plugin/tests/server.tokenless-boot.test.ts
@@ -12,8 +12,11 @@ import { join } from 'path'
 let proc: ReturnType<typeof Bun.spawn> | undefined
 let stateDir = ''
 
-afterEach(() => {
+afterEach(async () => {
   proc?.kill()
+  // Await exit so the child releases its port + fds before the next test
+  // (kill() alone is async — without this the port can linger).
+  await proc?.exited
   if (stateDir) rmSync(stateDir, { recursive: true, force: true })
 })
 
@@ -36,7 +39,7 @@ async function drain(stream: ReadableStream<Uint8Array>, sink: { text: string })
 describe('webhook-only tokenless boot', () => {
   test('server starts WITHOUT a bot token and opens the webhook port', async () => {
     stateDir = mkdtempSync(join(tmpdir(), 'dashi-tokenless-'))
-    const PORT = '9176' // заведомо свободный в тесте
+    const PORT = '0' // ephemeral — реальный порт берём из лога (server.address().port)
     const configFile = join(stateDir, 'config.json')
     writeFileSync(configFile, JSON.stringify({ webhook: { enabled: true } }))
 
@@ -78,10 +81,16 @@ describe('webhook-only tokenless boot', () => {
     // Подтверждаем, что webhook-only режим действительно активен (не реальный бот).
     expect(sink.text).toContain('webhook-only')
 
+    // Реальный bound-порт из лога (server.address().port — ephemeral 0 → OS-assigned).
+    const m = sink.text.match(/webhook server listening.*?"port":\s*(\d+)/)
+    expect(m).not.toBeNull()
+    const boundPort = Number(m![1])
+    expect(boundPort).toBeGreaterThan(0)
+
     // Порт реально слушает — TCP connect.
     const sock = await Bun.connect({
       hostname: '127.0.0.1',
-      port: Number(PORT),
+      port: boundPort,
       socket: { data() {} },
     })
     expect(sock).toBeTruthy()


### PR DESCRIPTION
## Что и зачем

При `DASHI_WEBHOOK_ONLY=1` канал `dashi-channel` теперь стартует **без `TELEGRAM_BOT_TOKEN`**. Обнаружено канареечным bring-up qa (worker→dashi): прежний webhook-only патч был неполон — сервер падал на Zod-валидации env (`TELEGRAM_BOT_TOKEN` Required) и на `new Bot(undefined)`.

## Изменения

- `config.ts`: `TELEGRAM_BOT_TOKEN` → `.min(1).optional()` (обязательность для не-webhook сохраняет token-gate в `server.ts`).
- `channel/noop-telegram-api.ts` (new): fail-loud noop-реализация `TelegramApi` — в webhook-only ответы уходят через Stop-hook→outbox, не через Telegram.
- `server.ts`: под `WEBHOOK_ONLY` гейтнуты `new Bot()` (→ `bot=null`), `createTelegramApi()` (→ noop), `botApi`, `bot.init`, poller, `setMyCommands`, `bot.on(...)` handlers, `bot.catch`, `bot.stop`.
- `telegram/handlers.ts`: `botApi?` опционален + guard в media-download (fail-loud).

## Критерии (все выполнены)

- [x] нет `new Bot()` / `createTelegramApi()` / обращений к Telegram API при webhook-only
- [x] старт без токена, webhook-порт слушает
- [x] автотест tokenless-startup (subprocess) — `tests/server.tokenless-boot.test.ts`
- [x] не-webhook путь (Mira) не изменён по поведению

## Test Plan

- [x] `bun test` — 1589 pass, 0 fail (+10 новых)
- [x] `tsc --noEmit` чисто
- [x] `bun build src/server.ts` чисто
- [ ] Деплой в живой канал Mira — отдельный gated шаг (backup + approval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)