### PR TITLE
feat(callback): forward unhandled inline-button taps to the agent session

### DIFF
--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -799,6 +799,10 @@ bot.on('callback_query:data', async ctx => {
         ...(ctx.callbackQuery.message?.message_id !== undefined
           ? { messageId: String(ctx.callbackQuery.message.message_id) }
           : {}),
+        ...(ctx.callbackQuery.message && 'text' in ctx.callbackQuery.message
+        && typeof ctx.callbackQuery.message.text === 'string'
+          ? { cardText: ctx.callbackQuery.message.text }
+          : {}),
       })
       try {
         await multichatRouter.dispatch(inbound)

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -84,6 +84,7 @@ import {
   type AlbumEntry,
   type HandlerDeps,
 } from './telegram/handlers.js'
+import { buildCallbackInboundMessage, isForwardableCallback } from './telegram/callback-forward.js'
 import { AlbumBuffer } from './telegram/album-buffer.js'
 import {
   ensureAlbumsDir,
@@ -779,6 +780,33 @@ bot.on('callback_query:data', async ctx => {
       log.error('ask callback_query handler threw', {
         error: err instanceof Error ? err.message : String(err),
       })
+    }
+    return
+  }
+  // Unhandled tap (not ask:/perm:) — forward to the agent so a skill can
+  // act on it (e.g. medicine reminder taken::course::<id>). Gate on the
+  // same allowlist as inbound messages; ack immediately so the spinner
+  // clears, then dispatch a synthetic inbound through the router.
+  if (isForwardableCallback(data)) {
+    await ctx.answerCallbackQuery().catch(() => {})
+    if (config.allowed_user_ids.includes(ctx.from.id) && multichatRouter !== undefined) {
+      const inbound = buildCallbackInboundMessage({
+        data,
+        chatId: ctx.chat?.id !== undefined ? String(ctx.chat.id) : String(ctx.from.id),
+        userId: String(ctx.from.id),
+        user: ctx.from.username ?? ctx.from.first_name ?? 'unknown',
+        timestamp: new Date().toISOString(),
+        ...(ctx.callbackQuery.message?.message_id !== undefined
+          ? { messageId: String(ctx.callbackQuery.message.message_id) }
+          : {}),
+      })
+      try {
+        await multichatRouter.dispatch(inbound)
+      } catch (err) {
+        log.error('callback forward dispatch threw', {
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
     }
     return
   }

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -91,6 +91,8 @@ import {
   recoverPendingAlbums,
 } from './telegram/album-persistence.js'
 import type { BotIdentity } from './prompt/build.js'
+import { buildChannelContent } from './prompt/build.js'
+import { sendChannelNotification, type ChannelEvent } from './channel/notify.js'
 
 const INSTRUCTIONS_TEMPLATE = [
   'The sender reads Telegram, not this session. Anything you want them to see must go through the reply tool — your transcript output never reaches their chat.',
@@ -789,10 +791,12 @@ bot.on('callback_query:data', async ctx => {
   // clears, then dispatch a synthetic inbound through the router.
   if (isForwardableCallback(data)) {
     await ctx.answerCallbackQuery().catch(() => {})
-    if (config.allowed_user_ids.includes(ctx.from.id) && multichatRouter !== undefined) {
+    if (config.allowed_user_ids.includes(ctx.from.id)) {
+      const chatId =
+        ctx.chat?.id !== undefined ? String(ctx.chat.id) : String(ctx.from.id)
       const inbound = buildCallbackInboundMessage({
         data,
-        chatId: ctx.chat?.id !== undefined ? String(ctx.chat.id) : String(ctx.from.id),
+        chatId,
         userId: String(ctx.from.id),
         user: ctx.from.username ?? ctx.from.first_name ?? 'unknown',
         timestamp: new Date().toISOString(),
@@ -805,7 +809,17 @@ bot.on('callback_query:data', async ctx => {
           : {}),
       })
       try {
-        await multichatRouter.dispatch(inbound)
+        if (multichatRouter !== undefined) {
+          await multichatRouter.dispatch(inbound)
+        } else {
+          // Legacy DM mode: inject straight into the master session — the
+          // same transport handleInboundText uses when no router is wired.
+          const event: ChannelEvent = {
+            content: buildChannelContent({ text: inbound.text, bot: botIdentity }),
+            meta: { chat_id: chatId },
+          }
+          await sendChannelNotification(mcp, event, log)
+        }
       } catch (err) {
         log.error('callback forward dispatch threw', {
           error: err instanceof Error ? err.message : String(err),

--- a/plugin/src/telegram/callback-forward.ts
+++ b/plugin/src/telegram/callback-forward.ts
@@ -23,9 +23,17 @@ export function buildCallbackInboundMessage(opts: {
   user: string
   timestamp: string
   messageId?: string
+  /** Text of the message the tapped keyboard belonged to. Appended so the
+   *  agent's keyword routing (e.g. a medicine name) can pick the right skill. */
+  cardText?: string
 }): InboundMessage {
+  const text =
+    opts.cardText !== undefined && opts.cardText.length > 0
+      ? `[inline-button] ${opts.data}
+${opts.cardText}`
+      : `[inline-button] ${opts.data}`
   return {
-    text: `[inline-button] ${opts.data}`,
+    text,
     chat_id: opts.chatId,
     user_id: opts.userId,
     user: opts.user,

--- a/plugin/src/telegram/callback-forward.ts
+++ b/plugin/src/telegram/callback-forward.ts
@@ -1,0 +1,35 @@
+// Forward an inline-button tap that no built-in handler claimed (not an
+// AskUserQuestion `ask:` keyboard, not a permission `perm:` card) to the
+// agent session as a synthetic inbound message. The plugin owns the bot's
+// update stream, so a cron-sent reminder keyboard (e.g. medicine
+// `taken::course::<id>`) has no other consumer — without this its taps are
+// silently dropped. Keeping the plugin generic: it forwards the raw tap and
+// the agent (a skill) decides what it means.
+
+import type { InboundMessage } from '../router/inbox-bridge.js'
+
+// Prefixes the plugin handles itself; everything else is forwardable.
+const HANDLED_PREFIXES = ['ask:', 'perm:']
+
+export function isForwardableCallback(data: string): boolean {
+  if (data.length === 0) return false
+  return !HANDLED_PREFIXES.some(p => data.startsWith(p))
+}
+
+export function buildCallbackInboundMessage(opts: {
+  data: string
+  chatId: string
+  userId: string
+  user: string
+  timestamp: string
+  messageId?: string
+}): InboundMessage {
+  return {
+    text: `[inline-button] ${opts.data}`,
+    chat_id: opts.chatId,
+    user_id: opts.userId,
+    user: opts.user,
+    timestamp: opts.timestamp,
+    ...(opts.messageId !== undefined ? { message_id: opts.messageId } : {}),
+  }
+}

--- a/plugin/tests/telegram/callback-forward.test.ts
+++ b/plugin/tests/telegram/callback-forward.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  isForwardableCallback,
+  buildCallbackInboundMessage,
+} from '../../src/telegram/callback-forward.js'
+
+describe('isForwardableCallback', () => {
+  test('false for ask: and perm: (already handled)', () => {
+    expect(isForwardableCallback('ask:opt:abcde:0:1')).toBe(false)
+    expect(isForwardableCallback('perm:allow:abcde')).toBe(false)
+  })
+  test('false for empty data', () => {
+    expect(isForwardableCallback('')).toBe(false)
+  })
+  test('true for a medicine reminder callback', () => {
+    expect(isForwardableCallback('taken::course::55ba6618')).toBe(true)
+    expect(isForwardableCallback('snooze::course::55ba6618')).toBe(true)
+  })
+})
+
+describe('buildCallbackInboundMessage', () => {
+  test('wraps callback data as a synthetic inbound message', () => {
+    const msg = buildCallbackInboundMessage({
+      data: 'taken::course::55ba6618',
+      chatId: '1134075676',
+      userId: '1134075676',
+      user: 'viktor',
+      timestamp: '2026-06-14T05:00:00.000Z',
+      messageId: '4242',
+    })
+    expect(msg).toEqual({
+      text: '[inline-button] taken::course::55ba6618',
+      chat_id: '1134075676',
+      user_id: '1134075676',
+      user: 'viktor',
+      timestamp: '2026-06-14T05:00:00.000Z',
+      message_id: '4242',
+    })
+  })
+  test('omits message_id when absent', () => {
+    const msg = buildCallbackInboundMessage({
+      data: 'skipped::course::x',
+      chatId: '1', userId: '1', user: 'u', timestamp: 't',
+    })
+    expect('message_id' in msg).toBe(false)
+  })
+})

--- a/plugin/tests/telegram/callback-forward.test.ts
+++ b/plugin/tests/telegram/callback-forward.test.ts
@@ -45,4 +45,16 @@ describe('buildCallbackInboundMessage', () => {
     })
     expect('message_id' in msg).toBe(false)
   })
+
+  test('appends the original card text so keyword routing can fire', () => {
+    const msg = buildCallbackInboundMessage({
+      data: 'taken::course::55ba6618',
+      chatId: 'c', userId: 'u', user: 'n', timestamp: 't',
+      cardText: 'Время принять Детралекс',
+    })
+    expect(msg.text).toBe(
+      `[inline-button] taken::course::55ba6618
+Время принять Детралекс`,
+    )
+  })
 })


### PR DESCRIPTION
The plugin owns the bot's update stream, so an inline keyboard sent **out-of-band** (e.g. a cron-scheduled reminder with `taken::course::<id>` buttons) has no consumer: its `callback_query` is neither an AskUserQuestion `ask:` keyboard nor a permission `perm:` card, so the built-in handlers don't claim it and the tap is silently dropped. Reproduced on a live deployment (a medicine-reminder keyboard whose taps never reached the session).

## Fix

Forward any tap **no built-in handler claimed** to the agent as a synthetic inbound message, gated on the same `allowed_user_ids` allowlist as inbound text. The plugin stays generic — it forwards the raw callback data and the agent (a skill) decides what it means.

Three small commits:

1. **forward unhandled taps** — new `src/telegram/callback-forward.ts` with two pure helpers: `isForwardableCallback(data)` (everything except `ask:` / `perm:` / empty) and `buildCallbackInboundMessage(...)` (wraps the tap as `[inline-button] <data>`). The `callback_query:data` handler acks immediately (clears the spinner), then dispatches the synthetic inbound through the router.
2. **include the card text** — append the text of the message the tapped keyboard belonged to, so the agent's keyword routing (e.g. a medicine name on the reminder card) can pick the right skill.
3. **legacy DM mode** — when no multichat router is wired (`multichatRouter === undefined`), the original code skipped the dispatch entirely and the tap was still dropped. Inject straight into the master session via `sendChannelNotification` / `buildChannelContent` — the same transport `handleInboundText` uses in DM-only mode.

## Tests

- `tests/telegram/callback-forward.test.ts` — covers `ask:`/`perm:`/empty are not forwardable, medicine callbacks are, the synthetic message shape (with/without `message_id`), and card-text appending for keyword routing.
- The two pure helpers are unit-tested; the `server.ts` wiring (both router and legacy paths) was verified **end-to-end on a live bot** — a real reminder tap forwarded and acted on correctly.

Self-contained: touches only `src/server.ts` + the new module/test, independent of #87.