### PR TITLE
fix(permission-gate): confirm risky commands only when invoked, not when merely mentioned

### DIFF
--- a/plugin/src/security/permission-policy.ts
+++ b/plugin/src/security/permission-policy.ts
@@ -1538,6 +1538,145 @@ function matchAllBashRules(rules: readonly string[], commandLower: string): stri
   return hits
 }
 
+// ── command-position awareness for the built-in confirm tier ─────────────
+//
+// BUILTIN_CONFIRM_BASH rules are command names (optionally + subcommand/flag):
+// `sudo `, `docker `, `kill `, `git push`, `rm -rf `, … . Plain substring /
+// token-start matching (bashMatch) fires whenever the WORD appears anywhere —
+// including as an ARGUMENT or a mention, not an invocation. Live FP 2026-06-16:
+// `for c in rsync docker psql pm2; do command -v "$c"; done` (an install check)
+// and `command -v docker` raised a confirm card because the bare word "docker"
+// appears in the for-list / as a `command -v` argument. This mirrors the
+// already-fixed systemctl (verb-aware) and git (segment-aware) mention FPs.
+//
+// We therefore confirm a built-in rule only when its command name is in COMMAND
+// POSITION — the head of a shell stage, after stripping leading shell keywords
+// (for/while/do/if/…), `VAR=val` assignments, and command wrappers (sudo/env/
+// nice/timeout/…). Wrappers that THEMSELVES run the next program (sudo, env,
+// exec, nice, nohup, timeout, …) are descended so `sudo docker ps` still
+// matches BOTH `sudo ` and `docker `. `command`/`builtin` are intentionally NOT
+// descended — `command -v docker` is a read-only lookup, not a docker run.
+//
+// Accepted residuals (consistent with systemctl/git matchers): a risky command
+// fed through `xargs` (`… | xargs docker rmi`) or via `command <cmd>` is not
+// carded — the catastrophic hard-deny (rm -rf /, mkfs, dd-to-disk) is a separate
+// matcher that still fires, and the threat model here is agent mistakes, not an
+// adversarial operator. Unparseable quoting falls back to substring matching
+// (fail-safe: never DROP a confirm because the structure was unclear).
+
+const CONFIRM_DESCEND_WRAPPERS = new Set<string>([
+  'sudo', 'doas', 'env', 'nice', 'nohup', 'exec', 'setsid', 'stdbuf', 'ionice',
+])
+const SHELL_LEAD_KEYWORDS = new Set<string>([
+  'for', 'while', 'until', 'if', 'then', 'else', 'elif', 'do', 'done', 'fi',
+  'case', 'esac', 'select', 'time', 'function', '{', '}', '!', '[[', ']]',
+])
+
+/** Append the command-head-onward strings (lowercased, one per wrapper level) of
+ *  one shell stage to `heads`. Skips leading keywords / `VAR=val`, descends
+ *  through wrappers (emitting a head string at each level so `sudo docker ps`
+ *  yields both `sudo docker ps` and `docker ps`). */
+function collectStageHeads(st: BashStage, heads: string[]): void {
+  const toks = tokenizeStage(st)
+  let k = 0
+  while (k < toks.length) {
+    const w = toks[k] as BashWord
+    if (ASSIGN_RE.test(w.masked)) { k += 1; continue }
+    if (SHELL_LEAD_KEYWORDS.has(dequoteWord(w.raw).toLowerCase())) { k += 1; continue }
+    break
+  }
+  for (let guard = 0; guard < 8 && k < toks.length; guard += 1) {
+    heads.push(toks.slice(k).map((t) => dequoteWord(t.raw)).join(' ').toLowerCase())
+    const name = dequoteWord((toks[k] as BashWord).raw).replace(/^.*\//, '').toLowerCase()
+    if (CONFIRM_DESCEND_WRAPPERS.has(name)) {
+      k += 1
+      while (k < toks.length && (/^-/.test((toks[k] as BashWord).masked) || ASSIGN_RE.test((toks[k] as BashWord).masked))) {
+        const takesValue = WRAPPER_VALUE_FLAG_RE.test((toks[k] as BashWord).masked)
+        k += 1
+        if (takesValue && k < toks.length) k += 1
+      }
+      continue
+    }
+    if (DURATION_WRAPPERS.has(name)) {
+      k += 1
+      while (k < toks.length && /^-/.test((toks[k] as BashWord).masked)) {
+        const takesValue = WRAPPER_VALUE_FLAG_RE.test((toks[k] as BashWord).masked)
+        k += 1
+        if (takesValue && k < toks.length) k += 1
+      }
+      if (k < toks.length && /^[0-9.]+[smhd]?$/i.test(dequoteWord((toks[k] as BashWord).raw))) k += 1
+      continue
+    }
+    break
+  }
+}
+
+/** Lowercased command-head-onward strings across every stage of `rawCommand`,
+ *  or null when the structure could HIDE a command head from this top-level scan
+ *  (caller then falls back to substring matching — fail-safe to confirm, never a
+ *  miss). We bail on:
+ *   - unbalanced quoting (mask returns null);
+ *   - command substitutions / subshells — `$(docker …)`, `` `docker …` ``,
+ *     `(cd x && docker build)`: splitPipelines treats these as opaque, so a real
+ *     invocation inside them would not appear as a head. A bare `(`/backtick in
+ *     the MASKED command (quoted text already blanked) signals such a construct. */
+function bashInvocationHeads(rawCommand: string): string[] | null {
+  const masked = maskQuotedLiterals(maskHeredocBodies(rawCommand))
+  if (masked === null) return null
+  if (masked.includes('(') || masked.includes('`')) return null
+  const heads: string[] = []
+  for (const stages of splitPipelines(rawCommand, masked)) {
+    for (const st of stages) collectStageHeads(st, heads)
+  }
+  return heads
+}
+
+/** Built-in confirm hits that are actually INVOKED (command-position), not mere
+ *  mentions. Falls back to substring matching on unparseable quoting so a
+ *  confirm is never silently dropped. */
+function matchAllBashConfirmRules(rawCommand: string, commandLower: string): string[] {
+  const heads = bashInvocationHeads(rawCommand)
+  if (heads === null) return matchAllBashRules(BUILTIN_CONFIRM_BASH, commandLower)
+  const hits: string[] = []
+  for (const rule of BUILTIN_CONFIRM_BASH) {
+    const pat = rule.toLowerCase()
+    if (heads.some((h) => h.startsWith(pat))) hits.push(rule)
+  }
+  return hits
+}
+
+/** Operator bash_patterns, command-position aware for command-NAME patterns
+ *  (`psql`, `rsync`, `pm2 restart`) while keeping plain substring for path /
+ *  script patterns (`deploy.sh`, `infra/deploy`) and glob patterns. Same FP class
+ *  as the built-in fix: a mere MENTION of `psql`/`rsync` in a `command -v`
+ *  argument or a for-list must not raise a card (live FP 2026-06-16). Used for
+ *  the operator CONFIRM tier only — deny stays substring (fail-safe broad) and
+ *  allow stays substring (changing it could only widen auto-allow, never desired
+ *  here). Falls back to substring on unparseable structure (never DROP a match). */
+function matchBashInvocationPatterns(
+  patterns: readonly string[] | undefined,
+  rawCommand: string,
+  commandLower: string,
+): string | undefined {
+  if (!patterns) return undefined
+  const heads = bashInvocationHeads(rawCommand)
+  for (const rule of patterns) {
+    if (typeof rule !== 'string') continue
+    const p = rule.toLowerCase()
+    // Path / script / glob patterns are not command-name shaped — a script runs
+    // path-qualified (`./scripts/deploy.sh`) or behind an interpreter, so the
+    // pattern is not at a head position. Keep substring for those and when the
+    // structure could hide a head (heads === null).
+    const substringy = heads === null || p.includes('/') || p.includes('.') || p.includes('*') || p.includes('?')
+    if (substringy) {
+      if (bashMatch(rule, commandLower)) return rule
+    } else if (heads.some((h) => h.startsWith(p))) {
+      return rule
+    }
+  }
+  return undefined
+}
+
 /** Merge global + scope rules for one tier (scope rules are additive). */
 function mergeRules(global: PolicyRules | undefined, scope: PolicyRules | undefined): PolicyRules {
   return {
@@ -1558,6 +1697,10 @@ function rulesMatch(
   toolName: string,
   pathCands: string[] | undefined,
   commandLower: string | undefined,
+  // When set (operator CONFIRM tier), bash_patterns are matched command-position
+  // aware via rawCommand instead of plain substring — so `psql`/`rsync` mentions
+  // don't card. Omitted for deny/allow, which keep substring semantics.
+  rawCommand?: string,
 ): string | undefined {
   const tool = matchToolRules(rules.tools, toolName)
   if (tool) return `tools:${tool}`
@@ -1574,7 +1717,9 @@ function rulesMatch(
   }
 
   if (commandLower !== undefined) {
-    const bp = matchBashRules(rules.bash_patterns, commandLower)
+    const bp = rawCommand !== undefined
+      ? matchBashInvocationPatterns(rules.bash_patterns, rawCommand, commandLower)
+      : matchBashRules(rules.bash_patterns, commandLower)
     if (bp) return `bash_patterns:${bp}`
   }
   return undefined
@@ -1697,7 +1842,10 @@ export function classifyToolCall(input: ClassifyInput): PermissionVerdict {
   // still confirms. The evasion detector below is never overridable.
   if (commandLower !== undefined) {
     const overridden = policy.confirm_overrides?.builtin_rules ?? []
-    const hits = matchAllBashRules(BUILTIN_CONFIRM_BASH, commandLower)
+    // Command-position aware (rawCommand !== undefined ⇒ commandLower defined):
+    // a built-in rule confirms only when its command name is actually invoked,
+    // not merely mentioned as an argument / in a for-list (live FP 2026-06-16).
+    const hits = matchAllBashConfirmRules(rawCommand!, commandLower)
     const standing = hits.filter((h) => !overridden.includes(h))
     if (standing.length > 0) {
       return { tier: 'confirm', reason: `risky command needs confirmation: ${standing[0]}`, matchedRule: `builtin:confirm_bash:${standing[0]}` }
@@ -1723,8 +1871,9 @@ export function classifyToolCall(input: ClassifyInput): PermissionVerdict {
     }
   }
 
-  // 5. Operator confirm.
-  const confirmHit = rulesMatch(confirmRules, toolName, pathCands, commandLower)
+  // 5. Operator confirm. bash_patterns are command-position aware (rawCommand)
+  // so a mention of e.g. `psql`/`rsync` does not card — mirrors the built-in fix.
+  const confirmHit = rulesMatch(confirmRules, toolName, pathCands, commandLower, rawCommand)
   if (confirmHit) {
     return { tier: 'confirm', reason: `policy confirm (${confirmHit})`, matchedRule: `confirm:${confirmHit}` }
   }

--- a/plugin/tests/security/permission-policy.test.ts
+++ b/plugin/tests/security/permission-policy.test.ts
@@ -118,6 +118,76 @@ describe('built-in confirm bash (interpreter/exfil evasion)', () => {
   })
 })
 
+describe('built-in confirm is command-position aware — a risky WORD as an argument/mention does not confirm (live FP 2026-06-16)', () => {
+  test('the live FP: `command -v docker` in a for-list install check auto-allows', () => {
+    // `for c in … docker …; do command -v "$c"; done` raised a real confirm card
+    // (matchedRule builtin:confirm_bash:`docker `) while checking which tools are
+    // installed — "docker" is a for-list item / `command -v` argument, never a
+    // docker invocation. (NB: operator bash_patterns like `psql`/`rsync` are a
+    // separate substring layer and are intentionally left untouched here, so the
+    // for-list below avoids those words to isolate the built-in fix.)
+    expect(classify('Bash', { command: 'for c in docker podman buildah; do printf "%s: " "$c"; command -v "$c" || echo MISSING; done' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'command -v docker' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'which docker' }, VARIANT1).tier).toBe('allow')
+  })
+  test('risky words as arguments / inside strings do not confirm', () => {
+    expect(classify('Bash', { command: 'grep -rn "kill" logs/' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'echo "remember to run sudo later"' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'echo "git push to deploy"' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'cat notes-about-docker.md' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'ls /usr/bin | grep docker' }, VARIANT1).tier).toBe('allow')
+  })
+  test('REGRESSION: real invocations still confirm — bare, piped, compound, wrapped', () => {
+    expect(classify('Bash', { command: 'docker run -it ubuntu' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'kill 1234' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'pkill -f gateway' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'git push origin main' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'rm -rf /tmp/junk' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'pip install requests' }, VARIANT1).tier).toBe('confirm')
+    // piped invocation: docker is the head of a later pipeline stage
+    expect(classify('Bash', { command: 'cat img.tar | docker load' }, VARIANT1).tier).toBe('confirm')
+    // compound: kill is the head of a later `&&` segment
+    expect(classify('Bash', { command: 'cd /x && kill -9 99' }, VARIANT1).tier).toBe('confirm')
+  })
+  test('REGRESSION: wrappers are descended — sudo/env/timeout in front of a risky command still confirm', () => {
+    // sudo X matches both `sudo ` and the wrapped command.
+    expect(classify('Bash', { command: 'sudo docker ps' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'env FOO=bar docker ps' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'timeout 5 docker ps' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'nohup kill 1' }, VARIANT1).tier).toBe('confirm')
+  })
+  test('SAFETY: a risky command hidden in a substitution / subshell still confirms (no miss — substring fallback)', () => {
+    // splitPipelines treats `$(…)` / `(…)` as opaque, so a real invocation inside
+    // them would not surface as a head; we fall back to substring so it still
+    // confirms rather than silently running.
+    expect(classify('Bash', { command: 'echo $(docker ps)' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: '(cd /srv && docker build .)' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'x=`kill 1`' }, VARIANT1).tier).toBe('confirm')
+  })
+})
+
+describe('operator confirm bash_patterns are command-position aware for command-NAME patterns (live FP 2026-06-16)', () => {
+  // VARIANT1 operator confirm = ['deploy.sh', 'psql', 'supabase db'].
+  test('a MENTION of a command-name confirm pattern (psql) does not card', () => {
+    expect(classify('Bash', { command: 'command -v psql' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'for c in psql redis; do command -v "$c"; done' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'grep -rn "psql" docs/' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'echo "run psql later"' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'command -v supabase' }, VARIANT1).tier).toBe('allow')
+  })
+  test('REGRESSION: a real invocation of an operator pattern still confirms', () => {
+    expect(classify('Bash', { command: 'psql -h db -c "select 1"' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'sudo -u postgres psql' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'supabase db push' }, VARIANT1).tier).toBe('confirm')
+  })
+  test('REGRESSION: path/script operator patterns keep substring matching (deploy.sh)', () => {
+    // `deploy.sh` runs path-qualified / behind an interpreter — never at a bare
+    // head position — so it must stay substring-matched.
+    expect(classify('Bash', { command: './scripts/deploy.sh --prod' }, VARIANT1).tier).toBe('confirm')
+    expect(classify('Bash', { command: 'bash deploy.sh' }, VARIANT1).tier).toBe('confirm')
+  })
+})
+
 describe('systemctl is verb-aware — read-only verbs and mentions do not confirm (live FP 2026-06-10)', () => {
   test('read-only systemctl verbs auto-allow', () => {
     // `systemctl cat channel-thrall.service` raised a real confirm card while


### PR DESCRIPTION
## Problem

The permission gate's built-in confirm tier (`BUILTIN_CONFIRM_BASH`) and the operator `confirm` bash_patterns matched a risky command name (e.g. `docker`, `kill`, `sudo`, `rm -rf`, `git push`, or operator words like `psql`/`rsync`) **anywhere** in the command via substring / token-start. This raised a confirmation card when the word merely appeared as an **argument or mention**, not as an invocation.

Real false positives observed in a `bypassPermissions` Telegram-driven session:

- `command -v docker` (checking whether a tool is installed)
- `for c in rsync docker psql pm2; do command -v "$c"; done`
- `grep -rn "kill" logs/`

This is the same "mention ≠ invocation" class already handled for `systemctl` (verb-aware) and `git` (segment-aware), but not yet for the substring rules.

## Fix

Make `BUILTIN_CONFIRM_BASH` and the operator `confirm` bash_patterns **command-position aware**: a risky name confirms only when it is the head of a shell stage (after stripping leading shell keywords, `VAR=val` assignments, and command wrappers `sudo`/`env`/`nice`/`timeout`/…). Wrappers that run the next program are descended, so `sudo docker ps` still matches both `sudo ` and `docker `. `command`/`builtin`/`xargs` are intentionally **not** descended (`command -v docker` is a lookup, not a run — accepted residual, mirroring the systemctl matcher).

Operator patterns that look like paths/scripts (`deploy.sh`, `infra/deploy`) or contain glob metacharacters keep substring matching.

## Safety

- Real invocations still confirm: `docker run`, `kill 1234`, `sudo …`, `rm -rf …`, `git push`, `rsync -a`, `psql -h`, `pm2 restart`.
- A risky command hidden in a substitution / subshell (`$(docker …)`, `` `kill 1` ``, `(cd x && docker build)`) falls back to substring matching — **fail-safe to confirm, never a miss** (`splitPipelines` treats these as opaque, so a head inside them would not surface).
- The catastrophic hard-deny tier (`rm -rf /`, `mkfs`, `dd`-to-disk, fork bombs) and all deny rules are untouched.
- Operator `deny` and `allow` patterns keep substring semantics (deny stays fail-safe-broad).

## Tests

+9 cases covering the false positives, regressions (real invocations still confirm), the substitution/subshell safety fallback, and path-pattern preservation. Full suite: **1678 pass / 0 fail**; `tsc --noEmit` and `bun build` clean.
