### PR TITLE
AskUserQuestion UX: карточка вопроса закрывается после ответа/таймаута

### DIFF
--- a/plugin/src/channel/ask-user-question.ts
+++ b/plugin/src/channel/ask-user-question.ts
@@ -79,6 +79,30 @@ export type AskUserQuestionStatus =
   | 'unauthorized'
   | 'idempotent'
 
+// Fired by the relay whenever a request reaches a terminal state (answered
+// / timeout / expire). The relay owns lifecycle (the internal timeout timer
+// + external expire()), so this is the ONLY seam through which the UI (which
+// owns rendering/edits) learns about a settle it did NOT drive itself — most
+// importantly the internal timeout, where no callback path runs. The snapshot
+// carries just enough render state (chatId, the currently-open keyboard's
+// message id, the current question text/index) for the UI to close the open
+// card. Pure data — the relay never touches Telegram.
+export interface AskSettleEvent {
+  requestId: string
+  toolUseId: string
+  status: AskUserQuestionStatus
+  // The chat + message id of the CURRENTLY-OPEN question keyboard at settle
+  // time. On `answered` the relay has already cleared the anchor (undefined);
+  // on `timeout`/expire it points at the card the warchief left un-answered.
+  chatId: string | undefined
+  telegramMessageId: number | undefined
+  currentIndex: number
+  totalQuestions: number
+  // Text of the currently-open question (for the closed-card re-render).
+  questionText: string | undefined
+  reason: string | undefined
+}
+
 export interface AskUserQuestionResult {
   status: AskUserQuestionStatus
   requestId?: string
@@ -93,6 +117,27 @@ export interface AskUserQuestionResult {
   }
   reason?: string
 }
+
+// Return shape of the answer-mutation methods (answerChoice / answerOther /
+// done). Computed SYNCHRONOUSLY at mutation time so the UI can decide the
+// follow-up rendering without re-inferring state after an await — inferring
+// finality from `getPending() === undefined` later is racy: the internal
+// timeout can settle the request during the await, making a NON-final answer
+// look like «answered final» (Codex HIGH, 2026-07-02).
+export interface AskAnswerOutcome {
+  /** The call mutated state (recorded/accumulated an answer). False for
+   *  missing request, stale questionIndex, out-of-range option, empty
+   *  Other-text, done() on non-multiSelect or with empty selection. */
+  applied: boolean
+  /** The call moved PAST the question (single-select pick / multiSelect
+   *  commit) — as opposed to accumulating into the in-flight list. */
+  advanced: boolean
+  /** THIS call settled the whole request as `answered` (it was the final
+   *  question). The ONLY trustworthy trigger for the completion message. */
+  final: boolean
+}
+
+const NOOP_OUTCOME: AskAnswerOutcome = { applied: false, advanced: false, final: false }
 
 // ─────────────────────────────────────────────────────────────────────
 // PendingAskRequest — the mutable per-request record.
@@ -133,6 +178,12 @@ export interface AskUserQuestionRelayDeps {
   // window, shorter than the typical timeout itself so we don't bloat
   // memory under load.
   completedTtlMs?: number
+  // Terminal-state notifier. Fired once per request on settle (answered /
+  // timeout / expire), AFTER the result Promise resolves. The UI registers
+  // this to close the open keyboard on the paths it can't observe itself
+  // (chiefly the internal timeout). Never awaited — best-effort, and a
+  // throwing handler is logged, never allowed to break settle.
+  onSettle?: (event: AskSettleEvent) => void
 }
 
 // Phase 5 FIX-T3 F1 (2026-05-27): submit() returns the requestId
@@ -154,15 +205,17 @@ export interface AskUserQuestionRelay {
   submit(input: SubmitInput): SubmittedRequest
   // Record an option pick for the current question and advance.
   // `optionIndex` indexes into the current question's `options`.
-  answerChoice(requestId: string, questionIndex: number, optionIndex: number): void
+  // Returns the mutation outcome (applied / advanced / final) computed
+  // synchronously so the caller never has to re-infer it post-await.
+  answerChoice(requestId: string, questionIndex: number, optionIndex: number): AskAnswerOutcome
   // Record free-form text (the "Other" button path) as the answer for
   // the current question. For multiSelect, appends to the in-flight
   // list; for single-select, advances immediately.
-  answerOther(requestId: string, questionIndex: number, otherText: string): void
+  answerOther(requestId: string, questionIndex: number, otherText: string): AskAnswerOutcome
   // Toggle a multi-select option on/off. No-op if not multiSelect.
   toggle(requestId: string, questionIndex: number, optionIndex: number): void
   // Commit the multi-select in-flight list as the answer and advance.
-  done(requestId: string, questionIndex: number): void
+  done(requestId: string, questionIndex: number): AskAnswerOutcome
   // External "give up" — resolves with status='timeout' and reason.
   expire(requestId: string, reason?: string): void
   isPending(requestId: string): boolean
@@ -189,6 +242,7 @@ export function createAskUserQuestionRelay(
   const now = deps.now ?? (() => Date.now())
   const defaultTimeoutMs = deps.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS
   const completedTtlMs = deps.completedTtlMs ?? DEFAULT_COMPLETED_TTL_MS
+  const onSettle = deps.onSettle
 
   const pending = new Map<string, PendingAskRequest>()
   // toolUseId → live requestId (only while pending; cleared on settle so
@@ -235,6 +289,32 @@ export function createAskUserQuestionRelay(
         request_id: req.requestId,
         error: err instanceof Error ? err.message : String(err),
       })
+    }
+    // Notify the UI so it can close the open keyboard on paths it can't
+    // observe itself (the internal timeout timer, external expire). We read
+    // the render fields off `req` — still intact even though we removed it
+    // from the pending map above. Best-effort: a throwing handler is logged,
+    // never allowed to poison the settle.
+    if (onSettle) {
+      try {
+        const currentQuestion = req.questions[req.currentIndex]
+        onSettle({
+          requestId: req.requestId,
+          toolUseId: req.toolUseId,
+          status: result.status,
+          chatId: req.chatId,
+          telegramMessageId: req.telegramMessageId,
+          currentIndex: req.currentIndex,
+          totalQuestions: req.questions.length,
+          questionText: currentQuestion?.question,
+          reason: result.reason,
+        })
+      } catch (err) {
+        log.error('ask_user_question onSettle handler threw', {
+          request_id: req.requestId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
     }
   }
 
@@ -416,15 +496,15 @@ export function createAskUserQuestionRelay(
     return { requestId, result: promise }
   }
 
-  function answerChoice(requestId: string, questionIndex: number, optionIndex: number): void {
+  function answerChoice(requestId: string, questionIndex: number, optionIndex: number): AskAnswerOutcome {
     // FIX-T2 F4 — call pruneCompleted on every public surface so cached
     // entries don't accumulate after a burst followed by idle time.
     pruneCompleted()
     const req = pending.get(requestId)
-    if (!req) return
-    if (!ensureCurrent(req, questionIndex, 'answerChoice')) return
+    if (!req) return NOOP_OUTCOME
+    if (!ensureCurrent(req, questionIndex, 'answerChoice')) return NOOP_OUTCOME
     const q = req.questions[req.currentIndex]
-    if (!q) return
+    if (!q) return NOOP_OUTCOME
     const opt = q.options[optionIndex]
     if (!opt) {
       log.warn('ask_user_question answerChoice out of range', {
@@ -432,40 +512,46 @@ export function createAskUserQuestionRelay(
         question_index: questionIndex,
         option_index: optionIndex,
       })
-      return
+      return NOOP_OUTCOME
     }
     if (q.multiSelect === true) {
       // For multi-select, a "choice" tap is a toggle. Keep semantics
       // explicit: callers should prefer toggle(); this is the safety
       // net if TASK-2 routes the wrong handler.
       toggleInternal(req, optionIndex)
-      return
+      return { applied: true, advanced: false, final: false }
     }
     recordSingle(req, opt.label)
     advance(req)
+    // `advance` only ever settles as `answered`; ensureCurrent guaranteed
+    // _settled was false on entry, and nothing between here and there
+    // awaits — so `req._settled` now means THIS call answered the final
+    // question. This synchronous read is the whole point of the outcome.
+    return { applied: true, advanced: true, final: req._settled }
   }
 
-  function answerOther(requestId: string, questionIndex: number, otherText: string): void {
+  function answerOther(requestId: string, questionIndex: number, otherText: string): AskAnswerOutcome {
     pruneCompleted() // FIX-T2 F4
     const req = pending.get(requestId)
-    if (!req) return
-    if (!ensureCurrent(req, questionIndex, 'answerOther')) return
+    if (!req) return NOOP_OUTCOME
+    if (!ensureCurrent(req, questionIndex, 'answerOther')) return NOOP_OUTCOME
     const q = req.questions[req.currentIndex]
-    if (!q) return
+    if (!q) return NOOP_OUTCOME
     const text = otherText.trim()
     if (text.length === 0) {
       log.debug('ask_user_question answerOther empty text', {
         request_id: requestId,
         question_index: questionIndex,
       })
-      return
+      return NOOP_OUTCOME
     }
     if (q.multiSelect === true) {
       req.multiSelectInFlight = [...req.multiSelectInFlight, text]
-      return
+      return { applied: true, advanced: false, final: false }
     }
     recordSingle(req, text)
     advance(req)
+    return { applied: true, advanced: true, final: req._settled }
   }
 
   function toggleInternal(req: PendingAskRequest, optionIndex: number): void {
@@ -493,18 +579,18 @@ export function createAskUserQuestionRelay(
     toggleInternal(req, optionIndex)
   }
 
-  function done(requestId: string, questionIndex: number): void {
+  function done(requestId: string, questionIndex: number): AskAnswerOutcome {
     pruneCompleted() // FIX-T2 F4
     const req = pending.get(requestId)
-    if (!req) return
-    if (!ensureCurrent(req, questionIndex, 'done')) return
+    if (!req) return NOOP_OUTCOME
+    if (!ensureCurrent(req, questionIndex, 'done')) return NOOP_OUTCOME
     const q = req.questions[req.currentIndex]
     if (!q || q.multiSelect !== true) {
       log.debug('ask_user_question done on non-multiselect ignored', {
         request_id: requestId,
         question_index: questionIndex,
       })
-      return
+      return NOOP_OUTCOME
     }
     if (req.multiSelectInFlight.length === 0) {
       // Defensive: TASK-2 should disable Done until at least one item is
@@ -513,10 +599,11 @@ export function createAskUserQuestionRelay(
         request_id: requestId,
         question_index: questionIndex,
       })
-      return
+      return NOOP_OUTCOME
     }
     recordMulti(req, req.multiSelectInFlight)
     advance(req)
+    return { applied: true, advanced: true, final: req._settled }
   }
 
   function expire(requestId: string, reason?: string): void {

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -619,9 +619,19 @@ const callbackDeps = {
 // reads `askUserQuestionRelay` to submit new requests; TASK-2's UI is
 // invoked from the callback_query handler below and the text-reply
 // path in handlers.ts (Other follow-up).
+// Late-bound UI ref: the relay's onSettle notifier must reach the UI, but the
+// UI is constructed AFTER the relay (it depends on it). The closure below only
+// fires on a terminal settle — long after both are assigned — so capturing the
+// `let` is safe. This is the seam through which the UI learns about the relay's
+// internal timeout (no callback path runs there) and closes the open keyboard.
+let askUserQuestionUiRef: AskUserQuestionUi | undefined
 const askUserQuestionRelay = createAskUserQuestionRelay({
   log,
   defaultTimeoutMs: config.ask_user_question.timeout_ms,
+  onSettle: (event) => {
+    // Fire-and-forget: handleSettle is best-effort and never throws.
+    void askUserQuestionUiRef?.handleSettle(event)
+  },
 })
 const askUserQuestionUi: AskUserQuestionUi = createAskUserQuestionUi({
   config,
@@ -629,6 +639,7 @@ const askUserQuestionUi: AskUserQuestionUi = createAskUserQuestionUi({
   telegramApi,
   relay: askUserQuestionRelay,
 })
+askUserQuestionUiRef = askUserQuestionUi
 // Permission gate (2026-06-09): interactive Allow/Deny confirm relay for the
 // bypassPermissions DM session. The PreToolUse hook POSTs confirm-tier calls
 // to /hooks/permission/request (webhook layer reads `permissionGateRelay`);

--- a/plugin/src/telegram/ask-user-question.ts
+++ b/plugin/src/telegram/ask-user-question.ts
@@ -46,6 +46,8 @@ import type { Logger } from '../log.js'
 import type { AppConfig } from '../config.js'
 import { resolveAskUserQuestionAllowedUserIds } from '../config.js'
 import type {
+  AskAnswerOutcome,
+  AskSettleEvent,
   AskUserQuestionRelay,
   PendingAskRequest,
 } from '../channel/ask-user-question.js'
@@ -91,6 +93,44 @@ const MAX_OPTION_DESCRIPTION_CHARS = 500
 // Marker appended when the assembled body would overflow MAX_BODY_CHARS.
 // Self-contained HTML — no open tags, never sliced.
 const OVERFLOW_MARKER = '\n<i>… (обрезано)</i>'
+
+// ── Card-close copy (2026-07-02, warchief UX feedback) ────────────────
+// When a question is answered / times out we STRIP the keyboard and edit
+// the message so it no longer looks tappable, keeping the question text
+// for context and appending a one-line outcome. Tone matches the
+// permission relay's «✅ Allowed / ❌ Denied» verdict-edit convention.
+
+// Raw cap for the chosen-answer echo. «Другое» free-text can be long —
+// truncate so the closed card stays compact.
+const MAX_ANSWER_CHARS = 100
+// Outcome line shown once the warchief has answered a question.
+function formatChosenLine(rawAnswer: string): string {
+  return `✅ Ответ: <b>${escapeHtml(clipRaw(rawAnswer, MAX_ANSWER_CHARS))}</b>`
+}
+// Outcome line shown when the request times out (or is externally expired)
+// with the card still open. Static, HTML-safe literal.
+const TIMEOUT_OUTCOME_LINE = '⏰ Время истекло — спрошу заново'
+// One-shot completion message sent after the LAST question is answered.
+const COMPLETION_TEXT = 'Ответы принял, продолжаю ✅'
+
+/**
+ * Render a CLOSED question card: header + original question text + a single
+ * outcome line, no keyboard. Used both when a question is answered (outcome
+ * = the chosen answer) and on timeout (outcome = the «время истекло» note).
+ * `outcomeLineHtml` is trusted HTML — callers build it via `formatChosenLine`
+ * (escapes user content) or a static safe literal. Header + question are
+ * escaped here. Exported for tests.
+ */
+export function renderClosedQuestionBody(
+  questionRaw: string,
+  currentIndex: number,
+  totalQuestions: number,
+  outcomeLineHtml: string,
+): string {
+  const header = clipRaw(`Вопрос ${currentIndex + 1}/${totalQuestions}`, MAX_HEADER_CHARS)
+  const question = escapeHtml(clipRaw(questionRaw, MAX_QUESTION_CHARS))
+  return `<b>${escapeHtml(header)}</b>\n${question}\n\n${outcomeLineHtml}`
+}
 
 // ─────────────────────────────────────────────────────────────────────
 // Public types
@@ -146,6 +186,16 @@ export interface AskUserQuestionUi {
     text: string
     replyToMessageId?: number
   }): Promise<boolean>
+
+  /**
+   * React to a terminal settle the UI did NOT drive itself — chiefly the
+   * relay's internal timeout, where no callback path runs to close the open
+   * keyboard. Wired to the relay's `onSettle` in server.ts. Best-effort:
+   * closes the currently-open question card (strips keyboard, appends the
+   * timeout note) and never throws. A no-op for `answered` (the driven
+   * callback path already closed the card + sent the completion message).
+   */
+  handleSettle(event: AskSettleEvent): Promise<void>
 
   /** Test/inspection — pending «Other» prompts. */
   awaitingOtherCount(): number
@@ -759,27 +809,116 @@ export function createAskUserQuestionUi(
     }
   }
 
-  async function advanceAfterAnswer(requestId: string, prevMessageId: number | undefined, prevChatId: string | undefined): Promise<void> {
-    const stillPending = relay.getPending(requestId)
-    if (stillPending) {
-      // Clear the previous keyboard so the warchief can't double-answer
-      // the question we just consumed, then render the next.
-      if (prevChatId !== undefined && prevMessageId !== undefined) {
-        await clearKeyboard(requestId, prevChatId, prevMessageId, '<i>Ответ принят. Следующий вопрос…</i>')
-      }
-      // FIX-T2 F1: if clearKeyboard hit `forbidden` it already expired
-      // the relay; do NOT proceed to startQuestion on a settled request
-      // (would just no-op since getPending returns undefined, but the
-      // explicit check avoids a stray log line at debug).
-      if (relay.getPending(requestId) === undefined) return
-      await startQuestion(requestId)
+  // Snapshot of the just-answered question, captured in the callback handler
+  // BEFORE the relay mutation (which advances currentIndex / clears the
+  // in-flight list / drops the anchor). Carries everything needed to close
+  // the card with the chosen answer.
+  interface AnswerSnapshot {
+    requestId: string
+    chatId: string | undefined
+    messageId: number | undefined
+    questionIndex: number
+    questionText: string
+    totalQuestions: number
+    // Pre-built, HTML-safe outcome line («✅ Ответ: <label>»).
+    outcomeLineHtml: string
+  }
+
+  // One-shot «Ответы приняты» confirmation after the final question. New
+  // message (not an edit) so the warchief's device pings. Best-effort.
+  async function sendCompletion(chatId: string): Promise<void> {
+    try {
+      await telegramApi.sendMessage(chatId, COMPLETION_TEXT, { parse_mode: 'HTML' })
+    } catch (err) {
+      const cls = classifyEditError(err)
+      log.debug('ask_user_question completion send failed', {
+        chat_id: chatId,
+        kind: cls.kind,
+      })
+    }
+  }
+
+  // Codex HIGH (2026-07-02): the follow-up rendering path is decided by the
+  // relay's SYNCHRONOUS mutation outcome, NOT by re-inferring state from
+  // `getPending()` after an await. The pre-fix code awaited the callback ack
+  // between the mutation and this function; if the internal timeout settled
+  // the request during that await, a NON-final answer saw
+  // `getPending() === undefined` and took the «answered final» branch —
+  // closing the card + sending «Ответы принял…» although the request settled
+  // as timeout. `outcome.final` is computed at mutation time and immune.
+  async function advanceAfterAnswer(snap: AnswerSnapshot, outcome: AskAnswerOutcome): Promise<void> {
+    // Relay refused the mutation (stale/duplicate/out-of-range/empty text)
+    // — nothing changed, nothing to render.
+    if (!outcome.applied) return
+
+    // multiSelect accumulation: an «Другое» free-text entry (or a stray tap)
+    // added to the in-flight list WITHOUT advancing. The card stays open —
+    // just re-render it so the current state shows. No close, no completion.
+    if (!outcome.advanced) {
+      await rerenderCurrent(snap.requestId)
       return
     }
-    // Resolved — drop the keyboard and confirm.
-    if (prevChatId !== undefined && prevMessageId !== undefined) {
-      // No requestId — the relay already settled, so even if clearKeyboard
-      // sees forbidden there's nothing to expire.
-      await clearKeyboard(undefined, prevChatId, prevMessageId, '<b>Ответ принят.</b>')
+
+    // Close the answered card: keep the question text, append the chosen
+    // answer, strip the keyboard so it no longer looks tappable.
+    const closedBody = renderClosedQuestionBody(
+      snap.questionText,
+      snap.questionIndex,
+      snap.totalQuestions,
+      snap.outcomeLineHtml,
+    )
+
+    if (!outcome.final) {
+      // Advanced to the next question. Close the answered card, then render
+      // the next. clearKeyboard is best-effort + classifier-aware (a
+      // `forbidden` there expires the relay), so re-check before rendering.
+      if (snap.chatId !== undefined && snap.messageId !== undefined) {
+        await clearKeyboard(snap.requestId, snap.chatId, snap.messageId, closedBody)
+      }
+      // FIX-T2 F1 + timeout race: if clearKeyboard hit `forbidden` it already
+      // expired the relay, and the internal timeout may have settled it during
+      // the edit await — either way do NOT render a next question on a settled
+      // request. (handleSettle owns the timeout note; anchor was cleared by
+      // advance() so there is no double-edit of this card.)
+      if (relay.getPending(snap.requestId) === undefined) return
+      await startQuestion(snap.requestId)
+      return
+    }
+
+    // outcome.final — THIS answer settled the request as `answered`. Close
+    // the final card, then send ONE completion message. No requestId to
+    // clearKeyboard: the relay already settled, so a `forbidden` there has
+    // nothing left to expire.
+    if (snap.chatId !== undefined && snap.messageId !== undefined) {
+      await clearKeyboard(undefined, snap.chatId, snap.messageId, closedBody)
+    }
+    if (snap.chatId !== undefined) {
+      await sendCompletion(snap.chatId)
+    }
+  }
+
+  // Close the currently-open question card on a settle the UI did NOT drive
+  // (internal timeout / external expire). Best-effort — never throws.
+  async function handleSettle(event: AskSettleEvent): Promise<void> {
+    try {
+      // `answered` is fully handled by the driven callback path (per-question
+      // close + completion message); acting here would double-post. Only the
+      // timeout/expire family leaves a card open with a live keyboard.
+      if (event.status !== 'timeout') return
+      if (!event.chatId || event.telegramMessageId === undefined) return
+      const body = renderClosedQuestionBody(
+        event.questionText ?? '',
+        event.currentIndex,
+        event.totalQuestions,
+        TIMEOUT_OUTCOME_LINE,
+      )
+      // requestId undefined: relay already settled — nothing left to expire.
+      await clearKeyboard(undefined, event.chatId, event.telegramMessageId, body)
+    } catch (err) {
+      log.debug('ask_user_question handleSettle failed', {
+        request_id: event.requestId,
+        error: err instanceof Error ? err.message : String(err),
+      })
     }
   }
 
@@ -864,12 +1003,29 @@ export function createAskUserQuestionUi(
 
     const prevMessageId = pendingBefore.telegramMessageId
     const prevChatId = pendingBefore.chatId
+    const currentQuestion = pendingBefore.questions[pendingBefore.currentIndex]
+    const totalQuestions = pendingBefore.questions.length
 
     try {
       if (parsed.kind === 'choose') {
-        relay.answerChoice(parsed.requestId, parsed.questionIndex, parsed.optionIndex)
+        // Capture the chosen label BEFORE the relay advances past this
+        // question — afterwards currentIndex points at the next one.
+        const chosenLabel = currentQuestion?.options[parsed.optionIndex]?.label ?? ''
+        const snap: AnswerSnapshot = {
+          requestId: parsed.requestId,
+          chatId: prevChatId,
+          messageId: prevMessageId,
+          questionIndex: pendingBefore.currentIndex,
+          questionText: currentQuestion?.question ?? '',
+          totalQuestions,
+          outcomeLineHtml: formatChosenLine(chosenLabel),
+        }
+        const outcome = relay.answerChoice(parsed.requestId, parsed.questionIndex, parsed.optionIndex)
+        // Render BEFORE acking the spinner: the ack is cosmetic and can
+        // trail, while any await placed between the mutation and the
+        // follow-up render widens the timeout race window (Codex HIGH).
+        await advanceAfterAnswer(snap, outcome)
         await ctx.answerCallbackQuery().catch(() => {})
-        await advanceAfterAnswer(parsed.requestId, prevMessageId, prevChatId)
         return
       }
       if (parsed.kind === 'toggle') {
@@ -879,9 +1035,22 @@ export function createAskUserQuestionUi(
         return
       }
       if (parsed.kind === 'done') {
-        relay.done(parsed.requestId, parsed.questionIndex)
+        // Snapshot the committed multi-select labels BEFORE `done()` clears
+        // the in-flight list (advance resets it to []).
+        const committedLabels = [...pendingBefore.multiSelectInFlight]
+        const snap: AnswerSnapshot = {
+          requestId: parsed.requestId,
+          chatId: prevChatId,
+          messageId: prevMessageId,
+          questionIndex: pendingBefore.currentIndex,
+          questionText: currentQuestion?.question ?? '',
+          totalQuestions,
+          outcomeLineHtml: formatChosenLine(committedLabels.join(', ')),
+        }
+        const outcome = relay.done(parsed.requestId, parsed.questionIndex)
+        // Same ordering rationale as `choose`: render first, ack after.
+        await advanceAfterAnswer(snap, outcome)
         await ctx.answerCallbackQuery().catch(() => {})
-        await advanceAfterAnswer(parsed.requestId, prevMessageId, prevChatId)
         return
       }
       // kind === 'other'
@@ -993,11 +1162,20 @@ export function createAskUserQuestionUi(
     // logs at debug). We still clear the awaiting marker so the user
     // is not silently swallowed forever.
     const pendingBefore = relay.getPending(entry.requestId)
-    const prevMessageId = pendingBefore?.telegramMessageId
-    const prevChatId = pendingBefore?.chatId
+    const currentQuestion = pendingBefore?.questions[pendingBefore.currentIndex]
+    const snap: AnswerSnapshot = {
+      requestId: entry.requestId,
+      chatId: pendingBefore?.chatId,
+      messageId: pendingBefore?.telegramMessageId,
+      questionIndex: pendingBefore?.currentIndex ?? entry.questionIndex,
+      questionText: currentQuestion?.question ?? '',
+      totalQuestions: pendingBefore?.questions.length ?? 0,
+      // «Другое» free-text is the chosen answer (truncated in the echo).
+      outcomeLineHtml: formatChosenLine(input.text.trim()),
+    }
     awaitingOther.delete(input.chatId)
-    relay.answerOther(entry.requestId, entry.questionIndex, input.text)
-    await advanceAfterAnswer(entry.requestId, prevMessageId, prevChatId)
+    const outcome = relay.answerOther(entry.requestId, entry.questionIndex, input.text)
+    await advanceAfterAnswer(snap, outcome)
     return true
   }
 
@@ -1010,6 +1188,7 @@ export function createAskUserQuestionUi(
     startQuestion,
     handleAskCallback,
     tryHandleOtherText,
+    handleSettle,
     awaitingOtherCount,
   }
 }

--- a/plugin/tests/channel/ask-user-question.test.ts
+++ b/plugin/tests/channel/ask-user-question.test.ts
@@ -332,6 +332,63 @@ describe('submit() — multiSelect', () => {
   })
 })
 
+// ─────────────────────────────────────────────────────────────────────
+// AskAnswerOutcome (Codex HIGH 2026-07-02) — the answer methods report
+// applied/advanced/final SYNCHRONOUSLY at mutation time so the UI never
+// infers finality from getPending() after an await (timeout race).
+// ─────────────────────────────────────────────────────────────────────
+
+describe('AskAnswerOutcome contract', () => {
+  test('single-select: non-final advance vs final answer', () => {
+    const relay = mkRelay()
+    const { requestId } = relay.submit({
+      toolUseId: 'toolu_oc_1',
+      sessionId: 'sess',
+      chatId: '164795011',
+      questions: [
+        { question: 'Q1', options: [{ label: 'A' }, { label: 'B' }] },
+        { question: 'Q2', options: [{ label: 'C' }] },
+      ],
+    })
+    const reqId = requestId!
+    expect(relay.answerChoice(reqId, 0, 0)).toEqual({ applied: true, advanced: true, final: false })
+    expect(relay.answerChoice(reqId, 1, 0)).toEqual({ applied: true, advanced: true, final: true })
+  })
+
+  test('multiSelect: accumulate (choice-as-toggle / other) then final done', () => {
+    const relay = mkRelay()
+    const { requestId } = relay.submit(multiSelectQ())
+    const reqId = requestId!
+    // choice-as-toggle safety net + Other free-text accumulate — applied, not advanced.
+    expect(relay.answerChoice(reqId, 0, 0)).toEqual({ applied: true, advanced: false, final: false })
+    expect(relay.answerOther(reqId, 0, 'SolidJS')).toEqual({ applied: true, advanced: false, final: false })
+    // Commit — final (single question).
+    expect(relay.done(reqId, 0)).toEqual({ applied: true, advanced: true, final: true })
+  })
+
+  test('no-op paths report applied=false', () => {
+    const relay = mkRelay()
+    const { requestId } = relay.submit(singleQ())
+    const reqId = requestId!
+    expect(relay.answerChoice('zzzzz', 0, 0)).toEqual({ applied: false, advanced: false, final: false }) // unknown id
+    expect(relay.answerChoice(reqId, 5, 0)).toEqual({ applied: false, advanced: false, final: false }) // stale index
+    expect(relay.answerChoice(reqId, 0, 99)).toEqual({ applied: false, advanced: false, final: false }) // opt out of range
+    expect(relay.answerOther(reqId, 0, '   ')).toEqual({ applied: false, advanced: false, final: false }) // empty text
+    expect(relay.done(reqId, 0)).toEqual({ applied: false, advanced: false, final: false }) // done on non-multiselect
+    expect(relay.isPending(reqId)).toBe(true)
+    relay.expire(reqId, 'test cleanup')
+  })
+
+  test('answer after settle reports applied=false (timeout raced the tap)', async () => {
+    const relay = mkRelay({ defaultTimeoutMs: 15 })
+    const { requestId, result } = relay.submit(singleQ())
+    const reqId = requestId!
+    const verdict = await result // internal timeout settles it
+    expect(verdict.status).toBe('timeout')
+    expect(relay.answerChoice(reqId, 0, 0)).toEqual({ applied: false, advanced: false, final: false })
+  })
+})
+
 describe('timeout + expire', () => {
   test('timeout fires → status=timeout, map cleaned up', async () => {
     const relay = mkRelay({ defaultTimeoutMs: 20 })

--- a/plugin/tests/telegram/ask-user-question.test.ts
+++ b/plugin/tests/telegram/ask-user-question.test.ts
@@ -347,11 +347,17 @@ describe('handleAskCallback — choose', () => {
     await ui.handleAskCallback(ctx)
 
     expect(answers.length).toBeGreaterThanOrEqual(1)
-    // Previous keyboard cleared via editMessageText with empty inline_keyboard
+    // Answered card closed via editMessageText with empty inline_keyboard,
+    // keeping the question text and appending the chosen answer.
     expect(send.editCalls.length).toBe(1)
     expect(send.editCalls[0]?.messageId).toBe(1001)
     expect(send.editCalls[0]?.opts.reply_markup?.inline_keyboard).toEqual([])
-    expect(send.editCalls[0]?.text).toContain('Ответ принят')
+    expect(send.editCalls[0]?.text).toContain('Q') // original question kept
+    expect(send.editCalls[0]?.text).toContain('✅ Ответ:')
+    expect(send.editCalls[0]?.text).toContain('B') // chosen label echoed
+    // Exactly one completion message after the last question.
+    expect(send.sendCalls.length).toBe(1)
+    expect(send.sendCalls[0]?.text).toBe('Ответы принял, продолжаю ✅')
     // Single question; promise resolves answered.
     const result = await handle.result
     expect(result.status).toBe('answered')
@@ -621,6 +627,352 @@ describe('FIX-T1 F4 — Other prompt force_reply contract', () => {
     const result = await submitted.result
     expect(result.status).toBe('answered')
     expect(result.updatedInput?.answers).toEqual({ Q: 'explicit reply' })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// Card-close UX (2026-07-02, warchief feedback) — on answer the card is
+// closed (keyboard stripped + chosen answer appended); after the last
+// question ONE completion message is sent; on timeout the open card is
+// closed with «время истекло». Edits are best-effort.
+// ─────────────────────────────────────────────────────────────────────
+
+describe('card-close on answer + completion message', () => {
+  test('multiSelect commit closes the card with the joined labels + completion', async () => {
+    const { ui, relay, send } = await mkUi()
+    const handle = relay.submit({
+      toolUseId: 'toolu_ms_done',
+      sessionId: 'sess',
+      chatId: '164795011',
+      questions: [{
+        question: 'Pick frameworks',
+        multiSelect: true,
+        options: [{ label: 'React' }, { label: 'Vue' }, { label: 'Svelte' }],
+      }],
+    })
+    const reqId = handle.requestId!
+    await ui.startQuestion(reqId)
+
+    // Toggle two options on, then commit with «Готово».
+    await ui.handleAskCallback(mkCtx(`ask:toggle:${reqId}:0:0`, 164795011).ctx)
+    await ui.handleAskCallback(mkCtx(`ask:toggle:${reqId}:0:2`, 164795011).ctx)
+    send.editCalls.length = 0
+    send.sendCalls.length = 0
+
+    await ui.handleAskCallback(mkCtx(`ask:done:${reqId}:0`, 164795011).ctx)
+
+    // Card closed: keyboard stripped, both labels echoed on one line.
+    expect(send.editCalls.length).toBe(1)
+    expect(send.editCalls[0]?.opts.reply_markup?.inline_keyboard).toEqual([])
+    expect(send.editCalls[0]?.text).toContain('✅ Ответ:')
+    expect(send.editCalls[0]?.text).toContain('React, Svelte')
+    // Exactly one completion message.
+    expect(send.sendCalls.length).toBe(1)
+    expect(send.sendCalls[0]?.text).toBe('Ответы принял, продолжаю ✅')
+
+    const result = await handle.result
+    expect(result.status).toBe('answered')
+    expect(result.updatedInput?.answers).toEqual({ 'Pick frameworks': 'React, Svelte' })
+  })
+
+  test('«Другое» free-text is truncated to ~100 chars in the closed card', async () => {
+    const { ui, relay, send } = await mkUi()
+    const handle = relay.submit({
+      toolUseId: 'toolu_other_trunc',
+      sessionId: 'sess',
+      chatId: '164795011',
+      questions: [{ question: 'Q', options: [{ label: 'A' }] }],
+    })
+    const reqId = handle.requestId!
+    await ui.startQuestion(reqId)
+    await ui.handleAskCallback(mkCtx(`ask:other:${reqId}:0`, 164795011).ctx)
+    // startQuestion used 1001; Other prompt is 1002.
+    send.editCalls.length = 0
+    send.sendCalls.length = 0
+
+    const longText = 'z'.repeat(250)
+    const consumed = await ui.tryHandleOtherText({
+      chatId: '164795011',
+      fromUserId: 164795011,
+      text: longText,
+      replyToMessageId: 1002,
+    })
+    expect(consumed).toBe(true)
+
+    // Card closed; the echoed answer is capped (clipRaw → 99 chars + ellipsis),
+    // never the full 250.
+    expect(send.editCalls.length).toBe(1)
+    const closedText = send.editCalls[0]!.text
+    expect(closedText).toContain('✅ Ответ:')
+    expect(closedText.includes('z'.repeat(250))).toBe(false)
+    expect(closedText).toContain('z'.repeat(99))
+    // Completion still fires once.
+    expect(send.sendCalls.length).toBe(1)
+    expect(send.sendCalls[0]?.text).toBe('Ответы принял, продолжаю ✅')
+
+    const result = await handle.result
+    expect(result.status).toBe('answered')
+    expect((result.updatedInput?.answers.Q as string).length).toBe(250)
+  })
+
+  test('completion message is sent exactly once — a stale re-tap does not re-send', async () => {
+    const { ui, relay, send } = await mkUi()
+    const handle = relay.submit({
+      toolUseId: 'toolu_once',
+      sessionId: 'sess',
+      chatId: '164795011',
+      questions: [{ question: 'Q', options: [{ label: 'A' }, { label: 'B' }] }],
+    })
+    const reqId = handle.requestId!
+    await ui.startQuestion(reqId)
+    send.sendCalls.length = 0
+
+    await ui.handleAskCallback(mkCtx(`ask:choose:${reqId}:0:0`, 164795011).ctx)
+    expect(send.sendCalls.length).toBe(1)
+
+    // Telegram replays the same tap after the request already settled.
+    const { ctx, answers } = mkCtx(`ask:choose:${reqId}:0:0`, 164795011)
+    await ui.handleAskCallback(ctx)
+    expect(answers[0]?.text).toBe('Запрос уже закрыт')
+    // No second completion message.
+    expect(send.sendCalls.length).toBe(1)
+
+    await handle.result
+  })
+
+  test('multi-question flow: each answered card is closed with its own answer', async () => {
+    const { ui, relay, send } = await mkUi()
+    const handle = relay.submit({
+      toolUseId: 'toolu_two',
+      sessionId: 'sess',
+      chatId: '164795011',
+      questions: [
+        { question: 'Q1', options: [{ label: 'X' }, { label: 'Y' }] },
+        { question: 'Q2', options: [{ label: 'P' }, { label: 'Q' }] },
+      ],
+    })
+    const reqId = handle.requestId!
+    await ui.startQuestion(reqId) // Q1 = msg 1001
+    send.editCalls.length = 0
+    send.sendCalls.length = 0
+
+    // Answer Q1 → Q1 card closed with «X», Q2 rendered fresh (msg 1002).
+    await ui.handleAskCallback(mkCtx(`ask:choose:${reqId}:0:0`, 164795011).ctx)
+    expect(send.editCalls.length).toBe(1)
+    expect(send.editCalls[0]?.messageId).toBe(1001)
+    expect(send.editCalls[0]?.text).toContain('Q1')
+    expect(send.editCalls[0]?.text).toContain('X')
+    expect(send.sendCalls.length).toBe(1) // Q2 sent, NO completion yet
+    expect(send.sendCalls[0]?.text).toContain('Q2')
+
+    send.editCalls.length = 0
+    send.sendCalls.length = 0
+
+    // Answer Q2 → Q2 card closed with «Q», completion sent.
+    await ui.handleAskCallback(mkCtx(`ask:choose:${reqId}:1:1`, 164795011).ctx)
+    expect(send.editCalls.length).toBe(1)
+    expect(send.editCalls[0]?.messageId).toBe(1002)
+    expect(send.editCalls[0]?.text).toContain('Q2')
+    expect(send.editCalls[0]?.text).toContain('Q')
+    expect(send.sendCalls.length).toBe(1)
+    expect(send.sendCalls[0]?.text).toBe('Ответы принял, продолжаю ✅')
+
+    const result = await handle.result
+    expect(result.updatedInput?.answers).toEqual({ Q1: 'X', Q2: 'Q' })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// Codex HIGH regression (2026-07-02) — timeout racing a non-final answer.
+// Pre-fix, the handler awaited ctx.answerCallbackQuery() between the relay
+// mutation and advanceAfterAnswer(); if the internal timeout settled the
+// request during that await, advanceAfterAnswer saw getPending()===undefined
+// and took the «answered final» path — closing the card + sending «Ответы
+// принял, продолжаю ✅» although the request settled as timeout. The fix:
+// finality comes from the relay's synchronous AskAnswerOutcome, and the
+// completion message fires ONLY when THIS callback settled the request as
+// answered.
+// ─────────────────────────────────────────────────────────────────────
+
+describe('Codex regression — timeout during a non-final answer', () => {
+  test('callback-ack delayed past timeout after Q1 → timeout verdict, NO completion, NO render after settle', async () => {
+    const config = mkConfig({ timeoutMs: 30 })
+    const send: FakeTelegramSends = { sendCalls: [], editCalls: [], nextMessageId: 1001 }
+    const api = fakeTelegram(send)
+    let uiRef: ReturnType<typeof createAskUserQuestionUi> | undefined
+    const relay = createAskUserQuestionRelay({
+      log: silentLog(),
+      defaultTimeoutMs: 30,
+      onSettle: (event) => { void uiRef?.handleSettle(event) },
+    })
+    const ui = createAskUserQuestionUi({ config, log: silentLog(), telegramApi: api, relay })
+    uiRef = ui
+
+    const handle = relay.submit({
+      toolUseId: 'toolu_race_ack',
+      sessionId: 'sess',
+      chatId: '164795011',
+      timeoutMs: 30,
+      questions: [
+        { question: 'Q1', options: [{ label: 'X' }, { label: 'Y' }] },
+        { question: 'Q2', options: [{ label: 'P' }, { label: 'Q' }] },
+      ],
+    })
+    const reqId = handle.requestId!
+    await ui.startQuestion(reqId)
+    send.sendCalls.length = 0
+
+    // Answer Q1 with a callback whose ack stalls PAST the relay timeout —
+    // exactly the pre-fix race window.
+    const ctx: AskCallbackContext = {
+      callbackQuery: { data: `ask:choose:${reqId}:0:0` },
+      from: { id: 164795011 },
+      chatId: '164795011',
+      async answerCallbackQuery() {
+        await new Promise((r) => setTimeout(r, 90))
+      },
+    }
+    await ui.handleAskCallback(ctx)
+
+    const result = await handle.result
+    expect(result.status).toBe('timeout')
+    // Flush any fire-and-forget settle edits.
+    await new Promise((r) => setTimeout(r, 10))
+
+    // The poison symptom: NO completion message may exist anywhere.
+    const sentTexts = send.sendCalls.map((c) => c.text)
+    expect(sentTexts.some((t) => t.includes('Ответы принял'))).toBe(false)
+    // Nothing was sent after the request settled (Q2's render — if any —
+    // happened strictly before the timeout; record the count now and give
+    // the loop another tick to prove no trailing sends).
+    const sendsAtSettle = send.sendCalls.length
+    await new Promise((r) => setTimeout(r, 20))
+    expect(send.sendCalls.length).toBe(sendsAtSettle)
+  })
+
+  test('card-close edit stalls past timeout on a non-final answer → no Q2 render, no completion', async () => {
+    // Residual window: with the ack moved AFTER the render, the remaining
+    // await between the relay mutation and the pending re-check is the
+    // clearKeyboard edit itself. Stall that edit past the timeout: the
+    // outcome (final=false) must suppress the completion, and the settled
+    // relay must suppress the Q2 render.
+    const config = mkConfig({ timeoutMs: 30 })
+    const send: FakeTelegramSends = { sendCalls: [], editCalls: [], nextMessageId: 1001 }
+    const api: TelegramApi = {
+      ...fakeTelegram(send),
+      async editMessageText(chatId, messageId, text, editOpts) {
+        send.editCalls.push({ chatId, messageId, text, opts: editOpts })
+        await new Promise((r) => setTimeout(r, 90)) // straddle the timeout
+      },
+    }
+    let uiRef: ReturnType<typeof createAskUserQuestionUi> | undefined
+    const relay = createAskUserQuestionRelay({
+      log: silentLog(),
+      defaultTimeoutMs: 30,
+      onSettle: (event) => { void uiRef?.handleSettle(event) },
+    })
+    const ui = createAskUserQuestionUi({ config, log: silentLog(), telegramApi: api, relay })
+    uiRef = ui
+
+    const handle = relay.submit({
+      toolUseId: 'toolu_race_edit',
+      sessionId: 'sess',
+      chatId: '164795011',
+      timeoutMs: 30,
+      questions: [
+        { question: 'Q1', options: [{ label: 'X' }, { label: 'Y' }] },
+        { question: 'Q2', options: [{ label: 'P' }, { label: 'Q' }] },
+      ],
+    })
+    const reqId = handle.requestId!
+    await ui.startQuestion(reqId)
+    send.sendCalls.length = 0
+
+    await ui.handleAskCallback(mkCtx(`ask:choose:${reqId}:0:0`, 164795011).ctx)
+
+    const result = await handle.result
+    expect(result.status).toBe('timeout')
+    await new Promise((r) => setTimeout(r, 10))
+
+    // Q1's card WAS closed with the chosen answer (the warchief did answer
+    // it) — but Q2 was never rendered and no completion was sent.
+    expect(send.editCalls.some((c) => c.text.includes('✅ Ответ:'))).toBe(true)
+    expect(send.sendCalls.length).toBe(0)
+  })
+})
+
+describe('handleSettle — timeout closes the open card (relay onSettle seam)', () => {
+  test('internal timeout fires onSettle → open keyboard stripped + «время истекло» note', async () => {
+    // Wire the relay's onSettle to the UI exactly as server.ts does, with a
+    // tiny timeout so the internal timer fires on its own.
+    const config = mkConfig({ timeoutMs: 20 })
+    const send: FakeTelegramSends = { sendCalls: [], editCalls: [], nextMessageId: 1001 }
+    const api = fakeTelegram(send)
+    let uiRef: ReturnType<typeof createAskUserQuestionUi> | undefined
+    const relay = createAskUserQuestionRelay({
+      log: silentLog(),
+      defaultTimeoutMs: 20,
+      onSettle: (event) => { void uiRef?.handleSettle(event) },
+    })
+    const ui = createAskUserQuestionUi({ config, log: silentLog(), telegramApi: api, relay })
+    uiRef = ui
+
+    const handle = relay.submit({
+      toolUseId: 'toolu_timeout',
+      sessionId: 'sess',
+      chatId: '164795011',
+      timeoutMs: 20,
+      questions: [{ question: 'Pick a stack', options: [{ label: 'A' }, { label: 'B' }] }],
+    })
+    const reqId = handle.requestId!
+    await ui.startQuestion(reqId)
+    send.editCalls.length = 0
+
+    const result = await handle.result
+    expect(result.status).toBe('timeout')
+    // Give the fire-and-forget handleSettle a tick to run its edit.
+    await new Promise((r) => setTimeout(r, 5))
+
+    expect(send.editCalls.length).toBe(1)
+    expect(send.editCalls[0]?.messageId).toBe(1001)
+    expect(send.editCalls[0]?.opts.reply_markup?.inline_keyboard).toEqual([])
+    expect(send.editCalls[0]?.text).toContain('Pick a stack') // question kept
+    expect(send.editCalls[0]?.text).toContain('⏰ Время истекло')
+  })
+
+  test('handleSettle is a no-op for answered (driven path already closed it)', async () => {
+    const { ui, send } = await mkUi()
+    await ui.handleSettle({
+      requestId: 'aaaaa',
+      toolUseId: 'toolu_x',
+      status: 'answered',
+      chatId: '164795011',
+      telegramMessageId: 1001,
+      currentIndex: 0,
+      totalQuestions: 1,
+      questionText: 'Q',
+      reason: undefined,
+    })
+    expect(send.editCalls.length).toBe(0)
+  })
+
+  test('handleSettle tolerates an edit failure (best-effort, never throws)', async () => {
+    const { ui, send } = await mkUi({}, { editThrows: true })
+    await expect(
+      ui.handleSettle({
+        requestId: 'bbbbb',
+        toolUseId: 'toolu_y',
+        status: 'timeout',
+        chatId: '164795011',
+        telegramMessageId: 1001,
+        currentIndex: 0,
+        totalQuestions: 1,
+        questionText: 'Q',
+        reason: 'ask_user_question timed out',
+      }),
+    ).resolves.toBeUndefined()
+    // The edit was attempted (and threw) — swallowed, no crash.
+    expect(send.editCalls.length).toBe(1)
   })
 })
 


### PR DESCRIPTION
Фидбек вождя со скрином. Карточки гаснут (клавиатура снята + исход в тексте), одно completion-сообщение после последнего ответа, таймаут-карточки помечаются. Гонка settle-vs-advance закрыта синхронным AskAnswerOutcome (Codex BLOCK -> re-review SHIP, контрфактический тест). 1641 тест. Кодер: Opus-субагент. Применение: рестарт канальных сессий флота.

🤖 Generated with [Claude Code](https://claude.com/claude-code)