### PR TITLE
Канал: индикатор загрузки контекста + надёжные команды управления

### DIFF
--- a/plugin/src/commands/keys.ts
+++ b/plugin/src/commands/keys.ts
@@ -228,7 +228,21 @@ export function parseCcCommand(args: string): ParsedCc | { error: string } {
 // Type `/<name> [rest]` into the pane and submit with Enter. Clears the input
 // line first (C-u) so a leftover draft can't corrupt the command — the same
 // hygiene used when driving another agent's pane by hand.
-export async function sendSlashCommand(
+//
+// IT2-7: funnelled through the SAME per-pane serialization chain as
+// sendControlCommand (via runOnPaneChain, defined below) so an argful /cc, a
+// /keys tap, or /stop cannot interleave its keystrokes with an in-flight control
+// 3-shot. The raw body lives in `sendSlashCommandInner`; the export is the
+// chained wrapper. Return contract is unchanged.
+export function sendSlashCommand(
+  target: TmuxKeysTarget,
+  parsed: ParsedCc,
+  exec: KeysExec = defaultKeysExec,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  return runOnPaneChain(target, () => sendSlashCommandInner(target, parsed, exec))
+}
+
+async function sendSlashCommandInner(
   target: TmuxKeysTarget,
   parsed: ParsedCc,
   exec: KeysExec = defaultKeysExec,
@@ -256,7 +270,20 @@ export async function sendSlashCommand(
 
 // Send a single named key (Escape, Enter, …) to the pane — used by /stop to
 // interrupt Claude, and reusable by other control commands.
-export async function sendNamedKey(
+//
+// IT2-7: the export is serialized through the per-pane chain (runOnPaneChain) so
+// a /stop Escape can't land between an in-flight control 3-shot's keystrokes.
+// The raw body is `sendNamedKeyInner`; sendControlCommandInner calls the INNER
+// form directly (it already holds the pane chain — re-chaining would deadlock).
+export function sendNamedKey(
+  target: TmuxKeysTarget,
+  key: string,
+  exec: KeysExec = defaultKeysExec,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  return runOnPaneChain(target, () => sendNamedKeyInner(target, key, exec))
+}
+
+async function sendNamedKeyInner(
   target: TmuxKeysTarget,
   key: string,
   exec: KeysExec = defaultKeysExec,
@@ -271,4 +298,467 @@ export async function sendNamedKey(
     return { ok: false, error: res.stderr.slice(0, 200) || `tmux exited ${res.exitCode}` }
   }
   return { ok: true }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// /clear, /compact & friends — RELIABLE control-command injection.
+//
+// Problem (warchief, 2026-07-01, verified empirically): the 3-shot
+// `sendSlashCommand` above (C-u / -l '/cmd' / Enter) is correct ONLY when the
+// pane is IDLE. It fails in two states:
+//   - BUSY: Claude Code QUEUES text typed while it is working; the command
+//     sits in the queue and runs ~25s later (or is silently dropped).
+//   - DIALOG: a native permission/confirm dialog is open; the trailing Enter
+//     APPROVES THE DIALOG and the typed command is lost.
+// Fix: PROBE the pane state before sending, then CONFIRM the command actually
+// fired afterwards. Never blind-Enter into a busy pane or an open dialog.
+//
+// Additive — `sendSlashCommand` stays for argful /cc passthrough (idle only).
+// Everything here is driven by `capture-pane`, whose stdout the send-only
+// `KeysExec` deliberately drops, so a dedicated capture exec type is needed.
+
+// A capture-capable exec: like `KeysExec` but KEEPS stdout, which `capture-pane`
+// needs. Kept SEPARATE from `KeysExec` so the send-only path can never grow a
+// stdout dependency, and so tests can script pane snapshots independently of the
+// send-keys fake.
+export type KeysCaptureExec = (
+  args: readonly string[],
+) => Promise<{ exitCode: number; stdout: string; stderr: string }>
+
+async function defaultKeysCaptureExec(
+  args: readonly string[],
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  try {
+    const { stdout, stderr } = await execFileAsync('tmux', args as string[], {
+      encoding: 'utf8',
+      timeout: 5000,
+    })
+    return { exitCode: 0, stdout, stderr }
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; code?: number; message?: string }
+    return {
+      exitCode: typeof e.code === 'number' ? e.code : 1,
+      stdout: e.stdout ?? '',
+      stderr: e.stderr ?? e.message ?? 'tmux exec failed',
+    }
+  }
+}
+
+// Snapshot the pane's visible text (`capture-pane -p`). Returns '' on ANY tmux
+// failure — callers classify '' as 'unknown' (never idle), so a failed capture
+// can never be mistaken for a safe-to-send idle pane.
+export async function capturePane(
+  target: TmuxKeysTarget,
+  exec: KeysCaptureExec = defaultKeysCaptureExec,
+): Promise<string> {
+  const socketArgs = target.socketPath
+    ? ['-S', target.socketPath]
+    : target.socketName
+      ? ['-L', target.socketName]
+      : []
+  const res = await exec([...socketArgs, 'capture-pane', '-p', '-t', target.paneTarget])
+  if (res.exitCode !== 0) return ''
+  return res.stdout
+}
+
+export type PaneState = 'idle' | 'busy' | 'dialog' | 'unknown'
+
+// Number of trailing lines that constitute the LIVE UI chrome (the composer box
+// + footer hints + the status/spinner line just above the box). We match the
+// pane-state markers ONLY within this bottom region so the agent's OWN
+// transcript — which can literally contain strings like "esc to interrupt" or
+// "Do you want to proceed?" (this very plugin discusses them) — scrolls ABOVE
+// the chrome and can never be misread as live pane state (FIX-5, Fable M3).
+//
+// Fail-safe bias: a marker that quotes chrome text in the last few transcript
+// lines yields a FALSE busy/dialog, which only makes us REFUSE to send (safe),
+// never a false idle (which would blind-send). 12 lines comfortably spans a
+// tall permission dialog box while excluding scrolled-up history.
+const BOTTOM_CHROME_LINES = 12
+
+// The bottom UI chrome region of a capture (geometry anchor for classifyPane,
+// the queued-check and the fired-marker count). Exported-internal helper; PURE.
+//
+// IT2-4: strip trailing whitespace-only lines BEFORE taking the last N. When a
+// taller render shrinks (a dialog box closed, a compaction finished) tmux can
+// leave blank rows padding the bottom of the capture; without trimming them the
+// real chrome markers get pushed OUT of the last-N window and we go blind to the
+// live pane state (a false 'unknown'/'idle'). Trimming the blank tail keeps the
+// markers inside the window. classifyPane, the queued-check and firedMarkerCount
+// all read through this trimmed region.
+function bottomChrome(text: string): string {
+  const lines = text.split('\n')
+  let end = lines.length
+  while (end > 0 && lines[end - 1]!.trim().length === 0) end--
+  const trimmed = lines.slice(0, end)
+  if (trimmed.length <= BOTTOM_CHROME_LINES) return trimmed.join('\n')
+  return trimmed.slice(trimmed.length - BOTTOM_CHROME_LINES).join('\n')
+}
+
+// Classify a pane snapshot by string-matching Claude Code TUI v2.1.200 markers,
+// anchored to the bottom UI chrome (FIX-5). PURE (no I/O) so it is trivially
+// unit-testable against canned captures.
+//
+// Idle footer is MODE-DEPENDENT (verified on the live pane, v2.1.200): Manual
+// mode shows `? for shortcuts`; bypass / accept-edits / plan modes show
+// `⏵⏵ … (shift+tab to cycle)` — which PERSISTS on line 1 even while the slash
+// autocomplete popup is open. We OR both markers so idle is recognised in every
+// mode.
+//
+// Ordering is load-bearing: DIALOG is checked BEFORE BUSY, because a native
+// permission dialog can ALSO render an "esc to interrupt" hint while a tool runs
+// behind it — but a dialog needs an explicit answer, never a blind Enter, so
+// dialog must win. Dialog markers (`Do you want to proceed?`, `❯ 1.`,
+// `Esc to cancel`) confirmed exact on v2.1.200 — the folder-trust dialog uses
+// `❯ 1. Yes…` + `Esc to cancel` (no "Do you want to proceed?"), still caught.
+//
+// Callers MUST treat 'unknown' as NOT-idle: if we cannot POSITIVELY identify an
+// idle composer, we never blind-Enter (the trailing Enter of a slash command
+// could otherwise approve a prompt we failed to recognise). Geometry-detection
+// failure (empty capture, no recognisable chrome) → 'unknown' → refuse.
+export function classifyPane(text: string): PaneState {
+  const chrome = bottomChrome(text)
+  if (
+    chrome.includes('Do you want to proceed?') ||
+    chrome.includes('❯ 1.') ||
+    chrome.includes('Esc to cancel')
+  ) {
+    return 'dialog'
+  }
+  if (chrome.includes('esc to interrupt')) {
+    return 'busy'
+  }
+  if (
+    (chrome.includes('shift+tab to cycle') || chrome.includes('? for shortcuts')) &&
+    !chrome.includes('esc to interrupt')
+  ) {
+    return 'idle'
+  }
+  return 'unknown'
+}
+
+// Real timer sleep. Tests inject an instant no-op so the confirm-fire poll does
+// not actually wait ~1.5s.
+const realSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms))
+
+export interface ControlCommandOpts {
+  // Interrupt a BUSY pane (Escape, wait, re-probe) before sending. When false
+  // (default) a busy pane is left untouched and reported as busy.
+  interruptIfBusy?: boolean
+  // Delay primitive — injected as an instant no-op in tests.
+  sleep?: (ms: number) => Promise<void>
+  // Send-only exec (send-keys). Defaults to the real tmux exec.
+  exec?: KeysExec
+  // Capture-capable exec (capture-pane). Defaults to the real tmux exec.
+  captureExec?: KeysCaptureExec
+}
+
+// Discriminated union: either it fired, or it did not — with the precise reason
+// so the caller can tell the user WHY (dialog open, pane busy, never submitted,
+// a raw tmux failure, or an UNKNOWN pane we refused to blind-send into).
+//
+// `unknown` (FIX-1, both reviews): a failed capture-pane returns '' and an
+// unrecognised screen both classify as `unknown`. We NEVER send into an
+// unknown pane — a blind Enter could approve a dialog we failed to recognise —
+// so the caller sees an explicit `unknown` reason rather than a silent send.
+export type ControlCommandResult =
+  | { ok: true }
+  | { ok: false; reason: 'dialog' | 'busy' | 'not-submitted' | 'tmux' | 'unknown' }
+
+// The composer text region = the lines framed by the LAST two horizontal box
+// rules (the input box borders). We check THIS region — not the whole capture —
+// for a leftover '/'+name, so a transcript ECHO of the submitted command
+// (rendered OUTSIDE the box) is never mistaken for an un-submitted draft.
+function composerRegion(text: string): string {
+  const lines = text.split('\n')
+  const ruleIdx: number[] = []
+  for (let i = 0; i < lines.length; i++) {
+    // A box border: 3+ consecutive ─ (U+2500) or a long ASCII dash run.
+    if (/─{3,}/.test(lines[i]!) || /-{5,}/.test(lines[i]!)) ruleIdx.push(i)
+  }
+  if (ruleIdx.length === 0) return text // no box drawn — be conservative
+  const last = ruleIdx[ruleIdx.length - 1]!
+  const prev = ruleIdx.length >= 2 ? ruleIdx[ruleIdx.length - 2]! : -1
+  return lines.slice(prev + 1, last).join('\n')
+}
+
+// Count non-overlapping occurrences of `needle` in `haystack`. PURE. Empty
+// needle → 0 (never matches, so it can't spuriously certify a fire).
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle.length === 0) return 0
+  let count = 0
+  let idx = haystack.indexOf(needle)
+  while (idx !== -1) {
+    count++
+    idx = haystack.indexOf(needle, idx + needle.length)
+  }
+  return count
+}
+
+// Positive "it actually ran" marker strings per command. Scoped to the bottom UI
+// chrome (FIX-5) by the caller so a transcript far above that quotes
+// "Compacting" is not misread. For `compact` we track BOTH the
+// `Compacting conversation…` banner AND the `❯ /compact` echo — a fresh compact
+// always prints at least the echo, so summing them makes a genuine fire reliably
+// ADD to the count even when a prior run's banner is still on screen.
+//
+// CRITICAL (coordinator smoke-test, v2.1.200): `Ctrl+Y to paste` does NOT render
+// after /clear in this build — using it as the clear marker made /clear and /new
+// ALWAYS report not-submitted even on success. /clear success is the fresh
+// `❯ /clear` echo (plus the transcript collapse handled in confirmedFired).
+function firedMarkers(name: string): readonly string[] {
+  if (name === 'clear') {
+    // /clear echoes an accepted `❯ /clear` into the (now-collapsed) transcript.
+    return ['❯ /clear']
+  }
+  if (name === 'compact') {
+    return ['Compacting', `❯ /${name}`]
+  }
+  // Generic: Claude Code echoes an accepted slash command into the transcript
+  // as `❯ /name`. (Distinct from the dialog option marker `❯ 1.`.)
+  return [`❯ /${name}`]
+}
+
+// IT2-2: the total occurrence count of a command's fired-markers WITHIN the
+// bottom UI chrome. Success is judged by an INCREASE of this count vs the
+// pre-send baseline (a fresh occurrence), never by mere presence — a stale
+// marker already on screen no longer certifies a fire.
+function firedMarkerCount(name: string, text: string): number {
+  const chrome = bottomChrome(text)
+  let total = 0
+  for (const m of firedMarkers(name)) total += countOccurrences(chrome, m)
+  return total
+}
+
+// Transcript region = everything ABOVE the composer box (before its top rule).
+// Used only to detect that /clear visibly WIPED the conversation.
+function transcriptRegion(text: string): string {
+  const lines = text.split('\n')
+  const ruleIdx: number[] = []
+  for (let i = 0; i < lines.length; i++) {
+    if (/─{3,}/.test(lines[i]!) || /-{5,}/.test(lines[i]!)) ruleIdx.push(i)
+  }
+  if (ruleIdx.length < 2) return ''
+  const boxTop = ruleIdx[ruleIdx.length - 2]!
+  return lines.slice(0, boxTop).join('\n')
+}
+
+function nonEmptyLineCount(text: string): number {
+  return text.split('\n').filter((l) => l.trim().length > 0).length
+}
+
+// FIX-2 / IT2-2 (both reviews): a merely-PRESENT positive marker is not proof of
+// success — a marker left over from a PREVIOUS command (a stale "Compacting…",
+// "Ctrl+Y to paste", or "❯ /name") would otherwise certify a command that never
+// fired (a false NEGATIVE the other way: it made a real fire read as
+// not-submitted, and broke back-to-back compacts). Require a FRESH OCCURRENCE:
+// the marker count within the bottom chrome must INCREASE vs the PRE-SEND
+// baseline. A stale marker leaves the count unchanged (refuse); a genuine
+// (even back-to-back) fire adds a new occurrence on top (accept). For /clear we
+// ALSO accept a visibly collapsed transcript (the old conversation wiped) as
+// proof it ran, covering the case where a stale paste-hint was already on screen
+// and the count cannot move.
+function confirmedFired(name: string, snap: string, baseline: string): boolean {
+  // Primary: a FRESH occurrence of the command's marker in the bottom chrome.
+  if (firedMarkerCount(name, snap) > firedMarkerCount(name, baseline)) return true
+  if (name === 'clear') {
+    // /clear success #2: the conversation visibly COLLAPSED (fewer transcript
+    // lines than before) — the wipe landed.
+    if (nonEmptyLineCount(transcriptRegion(snap)) < nonEmptyLineCount(transcriptRegion(baseline))) {
+      return true
+    }
+    // /clear success #3 (coordinator, v2.1.200): on an ALREADY-SHORT / already-
+    // clear session neither the count nor the transcript can move, yet the clear
+    // did run. The reliable sender only pressed Enter on a VERIFIED `/clear` draft
+    // in an idle pane, so an empty composer (the caller already checked that) with
+    // the `❯ /clear` echo on screen AND an idle footer back is a confident
+    // success — prefer it over a false not-submitted.
+    if (bottomChrome(snap).includes('❯ /clear') && classifyPane(snap) === 'idle') {
+      return true
+    }
+  }
+  return false
+}
+
+// FIX-4 (both reviews): per-pane serialization. This code drives the user's
+// ONLY communication channel by injecting keystrokes; two concurrent control
+// sends into the SAME pane (e.g. a HUD «Сжать» tap racing a typed /compact)
+// could interleave C-u / text / Enter and corrupt the command — or worse,
+// let one call's Enter land on another's half-typed draft. IT2-7: EVERY pane
+// write — sendControlCommand, sendSlashCommand, sendNamedKey — chains through
+// this per-target promise (runOnPaneChain) so they run strictly one-at-a-time.
+// Keyed by socket+pane so distinct panes stay independent. The stored chain is
+// the SETTLED (never-rejecting) tail, so a failed/throwing call never poisons the
+// next one.
+const paneChains = new Map<string, Promise<void>>()
+
+// IT2-7: run `fn` strictly after any in-flight pane operation for the SAME
+// target, and make the next caller wait for `fn`. The single per-pane
+// serialization primitive shared by sendControlCommand, sendSlashCommand and
+// sendNamedKey so their keystrokes can never interleave. The stored chain tail
+// is the SETTLED (never-rejecting) promise, so a throwing/failing op never
+// poisons the next one. NOT re-entrant: an op already running inside the chain
+// must call the *Inner form directly, never re-enter through here (it would
+// deadlock waiting on its own tail).
+function runOnPaneChain<T>(target: TmuxKeysTarget, fn: () => Promise<T>): Promise<T> {
+  const key = paneKey(target)
+  const prior = paneChains.get(key) ?? Promise.resolve()
+  // Chain on the prior tail (which never rejects) so an earlier failure can't
+  // skip this call's body.
+  const result = prior.then(fn)
+  const settled: Promise<void> = result.then(
+    () => undefined,
+    () => undefined,
+  )
+  paneChains.set(key, settled)
+  // Opportunistic cleanup: drop the entry once WE are the tail and have settled.
+  void settled.then(() => {
+    if (paneChains.get(key) === settled) paneChains.delete(key)
+  })
+  return result
+}
+
+function paneKey(target: TmuxKeysTarget): string {
+  return `${target.socketPath ?? ''} ${target.socketName ?? ''} ${target.paneTarget}`
+}
+
+// Reliable control-command injection: probe → (optionally interrupt) → send →
+// CONFIRM, serialized per pane. `name` must pass `SLASH_NAME_RE` — the SAME
+// closed slash-name whitelist `sendSlashCommand` uses. Control commands here
+// take NO args (/clear, /compact, …).
+export function sendControlCommand(
+  target: TmuxKeysTarget,
+  name: string,
+  opts: ControlCommandOpts = {},
+): Promise<ControlCommandResult> {
+  return runOnPaneChain(target, () => sendControlCommandInner(target, name, opts))
+}
+
+async function sendControlCommandInner(
+  target: TmuxKeysTarget,
+  name: string,
+  opts: ControlCommandOpts,
+): Promise<ControlCommandResult> {
+  // Reuse the frozen slash-name whitelist. A name outside it is a programming
+  // error (callers validate via `parseCcCommand` first), so fail loudly rather
+  // than smuggle an unvalidated token toward the pane.
+  if (!SLASH_NAME_RE.test(name)) {
+    throw new RangeError(`sendControlCommand: invalid command name «${name}»`)
+  }
+  const exec = opts.exec ?? defaultKeysExec
+  const captureExec = opts.captureExec ?? defaultKeysCaptureExec
+  const sleep = opts.sleep ?? realSleep
+  const interruptIfBusy = opts.interruptIfBusy ?? false
+
+  const socketArgs = target.socketPath
+    ? ['-S', target.socketPath]
+    : target.socketName
+      ? ['-L', target.socketName]
+      : []
+
+  // a. Probe pane state. This snapshot is ALSO the PRE-SEND baseline (FIX-2) —
+  //    the fired-marker check below requires a FRESH transition against it.
+  let baseline = await capturePane(target, captureExec)
+  let state = classifyPane(baseline)
+
+  // b. Dialog open → send NOTHING (the trailing Enter would approve it).
+  if (state === 'dialog') {
+    return { ok: false, reason: 'dialog' }
+  }
+
+  // c. Busy → either interrupt (Escape, wait, re-probe) or refuse.
+  if (state === 'busy') {
+    if (!interruptIfBusy) {
+      return { ok: false, reason: 'busy' }
+    }
+    // IT2-7: call the INNER (unchained) form — we already hold the pane chain,
+    // so re-entering runOnPaneChain here would deadlock on our own tail.
+    const esc = await sendNamedKeyInner(target, 'Escape', exec)
+    if (!esc.ok) return { ok: false, reason: 'tmux' }
+    await sleep(350)
+    baseline = await capturePane(target, captureExec)
+    state = classifyPane(baseline)
+    if (state === 'busy') {
+      return { ok: false, reason: 'busy' }
+    }
+    if (state === 'dialog') {
+      // Interrupting surfaced a confirm dialog — never type a command into it.
+      return { ok: false, reason: 'dialog' }
+    }
+  }
+
+  // FIX-1 (both reviews): require a POSITIVE idle before sending. A failed
+  // capture ('' → unknown) or any unrecognised screen must NEVER fall through
+  // to the 3-shot — a blind Enter could approve a dialog we failed to classify.
+  if (state !== 'idle') {
+    return { ok: false, reason: 'unknown' }
+  }
+
+  // d. 3-shot: clear the line, type '/'+name, (settle) then submit with Enter.
+  const text = `/${name}`
+  // `text` always starts with '/', so it can never be parsed as a tmux flag.
+  const preEnter: Array<readonly string[]> = [
+    [...socketArgs, 'send-keys', '-t', target.paneTarget, 'C-u'],
+    [...socketArgs, 'send-keys', '-t', target.paneTarget, '-l', text],
+  ]
+  for (const args of preEnter) {
+    const res = await exec(args)
+    if (res.exitCode !== 0) return { ok: false, reason: 'tmux' }
+  }
+  await sleep(120) // let the TUI render the typed text before Enter
+
+  // FIX-3 + IT2-3 (both reviews): TOCTOU guard, refined. Between typing the draft
+  // and pressing Enter a native dialog / busy state can surface — those are the
+  // DANGEROUS states (a trailing Enter would approve a dialog or queue behind a
+  // running tool), so we ABORT on them (wipe the draft, refuse). But typing a
+  // slash command ALSO opens Claude Code's autocomplete popup, which can REPLACE
+  // the idle footer hints → classifyPane === 'unknown'; a slow paint can also
+  // hide the draft transiently. Refusing on unknown/absent here would kill every
+  // control send. So we poll a short window (~600ms) for the composer to actually
+  // show our '/name' draft, and as long as the pane is NOT busy/dialog we press
+  // Enter once the draft is visible. Only if the draft never appears do we refuse
+  // (not-submitted).
+  let draftReady = false
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const snap = await capturePane(target, captureExec)
+    const st = classifyPane(snap)
+    if (st === 'dialog' || st === 'busy') {
+      // A dangerous state surfaced in the settle window — never Enter. Wipe the
+      // draft so it can't be submitted by a later keystroke.
+      await exec([...socketArgs, 'send-keys', '-t', target.paneTarget, 'C-u'])
+      return { ok: false, reason: st }
+    }
+    if (composerRegion(snap).includes(text)) {
+      draftReady = true
+      break
+    }
+    if (attempt < 2) await sleep(250)
+  }
+  if (!draftReady) {
+    await exec([...socketArgs, 'send-keys', '-t', target.paneTarget, 'C-u'])
+    return { ok: false, reason: 'not-submitted' }
+  }
+
+  const enter = await exec([...socketArgs, 'send-keys', '-t', target.paneTarget, 'Enter'])
+  if (enter.exitCode !== 0) return { ok: false, reason: 'tmux' }
+
+  // e. Confirm-fire: poll for the fired signal. IT2-2: capture IMMEDIATELY after
+  //    Enter (a fresh marker often lands right away), then a few short intervals
+  //    to cover a slow render — waiting a full 500ms first needlessly delayed the
+  //    ok. Success requires ALL of: composer emptied (the region above the last
+  //    rule no longer holds '/'+name) AND not queued ('Press up to edit queued
+  //    messages' absent WITHIN the bottom chrome, so a stale/scrolled quote of it
+  //    can't false-fail) AND a FRESH command-specific fired OCCURRENCE vs the
+  //    pre-send baseline (a stale marker never certifies success).
+  for (let attempt = 0; attempt < 4; attempt++) {
+    if (attempt > 0) await sleep(400)
+    const snap = await capturePane(target, captureExec)
+    const composerEmptied = !composerRegion(snap).includes(text)
+    const queued = bottomChrome(snap).includes('Press up to edit queued messages')
+    if (composerEmptied && !queued && confirmedFired(name, snap, baseline)) {
+      return { ok: true }
+    }
+  }
+  return { ok: false, reason: 'not-submitted' }
 }

--- a/plugin/src/commands/oob.ts
+++ b/plugin/src/commands/oob.ts
@@ -1,45 +1,61 @@
 // Out-of-band (OOB) commands handled by the plugin BEFORE a channel
-// notification is sent to Claude. Mirrors gateway.py:_OOB_COMMANDS +
-// _handle_oob_command + handle_command (status/help/reset/new branches).
+// notification is sent to Claude.
 //
-// Scope A commands: /help, /status, /stop, /reset, /new.
-// Explicitly NOT included: /compact, /halt (Scope B per PLAN.md T10).
+// Control commands: /help, /status, /stop, /compact, /new, /mirror, /keys, /cc.
+// The session-driving controls (/stop, /compact, /new-confirm, /cc, /keys) act
+// on the agent's tmux pane through the RELIABLE injection layer in keys.ts
+// (probe → optionally interrupt → send → confirm), never a blind Enter.
+// Still NOT a command: /halt.
 //
-// Parsing rules (gateway.py:3037-3046 + 3366-3370):
+// Parsing rules:
 //   - Must start with `/`.
 //   - Optional `@botname` suffix is stripped when it matches our bot's
 //     username (case-insensitive).
 //   - Command word is lowercased.
-//   - Trailing `force` token in args sets hasForceFlag (for /reset force,
-//     /new force).
+//   - Trailing `force` token in args sets hasForceFlag (legacy; unused by the
+//     current commands but preserved for source-compat).
 //
 // Handling notes:
 //   - /help and /status reply directly to Telegram and DO NOT wake Claude
-//     (no channel notification). Status is a snapshot of plugin-side state
-//     only — Claude session lives in the host process and we don't poke it.
-//   - /stop, /reset force, /new force ack the user AND emit a channel
-//     notification with meta.command=<name>. The plugin can't truly
-//     interrupt Claude (no public API for that yet); /help documents this
-//     limitation.
-//   - /reset and /new without `force` return a short reply asking for the
-//     flag, no channel notification.
+//     (no channel notification).
+//   - /compact injects Claude Code's own /compact into the pane via
+//     sendControlCommand and reports the REAL result (ok/busy/dialog/…).
+//   - /new is one-tap-with-confirm: a bare /new posts a confirmation card;
+//     the tap (newq: callback in server.ts) runs the destructive /clear.
+//   - /stop sends Escape (interrupt) into the pane; falls back to a channel
+//     signal when no pane is resolvable.
 
 import type { AppConfig } from '../config.js'
 import type { Logger } from '../log.js'
 import type { TelegramApi, InlineKeyboardLike } from '../channel/tools.js'
 import { sendChannelNotification, type ChannelEvent } from '../channel/notify.js'
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js'
-import { parseCcCommand, sendSlashCommand, sendNamedKey, type KeysExec, type TmuxKeysTarget } from './keys.js'
+import {
+  capturePane,
+  classifyPane,
+  parseCcCommand,
+  sendSlashCommand,
+  sendNamedKey,
+  sendControlCommand,
+  type ControlCommandOpts,
+  type KeysCaptureExec,
+  type KeysExec,
+  type TmuxKeysTarget,
+} from './keys.js'
 import { buildKeysKeyboard, KEYS_PANEL_HEADER } from '../telegram/keys-panel-ui.js'
 import { buildCcKeyboard, CC_PANEL_HEADER } from '../telegram/cc-panel-ui.js'
+import { buildNewConfirmCard } from '../telegram/newq-confirm-ui.js'
+import { controlFailureMessage } from '../telegram/control-result.js'
+import { readContextUsage, formatContextUsage } from '../status/context-usage.js'
+import { DEFAULT_CONTEXT_WINDOW_TOKENS } from '../config.js'
 
-export type OobCommandName = 'help' | 'status' | 'stop' | 'reset' | 'new' | 'mirror' | 'keys' | 'cc'
+export type OobCommandName = 'help' | 'status' | 'stop' | 'compact' | 'new' | 'mirror' | 'keys' | 'cc'
 
 const KNOWN_COMMANDS = new Set<OobCommandName>([
   'help',
   'status',
   'stop',
-  'reset',
+  'compact',
   'new',
   'mirror',
   'keys',
@@ -144,10 +160,27 @@ export interface OobContext {
   tmuxMirror?: TmuxMirrorControl
   // /keys target — the pane of the agent's Claude session. Undefined when the
   // plugin can't resolve a pane (no tmux config); the handler then explains.
-  tmuxKeys?: { target: TmuxKeysTarget; exec?: KeysExec }
+  // `exec` (send-keys) / `captureExec` (capture-pane) / `sleep` are test-only
+  // injection seams — production wires only `target`, so /compact drives the
+  // real tmux through sendControlCommand's own defaults.
+  tmuxKeys?: {
+    target: TmuxKeysTarget
+    exec?: KeysExec
+    captureExec?: KeysCaptureExec
+    sleep?: (ms: number) => Promise<void>
+  }
   // Identity bits surfaced by /status.
   botId?: number
   stateDir?: string
+  // Context-usage bits for /status (task 5). transcriptPath comes from the
+  // SessionInfoStore (latest hook event); modelName from a SessionStart hook;
+  // contextWindowTokens from config (resolveContextWindowTokens). All optional
+  // — when transcriptPath is absent /status shows «контекст: —».
+  transcriptPath?: string
+  modelName?: string
+  contextWindowTokens?: number
+  // Process uptime in seconds (process.uptime()); rendered when present.
+  uptimeSeconds?: number
 }
 
 export interface OobResult {
@@ -162,23 +195,22 @@ export interface OobResult {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// /help text. Lists ONLY Scope A commands. Do not add /compact, /halt
-// here — they belong to Scope B and grep checks enforce their absence.
+// /help text. Lists the control commands. /halt is intentionally absent.
 // ─────────────────────────────────────────────────────────────────────
 
 function helpText(): string {
   return (
     '<b>команды</b>\n\n'
     + '<code>/help</code> — эта справка\n'
-    + '<code>/status</code> — снимок плагина и сессии\n'
-    + '<code>/stop</code> — попросить Claude остановить текущую задачу\n'
-    + '<code>/reset force</code> — сбросить состояние сессии (подтверди флагом <code>force</code>)\n'
-    + '<code>/new force</code> — начать новую сессию (подтверди флагом <code>force</code>)\n'
+    + '<code>/status</code> — снимок плагина и сессии (+ расход контекста)\n'
+    + '<code>/stop</code> — прервать текущую задачу (Escape в сессию)\n'
+    + '<code>/compact</code> — сжать контекст сессии\n'
+    + '<code>/new</code> — начать новый диалог (очистит контекст — спросит подтверждение)\n'
     + '<code>/mirror on|off|status</code> — управлять зеркалом терминала (tmux, обновляется в реальном времени)\n'
     + '<code>/keys</code> — панель кнопок: тап = нажатие в сессии (ответить на нативный диалог Claude Code; есть ⌫ backspace и 🧹 clear)\n'
-    + '<code>/cc</code> — панель команд Claude Code (тап = выполнить); либо <code>/cc &lt;команда&gt;</code>: <code>/cc compact</code>, <code>/cc model opus</code>\n\n'
-    + '<i>примечание: /stop — best-effort: плагин передаёт сигнал остановки через '
-    + 'канал, но не может гарантировать прерывание посреди вызова инструмента.</i>'
+    + '<code>/cc</code> — панель команд Claude Code (тап = выполнить); либо <code>/cc &lt;команда&gt;</code>: <code>/cc model opus</code>\n\n'
+    + '<i>примечание: /stop — best-effort: посылает Escape в сессию, но не может '
+    + 'гарантировать прерывание посреди вызова инструмента.</i>'
   )
 }
 
@@ -191,15 +223,28 @@ export interface BotCommandSpec {
 export const BOT_COMMANDS: ReadonlyArray<BotCommandSpec> = [
   { command: 'help', description: 'справка по командам' },
   { command: 'status', description: 'снимок плагина и сессии' },
-  { command: 'stop', description: 'попросить Claude остановиться' },
-  { command: 'reset', description: 'сбросить сессию (нужен force)' },
-  { command: 'new', description: 'начать новую сессию (нужен force)' },
+  { command: 'stop', description: 'прервать текущую задачу' },
+  { command: 'compact', description: 'сжать контекст сессии' },
+  { command: 'new', description: 'новый диалог (очистит контекст, с подтверждением)' },
   { command: 'mirror', description: 'зеркало терминала: on | off | status' },
   { command: 'keys', description: 'панель кнопок для подтверждений (нажатия в сессию)' },
   { command: 'cc', description: 'панель команд Claude Code (тап) или /cc <команда>' },
 ]
 
-function statusText(ctx: OobContext): string {
+// Format process uptime seconds as a compact human string (e.g. `2h 15m`).
+function formatUptime(sec: number): string {
+  const s = Math.max(0, Math.floor(sec))
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  if (h > 0) return `${h}h ${m}m`
+  const secs = s % 60
+  return m > 0 ? `${m}m ${secs}s` : `${secs}s`
+}
+
+// Async because it reads the session transcript tail for context usage (task 5).
+// The transcript read is bounded (~256 KB tail) and never throws — a null
+// usage renders «контекст: —».
+async function statusText(ctx: OobContext): Promise<string> {
   const lines: string[] = ['<b>статус</b>']
   if (ctx.botId !== undefined) {
     lines.push(`bot_id: <code>${escapeHtml(String(ctx.botId))}</code>`)
@@ -227,6 +272,24 @@ function statusText(ctx: OobContext): string {
     const ws = ctx.webhookStatus()
     const w = ws.enabled ? `on:${ws.port}` : 'off'
     lines.push(`webhook: <code>${w}</code>`)
+  }
+
+  if (ctx.modelName) {
+    lines.push(`model: <code>${escapeHtml(ctx.modelName)}</code>`)
+  }
+
+  // Context usage — read the transcript tail when we have a path. `usage` is
+  // null on any read failure / no usable turn → render «—».
+  const windowTokens = ctx.contextWindowTokens ?? DEFAULT_CONTEXT_WINDOW_TOKENS
+  let contextLine = '—'
+  if (ctx.transcriptPath) {
+    const usage = await readContextUsage(ctx.transcriptPath, windowTokens)
+    if (usage) contextLine = formatContextUsage(usage, windowTokens)
+  }
+  lines.push(`контекст: <code>${escapeHtml(contextLine)}</code>`)
+
+  if (ctx.uptimeSeconds !== undefined) {
+    lines.push(`uptime: <code>${escapeHtml(formatUptime(ctx.uptimeSeconds))}</code>`)
   }
 
   return lines.join('\n')
@@ -272,7 +335,7 @@ export async function handleOobCommand(
       return {
         handled: true,
         command: 'status',
-        replyToTelegram: { text: statusText(ctx), parseMode: 'HTML' },
+        replyToTelegram: { text: await statusText(ctx), parseMode: 'HTML' },
       }
     }
 
@@ -321,78 +384,52 @@ export async function handleOobCommand(
       }
     }
 
-    case 'reset': {
-      if (!parsed.hasForceFlag) {
+    case 'compact': {
+      // Non-destructive: shrink the session context. Runs Claude Code's own
+      // /compact reliably (probe → interrupt-if-busy → send → confirm) and
+      // reports the REAL outcome so the warchief knows if it actually fired.
+      if (!ctx.tmuxKeys) {
         return {
           handled: true,
-          command: 'reset',
+          command: 'compact',
           replyToTelegram: {
-            text: 'Для подтверждения добавь <code>force</code>: <code>/reset force</code>',
+            text: '<b>compact</b> — недоступно: нет tmux-pane.',
             parseMode: 'HTML',
           },
         }
       }
-      ctx.log.info('oob /reset force', { chat_id: ctx.chatId })
-      // Real reset: type Claude Code's own /clear into the pane. Fallback to
-      // the (best-effort) channel signal when no pane is resolvable.
-      if (ctx.tmuxKeys) {
-        const sent = await sendSlashCommand(ctx.tmuxKeys.target, { name: 'clear', rest: '' }, ctx.tmuxKeys.exec)
-        return {
-          handled: true,
-          command: 'reset',
-          replyToTelegram: {
-            text: sent.ok
-              ? '<b>сессия сброшена</b> — отправил <code>/clear</code> в сессию.'
-              : `<b>reset</b> — tmux ошибка: <code>${escapeHtml(sent.error)}</code>`,
-            parseMode: 'HTML',
-          },
-        }
-      }
+      ctx.log.info('oob /compact', { chat_id: ctx.chatId })
+      const opts: ControlCommandOpts = { interruptIfBusy: true }
+      if (ctx.tmuxKeys.exec) opts.exec = ctx.tmuxKeys.exec
+      if (ctx.tmuxKeys.captureExec) opts.captureExec = ctx.tmuxKeys.captureExec
+      if (ctx.tmuxKeys.sleep) opts.sleep = ctx.tmuxKeys.sleep
+      const res = await sendControlCommand(ctx.tmuxKeys.target, 'compact', opts)
       return {
         handled: true,
-        command: 'reset',
+        command: 'compact',
         replyToTelegram: {
-          text: '<b>сессия сброшена (force)</b>\n\nследующее сообщение начнёт новую сессию',
+          text: res.ok
+            ? '<b>контекст сжимается</b> — команда принята сессией.'
+            : controlFailureMessage(res.reason),
           parseMode: 'HTML',
         },
-        notifyChannel: { content: '/reset force', meta: baseMeta },
       }
     }
 
     case 'new': {
-      if (!parsed.hasForceFlag) {
-        return {
-          handled: true,
-          command: 'new',
-          replyToTelegram: {
-            text: 'Для подтверждения добавь <code>force</code>: <code>/new force</code>',
-            parseMode: 'HTML',
-          },
-        }
-      }
-      ctx.log.info('oob /new force', { chat_id: ctx.chatId })
-      // Claude Code has no separate «new session» — /clear IS the reset.
-      if (ctx.tmuxKeys) {
-        const sent = await sendSlashCommand(ctx.tmuxKeys.target, { name: 'clear', rest: '' }, ctx.tmuxKeys.exec)
-        return {
-          handled: true,
-          command: 'new',
-          replyToTelegram: {
-            text: sent.ok
-              ? '<b>новая сессия</b> — отправил <code>/clear</code> в сессию.'
-              : `<b>new</b> — tmux ошибка: <code>${escapeHtml(sent.error)}</code>`,
-            parseMode: 'HTML',
-          },
-        }
-      }
+      // Destructive (/clear wipes the context) → one-tap-with-confirm. A bare
+      // /new posts a confirmation card; the tap runs the clear through the
+      // reliable injection layer (newq: callback in server.ts).
+      ctx.log.info('oob /new', { chat_id: ctx.chatId })
+      const card = buildNewConfirmCard()
       return {
         handled: true,
         command: 'new',
         replyToTelegram: {
-          text: '<b>новая сессия</b>\n\nследующее сообщение начнёт новую сессию',
+          text: card.text,
           parseMode: 'HTML',
+          inlineKeyboard: card.inlineKeyboard,
         },
-        notifyChannel: { content: '/new force', meta: baseMeta },
       }
     }
 
@@ -549,8 +586,67 @@ export async function handleOobCommand(
         }
       }
       ctx.log.info('oob /cc', { chat_id: ctx.chatId, name: cc.name })
-      const sent = await sendSlashCommand(ctx.tmuxKeys.target, cc, ctx.tmuxKeys.exec)
       const shown = cc.rest ? `/${cc.name} ${cc.rest}` : `/${cc.name}`
+
+      // IT2-6: typed `/cc clear` is DESTRUCTIVE (wipes the context) → route
+      // through the SAME confirm card as /new, hud:new and ccmd:clear. Never a
+      // one-tap clear, whatever the entry point. The tap's `newq:confirm` runs
+      // the reliable /clear.
+      if (cc.rest === '' && cc.name === 'clear') {
+        ctx.log.info('oob /cc clear → confirm card', { chat_id: ctx.chatId })
+        const card = buildNewConfirmCard()
+        return {
+          handled: true,
+          command: 'cc',
+          replyToTelegram: {
+            text: card.text,
+            parseMode: 'HTML',
+            inlineKeyboard: card.inlineKeyboard,
+          },
+        }
+      }
+
+      // FIX-6 (Codex): the typed /cc path must NOT blind-fire into a busy pane
+      // or an open dialog. Argless CONTROL `compact` goes through the reliable
+      // state-aware sender (probe → interrupt-if-busy → confirm), exactly like the
+      // ccmd: button, and reports the REAL result. `compact` is non-destructive so
+      // it stays one-tap.
+      if (cc.rest === '' && cc.name === 'compact') {
+        const opts: ControlCommandOpts = { interruptIfBusy: true }
+        if (ctx.tmuxKeys.exec) opts.exec = ctx.tmuxKeys.exec
+        if (ctx.tmuxKeys.captureExec) opts.captureExec = ctx.tmuxKeys.captureExec
+        if (ctx.tmuxKeys.sleep) opts.sleep = ctx.tmuxKeys.sleep
+        const res = await sendControlCommand(ctx.tmuxKeys.target, cc.name, opts)
+        return {
+          handled: true,
+          command: 'cc',
+          replyToTelegram: {
+            text: res.ok
+              ? `<b>отправлено в сессию:</b> <code>${escapeHtml(shown)}</code>`
+              : controlFailureMessage(res.reason),
+            parseMode: 'HTML',
+          },
+        }
+      }
+
+      // Other /cc <cmd> (argful, e.g. `model opus`, or read-only `context`):
+      // at MINIMUM probe the pane and refuse if it is not idle (dialog/busy/
+      // unknown), so a trailing Enter can never approve a dialog or get queued
+      // behind a busy tool. Only a positively-idle pane gets the blind send.
+      const state = classifyPane(await capturePane(ctx.tmuxKeys.target, ctx.tmuxKeys.captureExec))
+      if (state !== 'idle') {
+        return {
+          handled: true,
+          command: 'cc',
+          replyToTelegram: {
+            text:
+              `<b>/cc</b> — сессия не готова (<code>${state}</code>), не отправляю `
+              + `<code>${escapeHtml(shown)}</code>. Попробуй позже или через /keys.`,
+            parseMode: 'HTML',
+          },
+        }
+      }
+      const sent = await sendSlashCommand(ctx.tmuxKeys.target, cc, ctx.tmuxKeys.exec)
       return {
         handled: true,
         command: 'cc',

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -44,7 +44,19 @@ export const AppConfigSchema = z.object({
   dm_only: z.boolean().default(true),
   allowed_user_ids: z.array(z.number().int().positive()).min(1).default([164795011]),
   allowed_chat_ids: z.array(z.union([z.number(), z.string()])).default([164795011]),
+  // Owner DM chat ids for OWNER-ONLY surfaces (the pinned context HUD + the
+  // owner command menu). Distinct from `allowed_chat_ids`, which in multichat
+  // ALSO lists group/supergroup ids — a HUD with destructive buttons or the
+  // command menu must NEVER be pinned in a public group (FIX-8). Optional: when
+  // omitted, `resolveOwnerChatIds` falls back to `allowed_user_ids` (in a DM the
+  // chat id equals the positive user id). Positive ids only.
+  owner_chat_ids: z.array(z.number().int().positive()).optional(),
   workspace_root: z.string().optional(),
+  // Model context-window size in tokens, used by /status (context usage) and
+  // the context HUD. Optional — resolved via `resolveContextWindowTokens`,
+  // which applies the 200k default so the field stays absent-friendly for the
+  // many test config literals that predate it.
+  context_window_tokens: z.number().int().positive().optional(),
   // 2026-06-09 duplicate-windows fix: StatusManager and ProgressReporter
   // both defaulted ON, so a fresh install with hooks registered rendered two
   // hook-driven «working/running» Telegram windows next to the tmux mirror.
@@ -295,6 +307,18 @@ export const AppConfigSchema = z.object({
     timeout_ms: z.number().int().positive().default(120_000),
     allowed_user_ids: z.array(z.number().int().positive()).optional(),
   }).default({}),
+  // Context HUD (wave 3B) — a single pinned Telegram message in the owner's
+  // chat that shows context-window usage (bar + percentage) plus two action
+  // buttons (Сжать / Новый диалог), refreshed after each turn (SessionStart /
+  // Stop hooks). Default ON.
+  //
+  // The whole block is OPTIONAL (no `.default({})`) so `hud` reads as
+  // `hud?: { enabled: boolean }` on the inferred type — existing full-config
+  // test literals that predate this field stay valid without adding it.
+  // `resolveHudEnabled` applies the enabled-by-default fallback in one place.
+  hud: z.object({
+    enabled: z.boolean().default(true),
+  }).optional(),
 })
 export type AppConfig = z.infer<typeof AppConfigSchema>
 
@@ -678,4 +702,50 @@ export function resolvePermissionGateAllowedUserIds(
   const inherited = config.permission_relay.allowed_user_ids
   if (log) log.info('permission_gate: allowed_user_ids unset, inheriting from permission_relay', { count: inherited.length, fallback: true })
   return inherited
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// resolveContextWindowTokens — the model context-window size used by
+// /status (context usage) and the context HUD. Callers MUST go through this
+// helper rather than reading the raw field so the 200k default is applied in
+// exactly one place. Default matches the Claude 200k-token window.
+// ─────────────────────────────────────────────────────────────────────
+
+export const DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000
+
+export function resolveContextWindowTokens(config: AppConfig): number {
+  return config.context_window_tokens ?? DEFAULT_CONTEXT_WINDOW_TOKENS
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// resolveHudEnabled — whether the pinned context HUD (wave 3B) is active.
+// The `hud` config block is optional, so callers MUST go through this
+// helper rather than reading `config.hud?.enabled` directly: the
+// enabled-by-default fallback lives in exactly one place. A missing block
+// (older config.json / test literal) and an explicit `{ enabled: true }`
+// both resolve to true; only an explicit `{ enabled: false }` disables it.
+// ─────────────────────────────────────────────────────────────────────
+
+export function resolveHudEnabled(config: AppConfig): boolean {
+  return config.hud?.enabled ?? true
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// resolveOwnerChatIds — the OWNER DM chat ids for owner-only surfaces (the
+// pinned context HUD + the owner command menu). FIX-8 (both reviews): these
+// MUST come from the owner's DM ids, NEVER from `allowed_chat_ids` (which in
+// multichat also lists group ids — a HUD with destructive buttons or the
+// command menu pinned in a public group is a serious leak). Explicit
+// `owner_chat_ids` wins; otherwise we fall back to `allowed_user_ids` (in a DM
+// the chat id equals the positive user id). Positive ids only — a group id can
+// never be an owner DM.
+// ─────────────────────────────────────────────────────────────────────
+
+export function resolveOwnerChatIds(config: AppConfig): readonly number[] {
+  const explicit = config.owner_chat_ids
+  if (explicit !== undefined && explicit.length > 0) {
+    const positive = explicit.filter((n) => Number.isInteger(n) && n > 0)
+    if (positive.length > 0) return positive
+  }
+  return config.allowed_user_ids
 }

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -25,6 +25,9 @@ import {
   getStatePaths,
   loadConfig,
   redactToken,
+  resolveContextWindowTokens,
+  resolveHudEnabled,
+  resolveOwnerChatIds,
   type AppConfig,
   type StatePaths,
 } from './config.js'
@@ -43,6 +46,12 @@ import { StatusManager } from './status/status-manager.js'
 import { ProgressReporter } from './status/progress-reporter.js'
 import { TaskMirror } from './status/task-mirror.js'
 import { TmuxMirror } from './status/tmux-mirror.js'
+import { SessionInfoStore } from './status/session-info.js'
+import {
+  ContextHud,
+  handleHudCallback,
+  type HudTelegramApi,
+} from './status/context-hud.js'
 import { loadPolicyFromPath, type MultichatPolicy } from './chats/policy-loader.js'
 import { MultichatRouter } from './router/multichat-router.js'
 import { TmuxSessionPool } from './router/tmux-session-pool.js'
@@ -70,6 +79,8 @@ import { describePidHolder, readLockHolder } from './telegram/pid-inspect.js'
 import { BOT_COMMANDS } from './commands/oob.js'
 import { handleKkeyCallback } from './telegram/keys-panel-ui.js'
 import { handleCcmdCallback } from './telegram/cc-panel-ui.js'
+import { handleNewqCallback } from './telegram/newq-confirm-ui.js'
+import { registerOwnerScopedCommands } from './telegram/command-scope.js'
 import { startWebhookServer, type WebhookServerHandle } from './webhook/server.js'
 import {
   handleInboundAudio,
@@ -465,6 +476,53 @@ const statusManager = new StatusManager({
   policy: multichatPolicy ?? null,
 })
 
+// SessionInfoStore — records the latest transcript_path + model observed from
+// Claude hook events (via the webhook /hooks/agent path) so /status can show
+// context usage. In-memory, single instance shared by the webhook (writer) and
+// the OOB handler (reader).
+const sessionInfoStore = new SessionInfoStore()
+
+// Context HUD (wave 3B) — the single pinned Telegram message in the owner's
+// chat showing context-window usage + Сжать / Новый диалог buttons. Driven by
+// the SessionStart / Stop hooks (wired through the webhook deps below) and the
+// `hud:` callback branch further down. Owner chats: allowed_chat_ids, falling
+// back to allowed_user_ids (in a DM the chat id equals the user id). The HUD
+// gates on the owner chat internally, so a non-owner chatId is a safe no-op.
+//
+// The HUD's text sends/edits go through the SAME safe-wrapped, rate-limited
+// telegramApi as every other outbound call (redaction + HTML validation). Pin
+// carries no user text, so it is adapted straight from grammY here at the
+// composition root (mirrors registerOwnerScopedCommands' bot.api.* adapters).
+// Every HUD op is best-effort inside ContextHud — a broken HUD never breaks
+// message delivery.
+// FIX-8 (both reviews): owner chats come from resolveOwnerChatIds (owner_chat_ids
+// / allowed_user_ids = positive DM ids), NEVER allowed_chat_ids — which in
+// multichat also lists group ids. A HUD with destructive buttons must never be
+// pinned in a public group, and its control callbacks drive the single global
+// DM pane.
+const hudOwnerChatIds: ReadonlyArray<number | string> = resolveOwnerChatIds(config)
+const hudApi: HudTelegramApi = {
+  sendMessage: (chatId, text, opts) => telegramApi.sendMessage(chatId, text, opts),
+  editMessageText: (chatId, messageId, text, opts) =>
+    telegramApi.editMessageText(chatId, messageId, text, opts),
+  pinChatMessage: (chatId, messageId, opts) =>
+    bot.api.pinChatMessage(chatId, messageId, opts).then(() => undefined),
+}
+const contextHud = new ContextHud({
+  api: hudApi,
+  log,
+  sessionInfo: sessionInfoStore,
+  windowTokens: resolveContextWindowTokens(config),
+  ownerChatIds: hudOwnerChatIds,
+  stateDir: statePaths.root,
+  enabled: resolveHudEnabled(config),
+})
+log.info('context hud configured', {
+  enabled: resolveHudEnabled(config),
+  window_tokens: resolveContextWindowTokens(config),
+  owner_chats: hudOwnerChatIds.length,
+})
+
 // ProgressReporter (2026-05-18) — separate persistent thread showing
 // per-tool activity in real time. StatusManager owns the transient
 // bubble (cancelled by reply()); ProgressReporter owns a thread that
@@ -749,6 +807,7 @@ bot.on('callback_query:data', async ctx => {
         {
           callbackQuery: { data },
           from: { id: ctx.from?.id },
+          ...(ctx.chat?.id !== undefined ? { chatId: String(ctx.chat.id) } : {}),
           answerCallbackQuery: async arg => {
             await ctx.answerCallbackQuery(arg)
           },
@@ -757,6 +816,14 @@ bot.on('callback_query:data', async ctx => {
           allowedUserIds: config.allowed_user_ids,
           log,
           ...(tmuxKeysTarget !== undefined ? { tmuxKeysTarget } : {}),
+          // FIX-7: destructive `clear` posts the /new confirm card (fresh
+          // message through the safe-wrapped api), never a one-tap clear.
+          sendConfirmCard: async (chatId, text, keyboard) => {
+            await telegramApi.sendMessage(chatId, text, {
+              parse_mode: 'HTML',
+              reply_markup: keyboard,
+            })
+          },
         },
       )
     } catch (err) {
@@ -767,6 +834,102 @@ bot.on('callback_query:data', async ctx => {
         await ctx.answerCallbackQuery({ text: 'ошибка' })
       } catch (ackErr) {
         log.warn('ccmd error-ack answerCallbackQuery failed', {
+          error: ackErr instanceof Error ? ackErr.message : String(ackErr),
+        })
+      }
+    }
+    return
+  }
+  // /new confirm card (newq:*) — one-tap-with-confirm clear of the session
+  // context. Same fail-closed allowlist auth as kkey:/ccmd: (config
+  // .allowed_user_ids). confirm → reliable /clear + edit the card to the real
+  // result; cancel → edit «Отменено». Never drives the pane for a non-allowed
+  // user id. Dispatched on its own prefix so it never collides with the others.
+  if (data.startsWith('newq:')) {
+    try {
+      await handleNewqCallback(
+        {
+          callbackQuery: { data },
+          from: { id: ctx.from?.id },
+          ...(ctx.chat?.id !== undefined ? { chatId: String(ctx.chat.id) } : {}),
+          answerCallbackQuery: async arg => {
+            if (arg) await ctx.answerCallbackQuery(arg)
+            else await ctx.answerCallbackQuery()
+          },
+          editMessageText: async (text, opts) => {
+            // Adapt to grammY's stricter Other<> shape (our InlineKeyboardLike
+            // has optional callback_data). reply_markup is passed through to
+            // strip the buttons on first tap (FIX-14).
+            const other: Record<string, unknown> = {}
+            if (opts?.parse_mode) other.parse_mode = opts.parse_mode
+            if (opts?.reply_markup) other.reply_markup = opts.reply_markup
+            await ctx.editMessageText(text, other)
+          },
+        },
+        {
+          allowedUserIds: config.allowed_user_ids,
+          log,
+          ...(tmuxKeysTarget !== undefined ? { tmuxKeysTarget } : {}),
+          // FIX-8: refuse a confirm from any chat that is not the owner DM.
+          ownerChatIds: hudOwnerChatIds,
+        },
+      )
+    } catch (err) {
+      log.error('newq callback_query handler threw', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      try {
+        await ctx.answerCallbackQuery({ text: 'ошибка' })
+      } catch (ackErr) {
+        log.warn('newq error-ack answerCallbackQuery failed', {
+          error: ackErr instanceof Error ? ackErr.message : String(ackErr),
+        })
+      }
+    }
+    return
+  }
+  // Context HUD panel (hud:*) — the two buttons on the pinned HUD message.
+  // Same fail-closed allowlist auth as kkey:/ccmd:/newq: (config
+  // .allowed_user_ids). `hud:compact` drives the reliable /compact injection;
+  // `hud:new` posts the SAME /new confirm card whose newq:* buttons the branch
+  // above handles (so a destructive clear always confirms — never a blind
+  // clear). Dispatched on its own prefix so it never collides with the others.
+  if (data.startsWith('hud:')) {
+    try {
+      await handleHudCallback(
+        {
+          callbackQuery: { data },
+          from: { id: ctx.from?.id },
+          chatId: ctx.chat?.id !== undefined ? String(ctx.chat.id) : String(ctx.from?.id ?? ''),
+          answerCallbackQuery: async arg => {
+            if (arg) await ctx.answerCallbackQuery(arg)
+            else await ctx.answerCallbackQuery()
+          },
+        },
+        {
+          allowedUserIds: config.allowed_user_ids,
+          log,
+          ...(tmuxKeysTarget !== undefined ? { tmuxKeysTarget } : {}),
+          // FIX-8: refuse a HUD tap from any chat that is not the owner DM.
+          ownerChatIds: hudOwnerChatIds,
+          // Post the confirm card as a fresh message through the safe-wrapped
+          // api so the pinned HUD is left intact.
+          sendConfirmCard: async (chatId, text, keyboard) => {
+            await telegramApi.sendMessage(chatId, text, {
+              parse_mode: 'HTML',
+              reply_markup: keyboard,
+            })
+          },
+        },
+      )
+    } catch (err) {
+      log.error('hud callback_query handler threw', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      try {
+        await ctx.answerCallbackQuery({ text: 'ошибка' })
+      } catch (ackErr) {
+        log.warn('hud error-ack answerCallbackQuery failed', {
           error: ackErr instanceof Error ? ackErr.message : String(ackErr),
         })
       }
@@ -999,6 +1162,8 @@ const handlerDeps: HandlerDeps = {
   ...(tmuxMirror !== null ? { tmuxMirror } : {}),
   // /keys — deterministic keystrokes into the agent pane (DM allowlist only).
   ...(tmuxKeysTarget !== undefined ? { tmuxKeys: { target: tmuxKeysTarget } } : {}),
+  // Session facts (transcript_path + model) for /status context usage.
+  sessionInfo: sessionInfoStore,
   // Multichat router + policy. Both must be present for handlers.ts to
   // take the router path; passing one without the other is a wiring bug
   // (handlers.ts treats the pair atomically).
@@ -1150,6 +1315,8 @@ try {
     statePaths,
     log,
     statusManager,
+    sessionInfo: sessionInfoStore,
+    contextHud,
     progressReporter,
     taskMirror,
     watcher: inboundWatcher,
@@ -1202,20 +1369,28 @@ poller = new TelegramPoller({
   },
 })
 
-// Register the OOB command list with Telegram so they appear in the
-// client autocomplete («/» prefix in chat). Best-effort: a failure here
-// (no internet, token revoked) must not block the poller from starting.
+// Register the OOB command list with Telegram, scoped to the OWNER's chat(s)
+// only (not the default/all_private_chats scopes), so the «/» autocomplete menu
+// is visible to the warchief alone. Telegram scope precedence is
+// chat > all_private_chats > default, so we clear the broader scopes first and
+// then register per owner chat. Best-effort: any failure here (no internet,
+// token revoked) must not block the poller from starting.
 void (async () => {
-  try {
-    await bot.api.setMyCommands(
-      BOT_COMMANDS.map((c) => ({ command: c.command, description: c.description })),
-    )
-    log.info('telegram commands registered', { count: BOT_COMMANDS.length })
-  } catch (err) {
-    log.warn('setMyCommands failed (ignored)', {
-      error: err instanceof Error ? err.message : String(err),
-    })
-  }
+  const cmds = BOT_COMMANDS.map((c) => ({ command: c.command, description: c.description }))
+  // FIX-8: the owner command menu is DM-only. Owner chats come from
+  // resolveOwnerChatIds (owner_chat_ids / allowed_user_ids = positive DM ids),
+  // NEVER allowed_chat_ids — pinning the menu scope in a group would expose it
+  // publicly. registerOwnerScopedCommands additionally skips any non-DM id.
+  const ownerChatIds: ReadonlyArray<number | string> = resolveOwnerChatIds(config)
+  await registerOwnerScopedCommands(
+    {
+      deleteMyCommands: (options) => bot.api.deleteMyCommands(options),
+      setMyCommands: (commands, options) => bot.api.setMyCommands([...commands], options),
+    },
+    cmds,
+    ownerChatIds,
+    log,
+  )
 })()
 
 // FIX-G / M1 (Codex review 2026-05-27 #2): ordered async startup.

--- a/plugin/src/status/context-hud.ts
+++ b/plugin/src/status/context-hud.ts
@@ -1,0 +1,566 @@
+// Context HUD (wave 3B) — a single PINNED Telegram message in the owner's chat
+// that shows how full the model's context window is (a 10-segment unicode bar +
+// percentage) plus two action buttons: «Сжать» (/compact) and «Новый диалог»
+// (confirm-then-/clear). It is the KAI-style always-visible indicator, refreshed
+// after every turn from the SessionStart / Stop hook events — there are NO
+// timers or polling; the HUD only moves when a hook fires.
+//
+// CRITICAL isolation invariant: the plugin is the user's ONLY channel, so a
+// broken HUD must NEVER break message delivery. Every HUD operation
+// (send / pin / edit / persist) is best-effort — wrapped in try/catch, swallowed
+// and logged, NEVER thrown back into the hook/reply path. The public methods
+// (`onSessionStart`, `onStop`, `updateNow`) therefore resolve to `void` and can
+// be fired with `void hud.onStop(chatId)` from the hook dispatcher without any
+// error handling at the call site.
+//
+// Owner-only: the HUD acts solely for the owner's chat(s) (allowed chat / user
+// ids). A group / multichat non-owner chat never gets a HUD.
+//
+// Persistence: the HUD's Telegram message_id is stored per chat in a small JSON
+// file under the plugin state dir. On a plugin restart we re-use (and re-pin)
+// that message instead of spamming a fresh one; if the user deleted it we
+// recreate it exactly once.
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { classifyEditError } from '../safety/telegram-edit-classifier.js'
+import { readContextUsage as realReadContextUsage, type ContextUsage } from './context-usage.js'
+import type { EditOpts, InlineKeyboardLike, SendMessageOpts } from '../channel/tools.js'
+import type { Logger } from '../log.js'
+
+// The callback prefix for the HUD's two buttons. Distinct from kkey:/ccmd:/
+// newq:/pgate:/ask: by construction so it never collides in the shared
+// bot.on('callback_query:data') router.
+export const HUD_PREFIX = 'hud:'
+
+// ─────────────────────────────────────────────────────────────────────
+// Pure rendering helper (unit-tested in isolation).
+// ─────────────────────────────────────────────────────────────────────
+
+const BAR_SEGMENTS = 10
+const BAR_FILLED = '▰'
+const BAR_EMPTY = '▱'
+
+// Escape the model string for HTML parse mode. Model ids ("claude-opus-4-8")
+// carry no markup, but escape defensively so a surprising value can never break
+// the HUD's entity parsing (the safe wrapper would then downgrade it silently).
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+// Build the HUD's inline keyboard. Static (never changes) so the edit path can
+// re-send the same markup on every refresh and let Telegram no-op it.
+export function buildHudKeyboard(): InlineKeyboardLike {
+  return {
+    inline_keyboard: [
+      [{ text: '🗜 Сжать', callback_data: `${HUD_PREFIX}compact` }],
+      [{ text: '🧹 Новый диалог', callback_data: `${HUD_PREFIX}new` }],
+    ],
+  }
+}
+
+/**
+ * Render the HUD text + keyboard from a context-usage reading.
+ *
+ * text (HTML): `🧠 <b>Контекст</b>: <bar> <pct>% (<used>k / <window>k)` where
+ * `<bar>` is a 10-segment meter (`▰` filled / `▱` empty) proportional to the
+ * clamped percentage. An optional second line shows the model when known.
+ * A null usage (no transcript / no usable turn yet) renders `🧠 <b>Контекст</b>: —`.
+ *
+ * PURE — no I/O, no clock — so it is trivially unit-testable against fixed inputs.
+ */
+export function renderHud(
+  usage: { usedTokens: number } | null,
+  windowTokens: number,
+  model?: string,
+): { text: string; keyboard: InlineKeyboardLike } {
+  const keyboard = buildHudKeyboard()
+  const modelLine = model !== undefined && model.length > 0 ? `\n<i>${escapeHtml(model)}</i>` : ''
+
+  if (usage === null) {
+    return { text: `🧠 <b>Контекст</b>: —${modelLine}`, keyboard }
+  }
+
+  const windowK = Math.round(windowTokens / 1000)
+  const usedK = Math.round(usage.usedTokens / 1000)
+  const rawPct = windowTokens > 0 ? (usage.usedTokens / windowTokens) * 100 : 0
+  // Clamp to 0..100 for BOTH the bar and the displayed percentage so an
+  // over-full window (used > window) reads as a saturated 100%, never >100%.
+  const pct = Math.max(0, Math.min(100, Math.round(rawPct)))
+  const filled = Math.max(0, Math.min(BAR_SEGMENTS, Math.round(pct / 10)))
+  const bar = BAR_FILLED.repeat(filled) + BAR_EMPTY.repeat(BAR_SEGMENTS - filled)
+
+  const text = `🧠 <b>Контекст</b>: ${bar} ${pct}% (${usedK}k / ${windowK}k)${modelLine}`
+  return { text, keyboard }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Manager.
+// ─────────────────────────────────────────────────────────────────────
+
+// Narrow structural surface the HUD needs from the safe-wrapped TelegramApi.
+// `sendMessage` / `editMessageText` are satisfied by the safe-wrapped api
+// (redaction + HTML validation + rate limiting). `pinChatMessage` carries no
+// user text; the composition root adapts it from grammY. Kept narrow (the
+// StatusManagerForWebhook / SessionInfoRecorder pattern) so tests pass a tiny
+// fake and the HUD never imports grammY.
+export interface HudTelegramApi {
+  sendMessage(chatId: string, text: string, opts: SendMessageOpts): Promise<{ message_id: number }>
+  editMessageText(chatId: string, messageId: number, text: string, opts: EditOpts): Promise<void>
+  pinChatMessage(chatId: string, messageId: number, opts: { disable_notification?: boolean }): Promise<void>
+}
+
+// Read-only view of the SessionInfoStore the HUD consumes. Satisfied by
+// `SessionInfoStore.get`.
+export interface SessionInfoReader {
+  get(chatId?: string): { transcriptPath?: string; sessionId?: string; model?: string }
+}
+
+// Injectable transcript reader — defaults to the real `readContextUsage`. Tests
+// pass a fake so they never touch the filesystem.
+export type ReadContextUsageFn = (
+  transcriptPath: string,
+  windowTokens: number,
+) => Promise<ContextUsage | null>
+
+export interface ContextHudOptions {
+  api: HudTelegramApi
+  log: Logger
+  sessionInfo: SessionInfoReader
+  windowTokens: number
+  // Owner chat(s) — the ONLY chats the HUD acts in. Stringified for comparison
+  // against the hook payload's chatId.
+  ownerChatIds: ReadonlyArray<string | number>
+  // Plugin state dir; the HUD writes `context-hud-<chatId>.json` here.
+  stateDir: string
+  // Feature flag (resolveHudEnabled). When false every method is a no-op.
+  enabled: boolean
+  // Injected for tests; defaults to the real transcript reader.
+  readContextUsage?: ReadContextUsageFn
+}
+
+interface EnsuredMessage {
+  id: number
+  created: boolean
+}
+
+export class ContextHud {
+  private readonly api: HudTelegramApi
+  private readonly log: Logger
+  private readonly sessionInfo: SessionInfoReader
+  private readonly windowTokens: number
+  private readonly owner: ReadonlySet<string>
+  private readonly stateDir: string
+  private readonly enabled: boolean
+  private readonly readUsage: ReadContextUsageFn
+  // In-memory message-id cache per chat (mirrors the on-disk persistence).
+  private readonly messageIds = new Map<string, number>()
+  // FIX-9 (both reviews): per-chat serialization. A concurrent SessionStart +
+  // Stop (both firing before the first send persists an id) would each see an
+  // empty cache and sendFresh → TWO pinned HUDs. Chaining every HUD operation
+  // for a chat through this per-chat promise means the second waits for the
+  // first to cache/persist the id, then edits it in place. Stored tail is the
+  // SETTLED (never-rejecting) promise so a thrown op can't poison the chain.
+  private readonly chatLocks = new Map<string, Promise<void>>()
+
+  constructor(opts: ContextHudOptions) {
+    this.api = opts.api
+    this.log = opts.log
+    this.sessionInfo = opts.sessionInfo
+    this.windowTokens = opts.windowTokens
+    this.owner = new Set(opts.ownerChatIds.map((id) => String(id)))
+    this.stateDir = opts.stateDir
+    this.enabled = opts.enabled
+    this.readUsage = opts.readContextUsage ?? realReadContextUsage
+  }
+
+  // FIX-8 (both reviews): an owner chat is a configured owner id that is ALSO a
+  // DM (positive numeric chat id). A group/supergroup id is negative and can
+  // never own the pinned HUD — the HUD carries destructive buttons and must
+  // NEVER be created or pinned in a public group, even if a group id somehow
+  // slipped into the owner set. `ownerChatIds` is derived from resolveOwnerChatIds
+  // (owner_chat_ids / allowed_user_ids), never allowed_chat_ids.
+  private isOwner(chatId: string): boolean {
+    if (!this.owner.has(chatId)) return false
+    const n = Number(chatId)
+    return Number.isInteger(n) && n > 0
+  }
+
+  // Serialize an operation per chat (FIX-9). The returned promise resolves when
+  // THIS op completes; the next call for the same chat waits for it. `fn`
+  // already swallows its own errors, so the chain never rejects.
+  private runSerialized(chatId: string, fn: () => Promise<void>): Promise<void> {
+    const prior = this.chatLocks.get(chatId) ?? Promise.resolve()
+    const result = prior.then(fn, fn)
+    const settled: Promise<void> = result.then(
+      () => undefined,
+      () => undefined,
+    )
+    this.chatLocks.set(chatId, settled)
+    void settled.then(() => {
+      if (this.chatLocks.get(chatId) === settled) this.chatLocks.delete(chatId)
+    })
+    return result
+  }
+
+  // SessionStart: ensure the HUD message exists and is pinned, then refresh it.
+  // The whole method is best-effort — it never throws. Serialized per chat.
+  onSessionStart(chatId: string): Promise<void> {
+    if (!this.enabled || !this.isOwner(chatId)) return Promise.resolve()
+    return this.runSerialized(chatId, async () => {
+      try {
+        const { text, keyboard } = await this.renderCurrent(chatId)
+        const ensured = await this.ensureMessage(chatId, text, keyboard)
+        if (ensured === undefined) return
+        // A freshly-sent message already carries current content AND was pinned
+        // inside sendFresh — nothing more to do. A pre-existing message (reused
+        // from the in-memory cache or the persisted file across a plugin restart)
+        // must be (re)pinned so it stays stuck to the top, then refreshed.
+        if (!ensured.created) {
+          await this.pin(chatId, ensured.id)
+          await this.edit(chatId, ensured.id, text, keyboard)
+        }
+      } catch (err) {
+        this.log.warn('context hud onSessionStart failed (ignored)', {
+          chat_id: chatId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    })
+  }
+
+  // Stop / end-of-turn: refresh the percentage. No pin (that is SessionStart's
+  // job); updateNow self-heals a deleted message once.
+  async onStop(chatId: string): Promise<void> {
+    await this.updateNow(chatId)
+  }
+
+  // Read the latest usage and reconcile the HUD message. Best-effort: never
+  // throws. Creates the message if none exists yet (e.g. Stop before any
+  // SessionStart), otherwise edits it in place. Serialized per chat.
+  updateNow(chatId: string): Promise<void> {
+    if (!this.enabled || !this.isOwner(chatId)) return Promise.resolve()
+    return this.runSerialized(chatId, async () => {
+      try {
+        const { text, keyboard } = await this.renderCurrent(chatId)
+        const ensured = await this.ensureMessage(chatId, text, keyboard)
+        // No message and send failed → swallow. Freshly created → already current.
+        if (ensured === undefined || ensured.created) return
+        await this.edit(chatId, ensured.id, text, keyboard)
+      } catch (err) {
+        this.log.warn('context hud updateNow failed (ignored)', {
+          chat_id: chatId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    })
+  }
+
+  // ─── internals ────────────────────────────────────────────────────
+
+  // Render the HUD for the chat's CURRENT session facts. Reads the transcript
+  // (best-effort — a null usage renders «Контекст: —»).
+  private async renderCurrent(
+    chatId: string,
+  ): Promise<{ text: string; keyboard: InlineKeyboardLike }> {
+    const info = this.sessionInfo.get(chatId)
+    let usage: ContextUsage | null = null
+    if (info.transcriptPath !== undefined && info.transcriptPath.length > 0) {
+      try {
+        usage = await this.readUsage(info.transcriptPath, this.windowTokens)
+      } catch {
+        // readContextUsage already swallows I/O; guard the injected fn too.
+        usage = null
+      }
+    }
+    return renderHud(usage, this.windowTokens, info.model)
+  }
+
+  // Resolve the HUD message id for a chat: in-memory cache → persisted file →
+  // send a fresh one. Returns `created:true` only when a new message was sent.
+  private async ensureMessage(
+    chatId: string,
+    text: string,
+    keyboard: InlineKeyboardLike,
+  ): Promise<EnsuredMessage | undefined> {
+    const mem = this.messageIds.get(chatId)
+    if (mem !== undefined) return { id: mem, created: false }
+
+    const disk = this.loadPersisted(chatId)
+    if (disk !== undefined) {
+      this.messageIds.set(chatId, disk)
+      return { id: disk, created: false }
+    }
+
+    const created = await this.sendFresh(chatId, text, keyboard)
+    if (created === undefined) return undefined
+    return { id: created, created: true }
+  }
+
+  // Send a brand-new HUD message, persist its id, and pin it. All best-effort;
+  // returns the new id or undefined when the send itself failed.
+  private async sendFresh(
+    chatId: string,
+    text: string,
+    keyboard: InlineKeyboardLike,
+  ): Promise<number | undefined> {
+    let messageId: number
+    try {
+      const sent = await this.api.sendMessage(chatId, text, {
+        parse_mode: 'HTML',
+        reply_markup: keyboard,
+      })
+      messageId = sent.message_id
+    } catch (err) {
+      this.log.warn('context hud send failed (ignored)', {
+        chat_id: chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return undefined
+    }
+    this.messageIds.set(chatId, messageId)
+    this.persist(chatId, messageId)
+    await this.pin(chatId, messageId)
+    return messageId
+  }
+
+  // Edit the existing HUD message. Classifies Telegram errors:
+  //   • "not modified" → benign no-op (same pct rounding as last time)
+  //   • message deleted (400) → recreate + repin ONCE (sendFresh, no re-edit,
+  //     so there is no recreate loop)
+  //   • anything else → swallow + log
+  private async edit(
+    chatId: string,
+    messageId: number,
+    text: string,
+    keyboard: InlineKeyboardLike,
+  ): Promise<void> {
+    try {
+      await this.api.editMessageText(chatId, messageId, text, {
+        parse_mode: 'HTML',
+        reply_markup: keyboard,
+      })
+    } catch (err) {
+      const cls = classifyEditError(err)
+      if (cls.kind === 'benign') return
+      if (cls.kind === 'message_gone') {
+        // The user deleted the HUD. Drop the stale id and recreate exactly
+        // once — sendFresh persists + pins the replacement and does NOT call
+        // back into edit, so a permanently-gone message can't spin a loop.
+        this.messageIds.delete(chatId)
+        await this.sendFresh(chatId, text, keyboard)
+        return
+      }
+      this.log.warn('context hud edit failed (ignored)', {
+        chat_id: chatId,
+        kind: cls.kind,
+        description: 'description' in cls ? cls.description : undefined,
+      })
+    }
+  }
+
+  // Pin the HUD message silently. Best-effort — a pin failure (already pinned,
+  // lost permission, message gone) must never break a HUD refresh.
+  private async pin(chatId: string, messageId: number): Promise<void> {
+    try {
+      await this.api.pinChatMessage(chatId, messageId, { disable_notification: true })
+    } catch (err) {
+      this.log.warn('context hud pin failed (ignored)', {
+        chat_id: chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  // ─── persistence ──────────────────────────────────────────────────
+
+  private persistPath(chatId: string): string {
+    // chatId is a numeric string (possibly negative for supergroups); sanitize
+    // defensively so a surprising value can never escape the state dir.
+    const safe = chatId.replace(/[^0-9A-Za-z_-]/g, '_')
+    return join(this.stateDir, `context-hud-${safe}.json`)
+  }
+
+  private loadPersisted(chatId: string): number | undefined {
+    try {
+      const raw = readFileSync(this.persistPath(chatId), 'utf8')
+      const parsed: unknown = JSON.parse(raw)
+      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+        const id = (parsed as { message_id?: unknown }).message_id
+        if (typeof id === 'number' && Number.isInteger(id) && id > 0) return id
+      }
+    } catch {
+      // Missing file / malformed JSON → treat as "no persisted id".
+    }
+    return undefined
+  }
+
+  private persist(chatId: string, messageId: number): void {
+    try {
+      mkdirSync(this.stateDir, { recursive: true, mode: 0o700 })
+      writeFileSync(this.persistPath(chatId), JSON.stringify({ message_id: messageId }), {
+        mode: 0o600,
+      })
+    } catch (err) {
+      this.log.warn('context hud persist failed (ignored)', {
+        chat_id: chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Callback handler for the HUD's two buttons (hud:compact / hud:new).
+//
+// Fail-closed auth FIRST (config.allowed_user_ids — the SAME allowlist that
+// guards every other session-driving control), then parse, then act:
+//   • hud:compact → answer «Сжимаю…» and drive the reliable /compact injection
+//     (probe → interrupt-if-busy → send → confirm). On failure, best-effort
+//     toast the reason. The next Stop refreshes the HUD percentage.
+//   • hud:new → reuse the wave-3A /new confirm flow: post the SAME confirm card
+//     whose `newq:confirm` / `newq:cancel` buttons the existing router already
+//     handles, so a destructive clear ALWAYS confirms. Never clears directly.
+// ─────────────────────────────────────────────────────────────────────
+
+import {
+  sendControlCommand,
+  type ControlCommandResult,
+  type TmuxKeysTarget,
+} from '../commands/keys.js'
+import { buildNewConfirmCard, isOwnerDmChat, type ControlSender } from '../telegram/newq-confirm-ui.js'
+
+export type HudAction = 'compact' | 'new'
+
+// Parse a `hud:<action>` callback_data string. Returns the validated action or
+// null (non-hud prefix or unknown action) — null callers toast and do NOTHING.
+export function parseHudCallback(data: string): HudAction | null {
+  if (typeof data !== 'string') return null
+  if (!data.startsWith(HUD_PREFIX)) return null
+  const action = data.slice(HUD_PREFIX.length)
+  return action === 'compact' || action === 'new' ? action : null
+}
+
+// The failure arm of ControlCommandResult (`ok: false`) narrowed to its reason.
+type ControlFailureReason = Extract<ControlCommandResult, { ok: false }>['reason']
+
+// Short toast for a failed /compact injection. The reason is a bounded enum,
+// never user text.
+function compactFailureToast(reason: ControlFailureReason): string {
+  switch (reason) {
+    case 'busy':
+      return 'агент занят, попробуй ещё раз'
+    case 'dialog':
+      return 'сессия ждёт ответа в диалоге'
+    case 'unknown':
+      return 'не удалось определить состояние'
+    case 'not-submitted':
+    case 'tmux':
+      return 'не удалось отправить'
+  }
+}
+
+export interface HudCallbackContext {
+  callbackQuery: { data: string }
+  from?: { id?: number | undefined }
+  // The chat the tap came from — where the /new confirm card is posted.
+  chatId: string
+  answerCallbackQuery(arg?: { text: string }): Promise<void>
+}
+
+export interface HudCallbackDeps {
+  allowedUserIds: readonly number[]
+  tmuxKeysTarget?: TmuxKeysTarget
+  log: Logger
+  // Post the /new confirm card (buildNewConfirmCard) as a FRESH message so the
+  // pinned HUD is left intact. Wired in server.ts to the safe-wrapped api.
+  sendConfirmCard: (chatId: string, text: string, keyboard: InlineKeyboardLike) => Promise<void>
+  // Injected for tests; defaults to the real reliable sender.
+  sendControl?: ControlSender
+  // FIX-8 (both reviews): the OWNER DM chat ids (resolveOwnerChatIds). The HUD's
+  // control buttons drive the single global tmux pane = the MAIN DM session, so
+  // a tap from ANY other chat (a group where a stray HUD was somehow pinned)
+  // must be refused. When omitted (legacy/tests) the check is skipped.
+  ownerChatIds?: readonly (number | string)[]
+}
+
+// Dispatch a `hud:*` callback. Always answers the callback query and returns
+// true when it consumed the event. NEVER drives the pane / clears for a
+// non-allowed user id.
+export async function handleHudCallback(
+  ctx: HudCallbackContext,
+  deps: HudCallbackDeps,
+): Promise<boolean> {
+  // AUTH FIRST — before parsing or touching the pane. A missing/non-number id
+  // is unauthorized (fail-closed).
+  const fromId = ctx.from?.id
+  if (typeof fromId !== 'number' || !deps.allowedUserIds.includes(fromId)) {
+    deps.log.warn('hud unauthorized tap', {
+      user_id: fromId,
+      data: ctx.callbackQuery.data,
+    })
+    await ctx.answerCallbackQuery({ text: 'не авторизовано' })
+    return true
+  }
+
+  // FIX-8: a HUD tap only drives the pane from the OWNER DM. A tap whose chat is
+  // not the owner DM (a group where a stray HUD surfaced) is refused — the
+  // control buttons act on the single global DM session, never a group.
+  if (!isOwnerDmChat(ctx.chatId, deps.ownerChatIds)) {
+    deps.log.warn('hud tap from non-owner chat refused', {
+      chat_id: ctx.chatId,
+      user_id: fromId,
+    })
+    await ctx.answerCallbackQuery({ text: 'недоступно в этом чате' })
+    return true
+  }
+
+  const action = parseHudCallback(ctx.callbackQuery.data)
+  if (action === null) {
+    await ctx.answerCallbackQuery({ text: 'неизвестное действие' })
+    return true
+  }
+
+  if (action === 'new') {
+    // Reuse the wave-3A confirm-then-clear flow: post the SAME card. Its
+    // `newq:*` buttons are handled by the existing router branch, which drives
+    // the reliable /clear. We never clear directly here.
+    await ctx.answerCallbackQuery()
+    const card = buildNewConfirmCard()
+    try {
+      await deps.sendConfirmCard(ctx.chatId, card.text, card.inlineKeyboard)
+    } catch (err) {
+      deps.log.warn('hud new confirm-card send failed (ignored)', {
+        chat_id: ctx.chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+    return true
+  }
+
+  // action === 'compact'
+  if (deps.tmuxKeysTarget === undefined) {
+    await ctx.answerCallbackQuery({ text: 'pane недоступен' })
+    return true
+  }
+  await ctx.answerCallbackQuery({ text: 'Сжимаю…' })
+  const send = deps.sendControl ?? sendControlCommand
+  const result = await send(deps.tmuxKeysTarget, 'compact', { interruptIfBusy: true })
+  if (!result.ok) {
+    // L10 (IT2-8): a SECOND answerCallbackQuery on the same query id is DROPPED by
+    // Telegram, so the failure was invisible. Surface it VISIBLY with a fresh
+    // short message (empty keyboard) instead — the warchief must see that «Сжать»
+    // did not fire. Best-effort: a failed send must never throw out of the HUD.
+    const notice = `🗜 <b>Сжать</b> — ${compactFailureToast(result.reason)}`
+    try {
+      await deps.sendConfirmCard(ctx.chatId, notice, { inline_keyboard: [] })
+    } catch (err) {
+      deps.log.warn('hud compact failure notice send failed (ignored)', {
+        chat_id: ctx.chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+  return true
+}

--- a/plugin/src/status/context-usage.ts
+++ b/plugin/src/status/context-usage.ts
@@ -1,0 +1,187 @@
+// Context-window usage parser — read a Claude Code session transcript JSONL
+// and compute how much of the model's context window is currently in use.
+//
+// Claude Code persists each session as `~/.claude/projects/<slug>/<sid>.jsonl`,
+// one JSON object per line. Assistant turns carry `message.usage` with
+// `input_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`
+// and `output_tokens`. The live context size after a turn is:
+//
+//     input_tokens + cache_read_input_tokens + cache_creation_input_tokens
+//
+// (output_tokens is EXCLUDED — those are the freshly-generated tokens, they
+// become part of the NEXT turn's input, not the current window occupancy.)
+//
+// Sidechain discriminator: Claude Code tags every transcript record with a
+// top-level boolean `isSidechain`. Main-thread turns are `isSidechain: false`;
+// subagent / Task-tool turns are `isSidechain: true`. A subagent runs in its
+// own small context and its `usage` is unrelated to the main thread's window,
+// so those lines MUST be skipped. We key on `isSidechain === true` (not on
+// `parentUuid`/`userType`, which are present on main-thread lines too) because
+// it is the single field whose sole purpose is exactly this main/sidechain
+// split. Verified against real transcripts: main-thread assistant lines all
+// carry `isSidechain: false`.
+//
+// All I/O errors are swallowed and surface as `null` — a status/HUD caller
+// treats "no usable turn" as "unknown", never as a crash. Missing files,
+// permission denied, malformed JSON, a half-written trailing line from the
+// JSONL writer racing our read — none of them should throw.
+
+import { open, type FileHandle } from 'node:fs/promises'
+
+// NOT IN SCOPE (fast-follow): a single transcript line longer than TAIL_BYTES
+// (256 KB) would be truncated at the head of the tail read and dropped as the
+// "possibly-truncated first line", so a giant final turn could read as null.
+// An adaptive-tail (grow the read until a full trailing line is captured) is
+// tracked separately; 256 KB comfortably covers normal turns.
+const TAIL_BYTES = 256 * 1024
+
+export interface ContextUsage {
+  usedTokens: number
+  pct: number
+}
+
+// Coerce an unknown usage field to a non-negative finite integer, or null if
+// it is absent / not a usable number. Missing cache fields are the caller's
+// business (they default to 0); a missing/garbage `input_tokens` means the
+// line is not a real billing turn and should be skipped.
+function toNonNegNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null
+}
+
+/**
+ * Scan transcript lines BACKWARDS and return the context usage of the last
+ * main-thread assistant turn that carries a `message.usage`.
+ *
+ * Unparseable lines (a JSONL-writer race can leave a truncated trailing line)
+ * and sidechain lines are skipped, not fatal. Returns `null` when no usable
+ * assistant turn is found.
+ *
+ * `used = input_tokens + (cache_read_input_tokens ?? 0) + (cache_creation_input_tokens ?? 0)`.
+ * `pct = used / windowTokens` as a raw float — NOT clamped; formatting is the
+ * caller's job. When `windowTokens <= 0`, `pct` is reported as 0 to avoid
+ * Infinity/NaN while still returning the real `usedTokens`.
+ */
+export function computeContextUsage(
+  lines: string[],
+  windowTokens: number,
+): ContextUsage | null {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]
+    if (line === undefined || line.length === 0) continue
+
+    // Per-line parse boundary: valid JSON of the wrong shape (null, a bare
+    // array, a string) must skip, not escape and abort the whole scan.
+    let obj: unknown
+    try {
+      obj = JSON.parse(line)
+    } catch {
+      continue
+    }
+    if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) continue
+
+    const record = obj as { isSidechain?: unknown; message?: unknown }
+    // Skip subagent/sidechain turns — their usage is a separate context.
+    if (record.isSidechain === true) continue
+
+    const message = record.message
+    if (typeof message !== 'object' || message === null) continue
+    const msg = message as { role?: unknown; usage?: unknown }
+    if (msg.role !== 'assistant') continue
+
+    const usage = msg.usage
+    if (typeof usage !== 'object' || usage === null) continue
+    const u = usage as {
+      input_tokens?: unknown
+      cache_read_input_tokens?: unknown
+      cache_creation_input_tokens?: unknown
+    }
+
+    const input = toNonNegNumber(u.input_tokens)
+    if (input === null) continue // usage without a real input count = not a usable turn
+
+    const cacheRead = toNonNegNumber(u.cache_read_input_tokens) ?? 0
+    const cacheCreation = toNonNegNumber(u.cache_creation_input_tokens) ?? 0
+
+    const usedTokens = input + cacheRead + cacheCreation
+    // FIX-13 (Fable L3): skip synthetic assistant turns whose usage sums to 0.
+    // An API-error turn can persist a `usage` block of all-zeros; treating it as
+    // the live window would flash the HUD to 0% mid-session. A real turn always
+    // carries a non-zero input/cache footprint, so scan past a 0-sum turn to the
+    // last genuine one.
+    if (usedTokens === 0) continue
+    const pct = windowTokens > 0 ? usedTokens / windowTokens : 0
+    return { usedTokens, pct }
+  }
+  return null
+}
+
+/**
+ * Read the TAIL of a transcript file (~256 KB) and compute context usage.
+ *
+ * Only the trailing bytes are read to keep memory bounded on multi-megabyte
+ * transcripts. When we don't start at byte 0 the first line is likely
+ * truncated mid-object, so it is dropped. Missing/unreadable file → `null`;
+ * this function never throws.
+ */
+export async function readContextUsage(
+  transcriptPath: string,
+  windowTokens: number,
+): Promise<ContextUsage | null> {
+  let handle: FileHandle | undefined
+  try {
+    handle = await open(transcriptPath, 'r')
+    const st = await handle.stat()
+    if (st.size === 0) return null
+    const len = Math.min(st.size, TAIL_BYTES)
+    const start = st.size - len
+    const buf = Buffer.alloc(len)
+    // FIX-12 (Fable L1) + L13 (IT2-8): fill the buffer with a READ LOOP. A
+    // single read() can return FEWER bytes than requested (the JSONL writer
+    // racing our read, a shrinking file), which would DROP the newest tail
+    // lines — exactly the ones we scan backwards for. Loop until `len` bytes or
+    // EOF, then slice to the ACTUAL bytes read: a short final read leaves NUL
+    // padding whose decoded bytes would corrupt the last line and make
+    // JSON.parse fail silently.
+    let totalRead = 0
+    while (totalRead < len) {
+      const { bytesRead } = await handle.read(buf, totalRead, len - totalRead, start + totalRead)
+      if (bytesRead === 0) break // EOF — file shrank under us
+      totalRead += bytesRead
+    }
+    const text = buf.subarray(0, totalRead).toString('utf8')
+
+    const split = text.split('\n')
+    // Drop the possibly-truncated first line when we didn't start at byte 0;
+    // filter empties so a trailing newline doesn't produce an empty parse.
+    const lines = (start > 0 ? split.slice(1) : split).filter((l) => l.length > 0)
+
+    return computeContextUsage(lines, windowTokens)
+  } catch {
+    return null
+  } finally {
+    if (handle) {
+      try {
+        await handle.close()
+      } catch {
+        // close() race on an already-closed handle is harmless
+      }
+    }
+  }
+}
+
+/**
+ * Format usage as a compact human string, e.g. `114k / 200k (57%)`.
+ *
+ * Pure and separate from computation so the caller controls presentation.
+ * Token counts are rounded to the nearest 1k; the percentage to an integer.
+ * `windowTokens <= 0` yields a `0%` share to avoid Infinity/NaN.
+ */
+export function formatContextUsage(
+  u: { usedTokens: number },
+  windowTokens: number,
+): string {
+  const usedK = Math.round(u.usedTokens / 1000)
+  const windowK = Math.round(windowTokens / 1000)
+  const pct = windowTokens > 0 ? Math.round((u.usedTokens / windowTokens) * 100) : 0
+  return `${usedK}k / ${windowK}k (${pct}%)`
+}

--- a/plugin/src/status/session-info.ts
+++ b/plugin/src/status/session-info.ts
@@ -1,0 +1,59 @@
+// SessionInfoStore — remembers the LATEST Claude Code session facts the plugin
+// has observed from hook events, so /status (and later the context HUD) can
+// read them without poking the host Claude process.
+//
+// Every Claude hook payload (PreToolUse / PostToolUse / Stop / UserPromptSubmit
+// / SessionStart) carries `transcript_path` + `session_id`
+// (ClaudeHookCommonShape). SessionStart additionally carries `model`. We record
+// whatever a hook gives us, MERGING so a later event that lacks `model` (every
+// non-SessionStart hook) does not wipe the model captured at session start.
+//
+// Multichat: keyed by chatId when the hook payload carries one; a single-session
+// deployment (no chatId) falls back to a single `latest` slot. `get(chatId)`
+// returns the per-chat record when present, else the most recent record seen —
+// so a single-DM caller that never passes a chatId still gets live data.
+//
+// Pure in-memory: no I/O, so it never throws and needs no teardown. A restart
+// simply re-learns the facts from the next hook event.
+
+export interface SessionInfo {
+  transcriptPath?: string
+  sessionId?: string
+  model?: string
+}
+
+export class SessionInfoStore {
+  private readonly byChat = new Map<string, SessionInfo>()
+  private latest: SessionInfo = {}
+
+  // Record the facts from one hook event. Only NON-EMPTY fields overwrite the
+  // previous value, so a hook that omits `model` keeps the last known model.
+  // A blank/undefined chatId updates only the shared `latest` slot.
+  record(chatId: string | undefined, info: SessionInfo): void {
+    const key = chatId !== undefined && chatId.length > 0 ? chatId : undefined
+    const base = key !== undefined ? this.byChat.get(key) ?? {} : this.latest
+    const next: SessionInfo = { ...base }
+    if (info.transcriptPath) next.transcriptPath = info.transcriptPath
+    if (info.sessionId) next.sessionId = info.sessionId
+    if (info.model) next.model = info.model
+    if (key !== undefined) this.byChat.set(key, next)
+    // `latest` always tracks the most recent event so a single-session caller
+    // (no chatId passed to get()) still sees the freshest transcript/model.
+    this.latest = next
+  }
+
+  // Read the current facts.
+  //
+  // FIX-10 (both reviews): a chatId argument means "the facts FOR THIS CHAT".
+  // Returning the global `latest` when a known chatId has no record leaked one
+  // chat's session into another — e.g. /status in the DM could render a GROUP
+  // session's context %/transcript. So a chatId with no record returns `{}`
+  // (all fields absent), NOT `latest`. Only the no-arg `get()` — the legacy
+  // single-DM caller that never keys by chat — falls back to `latest`.
+  get(chatId?: string): SessionInfo {
+    if (chatId !== undefined && chatId.length > 0) {
+      return this.byChat.get(chatId) ?? {}
+    }
+    return this.latest
+  }
+}

--- a/plugin/src/telegram/cc-panel-ui.ts
+++ b/plugin/src/telegram/cc-panel-ui.ts
@@ -21,12 +21,31 @@
 // FROZEN whitelist — there is no way to type arbitrary text into the pane, so
 // a pane that dropped to a shell can't be driven to run a shell command.
 
-import { sendSlashCommand, type KeysExec, type TmuxKeysTarget } from '../commands/keys.js'
+import {
+  capturePane,
+  classifyPane,
+  sendControlCommand,
+  sendSlashCommand,
+  type ControlCommandOpts,
+  type KeysCaptureExec,
+  type KeysExec,
+  type TmuxKeysTarget,
+} from '../commands/keys.js'
+import { buildNewConfirmCard } from './newq-confirm-ui.js'
 import type { InlineKeyboardLike } from '../channel/tools.js'
 import type { Logger } from '../log.js'
 
 // The callback prefix. Distinct from kkey:/pgate:/ask:/perm: by construction.
 export const CCMD_PREFIX = 'ccmd:'
+
+// `compact` needs to interrupt a busy pane first, so it is routed through the
+// state-aware `sendControlCommand` (probe → interrupt-if-busy → send → confirm)
+// — but it is non-destructive, so it stays one-tap. `clear` is DESTRUCTIVE
+// (wipes the context) so FIX-7 routes it through the SAME /new confirm card as
+// /new and hud:new — never a one-tap clear from the panel. Every other panel
+// command is safe to type into the composer via `sendSlashCommand` (e.g.
+// `model` opens a picker, `context`/`cost`/`status` are read-only).
+const RELIABLE_CCMD: ReadonlySet<string> = new Set(['compact'])
 
 // Closed, frozen whitelist of the popular Claude Code slash commands the panel
 // exposes. name = the command typed (no leading slash, no args); label = the
@@ -97,6 +116,10 @@ export const CC_PANEL_HEADER =
 export interface CcmdCallbackContext {
   callbackQuery: { data: string }
   from?: { id?: number | undefined }
+  // The chat the tap came from — where the /new confirm card is posted for the
+  // destructive `clear` button (FIX-7). Optional for source-compat with older
+  // test stubs.
+  chatId?: string
   answerCallbackQuery(arg: { text: string }): Promise<void>
 }
 
@@ -105,6 +128,14 @@ export interface CcmdCallbackDeps {
   tmuxKeysTarget?: TmuxKeysTarget
   log: Logger
   exec?: KeysExec
+  // Capture-pane exec + sleep — used only by the reliable path (compact).
+  // Injected for tests; default to the real tmux exec / real timer.
+  captureExec?: KeysCaptureExec
+  sleep?: (ms: number) => Promise<void>
+  // FIX-7: post the /new confirm card (buildNewConfirmCard) as a FRESH message
+  // for the destructive `clear` button. Wired in server.ts to the safe-wrapped
+  // api. When absent, `clear` refuses (fail-closed — never a one-tap clear).
+  sendConfirmCard?: (chatId: string, text: string, keyboard: InlineKeyboardLike) => Promise<void>
 }
 
 // Dispatch a `ccmd:*` callback. Always answers the callback query and returns
@@ -132,8 +163,60 @@ export async function handleCcmdCallback(
     await ctx.answerCallbackQuery({ text: 'неизвестная команда' })
     return true
   }
+  // FIX-7: `clear` is destructive → route through the SAME /new confirm card as
+  // /new and hud:new. Never a one-tap clear from the panel. Handled BEFORE the
+  // pane check because posting a card needs no pane.
+  if (name === 'clear') {
+    if (deps.sendConfirmCard === undefined || ctx.chatId === undefined || ctx.chatId.length === 0) {
+      // Fail-closed: without a way to post the confirm card we refuse rather
+      // than fall back to a one-tap destructive clear.
+      await ctx.answerCallbackQuery({ text: 'недоступно' })
+      return true
+    }
+    const card = buildNewConfirmCard()
+    try {
+      await deps.sendConfirmCard(ctx.chatId, card.text, card.inlineKeyboard)
+    } catch (err) {
+      deps.log.warn('ccmd clear confirm-card send failed', {
+        chat_id: ctx.chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      // L12: the card never posted → do NOT claim «подтвердите очистку» (that
+      // would tell the warchief to look for a card that isn't there). Report the
+      // failure instead.
+      await ctx.answerCallbackQuery({ text: 'не удалось показать подтверждение' })
+      return true
+    }
+    await ctx.answerCallbackQuery({ text: 'подтвердите очистку' })
+    return true
+  }
   if (deps.tmuxKeysTarget === undefined) {
     await ctx.answerCallbackQuery({ text: 'pane недоступен' })
+    return true
+  }
+  // compact → reliable state-aware injection (probe, interrupt-if-busy,
+  // confirm-fire) so a busy pane or an open dialog can never eat the command.
+  if (RELIABLE_CCMD.has(name)) {
+    const opts: ControlCommandOpts = { interruptIfBusy: true }
+    if (deps.exec) opts.exec = deps.exec
+    if (deps.captureExec) opts.captureExec = deps.captureExec
+    if (deps.sleep) opts.sleep = deps.sleep
+    const res = await sendControlCommand(deps.tmuxKeysTarget, name, opts)
+    if (res.ok) {
+      await ctx.answerCallbackQuery({ text: `выполнено: /${name}` })
+    } else {
+      await ctx.answerCallbackQuery({ text: `не выполнено: ${res.reason}` })
+    }
+    return true
+  }
+  // IT2-1: the read-only / picker commands (context/cost/status/model/resume/
+  // export) previously blind-fired via sendSlashCommand — but a trailing Enter
+  // into an OPEN dialog APPROVES it, and into a BUSY pane the command is queued.
+  // Gate on a POSITIVE idle exactly like the /cc TEXT path (FIX-6): probe the
+  // pane, refuse with a toast when it is not idle, send only when idle.
+  const state = classifyPane(await capturePane(deps.tmuxKeysTarget, deps.captureExec))
+  if (state !== 'idle') {
+    await ctx.answerCallbackQuery({ text: `сессия не готова (${state})` })
     return true
   }
   // rest is always '' — the panel runs argless commands only.

--- a/plugin/src/telegram/command-scope.ts
+++ b/plugin/src/telegram/command-scope.ts
@@ -1,0 +1,93 @@
+// Owner-scoped Telegram command registration.
+//
+// Telegram command scopes have a precedence: chat > all_private_chats > default.
+// If we register commands under the DEFAULT scope, EVERY chat the bot is in sees
+// them in the «/» autocomplete. The warchief's requirement is that the command
+// menu is visible ONLY to the owner. So we:
+//   1. CLEAR the broader scopes (default + all_private_chats) that a previous
+//      build may have populated — otherwise their stale entries keep showing.
+//   2. Register the command list under the per-CHAT scope for each owner chat.
+//
+// Best-effort: each Bot API call is wrapped so a transient failure (offline,
+// revoked token) never blocks startup. The whole routine is a fire-and-forget
+// side effect at boot.
+
+import type { Logger } from '../log.js'
+
+export interface CommandSpec {
+  command: string
+  description: string
+}
+
+// Structural subset of grammY's `bot.api` this routine needs. Kept narrow so
+// the module never reaches into grammY internals and unit tests can pass a fake
+// recording object. The scope object literals match the exact Telegram
+// BotCommandScope variants we use.
+export interface CommandScopeApi {
+  deleteMyCommands(options?: { scope: { type: 'all_private_chats' } }): Promise<unknown>
+  setMyCommands(
+    commands: readonly CommandSpec[],
+    options: { scope: { type: 'chat'; chat_id: number | string } },
+  ): Promise<unknown>
+}
+
+// Register `commands` scoped to the owner's chat(s), clearing stale broader
+// scopes first. `chatIds` should be config.allowed_chat_ids (falling back to
+// allowed_user_ids as DM chat ids — in a DM the chat id equals the user id).
+export async function registerOwnerScopedCommands(
+  api: CommandScopeApi,
+  commands: readonly CommandSpec[],
+  chatIds: ReadonlyArray<number | string>,
+  log: Logger,
+): Promise<void> {
+  // 1. Clear the broader scopes so their old entries stop showing. FIX-11
+  //    (Fable L5): the two deletes live in SEPARATE try/catch so a failure of
+  //    the first (default scope) does not skip the second (all_private_chats).
+  //    Before, a single throw left all_private_chats populated and its stale
+  //    menu kept showing in every private chat.
+  try {
+    await api.deleteMyCommands() // default scope = bare call
+  } catch (err) {
+    log.warn('deleteMyCommands (default scope) failed (ignored)', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+  try {
+    await api.deleteMyCommands({ scope: { type: 'all_private_chats' } })
+  } catch (err) {
+    log.warn('deleteMyCommands (all_private_chats scope) failed (ignored)', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+
+  // 2. Register per owner chat. FIX-11 (both reviews): register the per-CHAT
+  //    scope ONLY for positive (DM) ids — in a DM the chat id equals the user
+  //    id. A negative group/supergroup id or an @channel string is NOT an owner
+  //    DM, and pinning the owner command menu there would expose it in a public
+  //    group. Such ids are skipped (fail-closed).
+  // NOT IN SCOPE (fast-follow): clearing the per-chat scope for chat ids that
+  // were DROPPED from the allowlist — a removed owner keeps a stale menu until
+  // its scope is explicitly deleted. Tracked separately.
+  let registered = 0
+  for (const chatId of chatIds) {
+    if (typeof chatId !== 'number' || !Number.isInteger(chatId) || chatId <= 0) {
+      log.info('command-scope: skipping non-DM chat id (owner menu is DM-only)', {
+        chat_id: chatId,
+      })
+      continue
+    }
+    try {
+      await api.setMyCommands(commands, { scope: { type: 'chat', chat_id: chatId } })
+      registered += 1
+    } catch (err) {
+      log.warn('setMyCommands (owner scope) failed (ignored)', {
+        chat_id: chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+  log.info('telegram commands registered (owner-scoped)', {
+    count: commands.length,
+    chats: registered,
+  })
+}

--- a/plugin/src/telegram/control-result.ts
+++ b/plugin/src/telegram/control-result.ts
@@ -1,0 +1,28 @@
+// Shared Telegram-facing wording for a reliable control-command
+// (`sendControlCommand`) FAILURE. The success text differs per command
+// (/compact vs /new/clear), but the failure reasons — dialog open, pane busy,
+// never submitted, raw tmux error — read the same everywhere, so both /compact
+// (src/commands/oob.ts) and the /new confirm callback
+// (src/telegram/newq-confirm-ui.ts) format them through this one helper.
+//
+// HTML parse mode. The `reason` is echoed verbatim inside <code> only for the
+// non-submitted / tmux cases (a bounded enum, never user text).
+
+import type { ControlCommandResult } from '../commands/keys.js'
+
+// The failure arm of ControlCommandResult (`ok: false`) narrowed to its reason.
+export type ControlFailureReason = Extract<ControlCommandResult, { ok: false }>['reason']
+
+export function controlFailureMessage(reason: ControlFailureReason): string {
+  switch (reason) {
+    case 'busy':
+      return '<b>не выполнено</b> — агент занят, не удалось прервать. Попробуй ещё раз через пару секунд.'
+    case 'dialog':
+      return '<b>не выполнено</b> — сессия ждёт ответа в диалоге. Ответь через /keys, потом повтори.'
+    case 'unknown':
+      return '<b>не выполнено</b> — не удалось определить состояние сессии. Попробуй ещё раз.'
+    case 'not-submitted':
+    case 'tmux':
+      return `<b>не выполнено</b> — не удалось отправить (<code>${reason}</code>).`
+  }
+}

--- a/plugin/src/telegram/handlers.ts
+++ b/plugin/src/telegram/handlers.ts
@@ -18,6 +18,7 @@ import type { Context } from 'grammy'
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js'
 
 import type { AppConfig, StatePaths } from '../config.js'
+import { resolveContextWindowTokens } from '../config.js'
 import type { Logger } from '../log.js'
 import type { TelegramApi } from '../channel/tools.js'
 import type { StatusManager } from '../status/status-manager.js'
@@ -150,6 +151,11 @@ export interface HandlerDeps {
   tmuxMirror?: TmuxMirrorControl
   // /keys target — resolved tmux pane of the agent session (server.ts wiring).
   tmuxKeys?: { target: TmuxKeysTarget }
+  // Session facts (transcript_path + model) learned from Claude hook events,
+  // surfaced by /status (context usage). Structural getter so handlers stay
+  // decoupled from the concrete SessionInfoStore. Optional — absent in legacy
+  // wiring / tests, in which case /status shows «контекст: —».
+  sessionInfo?: { get(chatId?: string): { transcriptPath?: string; model?: string } }
   // Multichat router. When present together with `policy`, all gated
   // inbound traffic is dispatched to the per-chat tmux session via
   // `router.dispatch(InboundMessage)` instead of the legacy
@@ -1111,6 +1117,10 @@ export async function handleInboundText(ctx: Context, deps: HandlerDeps): Promis
     const allowedChatSet = new Set(deps.config.allowed_chat_ids.map((v) => String(v)))
     const allowedChat = chatNum !== undefined && allowedChatSet.has(String(chatNum))
     if (chatType === 'private' && chatId && senderId && allowedSender && allowedChat) {
+      // Session facts for /status context usage: transcript_path + model
+      // learned from hook events (per chat when multichat). Snapshot at
+      // command time — /status is itself a snapshot.
+      const session = deps.sessionInfo?.get(chatId)
       const oobCtx: OobContext = {
         chatId,
         senderId,
@@ -1119,6 +1129,10 @@ export async function handleInboundText(ctx: Context, deps: HandlerDeps): Promis
         log: deps.log,
         botId: deps.bot.id,
         stateDir: deps.statePaths.root,
+        contextWindowTokens: resolveContextWindowTokens(deps.config),
+        uptimeSeconds: process.uptime(),
+        ...(session?.transcriptPath ? { transcriptPath: session.transcriptPath } : {}),
+        ...(session?.model ? { modelName: session.model } : {}),
         ...(deps.statusManager
           ? {
               statusManager: {

--- a/plugin/src/telegram/newq-confirm-ui.ts
+++ b/plugin/src/telegram/newq-confirm-ui.ts
@@ -1,0 +1,277 @@
+// /new confirm card — a one-tap-with-confirm destructive control.
+//
+// `/new` clears the current Claude Code context (it runs the native `/clear`).
+// Because that is irreversible, a bare `/new` does NOT act immediately: it
+// posts a confirmation card with two buttons. The tap is what actually drives
+// the pane, routed through the RELIABLE `sendControlCommand` (probe → optionally
+// interrupt → send → confirm), never a blind Enter.
+//
+// Callback data uses the `newq:` prefix so it never collides with the other
+// inline flows sharing bot.on('callback_query:data'):
+//   * `kkey:*`  — /keys keystroke keypad
+//   * `ccmd:*`  — /cc command panel
+//   * `pgate:*` — permission-gate Allow/Deny
+//   * `ask:*`   — AskUserQuestion
+//
+//   newq:confirm — clear the context (types /clear into the pane)
+//   newq:cancel  — abort, leave the session untouched
+//
+// Security: a tap is honoured ONLY for a user id in the same allow-list that
+// guards every other session-driving control (config.allowed_user_ids). Anyone
+// else gets an answerCallbackQuery toast and NOTHING is typed. Auth precedes
+// parsing so a non-allowed caller learns nothing about the flow.
+
+import {
+  sendControlCommand,
+  type ControlCommandResult,
+  type KeysCaptureExec,
+  type KeysExec,
+  type TmuxKeysTarget,
+} from '../commands/keys.js'
+import { controlFailureMessage } from './control-result.js'
+import type { InlineKeyboardLike } from '../channel/tools.js'
+import type { Logger } from '../log.js'
+
+// The callback prefix. Distinct from kkey:/ccmd:/pgate:/ask: by construction.
+export const NEWQ_PREFIX = 'newq:'
+
+// FIX-14 (Fable M2): confirm taps are only honoured within this window after the
+// card was built. A stale card left in the chat scrollback can't re-fire /clear.
+export const NEWQ_TTL_MS = 60_000
+
+export type NewqAction = 'confirm' | 'cancel'
+
+export interface ParsedNewq {
+  action: NewqAction
+  // The card's build-time timestamp (ms), or null for a legacy card that carries
+  // no nonce (`newq:confirm` without a suffix). Used for TTL staleness.
+  ts: number | null
+  // IT2-5: the FULL nonce string after the action — `<ts>:<rand>` (current) or a
+  // bare `<ts>` (legacy) — or null when absent. Used for double-tap dedup so two
+  // cards built in the SAME millisecond (same ts, different rand) don't collide.
+  nonce: string | null
+}
+
+// Parse a `newq:<action>[:<ts>[:<rand>]]` callback_data string. Returns the
+// validated action + optional nonce, or null for anything else — a non-newq
+// prefix, an unknown action, or a malformed nonce. Null callers answer with a
+// toast and do NOTHING (fail-closed).
+export function parseNewqCallback(data: string): ParsedNewq | null {
+  if (typeof data !== 'string') return null
+  if (!data.startsWith(NEWQ_PREFIX)) return null
+  const rest = data.slice(NEWQ_PREFIX.length)
+  const sep = rest.indexOf(':')
+  const actionRaw = sep === -1 ? rest : rest.slice(0, sep)
+  const nonceRaw = sep === -1 ? '' : rest.slice(sep + 1)
+  if (actionRaw !== 'confirm' && actionRaw !== 'cancel') return null
+  let ts: number | null = null
+  let nonce: string | null = null
+  if (nonceRaw.length > 0) {
+    // Nonce shape: `<ts>` or `<ts>:<rand>`. The TS component (up to the first
+    // ':') must be a positive integer — a present-but-garbage nonce is
+    // fail-closed (reject), not silently ignored. The optional `<rand>` suffix
+    // is opaque (dedup key only), so it is not further validated.
+    const tsEnd = nonceRaw.indexOf(':')
+    const tsPart = tsEnd === -1 ? nonceRaw : nonceRaw.slice(0, tsEnd)
+    const n = Number(tsPart)
+    if (!Number.isInteger(n) || n <= 0) return null
+    ts = n
+    nonce = nonceRaw
+  }
+  return { action: actionRaw, ts, nonce }
+}
+
+// A tap's chat is an owner DM iff it is a configured owner id AND a positive
+// (DM) numeric chat id. Shared by the /new confirm + HUD callbacks (FIX-8).
+// Lives here (not context-hud) so context-hud can import it without a cycle.
+export function isOwnerDmChat(
+  chatId: string | undefined,
+  ownerChatIds: readonly (number | string)[] | undefined,
+): boolean {
+  // No owner set configured → skip the check (legacy single-DM / tests).
+  if (ownerChatIds === undefined) return true
+  if (chatId === undefined || chatId.length === 0) return false
+  const n = Number(chatId)
+  if (!Number.isInteger(n) || n <= 0) return false
+  return ownerChatIds.some((id) => String(id) === chatId)
+}
+
+// FIX-14: a tiny consumed-nonce guard so a double/stale tap of the SAME card
+// can't fire /clear twice (belt-and-suspenders alongside removing the buttons
+// on first tap). `claim` returns true only the FIRST time a nonce is seen.
+// TTL-swept so the map cannot grow unbounded.
+export interface NewqNonceGuard {
+  claim(nonce: string): boolean
+}
+
+export function createNewqNonceGuard(ttlMs: number = 5 * 60 * 1000): NewqNonceGuard {
+  const seen = new Map<string, number>()
+  return {
+    claim(nonce: string): boolean {
+      const now = Date.now()
+      for (const [k, t] of seen) {
+        if (now - t > ttlMs) seen.delete(k)
+      }
+      if (seen.has(nonce)) return false
+      seen.set(nonce, now)
+      return true
+    },
+  }
+}
+
+// Process-wide default guard (production). Tests inject their own so the shared
+// module state can't couple test cases.
+const defaultNonceGuard = createNewqNonceGuard()
+
+// Build the confirm card (text + inline keyboard). Kept as a small pure helper
+// (like buildKeysKeyboard) so both the /new OOB handler and unit tests render
+// the exact same surface. FIX-14: the confirm button embeds a build-time nonce
+// (`newq:confirm:<ts>:<rand>`) so a stale/duplicate tap can be rejected.
+export function buildNewConfirmCard(): { text: string; inlineKeyboard: InlineKeyboardLike } {
+  const ts = Date.now()
+  // IT2-5: append a random suffix so two cards built in the SAME millisecond get
+  // DISTINCT nonces. Keyed by ts alone, the second card's first tap would hit the
+  // consumed-nonce guard and be wrongly refused as «уже выполнено». The suffix
+  // keeps the callback_data well under Telegram's 64-byte limit.
+  const rand = Math.random().toString(36).slice(2, 10)
+  const nonce = `${ts}:${rand}`
+  return {
+    text: '<b>Новый диалог</b> — очистит текущий контекст. Продолжить?',
+    inlineKeyboard: {
+      inline_keyboard: [
+        [{ text: 'Да, очистить', callback_data: `${NEWQ_PREFIX}confirm:${nonce}` }],
+        [{ text: 'Отмена', callback_data: `${NEWQ_PREFIX}cancel` }],
+      ],
+    },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Callback handler. Mirrors handleCcmdCallback's fail-closed shape:
+// auth FIRST → parse → act. Edits the card message to the real outcome so the
+// warchief sees whether the clear actually fired.
+// ─────────────────────────────────────────────────────────────────────
+
+export interface NewqCallbackContext {
+  callbackQuery: { data: string }
+  from?: { id?: number | undefined }
+  // The chat the tap came from (FIX-8). Optional for source-compat with older
+  // test stubs; when absent the owner-DM check is skipped (see deps.ownerChatIds).
+  chatId?: string
+  answerCallbackQuery(arg?: { text: string }): Promise<void>
+  // `reply_markup` lets the handler strip the buttons on first tap (FIX-14).
+  editMessageText(
+    text: string,
+    opts?: { parse_mode?: 'HTML'; reply_markup?: InlineKeyboardLike },
+  ): Promise<void>
+}
+
+// Injectable control-command sender — defaults to the real reliable
+// `sendControlCommand`. Tests pass a fake so they never touch tmux.
+export type ControlSender = (
+  target: TmuxKeysTarget,
+  name: string,
+  opts: { interruptIfBusy?: boolean; exec?: KeysExec; captureExec?: KeysCaptureExec; sleep?: (ms: number) => Promise<void> },
+) => Promise<ControlCommandResult>
+
+export interface NewqCallbackDeps {
+  allowedUserIds: readonly number[]
+  tmuxKeysTarget?: TmuxKeysTarget
+  log: Logger
+  // Injected for tests; defaults to the real reliable sender.
+  sendControl?: ControlSender
+  // FIX-8: owner DM chat ids (resolveOwnerChatIds). A confirm from a non-owner
+  // chat is refused (the /clear drives the single global DM session). Omitted →
+  // check skipped (legacy/tests).
+  ownerChatIds?: readonly (number | string)[]
+  // FIX-14: consumed-nonce guard. Injected for tests; defaults to the shared
+  // process-wide guard.
+  nonceGuard?: NewqNonceGuard
+}
+
+// Dispatch a `newq:*` callback. Always answers the callback query and returns
+// true when it consumed the event. NEVER drives the pane for a non-allowed user
+// id. On confirm it edits the card to the real clear outcome.
+export async function handleNewqCallback(
+  ctx: NewqCallbackContext,
+  deps: NewqCallbackDeps,
+): Promise<boolean> {
+  // AUTH FIRST — before parsing or touching the pane.
+  const fromId = ctx.from?.id
+  if (typeof fromId !== 'number' || !deps.allowedUserIds.includes(fromId)) {
+    deps.log.warn('newq unauthorized tap', {
+      user_id: fromId,
+      data: ctx.callbackQuery.data,
+    })
+    await ctx.answerCallbackQuery({ text: 'не авторизовано' })
+    return true
+  }
+  const parsed = parseNewqCallback(ctx.callbackQuery.data)
+  if (parsed === null) {
+    await ctx.answerCallbackQuery({ text: 'неизвестное действие' })
+    return true
+  }
+  if (parsed.action === 'cancel') {
+    await ctx.editMessageText('Отменено', { parse_mode: 'HTML' })
+    await ctx.answerCallbackQuery()
+    return true
+  }
+  // confirm — the destructive /clear path.
+
+  // FIX-8: a confirm only drives the pane from the OWNER DM. A tap from a
+  // non-owner chat is refused (the /clear acts on the single global DM session).
+  if (!isOwnerDmChat(ctx.chatId, deps.ownerChatIds)) {
+    deps.log.warn('newq confirm from non-owner chat refused', {
+      chat_id: ctx.chatId,
+      user_id: fromId,
+    })
+    await ctx.answerCallbackQuery({ text: 'недоступно в этом чате' })
+    return true
+  }
+
+  // FIX-14: reject a stale card. A nonce-bearing confirm older than NEWQ_TTL_MS
+  // is expired — a card sitting in the scrollback must not re-fire /clear.
+  if (parsed.ts !== null && Date.now() - parsed.ts > NEWQ_TTL_MS) {
+    await ctx.answerCallbackQuery({ text: 'запрос устарел, повтори /new' })
+    await ctx.editMessageText('<b>новый диалог</b> — запрос устарел.', { parse_mode: 'HTML' })
+    return true
+  }
+
+  // FIX-14 / IT2-5: reject an already-consumed nonce (double-tap before the
+  // button removal below lands). Keyed by the FULL nonce (`<ts>:<rand>`) so two
+  // cards built in the same millisecond do NOT share a dedup key. Only applies to
+  // nonce-bearing cards.
+  if (parsed.nonce !== null) {
+    const guard = deps.nonceGuard ?? defaultNonceGuard
+    if (!guard.claim(parsed.nonce)) {
+      await ctx.answerCallbackQuery({ text: 'уже выполнено' })
+      return true
+    }
+  }
+
+  if (deps.tmuxKeysTarget === undefined) {
+    await ctx.answerCallbackQuery({ text: 'pane недоступен' })
+    await ctx.editMessageText('<b>новый диалог</b> — pane недоступен.', { parse_mode: 'HTML' })
+    return true
+  }
+  await ctx.answerCallbackQuery({ text: 'Очищаю…' })
+  // FIX-14: strip the buttons on first tap so a stale/double tap can't re-fire.
+  // Best-effort — a failed edit must not block the clear.
+  try {
+    await ctx.editMessageText('<b>новый диалог</b> — очищаю…', {
+      parse_mode: 'HTML',
+      reply_markup: { inline_keyboard: [] },
+    })
+  } catch (err) {
+    deps.log.warn('newq button-removal edit failed (ignored)', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+  const send = deps.sendControl ?? sendControlCommand
+  const result = await send(deps.tmuxKeysTarget, 'clear', { interruptIfBusy: true })
+  const text = result.ok
+    ? '<b>новый диалог</b> — контекст очищен.'
+    : controlFailureMessage(result.reason)
+  await ctx.editMessageText(text, { parse_mode: 'HTML' })
+  return true
+}

--- a/plugin/src/webhook/server.ts
+++ b/plugin/src/webhook/server.ts
@@ -155,6 +155,26 @@ export interface StatusManagerForWebhook {
   ): Promise<void>
 }
 
+// Structural surface for the SessionInfoStore. Every claude_hook carries
+// transcript_path + session_id; SessionStart also carries model. We record the
+// latest so /status (and the context HUD) can read them. Write-only here.
+export interface SessionInfoRecorder {
+  record(
+    chatId: string | undefined,
+    info: { transcriptPath?: string; sessionId?: string; model?: string },
+  ): void
+}
+
+// Structural surface for the context HUD (wave 3B). SessionStart (re)pins +
+// refreshes the pinned HUD message; Stop refreshes its percentage. Both entry
+// points are best-effort inside the HUD (they swallow + log, never throw), so
+// the webhook fires them fire-and-forget and never blocks the 200. Optional —
+// when absent the hook path is unchanged (no HUD).
+export interface ContextHudForWebhook {
+  onSessionStart(chatId: string): Promise<void> | void
+  onStop(chatId: string): Promise<void> | void
+}
+
 // Structural surface for the AskUserQuestion Telegram UI handler (TASK-2).
 // We accept any object exposing `startQuestion(requestId)` so the webhook
 // layer is decoupled from the concrete implementation in
@@ -174,6 +194,15 @@ export interface WebhookDeps {
   // status update happens. The 200 path stays open so Claude hooks never
   // back-pressure on visibility outages.
   statusManager?: StatusManagerForWebhook
+  // Session facts store (task: context HUD). Records transcript_path + model
+  // from every claude_hook so /status can show context usage. Optional — when
+  // absent the hook path is unchanged (no capture). Pure in-memory, never
+  // throws, so the record call needs no error wrapping.
+  sessionInfo?: SessionInfoRecorder
+  // Context HUD (wave 3B): the pinned context-usage indicator. SessionStart /
+  // Stop hooks drive it. Optional — when absent no HUD is rendered. Fired
+  // fire-and-forget so a HUD failure never back-pressures the 200.
+  contextHud?: ContextHudForWebhook
   // Phase 8: optional memory writer. Receives a sibling dispatch of every
   // hook payload (UserPromptSubmit buffers, Stop writes recent.md +
   // verbose.jsonl). Throws are caught and logged — never block the 200.
@@ -500,6 +529,39 @@ async function handleRequest(
   // Branch on payload variant. Discriminator was set by the Zod transform
   // so we don't have to re-sniff fields here.
   if (payload.kind === 'claude_hook') {
+    // Capture the latest session facts (transcript_path + model) so /status and
+    // the context HUD can read them. transcript_path + session_id ride on every
+    // hook; model is present only on SessionStart. Pure in-memory record.
+    if (deps.sessionInfo) {
+      const info: { transcriptPath?: string; sessionId?: string; model?: string } = {
+        transcriptPath: payload.transcript_path,
+        sessionId: payload.session_id,
+      }
+      if (
+        payload.hook_event_name === 'SessionStart'
+        && typeof payload.model === 'string'
+        && payload.model.length > 0
+      ) {
+        info.model = payload.model
+      }
+      deps.sessionInfo.record(payload.chatId, info)
+    }
+
+    // Context HUD (wave 3B): drive the pinned indicator on the session
+    // lifecycle. SessionStart (re)pins + refreshes; Stop refreshes the
+    // percentage after a turn. COMPLETELY isolated from the 200 path: the HUD
+    // methods swallow + log internally, and we still `void`+`.catch` here so a
+    // synchronous throw (defensive) can never escape into the hook response.
+    // The HUD gates on the owner chat internally, so a non-owner chatId is a
+    // safe no-op.
+    if (deps.contextHud) {
+      if (payload.hook_event_name === 'SessionStart') {
+        void Promise.resolve(deps.contextHud.onSessionStart(payload.chatId)).catch(() => {})
+      } else if (payload.hook_event_name === 'Stop') {
+        void Promise.resolve(deps.contextHud.onStop(payload.chatId)).catch(() => {})
+      }
+    }
+
     // Phase 8: dispatch to memory writer first, BEFORE the status branch,
     // so memory persistence runs regardless of status.enabled. Errors are
     // logged and swallowed — memory must never back-pressure the 200.

--- a/plugin/tests/commands/keys-control.test.ts
+++ b/plugin/tests/commands/keys-control.test.ts
@@ -1,0 +1,566 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  capturePane,
+  classifyPane,
+  sendControlCommand,
+  sendSlashCommand,
+  type KeysCaptureExec,
+  type KeysExec,
+} from '../../src/commands/keys.js'
+
+// ─── Canned pane snapshots (Claude Code TUI v2.1.200 shapes) ─────────────
+
+const IDLE = [
+  'assistant said something useful',
+  '╭────────────────────────────────╮',
+  '│ >                              │',
+  '╰────────────────────────────────╯',
+  '  ? for shortcuts',
+].join('\n')
+
+const BUSY = [
+  '● Running a tool…',
+  '✳ Working… (esc to interrupt)',
+  '╭────────────────────────────────╮',
+  '│ >                              │',
+  '╰────────────────────────────────╯',
+].join('\n')
+
+const DIALOG = [
+  '╭─ Bash command ─────────────────╮',
+  '│ rm -rf /tmp/x                  │',
+  '│                                │',
+  '│ Do you want to proceed?        │',
+  '│ ❯ 1. Yes                       │',
+  '│   2. No                        │',
+  '╰────────────────────────────────╯',
+].join('\n')
+
+// A dialog that ALSO shows the busy interrupt hint — classifyPane must still
+// call it a dialog (dialog is checked before busy).
+const DIALOG_WITH_INTERRUPT = [
+  '✳ Working… (esc to interrupt)',
+  '│ Do you want to proceed?        │',
+  '│ ❯ 1. Yes                       │',
+].join('\n')
+
+const UNKNOWN = 'openclaw@mac ~ % raw shell prompt, no TUI markers'
+
+// After /clear (v2.1.200): a fresh `❯ /clear` echo, the transcript collapses to
+// the welcome banner, and the idle footer returns. NOTE: there is NO
+// "Ctrl+Y to paste" line in this build — the clear-success signal is the fresh
+// `❯ /clear` echo (+ the transcript collapse), never a paste hint.
+const CLEARED = [
+  '❯ /clear',
+  '✻ Welcome back to Claude Code',
+  '╭────────────────────────────────╮',
+  '│ >                              │',
+  '╰────────────────────────────────╯',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// After /compact accepted: echoed command + Compacting banner, composer empty.
+const COMPACTING = [
+  '❯ /compact',
+  'Compacting conversation…',
+  '╭────────────────────────────────╮',
+  '│ >                              │',
+  '╰────────────────────────────────╯',
+].join('\n')
+
+// The command was typed but never submitted — it still sits in the composer.
+const NOT_SUBMITTED = [
+  '╭────────────────────────────────╮',
+  '│ > /clear                       │',
+  '╰────────────────────────────────╯',
+  '  ? for shortcuts',
+].join('\n')
+
+// Idle pane with a typed '/cmd' draft in the composer — the pre-Enter TOCTOU
+// snapshot (FIX-3) that sendControlCommand re-captures right before Enter.
+function typed(cmd: string): string {
+  return [
+    'assistant said something useful',
+    '╭────────────────────────────────╮',
+    `│ > /${cmd}                        │`,
+    '╰────────────────────────────────╯',
+    '  ? for shortcuts',
+  ].join('\n')
+}
+
+// ─── Fakes: no real tmux, scripted capture-pane outputs + recorded sends ──
+
+const noSleep = async (_ms: number): Promise<void> => {}
+
+function scriptedSend(): { calls: string[][]; exec: KeysExec } {
+  const calls: string[][] = []
+  const exec: KeysExec = async (args) => {
+    calls.push([...args])
+    return { exitCode: 0, stderr: '' }
+  }
+  return { calls, exec }
+}
+
+// Returns each scripted snapshot in order; once the script is exhausted it
+// repeats the last one (so polling loops don't have to be counted exactly).
+function scriptedCapture(outputs: string[]): { calls: string[][]; exec: KeysCaptureExec } {
+  const calls: string[][] = []
+  let i = 0
+  const exec: KeysCaptureExec = async (args) => {
+    calls.push([...args])
+    const out = i < outputs.length ? outputs[i]! : (outputs[outputs.length - 1] ?? '')
+    i++
+    return { exitCode: 0, stdout: out, stderr: '' }
+  }
+  return { calls, exec }
+}
+
+// ─── classifyPane (pure) ─────────────────────────────────────────────────
+
+describe('classifyPane', () => {
+  test('idle / busy / dialog / unknown are labelled correctly', () => {
+    expect(classifyPane(IDLE)).toBe('idle')
+    expect(classifyPane(BUSY)).toBe('busy')
+    expect(classifyPane(DIALOG)).toBe('dialog')
+    expect(classifyPane(UNKNOWN)).toBe('unknown')
+  })
+
+  test('dialog wins over busy when both hints are present', () => {
+    expect(classifyPane(DIALOG_WITH_INTERRUPT)).toBe('dialog')
+  })
+
+  test('idle needs a composer hint AND no interrupt hint', () => {
+    expect(classifyPane('? for shortcuts')).toBe('idle')
+    expect(classifyPane('shift+tab to cycle')).toBe('idle')
+    // interrupt hint present ⇒ never idle
+    expect(classifyPane('? for shortcuts\n✳ Working… (esc to interrupt)')).toBe('busy')
+  })
+
+  test('empty capture (failed capture-pane) → unknown, never idle', () => {
+    expect(classifyPane('')).toBe('unknown')
+  })
+
+  // FIX-5 (Fable M3): markers are anchored to the BOTTOM UI chrome, so the
+  // agent's own transcript quoting "Do you want to proceed?" / "esc to
+  // interrupt" (this very plugin discusses these strings) far above the
+  // composer is NOT misread as live pane state.
+  test('transcript far above that QUOTES chrome text is not misread', () => {
+    const geom = [
+      'The plugin discusses: Do you want to proceed?',
+      'and also the string: esc to interrupt — quoted here',
+      'filler line 3',
+      'filler line 4',
+      'filler line 5',
+      'filler line 6',
+      'filler line 7',
+      'filler line 8',
+      'filler line 9',
+      'filler line 10',
+      'filler line 11',
+      'filler line 12',
+      '╭────────────────────────────────╮',
+      '│ >                              │',
+      '╰────────────────────────────────╯',
+      '  ? for shortcuts',
+    ].join('\n')
+    // Bottom chrome is a clean idle composer → idle, NOT dialog/busy.
+    expect(classifyPane(geom)).toBe('idle')
+  })
+})
+
+// ─── capturePane ─────────────────────────────────────────────────────────
+
+describe('capturePane', () => {
+  test('returns stdout and issues the right capture-pane args', async () => {
+    const cap = scriptedCapture([IDLE])
+    const out = await capturePane({ paneTarget: '%7', socketPath: '/tmp/s' }, cap.exec)
+    expect(out).toBe(IDLE)
+    expect(cap.calls).toEqual([['-S', '/tmp/s', 'capture-pane', '-p', '-t', '%7']])
+  })
+
+  test('returns empty string on tmux failure', async () => {
+    const exec: KeysCaptureExec = async () => ({ exitCode: 1, stdout: '', stderr: 'no pane' })
+    const out = await capturePane({ paneTarget: '%9' }, exec)
+    expect(out).toBe('')
+  })
+})
+
+// ─── sendControlCommand ──────────────────────────────────────────────────
+
+describe('sendControlCommand', () => {
+  const target = { paneTarget: '%7', socketPath: '/tmp/s' } as const
+
+  test('idle → 3-shot fires in exact order, confirm sees cleared → ok', async () => {
+    const send = scriptedSend()
+    // probe → pre-Enter re-check (FIX-3) → confirm.
+    const cap = scriptedCapture([IDLE, typed('clear'), CLEARED])
+    const r = await sendControlCommand(target, 'clear', {
+      sleep: noSleep,
+      exec: send.exec,
+      captureExec: cap.exec,
+    })
+    expect(r).toEqual({ ok: true })
+    expect(send.calls).toEqual([
+      ['-S', '/tmp/s', 'send-keys', '-t', '%7', 'C-u'],
+      ['-S', '/tmp/s', 'send-keys', '-t', '%7', '-l', '/clear'],
+      ['-S', '/tmp/s', 'send-keys', '-t', '%7', 'Enter'],
+    ])
+  })
+
+  test('dialog → {ok:false, reason:dialog} and sends NOTHING', async () => {
+    const send = scriptedSend()
+    const cap = scriptedCapture([DIALOG])
+    const r = await sendControlCommand(target, 'clear', {
+      interruptIfBusy: true,
+      sleep: noSleep,
+      exec: send.exec,
+      captureExec: cap.exec,
+    })
+    expect(r).toEqual({ ok: false, reason: 'dialog' })
+    expect(send.calls).toEqual([]) // not one send-key issued
+  })
+
+  test('busy then idle-after-Escape → Escape sent, then 3-shot → ok', async () => {
+    const send = scriptedSend()
+    const cap = scriptedCapture([BUSY, IDLE, typed('clear'), CLEARED])
+    const r = await sendControlCommand(target, 'clear', {
+      interruptIfBusy: true,
+      sleep: noSleep,
+      exec: send.exec,
+      captureExec: cap.exec,
+    })
+    expect(r).toEqual({ ok: true })
+    expect(send.calls).toEqual([
+      ['-S', '/tmp/s', 'send-keys', '-t', '%7', 'Escape'],
+      ['-S', '/tmp/s', 'send-keys', '-t', '%7', 'C-u'],
+      ['-S', '/tmp/s', 'send-keys', '-t', '%7', '-l', '/clear'],
+      ['-S', '/tmp/s', 'send-keys', '-t', '%7', 'Enter'],
+    ])
+  })
+
+  test('busy stays busy after Escape → {ok:false, reason:busy}', async () => {
+    const send = scriptedSend()
+    const cap = scriptedCapture([BUSY, BUSY])
+    const r = await sendControlCommand(target, 'clear', {
+      interruptIfBusy: true,
+      sleep: noSleep,
+      exec: send.exec,
+      captureExec: cap.exec,
+    })
+    expect(r).toEqual({ ok: false, reason: 'busy' })
+    expect(send.calls).toEqual([['-S', '/tmp/s', 'send-keys', '-t', '%7', 'Escape']])
+  })
+
+  test('busy without interruptIfBusy → busy, sends nothing', async () => {
+    const send = scriptedSend()
+    const cap = scriptedCapture([BUSY])
+    const r = await sendControlCommand(target, 'clear', {
+      sleep: noSleep,
+      exec: send.exec,
+      captureExec: cap.exec,
+    })
+    expect(r).toEqual({ ok: false, reason: 'busy' })
+    expect(send.calls).toEqual([])
+  })
+
+  // FIX-1 (both reviews): a pane we cannot POSITIVELY identify as idle must
+  // never receive a blind send. An unrecognised screen classifies as unknown.
+  test('unknown pane at probe → zero send-keys, {ok:false, reason:unknown}', async () => {
+    const send = scriptedSend()
+    const cap = scriptedCapture([UNKNOWN])
+    const r = await sendControlCommand(target, 'clear', {
+      interruptIfBusy: true,
+      sleep: noSleep,
+      exec: send.exec,
+      captureExec: cap.exec,
+    })
+    expect(r).toEqual({ ok: false, reason: 'unknown' })
+    expect(send.calls).toEqual([]) // never send into an unknown pane
+  })
+
+  // FIX-1: a FAILED capture-pane returns '' → unknown → refuse (not idle).
+  test('failed capture-pane (empty) → refuses with reason unknown, sends nothing', async () => {
+    const send = scriptedSend()
+    const failCapture: KeysCaptureExec = async () => ({ exitCode: 1, stdout: '', stderr: 'boom' })
+    const r = await sendControlCommand(target, 'clear', {
+      sleep: noSleep,
+      exec: send.exec,
+      captureExec: failCapture,
+    })
+    expect(r).toEqual({ ok: false, reason: 'unknown' })
+    expect(send.calls).toEqual([])
+  })
+
+  // FIX-3 (both reviews): a dialog surfaced between typing the draft and Enter.
+  // The pre-Enter re-check must abort — NEVER press Enter (it would approve the
+  // dialog) — clear the draft and refuse.
+  test('idle at probe, dialog at pre-Enter re-check → no Enter, refused dialog', async () => {
+    const send = scriptedSend()
+    const cap = scriptedCapture([IDLE, DIALOG])
+    const r = await sendControlCommand(target, 'clear', {
+      sleep: noSleep,
+      exec: send.exec,
+      captureExec: cap.exec,
+    })
+    expect(r).toEqual({ ok: false, reason: 'dialog' })
+    // Enter was NEVER sent; the typed draft was wiped with a C-u.
+    expect(send.calls.some((c) => c.includes('Enter'))).toBe(false)
+    expect(send.calls).toEqual([
+      ['-S', '/tmp/s', 'send-keys', '-t', '%7', 'C-u'],
+      ['-S', '/tmp/s', 'send-keys', '-t', '%7', '-l', '/clear'],
+      ['-S', '/tmp/s', 'send-keys', '-t', '%7', 'C-u'],
+    ])
+  })
+
+  test('composer still shows /clear after send → {ok:false, reason:not-submitted}', async () => {
+    const send = scriptedSend()
+    const cap = scriptedCapture([IDLE, NOT_SUBMITTED, NOT_SUBMITTED, NOT_SUBMITTED, NOT_SUBMITTED])
+    const r = await sendControlCommand(target, 'clear', {
+      sleep: noSleep,
+      exec: send.exec,
+      captureExec: cap.exec,
+    })
+    expect(r).toEqual({ ok: false, reason: 'not-submitted' })
+    // the 3-shot was still attempted (the failure is in confirm, not send)
+    expect(send.calls).toEqual([
+      ['-S', '/tmp/s', 'send-keys', '-t', '%7', 'C-u'],
+      ['-S', '/tmp/s', 'send-keys', '-t', '%7', '-l', '/clear'],
+      ['-S', '/tmp/s', 'send-keys', '-t', '%7', 'Enter'],
+    ])
+  })
+
+  // Coordinator (v2.1.200): on an ALREADY-CLEAR / already-short session neither
+  // the `❯ /clear` occurrence count NOR the transcript line-count can move, yet
+  // the clear DID run. The reliable sender only Enters a verified '/clear' draft
+  // in an idle pane, so an empty composer + idle footer + a visible `❯ /clear`
+  // echo is a confident success — prefer OK over a false not-submitted (which
+  // would have made /clear and /new look broken on a fresh session).
+  test('clear on an already-clear session → ok via echo+idle fallback (no false not-submitted)', async () => {
+    const send = scriptedSend()
+    const alreadyClearDraft = [
+      '❯ /clear',
+      '✻ Welcome back to Claude Code',
+      '╭────────────────────────────────╮',
+      '│ > /clear                       │',
+      '╰────────────────────────────────╯',
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    // baseline already carries the `❯ /clear` echo; the confirm snap is the SAME
+    // already-clear view (count unchanged, transcript unchanged), composer empty.
+    const cap = scriptedCapture([CLEARED, alreadyClearDraft, CLEARED, CLEARED, CLEARED])
+    const r = await sendControlCommand(target, 'clear', {
+      sleep: noSleep,
+      exec: send.exec,
+      captureExec: cap.exec,
+    })
+    expect(r).toEqual({ ok: true })
+  })
+
+  test('compact confirms via a FRESH Compacting marker', async () => {
+    const send = scriptedSend()
+    const cap = scriptedCapture([IDLE, typed('compact'), COMPACTING])
+    const r = await sendControlCommand(target, 'compact', {
+      sleep: noSleep,
+      exec: send.exec,
+      captureExec: cap.exec,
+    })
+    expect(r).toEqual({ ok: true })
+    expect(send.calls[1]).toEqual(['-S', '/tmp/s', 'send-keys', '-t', '%7', '-l', '/compact'])
+  })
+
+  test('invalid command name throws (reuses SLASH_NAME_RE)', async () => {
+    const send = scriptedSend()
+    const cap = scriptedCapture([IDLE])
+    await expect(
+      sendControlCommand(target, 'bad name!', {
+        sleep: noSleep,
+        exec: send.exec,
+        captureExec: cap.exec,
+      }),
+    ).rejects.toThrow()
+    expect(send.calls).toEqual([])
+  })
+
+  // ─── IT2-2: fresh OCCURRENCE-COUNT delta (not a stale boolean) ─────────────
+
+  // A back-to-back /compact: the PROBE baseline already carries a stale
+  // `❯ /compact` + `Compacting…` (from the previous run) in the bottom chrome.
+  // The old present/absent boolean would read the marker as "already there" and
+  // report not-submitted; the occurrence-count delta sees a SECOND occurrence
+  // appear after Enter → ok.
+  const STALE_COMPACT_IDLE = [
+    '❯ /compact',
+    'Compacting conversation…',
+    '╭────────────────────────────────╮',
+    '│ >                              │',
+    '╰────────────────────────────────╯',
+    '  ? for shortcuts',
+  ].join('\n')
+  const STALE_COMPACT_DRAFT = [
+    '❯ /compact',
+    'Compacting conversation…',
+    '╭────────────────────────────────╮',
+    '│ > /compact                     │',
+    '╰────────────────────────────────╯',
+    '  ? for shortcuts',
+  ].join('\n')
+  const TWO_COMPACT = [
+    '❯ /compact',
+    'Compacting conversation…',
+    '❯ /compact',
+    'Compacting conversation…',
+    '╭────────────────────────────────╮',
+    '│ >                              │',
+    '╰────────────────────────────────╯',
+  ].join('\n')
+
+  test('IT2-2: back-to-back compact (stale marker pre-send + FRESH occurrence) → ok', async () => {
+    const send = scriptedSend()
+    const cap = scriptedCapture([STALE_COMPACT_IDLE, STALE_COMPACT_DRAFT, TWO_COMPACT])
+    const r = await sendControlCommand(target, 'compact', {
+      sleep: noSleep,
+      exec: send.exec,
+      captureExec: cap.exec,
+    })
+    expect(r).toEqual({ ok: true })
+    expect(send.calls.some((c) => c.includes('/compact'))).toBe(true)
+  })
+
+  test('IT2-2: genuinely-not-fired (marker count unchanged) → not-submitted', async () => {
+    const send = scriptedSend()
+    // Baseline has the stale markers; after Enter the SAME view persists (no new
+    // occurrence) → count does not increase → refuse.
+    const cap = scriptedCapture([
+      STALE_COMPACT_IDLE,
+      STALE_COMPACT_DRAFT,
+      STALE_COMPACT_IDLE,
+      STALE_COMPACT_IDLE,
+      STALE_COMPACT_IDLE,
+      STALE_COMPACT_IDLE,
+    ])
+    const r = await sendControlCommand(target, 'compact', {
+      sleep: noSleep,
+      exec: send.exec,
+      captureExec: cap.exec,
+    })
+    expect(r).toEqual({ ok: false, reason: 'not-submitted' })
+  })
+
+  // ─── IT2-3: pre-Enter re-check aborts ONLY on busy/dialog ──────────────────
+
+  // Typing '/compact' opens Claude Code's autocomplete popup, which REPLACES the
+  // idle footer hints → classifyPane === 'unknown'. The pre-Enter gate must NOT
+  // refuse on unknown (that would kill every control send); as long as the draft
+  // is visible and the pane is not busy/dialog it presses Enter.
+  const POPUP_WITH_DRAFT = [
+    '╭────────────────────────────────╮',
+    '│ > /compact                     │',
+    '╰────────────────────────────────╯',
+    '  /compact       Compact the conversation',
+    '  /compact-full  Full compaction',
+  ].join('\n')
+
+  test('IT2-3: autocomplete popup (unknown) but draft visible → sends Enter, ok', async () => {
+    // Sanity: the popup snapshot really does classify as unknown (not idle).
+    expect(classifyPane(POPUP_WITH_DRAFT)).toBe('unknown')
+    const send = scriptedSend()
+    const cap = scriptedCapture([IDLE, POPUP_WITH_DRAFT, COMPACTING])
+    const r = await sendControlCommand(target, 'compact', {
+      sleep: noSleep,
+      exec: send.exec,
+      captureExec: cap.exec,
+    })
+    expect(r).toEqual({ ok: true })
+    expect(send.calls.some((c) => c.includes('Enter'))).toBe(true)
+  })
+
+  test('IT2-3: busy surfaces at pre-Enter re-check → no Enter, refused busy', async () => {
+    const send = scriptedSend()
+    const cap = scriptedCapture([IDLE, BUSY])
+    const r = await sendControlCommand(target, 'compact', {
+      sleep: noSleep,
+      exec: send.exec,
+      captureExec: cap.exec,
+    })
+    expect(r).toEqual({ ok: false, reason: 'busy' })
+    expect(send.calls.some((c) => c.includes('Enter'))).toBe(false)
+    // The typed draft was wiped (C-u) — never left submittable.
+    expect(send.calls).toEqual([
+      ['-S', '/tmp/s', 'send-keys', '-t', '%7', 'C-u'],
+      ['-S', '/tmp/s', 'send-keys', '-t', '%7', '-l', '/compact'],
+      ['-S', '/tmp/s', 'send-keys', '-t', '%7', 'C-u'],
+    ])
+  })
+
+  test('IT2-3: draft never appears in the window → not-submitted (no Enter)', async () => {
+    const send = scriptedSend()
+    // Pane stays a bare idle composer (no draft ever renders) across the poll.
+    const cap = scriptedCapture([IDLE, IDLE, IDLE, IDLE])
+    const r = await sendControlCommand(target, 'compact', {
+      sleep: noSleep,
+      exec: send.exec,
+      captureExec: cap.exec,
+    })
+    expect(r).toEqual({ ok: false, reason: 'not-submitted' })
+    expect(send.calls.some((c) => c.includes('Enter'))).toBe(false)
+  })
+
+  // ─── IT2-7: sendSlashCommand also serializes through the pane chain ─────────
+
+  // A typed argful /cc (sendSlashCommand) racing a control /compact must NOT
+  // interleave keystrokes. When serialized, each op emits a clean [C-u, literal,
+  // Enter] triple, so the two literal sends are exactly 3 positions apart
+  // (literal, Enter, C-u, literal). Interleaving would place them closer.
+  test('IT2-7: sendSlashCommand + sendControlCommand on one pane serialize (no interleave)', async () => {
+    const calls: string[][] = []
+    const exec: KeysExec = async (args) => {
+      await Promise.resolve() // yield so a non-serialized impl WOULD interleave
+      calls.push([...args])
+      return { exitCode: 0, stderr: '' }
+    }
+    const cap = scriptedCapture([IDLE, typed('compact'), COMPACTING])
+    const mixTarget = { paneTarget: '%mix', socketPath: '/tmp/s' } as const
+    await Promise.all([
+      sendControlCommand(mixTarget, 'compact', { sleep: noSleep, exec, captureExec: cap.exec }),
+      sendSlashCommand(mixTarget, { name: 'context', rest: '' }, exec),
+    ])
+    const ctxIdx = calls.findIndex((c) => c.includes('/context'))
+    const compactIdx = calls.findIndex((c) => c.includes('/compact'))
+    expect(ctxIdx).toBeGreaterThanOrEqual(0)
+    expect(compactIdx).toBeGreaterThanOrEqual(0)
+    // Serialized ⇒ the two literal sends are separated by exactly Enter + C-u.
+    expect(Math.abs(ctxIdx - compactIdx)).toBe(3)
+    // And exactly two Enters (one per op), never fewer (a lost/merged submit).
+    expect(calls.filter((c) => c.includes('Enter')).length).toBe(2)
+  })
+
+  // FIX-4 (both reviews): two concurrent control sends into the SAME pane must
+  // serialize — their keystrokes must never interleave. We prove ordering by
+  // recording the send stream of two overlapping calls and asserting the second
+  // call's C-u never lands before the first call's Enter.
+  test('concurrent sends to the same pane are serialized (no interleave)', async () => {
+    const calls: string[][] = []
+    const exec: KeysExec = async (args) => {
+      // Yield to the event loop so a non-serialized impl WOULD interleave.
+      await Promise.resolve()
+      calls.push([...args])
+      return { exitCode: 0, stderr: '' }
+    }
+    const cap1 = scriptedCapture([IDLE, typed('compact'), COMPACTING])
+    const cap2 = scriptedCapture([IDLE, typed('compact'), COMPACTING])
+    const serialTarget = { paneTarget: '%serial', socketPath: '/tmp/s' } as const
+    await Promise.all([
+      sendControlCommand(serialTarget, 'compact', { sleep: noSleep, exec, captureExec: cap1.exec }),
+      sendControlCommand(serialTarget, 'compact', { sleep: noSleep, exec, captureExec: cap2.exec }),
+    ])
+    // The full 3-shot of the first call (C-u, -l, Enter) precedes the second.
+    const enterIdxs = calls.map((c, i) => (c.includes('Enter') ? i : -1)).filter((i) => i >= 0)
+    const cuIdxs = calls.map((c, i) => (c.includes('C-u') ? i : -1)).filter((i) => i >= 0)
+    // Exactly two of each (one per call), and the first Enter comes before the
+    // second C-u — i.e. call #2 did not start typing until call #1 submitted.
+    expect(enterIdxs.length).toBe(2)
+    expect(cuIdxs.length).toBe(2)
+    expect(enterIdxs[0]!).toBeLessThan(cuIdxs[1]!)
+  })
+})

--- a/plugin/tests/commands/oob.test.ts
+++ b/plugin/tests/commands/oob.test.ts
@@ -128,24 +128,27 @@ describe('parseOobCommand', () => {
     expect(r!.name).toBe('status')
   })
 
-  test('parses /reset force with hasForceFlag=true', () => {
-    const r = parseOobCommand('/reset force')
+  test('parses /compact (now an intentional command)', () => {
+    const r = parseOobCommand('/compact')
     expect(r).not.toBeNull()
-    expect(r!.name).toBe('reset')
-    expect(r!.args).toBe('force')
-    expect(r!.hasForceFlag).toBe(true)
+    expect(r!.name).toBe('compact')
+    expect(r!.args).toBe('')
   })
 
-  test('parses /new without force has hasForceFlag=false', () => {
+  test('parses /new', () => {
     const r = parseOobCommand('/new')
     expect(r).not.toBeNull()
     expect(r!.name).toBe('new')
-    expect(r!.hasForceFlag).toBe(false)
   })
 
-  test('parses unknown /foo as null', () => {
+  test('/reset is no longer a known command', () => {
+    expect(parseOobCommand('/reset')).toBeNull()
+    expect(parseOobCommand('/reset force')).toBeNull()
+  })
+
+  test('parses unknown /foo as null; /halt still absent', () => {
     expect(parseOobCommand('/foo')).toBeNull()
-    expect(parseOobCommand('/compact')).toBeNull()
+    // /halt remains intentionally unimplemented.
     expect(parseOobCommand('/halt')).toBeNull()
   })
 
@@ -170,14 +173,14 @@ describe('handleOobCommand', () => {
     expect(result.replyToTelegram).toBeDefined()
     const text = result.replyToTelegram!.text
     expect(result.replyToTelegram!.parseMode).toBe('HTML')
-    // Lists all 5 Scope A commands.
+    // Lists the current control commands.
     expect(text).toContain('/help')
     expect(text).toContain('/status')
     expect(text).toContain('/stop')
-    expect(text).toContain('/reset')
+    expect(text).toContain('/compact')
     expect(text).toContain('/new')
-    // Scope B commands explicitly absent.
-    expect(text).not.toContain('/compact')
+    // /reset was removed; /halt remains intentionally absent.
+    expect(text).not.toContain('/reset')
     expect(text).not.toContain('/halt')
   })
 
@@ -229,37 +232,168 @@ describe('handleOobCommand', () => {
     expect(result.replyToTelegram).toBeDefined()
   })
 
-  test('/reset force emits channel notification meta.command=reset', async () => {
-    const parsed = parseOobCommand('/reset force')!
-    const result = await handleOobCommand(parsed, makeCtx())
-    expect(result.command).toBe('reset')
-    expect(result.notifyChannel).toBeDefined()
-    expect(result.notifyChannel!.meta.command).toBe('reset')
-    expect(result.replyToTelegram!.text).toContain('сброшена')
-  })
-
-  test('/reset (no force) returns reply asking for force flag, no channel notify', async () => {
-    const parsed = parseOobCommand('/reset')!
-    const result = await handleOobCommand(parsed, makeCtx())
-    expect(result.command).toBe('reset')
-    expect(result.notifyChannel).toBeUndefined()
-    expect(result.replyToTelegram).toBeDefined()
-    expect(result.replyToTelegram!.text).toContain('force')
-  })
-
-  test('/new force emits channel notification meta.command=new', async () => {
-    const parsed = parseOobCommand('/new force')!
-    const result = await handleOobCommand(parsed, makeCtx())
-    expect(result.command).toBe('new')
-    expect(result.notifyChannel).toBeDefined()
-    expect(result.notifyChannel!.meta.command).toBe('new')
-  })
-
-  test('/new (no force) returns reply asking for force flag, no channel notify', async () => {
+  test('/new renders a confirm card (buttons, no channel notify, no pane touched)', async () => {
     const parsed = parseOobCommand('/new')!
     const result = await handleOobCommand(parsed, makeCtx())
+    expect(result.command).toBe('new')
     expect(result.notifyChannel).toBeUndefined()
-    expect(result.replyToTelegram!.text).toContain('force')
+    expect(result.replyToTelegram).toBeDefined()
+    expect(result.replyToTelegram!.text).toContain('Новый диалог')
+    // Confirm keyboard with newq:confirm(:nonce) / newq:cancel buttons.
+    const kb = result.replyToTelegram!.inlineKeyboard
+    expect(kb).toBeDefined()
+    const datas = kb!.inline_keyboard.flat().map((b) => b.callback_data)
+    expect(datas.some((d) => d !== undefined && d.startsWith('newq:confirm'))).toBe(true)
+    expect(datas).toContain('newq:cancel')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// /compact — reliable control-command injection via sendControlCommand.
+// We drive it with a scripted capture-pane + send-keys fake (same shapes as
+// keys-control.test.ts) and assert the REAL-result → message mapping.
+// ─────────────────────────────────────────────────────────────────────
+
+const IDLE_PANE = [
+  '╭────────────────────────────────╮',
+  '│ >                              │',
+  '╰────────────────────────────────╯',
+  '  ? for shortcuts',
+].join('\n')
+
+const BUSY_PANE = [
+  '✳ Working… (esc to interrupt)',
+  '╭────────────────────────────────╮',
+  '│ >                              │',
+  '╰────────────────────────────────╯',
+].join('\n')
+
+const DIALOG_PANE = [
+  '│ Do you want to proceed?        │',
+  '│ ❯ 1. Yes                       │',
+  '│   2. No                        │',
+].join('\n')
+
+const COMPACTING_PANE = [
+  '❯ /compact',
+  'Compacting conversation…',
+  '╭────────────────────────────────╮',
+  '│ >                              │',
+  '╰────────────────────────────────╯',
+].join('\n')
+
+const NOT_SUBMITTED_PANE = [
+  '╭────────────────────────────────╮',
+  '│ > /compact                     │',
+  '╰────────────────────────────────╯',
+  '  ? for shortcuts',
+].join('\n')
+
+// Idle pane with a typed '/cmd' draft — the pre-Enter TOCTOU snapshot (FIX-3).
+function typedPane(cmd: string): string {
+  return [
+    '╭────────────────────────────────╮',
+    `│ > /${cmd}                        │`,
+    '╰────────────────────────────────╯',
+    '  ? for shortcuts',
+  ].join('\n')
+}
+
+const noSleep = async (_ms: number): Promise<void> => {}
+
+function compactCtx(panes: string[]): OobContext {
+  let i = 0
+  return makeCtx({
+    tmuxKeys: {
+      target: { paneTarget: '%1', socketPath: '/tmp/s' },
+      exec: async () => ({ exitCode: 0, stderr: '' }),
+      captureExec: async () => {
+        const out = i < panes.length ? panes[i]! : (panes[panes.length - 1] ?? '')
+        i++
+        return { exitCode: 0, stdout: out, stderr: '' }
+      },
+      sleep: noSleep,
+    },
+  })
+}
+
+describe('/compact', () => {
+  test('no tmux pane → «недоступно»', async () => {
+    const parsed = parseOobCommand('/compact')!
+    const result = await handleOobCommand(parsed, makeCtx())
+    expect(result.command).toBe('compact')
+    expect(result.replyToTelegram!.text).toContain('недоступно')
+    expect(result.notifyChannel).toBeUndefined()
+  })
+
+  test('ok → «контекст сжимается»', async () => {
+    const parsed = parseOobCommand('/compact')!
+    const result = await handleOobCommand(
+      parsed,
+      compactCtx([IDLE_PANE, typedPane('compact'), COMPACTING_PANE]),
+    )
+    expect(result.replyToTelegram!.text).toContain('контекст сжимается')
+  })
+
+  test('busy (stays busy after interrupt) → busy message', async () => {
+    const parsed = parseOobCommand('/compact')!
+    const result = await handleOobCommand(parsed, compactCtx([BUSY_PANE, BUSY_PANE]))
+    expect(result.replyToTelegram!.text).toContain('агент занят')
+  })
+
+  test('dialog → «ждёт ответа в диалоге»', async () => {
+    const parsed = parseOobCommand('/compact')!
+    const result = await handleOobCommand(parsed, compactCtx([DIALOG_PANE]))
+    expect(result.replyToTelegram!.text).toContain('ждёт ответа в диалоге')
+  })
+
+  test('not-submitted → «не удалось отправить»', async () => {
+    const parsed = parseOobCommand('/compact')!
+    const result = await handleOobCommand(
+      parsed,
+      compactCtx([IDLE_PANE, NOT_SUBMITTED_PANE, NOT_SUBMITTED_PANE, NOT_SUBMITTED_PANE]),
+    )
+    expect(result.replyToTelegram!.text).toContain('не удалось отправить')
+    expect(result.replyToTelegram!.text).toContain('not-submitted')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// /status — context-usage line (task 5). Fake transcript on disk + config
+// window tokens; assert the formatted line and the «—» fallback.
+// ─────────────────────────────────────────────────────────────────────
+
+describe('/status context line', () => {
+  test('renders «контекст: X/Y (Z%)» from a transcript', async () => {
+    const { writeFileSync, mkdtempSync } = await import('node:fs')
+    const { join } = await import('node:path')
+    const { tmpdir } = await import('node:os')
+    const dir = mkdtempSync(join(tmpdir(), 'oob-status-'))
+    const transcript = join(dir, 's.jsonl')
+    // One main-thread assistant turn: input 100000 + cache_read 10000 = 110000.
+    writeFileSync(
+      transcript,
+      JSON.stringify({
+        isSidechain: false,
+        message: { role: 'assistant', usage: { input_tokens: 100000, cache_read_input_tokens: 10000 } },
+      }) + '\n',
+    )
+    const parsed = parseOobCommand('/status')!
+    const result = await handleOobCommand(
+      parsed,
+      makeCtx({ transcriptPath: transcript, contextWindowTokens: 200000, modelName: 'opus' }),
+    )
+    const text = result.replyToTelegram!.text
+    expect(text).toContain('контекст:')
+    expect(text).toContain('110k / 200k (55%)')
+    expect(text).toContain('model:')
+    expect(text).toContain('opus')
+  })
+
+  test('no transcript path → «контекст: —»', async () => {
+    const parsed = parseOobCommand('/status')!
+    const result = await handleOobCommand(parsed, makeCtx())
+    expect(result.replyToTelegram!.text).toContain('контекст: <code>—</code>')
   })
 })
 
@@ -417,7 +551,66 @@ describe('/cc panel', () => {
     expect(res.notifyChannel).toBeUndefined()
   })
 
-  test('/cc <command> still types the command into the pane', async () => {
+  // IT2-6: typed `/cc clear` is destructive → posts the /new confirm card (with
+  // newq:* buttons) and types NOTHING into the pane. Never a one-tap clear.
+  test('/cc clear posts the confirm card, types NOTHING into the pane', async () => {
+    const parsed = parseOobCommand('/cc clear')
+    if (!parsed) throw new Error('parse failed')
+    const calls: string[][] = []
+    const ctx = makeCtx()
+    ctx.tmuxKeys = {
+      target: { paneTarget: '%1', socketPath: '/tmp/s' },
+      exec: async (args) => {
+        calls.push([...args])
+        return { exitCode: 0, stderr: '' }
+      },
+      captureExec: async () => ({ exitCode: 0, stdout: IDLE_PANE, stderr: '' }),
+      sleep: noSleep,
+    }
+    const res = await handleOobCommand(parsed, ctx)
+    expect(res.command).toBe('cc')
+    // A confirm card was returned (buttons), not a keystroke.
+    expect(res.replyToTelegram!.text).toContain('Новый диалог')
+    const kb = res.replyToTelegram!.inlineKeyboard
+    expect(kb).toBeDefined()
+    const datas = kb!.inline_keyboard.flat().map((b) => b.callback_data)
+    expect(datas.some((d) => d !== undefined && d.startsWith('newq:confirm'))).toBe(true)
+    expect(datas).toContain('newq:cancel')
+    // Nothing typed into the pane at command time.
+    expect(calls.length).toBe(0)
+  })
+
+  // FIX-6: typed `/cc compact` (argless control) routes through the RELIABLE
+  // state-aware sender (probe → confirm), exactly like the ccmd: button.
+  test('/cc compact routes through the reliable sender (probe + confirm)', async () => {
+    const parsed = parseOobCommand('/cc compact')
+    if (!parsed) throw new Error('parse failed')
+    const calls: string[][] = []
+    let i = 0
+    const panes = [IDLE_PANE, typedPane('compact'), COMPACTING_PANE]
+    const ctx = makeCtx()
+    ctx.tmuxKeys = {
+      target: { paneTarget: '%1', socketPath: '/tmp/s' },
+      exec: async (args) => {
+        calls.push([...args])
+        return { exitCode: 0, stderr: '' }
+      },
+      captureExec: async () => {
+        const out = i < panes.length ? panes[i]! : (panes[panes.length - 1] ?? '')
+        i++
+        return { exitCode: 0, stdout: out, stderr: '' }
+      },
+      sleep: noSleep,
+    }
+    const res = await handleOobCommand(parsed, ctx)
+    expect(res.command).toBe('cc')
+    expect(calls.some((c) => c.includes('/compact'))).toBe(true)
+    expect(res.replyToTelegram!.text).toContain('отправлено в сессию')
+  })
+
+  // FIX-6: typed `/cc compact` into a DIALOG pane must NOT blind-fire — the
+  // reliable sender refuses (a trailing Enter would approve the dialog).
+  test('/cc compact into a dialog pane refuses, types NOTHING', async () => {
     const parsed = parseOobCommand('/cc compact')
     if (!parsed) throw new Error('parse failed')
     const calls: string[][] = []
@@ -428,9 +621,52 @@ describe('/cc panel', () => {
         calls.push([...args])
         return { exitCode: 0, stderr: '' }
       },
+      captureExec: async () => ({ exitCode: 0, stdout: DIALOG_PANE, stderr: '' }),
+      sleep: noSleep,
     }
     const res = await handleOobCommand(parsed, ctx)
-    expect(res.command).toBe('cc')
-    expect(calls.some((c) => c.includes('/compact'))).toBe(true)
+    expect(calls.length).toBe(0) // never typed into an open dialog
+    expect(res.replyToTelegram!.text).toContain('ждёт ответа в диалоге')
+  })
+
+  // FIX-6: an ARGFUL `/cc <cmd>` (e.g. `model opus`) probes the pane and refuses
+  // when it is not idle, before the blind sendSlashCommand.
+  test('/cc model opus into a busy pane refuses (probe-before-send)', async () => {
+    const parsed = parseOobCommand('/cc model opus')
+    if (!parsed) throw new Error('parse failed')
+    const calls: string[][] = []
+    const ctx = makeCtx()
+    ctx.tmuxKeys = {
+      target: { paneTarget: '%1', socketPath: '/tmp/s' },
+      exec: async (args) => {
+        calls.push([...args])
+        return { exitCode: 0, stderr: '' }
+      },
+      captureExec: async () => ({ exitCode: 0, stdout: BUSY_PANE, stderr: '' }),
+      sleep: noSleep,
+    }
+    const res = await handleOobCommand(parsed, ctx)
+    expect(calls.length).toBe(0) // did not blind-send into a busy pane
+    expect(res.replyToTelegram!.text).toContain('сессия не готова')
+  })
+
+  // FIX-6: an argful `/cc <cmd>` into an IDLE pane still sends (probe passed).
+  test('/cc model opus into an idle pane sends the command', async () => {
+    const parsed = parseOobCommand('/cc model opus')
+    if (!parsed) throw new Error('parse failed')
+    const calls: string[][] = []
+    const ctx = makeCtx()
+    ctx.tmuxKeys = {
+      target: { paneTarget: '%1', socketPath: '/tmp/s' },
+      exec: async (args) => {
+        calls.push([...args])
+        return { exitCode: 0, stderr: '' }
+      },
+      captureExec: async () => ({ exitCode: 0, stdout: IDLE_PANE, stderr: '' }),
+      sleep: noSleep,
+    }
+    const res = await handleOobCommand(parsed, ctx)
+    expect(calls.some((c) => c.includes('/model opus'))).toBe(true)
+    expect(res.replyToTelegram!.text).toContain('отправлено в сессию')
   })
 })

--- a/plugin/tests/status/context-hud.test.ts
+++ b/plugin/tests/status/context-hud.test.ts
@@ -1,0 +1,561 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  ContextHud,
+  HUD_PREFIX,
+  buildHudKeyboard,
+  handleHudCallback,
+  parseHudCallback,
+  renderHud,
+  type HudCallbackContext,
+  type HudCallbackDeps,
+  type HudTelegramApi,
+  type SessionInfoReader,
+} from '../../src/status/context-hud.js'
+import type { ControlCommandResult } from '../../src/commands/keys.js'
+import type { ControlSender } from '../../src/telegram/newq-confirm-ui.js'
+import type { EditOpts, InlineKeyboardLike, SendMessageOpts } from '../../src/channel/tools.js'
+import type { Logger } from '../../src/log.js'
+
+const log = { info() {}, warn() {}, error() {}, debug() {} } as unknown as Logger
+const OWNER = '164795011'
+const WINDOW = 200_000
+const PANE = { paneTarget: '%1', socketPath: '/tmp/s' }
+const ALLOWED = [164795011]
+
+// Track temp dirs for cleanup.
+const tmpDirs: string[] = []
+function stateDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'hud-'))
+  tmpDirs.push(d)
+  return d
+}
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) {
+    try {
+      rmSync(d, { recursive: true, force: true })
+    } catch {
+      /* ignore */
+    }
+  }
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// Fakes
+// ─────────────────────────────────────────────────────────────────────
+
+interface SendRecord {
+  chatId: string
+  text: string
+  opts: SendMessageOpts
+  message_id: number
+}
+interface EditRecord {
+  chatId: string
+  messageId: number
+  text: string
+  opts: EditOpts
+}
+interface PinRecord {
+  chatId: string
+  messageId: number
+  opts: { disable_notification?: boolean }
+}
+
+class FakeApi implements HudTelegramApi {
+  sent: SendRecord[] = []
+  edited: EditRecord[] = []
+  pinned: PinRecord[] = []
+  nextId = 100
+  sendError: unknown
+  editError: unknown
+  pinError: unknown
+
+  async sendMessage(
+    chatId: string,
+    text: string,
+    opts: SendMessageOpts,
+  ): Promise<{ message_id: number }> {
+    if (this.sendError) throw this.sendError
+    const message_id = this.nextId++
+    this.sent.push({ chatId, text, opts, message_id })
+    return { message_id }
+  }
+
+  async editMessageText(
+    chatId: string,
+    messageId: number,
+    text: string,
+    opts: EditOpts,
+  ): Promise<void> {
+    this.edited.push({ chatId, messageId, text, opts })
+    if (this.editError) throw this.editError
+  }
+
+  async pinChatMessage(
+    chatId: string,
+    messageId: number,
+    opts: { disable_notification?: boolean },
+  ): Promise<void> {
+    this.pinned.push({ chatId, messageId, opts })
+    if (this.pinError) throw this.pinError
+  }
+}
+
+function fakeSession(info: {
+  transcriptPath?: string
+  model?: string
+}): SessionInfoReader {
+  return { get: () => info }
+}
+
+function makeHud(
+  api: HudTelegramApi,
+  opts: {
+    dir?: string
+    enabled?: boolean
+    usage?: { usedTokens: number; pct: number } | null
+    session?: SessionInfoReader
+  } = {},
+): ContextHud {
+  return new ContextHud({
+    api,
+    log,
+    sessionInfo: opts.session ?? fakeSession({ transcriptPath: '/t/a.jsonl', model: 'opus' }),
+    windowTokens: WINDOW,
+    ownerChatIds: [OWNER],
+    stateDir: opts.dir ?? stateDir(),
+    enabled: opts.enabled ?? true,
+    readContextUsage: async () =>
+      opts.usage === undefined ? { usedTokens: 114_000, pct: 0.57 } : opts.usage,
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// renderHud (pure)
+// ─────────────────────────────────────────────────────────────────────
+
+function filledCount(text: string): number {
+  return (text.match(/▰/g) ?? []).length
+}
+function emptyCount(text: string): number {
+  return (text.match(/▱/g) ?? []).length
+}
+
+describe('renderHud', () => {
+  test('0% → 0 filled segments, 10 empty', () => {
+    const { text } = renderHud({ usedTokens: 0 }, WINDOW)
+    expect(filledCount(text)).toBe(0)
+    expect(emptyCount(text)).toBe(10)
+    expect(text).toContain('0% (0k / 200k)')
+  })
+
+  test('50% → 5 filled segments', () => {
+    const { text } = renderHud({ usedTokens: 100_000 }, WINDOW)
+    expect(filledCount(text)).toBe(5)
+    expect(emptyCount(text)).toBe(5)
+    expect(text).toContain('50% (100k / 200k)')
+  })
+
+  test('57% → 6 filled segments (rounds 5.7)', () => {
+    const { text } = renderHud({ usedTokens: 114_000 }, WINDOW)
+    expect(filledCount(text)).toBe(6)
+    expect(text).toContain('🧠 <b>Контекст</b>:')
+    expect(text).toContain('57% (114k / 200k)')
+  })
+
+  test('100% → 10 filled segments', () => {
+    const { text } = renderHud({ usedTokens: 200_000 }, WINDOW)
+    expect(filledCount(text)).toBe(10)
+    expect(emptyCount(text)).toBe(0)
+    expect(text).toContain('100% (200k / 200k)')
+  })
+
+  test('over 100% clamps to a full bar and 100%', () => {
+    const { text } = renderHud({ usedTokens: 250_000 }, WINDOW)
+    expect(filledCount(text)).toBe(10)
+    expect(text).toContain('100% (250k / 200k)')
+  })
+
+  test('null usage → «Контекст: —», no bar', () => {
+    const { text } = renderHud(null, WINDOW)
+    expect(text).toContain('🧠 <b>Контекст</b>: —')
+    expect(filledCount(text)).toBe(0)
+    expect(emptyCount(text)).toBe(0)
+  })
+
+  test('model renders as an optional escaped second line', () => {
+    const { text } = renderHud({ usedTokens: 100_000 }, WINDOW, 'claude-opus-4-8')
+    expect(text).toContain('\n<i>claude-opus-4-8</i>')
+    const escaped = renderHud(null, WINDOW, 'a<b>&c').text
+    expect(escaped).toContain('<i>a&lt;b&gt;&amp;c</i>')
+  })
+
+  test('keyboard shape: Сжать / Новый диалог with hud: callbacks', () => {
+    const { keyboard } = renderHud({ usedTokens: 0 }, WINDOW)
+    expect(keyboard).toEqual(buildHudKeyboard())
+    const rows = keyboard.inline_keyboard
+    expect(rows.length).toBe(2)
+    expect(rows[0]![0]!.callback_data).toBe(`${HUD_PREFIX}compact`)
+    expect(rows[1]![0]!.callback_data).toBe(`${HUD_PREFIX}new`)
+    expect(rows[0]![0]!.text).toContain('Сжать')
+    expect(rows[1]![0]!.text).toContain('Новый диалог')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// ContextHud manager
+// ─────────────────────────────────────────────────────────────────────
+
+describe('ContextHud lifecycle', () => {
+  test('onSessionStart: first run sends + pins + persists id', async () => {
+    const api = new FakeApi()
+    const dir = stateDir()
+    const hud = makeHud(api, { dir })
+    await hud.onSessionStart(OWNER)
+
+    expect(api.sent.length).toBe(1)
+    expect(api.sent[0]!.opts.parse_mode).toBe('HTML')
+    expect(api.sent[0]!.opts.reply_markup).toEqual(buildHudKeyboard())
+    expect(api.pinned.length).toBeGreaterThanOrEqual(1)
+    expect(api.pinned[0]!.opts.disable_notification).toBe(true)
+
+    const persisted = JSON.parse(
+      readFileSync(join(dir, `context-hud-${OWNER}.json`), 'utf8'),
+    ) as { message_id: number }
+    expect(persisted.message_id).toBe(api.sent[0]!.message_id)
+  })
+
+  test('second refresh edits the SAME message id (no re-send)', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.onSessionStart(OWNER)
+    const id = api.sent[0]!.message_id
+    await hud.onStop(OWNER)
+
+    expect(api.sent.length).toBe(1)
+    expect(api.edited.length).toBe(1)
+    expect(api.edited[0]!.messageId).toBe(id)
+    expect(api.edited[0]!.opts.reply_markup).toEqual(buildHudKeyboard())
+  })
+
+  test('"not modified" edit error is swallowed, no recreate', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.onSessionStart(OWNER)
+    api.editError = new Error('Bad Request: message is not modified')
+    await hud.onStop(OWNER) // must not throw
+
+    expect(api.sent.length).toBe(1) // no recreate
+    expect(api.edited.length).toBe(1)
+  })
+
+  test('deleted message (400) recreates exactly once + repins', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.onSessionStart(OWNER)
+    const pinsBefore = api.pinned.length
+    api.editError = { error_code: 400, description: 'Bad Request: message to edit not found' }
+    await hud.onStop(OWNER)
+
+    expect(api.edited.length).toBe(1) // the failed edit
+    expect(api.sent.length).toBe(2) // recreated ONCE (no loop)
+    expect(api.pinned.length).toBeGreaterThan(pinsBefore) // repinned
+    // The new id is persisted (in-memory cache advanced): another refresh
+    // edits the NEW id, proving the recreate replaced the stale one.
+    api.editError = undefined
+    await hud.onStop(OWNER)
+    expect(api.sent.length).toBe(2)
+    expect(api.edited[api.edited.length - 1]!.messageId).toBe(api.sent[1]!.message_id)
+  })
+
+  test('send failure never throws (best-effort isolation)', async () => {
+    const api = new FakeApi()
+    api.sendError = new Error('network down')
+    const hud = makeHud(api)
+    await expect(hud.onSessionStart(OWNER)).resolves.toBeUndefined()
+    await expect(hud.onStop(OWNER)).resolves.toBeUndefined()
+    expect(api.sent.length).toBe(0)
+    expect(api.edited.length).toBe(0)
+  })
+
+  test('pin failure never throws and does not block the send', async () => {
+    const api = new FakeApi()
+    api.pinError = new Error('not enough rights to pin')
+    const hud = makeHud(api)
+    await expect(hud.onSessionStart(OWNER)).resolves.toBeUndefined()
+    expect(api.sent.length).toBe(1) // send still happened
+  })
+
+  test('null usage renders «—» through the manager', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api, { usage: null })
+    await hud.onSessionStart(OWNER)
+    expect(api.sent[0]!.text).toContain('🧠 <b>Контекст</b>: —')
+  })
+
+  test('non-owner chat is a no-op', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.onSessionStart('999')
+    await hud.onStop('999')
+    expect(api.sent.length).toBe(0)
+    expect(api.edited.length).toBe(0)
+  })
+
+  test('disabled HUD is a no-op', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api, { enabled: false })
+    await hud.onSessionStart(OWNER)
+    await hud.onStop(OWNER)
+    expect(api.sent.length).toBe(0)
+  })
+
+  // FIX-8: a group id is NEVER a HUD owner even if it slipped into the owner
+  // set — the pinned HUD (with destructive buttons) must never surface in a
+  // group. isOwner requires a positive (DM) numeric chat id.
+  test('group chat id in the owner set → still no HUD (DM-only)', async () => {
+    const api = new FakeApi()
+    const GROUP = '-1001234567890'
+    const hud = new ContextHud({
+      api,
+      log,
+      sessionInfo: fakeSession({ transcriptPath: '/t/a.jsonl', model: 'opus' }),
+      windowTokens: WINDOW,
+      ownerChatIds: [GROUP], // misconfigured: a group id
+      stateDir: stateDir(),
+      enabled: true,
+      readContextUsage: async () => ({ usedTokens: 100_000, pct: 0.5 }),
+    })
+    await hud.onSessionStart(GROUP)
+    await hud.onStop(GROUP)
+    expect(api.sent.length).toBe(0)
+    expect(api.pinned.length).toBe(0)
+  })
+
+  // FIX-9: a concurrent SessionStart + Stop (both firing before the first send
+  // persists an id) must NOT create two pinned HUDs. Per-chat serialization
+  // makes the second op reuse the id the first cached.
+  test('concurrent SessionStart + Stop → exactly ONE HUD created', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await Promise.all([hud.onSessionStart(OWNER), hud.onStop(OWNER)])
+    expect(api.sent.length).toBe(1) // one message, not two
+  })
+
+  test('persistence survives a restart: reuse + repin the same message', async () => {
+    const dir = stateDir()
+    const api1 = new FakeApi()
+    const hud1 = makeHud(api1, { dir })
+    await hud1.onSessionStart(OWNER)
+    const id = api1.sent[0]!.message_id
+
+    // Fresh instance (plugin restart) pointed at the SAME state dir.
+    const api2 = new FakeApi()
+    const hud2 = makeHud(api2, { dir })
+    await hud2.onStop(OWNER)
+    expect(api2.sent.length).toBe(0) // no new message spammed
+    expect(api2.edited.length).toBe(1)
+    expect(api2.edited[0]!.messageId).toBe(id) // reused persisted id
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// hud: callback handler
+// ─────────────────────────────────────────────────────────────────────
+
+function fakeSender(result: ControlCommandResult): { calls: string[]; sender: ControlSender } {
+  const calls: string[] = []
+  const sender: ControlSender = async (_target, name) => {
+    calls.push(name)
+    return result
+  }
+  return { calls, sender }
+}
+
+function makeCbCtx(
+  data: string,
+  fromId: number | undefined,
+): {
+  ctx: HudCallbackContext
+  answers: (string | undefined)[]
+} {
+  const answers: (string | undefined)[] = []
+  const ctx: HudCallbackContext = {
+    callbackQuery: { data },
+    from: { id: fromId },
+    chatId: OWNER,
+    answerCallbackQuery: async (arg) => {
+      answers.push(arg?.text)
+    },
+  }
+  return { ctx, answers }
+}
+
+function makeCards(): {
+  cards: { chatId: string; text: string; keyboard: InlineKeyboardLike }[]
+  send: HudCallbackDeps['sendConfirmCard']
+} {
+  const cards: { chatId: string; text: string; keyboard: InlineKeyboardLike }[] = []
+  const send: HudCallbackDeps['sendConfirmCard'] = async (chatId, text, keyboard) => {
+    cards.push({ chatId, text, keyboard })
+  }
+  return { cards, send }
+}
+
+describe('parseHudCallback', () => {
+  test('accepts compact / new; rejects the rest', () => {
+    expect(parseHudCallback(`${HUD_PREFIX}compact`)).toBe('compact')
+    expect(parseHudCallback(`${HUD_PREFIX}new`)).toBe('new')
+    expect(parseHudCallback(`${HUD_PREFIX}nope`)).toBeNull()
+    expect(parseHudCallback('newq:confirm')).toBeNull()
+    expect(parseHudCallback(`${HUD_PREFIX}`)).toBeNull()
+    // @ts-expect-error runtime guard for non-string
+    expect(parseHudCallback(undefined)).toBeNull()
+  })
+})
+
+describe('handleHudCallback', () => {
+  test('unauthorized user id → toast, NO compact, NO card', async () => {
+    const { calls, sender } = fakeSender({ ok: true })
+    const { cards, send } = makeCards()
+    const deps: HudCallbackDeps = {
+      allowedUserIds: ALLOWED,
+      tmuxKeysTarget: PANE,
+      log,
+      sendConfirmCard: send,
+      sendControl: sender,
+    }
+    const { ctx, answers } = makeCbCtx(`${HUD_PREFIX}compact`, 999)
+    await handleHudCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    expect(cards.length).toBe(0)
+    expect(answers[0]).toContain('не авторизовано')
+  })
+
+  test('missing id is unauthorized (fail-closed)', async () => {
+    const { calls, sender } = fakeSender({ ok: true })
+    const { send } = makeCards()
+    const deps: HudCallbackDeps = {
+      allowedUserIds: ALLOWED,
+      tmuxKeysTarget: PANE,
+      log,
+      sendConfirmCard: send,
+      sendControl: sender,
+    }
+    const { ctx, answers } = makeCbCtx(`${HUD_PREFIX}compact`, undefined)
+    await handleHudCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    expect(answers[0]).toContain('не авторизовано')
+  })
+
+  test('hud:compact ok → answers «Сжимаю…» and calls sendControlCommand', async () => {
+    const { calls, sender } = fakeSender({ ok: true })
+    const { send } = makeCards()
+    const deps: HudCallbackDeps = {
+      allowedUserIds: ALLOWED,
+      tmuxKeysTarget: PANE,
+      log,
+      sendConfirmCard: send,
+      sendControl: sender,
+    }
+    const { ctx, answers } = makeCbCtx(`${HUD_PREFIX}compact`, ALLOWED[0]!)
+    await handleHudCallback(ctx, deps)
+    expect(calls).toEqual(['compact'])
+    expect(answers[0]).toContain('Сжимаю')
+  })
+
+  // L10 (IT2-8): a failed compact must be surfaced VISIBLY (a fresh message),
+  // NOT via a second answerCallbackQuery (Telegram drops it → invisible). The
+  // first toast stays «Сжимаю…»; the reason arrives as a message.
+  test('hud:compact failure surfaces the reason as a message (not a 2nd toast)', async () => {
+    const { calls, sender } = fakeSender({ ok: false, reason: 'busy' })
+    const { cards, send } = makeCards()
+    const deps: HudCallbackDeps = {
+      allowedUserIds: ALLOWED,
+      tmuxKeysTarget: PANE,
+      log,
+      sendConfirmCard: send,
+      sendControl: sender,
+    }
+    const { ctx, answers } = makeCbCtx(`${HUD_PREFIX}compact`, ALLOWED[0]!)
+    await handleHudCallback(ctx, deps)
+    expect(calls).toEqual(['compact'])
+    // Failure went out as a visible message carrying the reason…
+    expect(cards.length).toBe(1)
+    expect(cards[0]!.text).toContain('занят')
+    // …NOT as a second toast (only the «Сжимаю…» spinner answer was sent).
+    expect(answers).toEqual(['Сжимаю…'])
+  })
+
+  test('hud:compact with no pane → toast, no sendControlCommand', async () => {
+    const { calls, sender } = fakeSender({ ok: true })
+    const { send } = makeCards()
+    const deps: HudCallbackDeps = {
+      allowedUserIds: ALLOWED,
+      log,
+      sendConfirmCard: send,
+      sendControl: sender,
+    }
+    const { ctx, answers } = makeCbCtx(`${HUD_PREFIX}compact`, ALLOWED[0]!)
+    await handleHudCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    expect(answers[0]).toContain('pane недоступен')
+  })
+
+  test('hud:new → posts the /new confirm card (NOT a direct clear)', async () => {
+    const { calls, sender } = fakeSender({ ok: true })
+    const { cards, send } = makeCards()
+    const deps: HudCallbackDeps = {
+      allowedUserIds: ALLOWED,
+      tmuxKeysTarget: PANE,
+      log,
+      sendConfirmCard: send,
+      sendControl: sender,
+    }
+    const { ctx } = makeCbCtx(`${HUD_PREFIX}new`, ALLOWED[0]!)
+    await handleHudCallback(ctx, deps)
+    // No control command was driven — the destructive clear must confirm first.
+    expect(calls.length).toBe(0)
+    expect(cards.length).toBe(1)
+    expect(cards[0]!.chatId).toBe(OWNER)
+    expect(cards[0]!.text).toContain('Новый диалог')
+    // The card carries the wave-3A newq:* buttons, reusing the existing flow.
+    // FIX-14: confirm now carries a build-time nonce; cancel stays plain.
+    const datas = cards[0]!.keyboard.inline_keyboard.flat().map((b) => b.callback_data)
+    expect(datas[0]).toMatch(/^newq:confirm:\d+:[a-z0-9]+$/)
+    expect(datas[1]).toBe('newq:cancel')
+  })
+
+  // FIX-8: a HUD tap from a non-owner chat (a group where a stray HUD surfaced)
+  // must be refused — the control buttons drive the single global DM pane.
+  test('hud tap from a non-owner chat → refused, NO compact/card', async () => {
+    const { calls, sender } = fakeSender({ ok: true })
+    const { cards, send } = makeCards()
+    const deps: HudCallbackDeps = {
+      allowedUserIds: ALLOWED,
+      tmuxKeysTarget: PANE,
+      log,
+      sendConfirmCard: send,
+      sendControl: sender,
+      ownerChatIds: [164795011],
+    }
+    // Tap from a group chat (negative id), authorized user, but wrong chat.
+    const answers: (string | undefined)[] = []
+    const ctx: HudCallbackContext = {
+      callbackQuery: { data: `${HUD_PREFIX}compact` },
+      from: { id: ALLOWED[0]! },
+      chatId: '-1001234567890',
+      answerCallbackQuery: async (arg) => {
+        answers.push(arg?.text)
+      },
+    }
+    await handleHudCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    expect(cards.length).toBe(0)
+    expect(answers[0]).toContain('недоступно')
+  })
+})

--- a/plugin/tests/status/context-usage.test.ts
+++ b/plugin/tests/status/context-usage.test.ts
@@ -1,0 +1,218 @@
+// Context-window usage parser tests. All fixtures are inline JSON strings —
+// never read a real transcript here (they are many MB and machine-specific).
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  computeContextUsage,
+  formatContextUsage,
+} from '../../src/status/context-usage.js'
+
+// Build one transcript line. `isSidechain` defaults to false (main thread).
+function assistantLine(
+  usage: Record<string, number> | null,
+  opts: { isSidechain?: boolean } = {},
+): string {
+  const message: Record<string, unknown> = { role: 'assistant', content: [] }
+  if (usage !== null) message.usage = usage
+  return JSON.stringify({
+    type: 'assistant',
+    isSidechain: opts.isSidechain ?? false,
+    parentUuid: 'p',
+    userType: 'external',
+    message,
+  })
+}
+
+function userLine(text: string): string {
+  return JSON.stringify({
+    type: 'user',
+    isSidechain: false,
+    message: { role: 'user', content: [{ type: 'text', text }] },
+  })
+}
+
+describe('computeContextUsage', () => {
+  test('normal main-thread turn → input + both cache fields, correct pct', () => {
+    const lines = [
+      userLine('hi'),
+      assistantLine({
+        input_tokens: 2,
+        cache_read_input_tokens: 100000,
+        cache_creation_input_tokens: 12000,
+        output_tokens: 5000,
+      }),
+    ]
+    const result = computeContextUsage(lines, 200000)
+    // 2 + 100000 + 12000 = 112002 (output_tokens EXCLUDED)
+    expect(result).toEqual({ usedTokens: 112002, pct: 112002 / 200000 })
+  })
+
+  test('missing cache fields → treated as 0', () => {
+    const lines = [assistantLine({ input_tokens: 50000, output_tokens: 100 })]
+    const result = computeContextUsage(lines, 200000)
+    expect(result).toEqual({ usedTokens: 50000, pct: 50000 / 200000 })
+  })
+
+  test('only cache_read present → cache_creation defaults to 0', () => {
+    const lines = [
+      assistantLine({ input_tokens: 10, cache_read_input_tokens: 30000 }),
+    ]
+    const result = computeContextUsage(lines, 100000)
+    expect(result).toEqual({ usedTokens: 30010, pct: 30010 / 100000 })
+  })
+
+  test('no assistant turn → null', () => {
+    const lines = [userLine('a'), userLine('b')]
+    expect(computeContextUsage(lines, 200000)).toBeNull()
+  })
+
+  test('empty input → null', () => {
+    expect(computeContextUsage([], 200000)).toBeNull()
+  })
+
+  test('assistant turns without usage are skipped, earlier good one wins', () => {
+    const lines = [
+      assistantLine({ input_tokens: 5, cache_read_input_tokens: 40000 }),
+      assistantLine(null), // no usage — skip
+    ]
+    const result = computeContextUsage(lines, 200000)
+    expect(result).toEqual({ usedTokens: 40005, pct: 40005 / 200000 })
+  })
+
+  test('malformed / truncated lines interleaved → skipped, good line still found', () => {
+    const good = assistantLine({
+      input_tokens: 3,
+      cache_read_input_tokens: 80000,
+      cache_creation_input_tokens: 2000,
+    })
+    const lines = [
+      good,
+      '', // blank
+      '{"type":"assistant","message":{"role":"assis', // truncated JSON
+      'not json at all',
+      'null', // valid JSON, wrong shape
+      '[1,2,3]', // valid JSON, bare array
+    ]
+    const result = computeContextUsage(lines, 200000)
+    expect(result).toEqual({ usedTokens: 82003, pct: 82003 / 200000 })
+  })
+
+  test('sidechain line AFTER real main-thread line → sidechain ignored', () => {
+    const main = assistantLine({
+      input_tokens: 4,
+      cache_read_input_tokens: 150000,
+      cache_creation_input_tokens: 3000,
+    })
+    const side = assistantLine(
+      { input_tokens: 500, cache_read_input_tokens: 1200 },
+      { isSidechain: true },
+    )
+    // Scanning backwards hits the sidechain line first; it must be skipped.
+    const lines = [main, side]
+    const result = computeContextUsage(lines, 200000)
+    expect(result).toEqual({ usedTokens: 153004, pct: 153004 / 200000 })
+  })
+
+  test('latest main-thread turn wins over earlier main-thread turns', () => {
+    const lines = [
+      assistantLine({ input_tokens: 1, cache_read_input_tokens: 10000 }),
+      assistantLine({ input_tokens: 1, cache_read_input_tokens: 90000 }),
+    ]
+    const result = computeContextUsage(lines, 200000)
+    expect(result?.usedTokens).toBe(90001)
+  })
+
+  test('windowTokens <= 0 → usedTokens real, pct 0 (no Infinity/NaN)', () => {
+    const lines = [assistantLine({ input_tokens: 10, cache_read_input_tokens: 20000 })]
+    const zero = computeContextUsage(lines, 0)
+    expect(zero).toEqual({ usedTokens: 20010, pct: 0 })
+    const neg = computeContextUsage(lines, -5)
+    expect(neg).toEqual({ usedTokens: 20010, pct: 0 })
+  })
+
+  test('usage present but input_tokens missing → not a usable turn, skip', () => {
+    const lines = [
+      assistantLine({ input_tokens: 7, cache_read_input_tokens: 60000 }),
+      // usage object with no input_tokens — skipped, falls back to earlier line
+      JSON.stringify({
+        type: 'assistant',
+        isSidechain: false,
+        message: { role: 'assistant', usage: { cache_read_input_tokens: 999 } },
+      }),
+    ]
+    const result = computeContextUsage(lines, 200000)
+    expect(result?.usedTokens).toBe(60007)
+  })
+
+  // FIX-13 (Fable L3): an API-error synthetic turn can persist a usage block
+  // that sums to 0. Treating it as the live window would flash the HUD to 0%
+  // mid-session — scan PAST it to the last genuine turn.
+  test('FIX-13: a zero-sum synthetic turn is skipped, earlier real turn wins', () => {
+    const lines = [
+      assistantLine({ input_tokens: 5, cache_read_input_tokens: 40000 }), // real
+      assistantLine({ input_tokens: 0, output_tokens: 120 }), // synthetic: used = 0
+    ]
+    const result = computeContextUsage(lines, 200000)
+    expect(result).toEqual({ usedTokens: 40005, pct: 40005 / 200000 })
+  })
+
+  test('FIX-13: all turns zero-sum → null (no usable window)', () => {
+    const lines = [assistantLine({ input_tokens: 0 }), assistantLine({ input_tokens: 0 })]
+    expect(computeContextUsage(lines, 200000)).toBeNull()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// readContextUsage — FIX-12 (bytesRead slicing). A normal read must still
+// parse correctly; a regression that decoded the whole allocation (NUL padding)
+// would corrupt the final line and return null.
+// ─────────────────────────────────────────────────────────────────────
+
+describe('readContextUsage (file tail)', () => {
+  test('reads the last main-thread turn from a real transcript file', async () => {
+    const { writeFileSync, mkdtempSync, rmSync } = await import('node:fs')
+    const { join } = await import('node:path')
+    const { tmpdir } = await import('node:os')
+    const { readContextUsage } = await import('../../src/status/context-usage.js')
+    const dir = mkdtempSync(join(tmpdir(), 'ctxusage-'))
+    try {
+      const p = join(dir, 's.jsonl')
+      writeFileSync(
+        p,
+        userLine('hi') +
+          '\n' +
+          assistantLine({ input_tokens: 100000, cache_read_input_tokens: 10000 }) +
+          '\n',
+      )
+      const usage = await readContextUsage(p, 200000)
+      expect(usage?.usedTokens).toBe(110000)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test('missing file → null (never throws)', async () => {
+    const { readContextUsage } = await import('../../src/status/context-usage.js')
+    expect(await readContextUsage('/no/such/transcript.jsonl', 200000)).toBeNull()
+  })
+})
+
+describe('formatContextUsage', () => {
+  test('rounds tokens to nearest 1k and pct to integer', () => {
+    expect(formatContextUsage({ usedTokens: 114000 }, 200000)).toBe('114k / 200k (57%)')
+  })
+
+  test('rounds k up at the half boundary', () => {
+    expect(formatContextUsage({ usedTokens: 115500 }, 200000)).toBe('116k / 200k (58%)')
+  })
+
+  test('rounds pct to nearest integer', () => {
+    // 91234 / 200000 = 45.617% → 46%
+    expect(formatContextUsage({ usedTokens: 91234 }, 200000)).toBe('91k / 200k (46%)')
+  })
+
+  test('windowTokens <= 0 → 0%', () => {
+    expect(formatContextUsage({ usedTokens: 50000 }, 0)).toBe('50k / 0k (0%)')
+  })
+})

--- a/plugin/tests/status/session-info.test.ts
+++ b/plugin/tests/status/session-info.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test'
+
+import { SessionInfoStore } from '../../src/status/session-info.js'
+
+describe('SessionInfoStore', () => {
+  test('records transcript + session id, reads back via latest', () => {
+    const s = new SessionInfoStore()
+    s.record(undefined, { transcriptPath: '/t/a.jsonl', sessionId: 'sid-1' })
+    expect(s.get()).toEqual({ transcriptPath: '/t/a.jsonl', sessionId: 'sid-1' })
+  })
+
+  test('model from SessionStart survives a later event that omits it', () => {
+    const s = new SessionInfoStore()
+    s.record('164795011', { transcriptPath: '/t/a.jsonl', sessionId: 'sid-1', model: 'opus' })
+    // A later PreToolUse hook carries transcript + session but NO model.
+    s.record('164795011', { transcriptPath: '/t/a.jsonl', sessionId: 'sid-1' })
+    expect(s.get('164795011')).toEqual({
+      transcriptPath: '/t/a.jsonl',
+      sessionId: 'sid-1',
+      model: 'opus',
+    })
+  })
+
+  test('per-chat isolation; a keyed get NEVER bleeds another chat (FIX-10)', () => {
+    const s = new SessionInfoStore()
+    s.record('chatA', { transcriptPath: '/t/A.jsonl', sessionId: 'A' })
+    s.record('chatB', { transcriptPath: '/t/B.jsonl', sessionId: 'B', model: 'sonnet' })
+    expect(s.get('chatA').transcriptPath).toBe('/t/A.jsonl')
+    expect(s.get('chatB').transcriptPath).toBe('/t/B.jsonl')
+    // FIX-10: an UNKNOWN chatId returns {} — it must NOT bleed the global
+    // `latest` (chatB's session) into a chat that never recorded anything.
+    expect(s.get('chatC')).toEqual({})
+    // No-arg get() still uses latest (legacy single-DM caller).
+    expect(s.get().transcriptPath).toBe('/t/B.jsonl')
+  })
+
+  test('FIX-10: /status in the DM never shows a GROUP session', () => {
+    const s = new SessionInfoStore()
+    // A busy group session records last…
+    s.record('-1009999', { transcriptPath: '/t/group.jsonl', sessionId: 'g', model: 'sonnet' })
+    // …but the owner DM never recorded → its keyed get must be empty, not the
+    // group's transcript.
+    expect(s.get('164795011')).toEqual({})
+  })
+
+  test('empty fields do not overwrite previous values', () => {
+    const s = new SessionInfoStore()
+    s.record('c', { transcriptPath: '/t/x.jsonl', sessionId: 'x', model: 'opus' })
+    s.record('c', { transcriptPath: '', sessionId: '', model: '' })
+    expect(s.get('c')).toEqual({ transcriptPath: '/t/x.jsonl', sessionId: 'x', model: 'opus' })
+  })
+
+  test('empty store returns an empty object (never null)', () => {
+    const s = new SessionInfoStore()
+    expect(s.get()).toEqual({})
+    expect(s.get('nope')).toEqual({})
+  })
+
+  test('blank chatId updates only the latest slot, not a per-chat entry', () => {
+    const s = new SessionInfoStore()
+    s.record('c', { transcriptPath: '/t/c.jsonl', sessionId: 'c' })
+    s.record('', { transcriptPath: '/t/latest.jsonl', sessionId: 'l' })
+    // per-chat 'c' unchanged
+    expect(s.get('c').transcriptPath).toBe('/t/c.jsonl')
+    // latest reflects the blank-chat record
+    expect(s.get().transcriptPath).toBe('/t/latest.jsonl')
+  })
+})

--- a/plugin/tests/telegram/cc-panel-ui.test.ts
+++ b/plugin/tests/telegram/cc-panel-ui.test.ts
@@ -15,6 +15,15 @@ const log = { info() {}, warn() {}, error() {}, debug() {} } as unknown as Logge
 const ALLOWED = [164795011]
 const PANE = { paneTarget: '%1', socketPath: '/tmp/s' }
 
+// A minimal idle composer — IT2-1 now probes the pane before the sendSlashCommand
+// fall-through, so the send-path fakes must serve an idle snapshot to proceed.
+const IDLE_PROBE = [
+  '╭────────────────────────────────╮',
+  '│ >                              │',
+  '╰────────────────────────────────╯',
+  '  ? for shortcuts',
+].join('\n')
+
 function makeCtx(data: string, fromId: number | undefined): {
   ctx: CcmdCallbackContext
   answers: string[]
@@ -40,6 +49,8 @@ function capturingExec(): { calls: string[][]; deps: CcmdCallbackDeps } {
       calls.push([...args])
       return { exitCode: 0, stderr: '' }
     },
+    // IT2-1: the non-control send path now probes the pane first; serve idle.
+    captureExec: async () => ({ exitCode: 0, stdout: IDLE_PROBE, stderr: '' }),
   }
   return { calls, deps }
 }
@@ -93,11 +104,13 @@ describe('handleCcmdCallback', () => {
   })
 
   test('authorized + valid command types /<name> into pane', async () => {
+    // Use a non-control command (`context`) — the simple sendSlashCommand path.
+    // (compact/clear have their own state-aware routing, covered separately.)
     const { calls, deps } = capturingExec()
-    const { ctx, answers } = makeCtx(`${CCMD_PREFIX}compact`, ALLOWED[0]!)
+    const { ctx, answers } = makeCtx(`${CCMD_PREFIX}context`, ALLOWED[0]!)
     await handleCcmdCallback(ctx, deps)
     // sendSlashCommand: C-u clear, then literal text, then Enter
-    expect(calls.some((c) => c.includes('/compact'))).toBe(true)
+    expect(calls.some((c) => c.includes('/context'))).toBe(true)
     expect(calls.some((c) => c.includes('C-u'))).toBe(true)
     expect(answers[0]).toContain('выполнено')
   })
@@ -124,5 +137,187 @@ describe('handleCcmdCallback', () => {
     await handleCcmdCallback(ctx, deps)
     expect(calls.length).toBe(0)
     expect(answers[0]).toContain('pane недоступен')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// Control-command routing (task 6): `clear` and `compact` go through the
+// state-aware sendControlCommand (probe → interrupt → confirm), while every
+// other panel command stays on sendSlashCommand. We prove the split by
+// scripting capture-pane snapshots for the control path and asserting the
+// send-keys / capture-pane calls.
+// ─────────────────────────────────────────────────────────────────────
+
+const IDLE = [
+  '╭────────────────────────────────╮',
+  '│ >                              │',
+  '╰────────────────────────────────╯',
+  '  ? for shortcuts',
+].join('\n')
+
+const COMPACTING = [
+  '❯ /compact',
+  'Compacting conversation…',
+  '╭────────────────────────────────╮',
+  '│ >                              │',
+  '╰────────────────────────────────╯',
+].join('\n')
+
+const BUSY = [
+  '✳ Working… (esc to interrupt)',
+  '╭────────────────────────────────╮',
+  '│ >                              │',
+  '╰────────────────────────────────╯',
+].join('\n')
+
+// Idle pane with a typed '/cmd' draft — the pre-Enter TOCTOU snapshot (FIX-3).
+function typed(cmd: string): string {
+  return [
+    '╭────────────────────────────────╮',
+    `│ > /${cmd}                        │`,
+    '╰────────────────────────────────╯',
+    '  ? for shortcuts',
+  ].join('\n')
+}
+
+const noSleep = async (_ms: number): Promise<void> => {}
+
+// Builds deps whose capture-pane fake replays the scripted panes and whose
+// send-keys fake records every call. sleep is a no-op so confirm polls are instant.
+function controlDeps(panes: string[]): {
+  sends: string[][]
+  captures: string[][]
+  deps: CcmdCallbackDeps
+} {
+  const sends: string[][] = []
+  const captures: string[][] = []
+  let i = 0
+  const deps: CcmdCallbackDeps = {
+    allowedUserIds: ALLOWED,
+    tmuxKeysTarget: PANE,
+    log,
+    exec: async (args) => {
+      sends.push([...args])
+      return { exitCode: 0, stderr: '' }
+    },
+    captureExec: async (args) => {
+      captures.push([...args])
+      const out = i < panes.length ? panes[i]! : (panes[panes.length - 1] ?? '')
+      i++
+      return { exitCode: 0, stdout: out, stderr: '' }
+    },
+    sleep: noSleep,
+  }
+  return { sends, captures, deps }
+}
+
+describe('handleCcmdCallback control routing', () => {
+  test('compact → reliable path: probes pane (capture-pane) then confirms fire', async () => {
+    // probe → pre-Enter re-check (FIX-3) → confirm.
+    const { sends, captures, deps } = controlDeps([IDLE, typed('compact'), COMPACTING])
+    const { ctx, answers } = makeCtx(`${CCMD_PREFIX}compact`, ALLOWED[0]!)
+    await handleCcmdCallback(ctx, deps)
+    // capture-pane was used (state-aware), and /compact typed + Enter submitted.
+    expect(captures.some((c) => c.includes('capture-pane'))).toBe(true)
+    expect(sends.some((c) => c.includes('/compact'))).toBe(true)
+    expect(sends.some((c) => c.includes('Enter'))).toBe(true)
+    expect(answers[0]).toContain('выполнено: /compact')
+  })
+
+  // FIX-7: the destructive `clear` button posts the /new confirm card — it is
+  // NEVER a one-tap clear. Nothing is typed into the pane at tap time.
+  test('clear → posts the /new confirm card, types NOTHING into the pane', async () => {
+    const cards: { chatId: string; text: string; keyboard: unknown }[] = []
+    const sends: string[][] = []
+    const deps: CcmdCallbackDeps = {
+      allowedUserIds: ALLOWED,
+      tmuxKeysTarget: PANE,
+      log,
+      exec: async (args) => {
+        sends.push([...args])
+        return { exitCode: 0, stderr: '' }
+      },
+      sendConfirmCard: async (chatId, text, keyboard) => {
+        cards.push({ chatId, text, keyboard })
+      },
+    }
+    const ctx: CcmdCallbackContext = {
+      callbackQuery: { data: `${CCMD_PREFIX}clear` },
+      from: { id: ALLOWED[0]! },
+      chatId: '164795011',
+      answerCallbackQuery: async () => {},
+    }
+    await handleCcmdCallback(ctx, deps)
+    expect(cards.length).toBe(1)
+    expect(cards[0]!.chatId).toBe('164795011')
+    expect(cards[0]!.text).toContain('Новый диалог')
+    // Not a single keystroke typed into the pane.
+    expect(sends.length).toBe(0)
+  })
+
+  // FIX-7 fail-closed: without a way to post the card, `clear` refuses rather
+  // than fall back to a one-tap destructive clear.
+  test('clear without sendConfirmCard → refuses, types NOTHING', async () => {
+    const sends: string[][] = []
+    const deps: CcmdCallbackDeps = {
+      allowedUserIds: ALLOWED,
+      tmuxKeysTarget: PANE,
+      log,
+      exec: async (args) => {
+        sends.push([...args])
+        return { exitCode: 0, stderr: '' }
+      },
+    }
+    const { ctx, answers } = makeCtx(`${CCMD_PREFIX}clear`, ALLOWED[0]!)
+    await handleCcmdCallback(ctx, deps)
+    expect(sends.length).toBe(0)
+    expect(answers[0]).toContain('недоступно')
+  })
+
+  test('compact busy → reports «не выполнено: busy» (state-aware refusal)', async () => {
+    // busy then still busy after Escape → busy verdict.
+    const { deps } = controlDeps([BUSY, BUSY])
+    const { ctx, answers } = makeCtx(`${CCMD_PREFIX}compact`, ALLOWED[0]!)
+    await handleCcmdCallback(ctx, deps)
+    expect(answers[0]).toContain('не выполнено: busy')
+  })
+
+  // IT2-1: the non-control `context` button now PROBES the pane (an idle gate)
+  // before the sendSlashCommand path — one capture-pane, then the send at idle.
+  test('non-control command (context) probes idle, then sends via sendSlashCommand', async () => {
+    const { sends, captures, deps } = controlDeps([IDLE])
+    const { ctx, answers } = makeCtx(`${CCMD_PREFIX}context`, ALLOWED[0]!)
+    await handleCcmdCallback(ctx, deps)
+    // Exactly one probe (the idle gate), then the /context send.
+    expect(captures.length).toBe(1)
+    expect(sends.some((c) => c.includes('/context'))).toBe(true)
+    expect(answers[0]).toContain('выполнено: /context')
+  })
+
+  // IT2-1: a non-control button tapped while a permission dialog is OPEN must NOT
+  // blind-fire — the trailing Enter would approve the dialog. Refuse, send nothing.
+  test('non-control command (status) on a DIALOG pane refuses, types NOTHING', async () => {
+    const dialog = [
+      '│ Do you want to proceed?        │',
+      '│ ❯ 1. Yes                       │',
+      '│   2. No                        │',
+    ].join('\n')
+    const { sends, deps } = controlDeps([dialog])
+    const { ctx, answers } = makeCtx(`${CCMD_PREFIX}status`, ALLOWED[0]!)
+    await handleCcmdCallback(ctx, deps)
+    expect(sends.length).toBe(0) // never typed into an open dialog
+    expect(answers[0]).toContain('сессия не готова')
+    expect(answers[0]).toContain('dialog')
+  })
+
+  // IT2-1: likewise a BUSY pane refuses (the command would be queued behind a
+  // running tool), rather than blind-firing.
+  test('non-control command (context) on a BUSY pane refuses, types NOTHING', async () => {
+    const { sends, deps } = controlDeps([BUSY])
+    const { ctx, answers } = makeCtx(`${CCMD_PREFIX}context`, ALLOWED[0]!)
+    await handleCcmdCallback(ctx, deps)
+    expect(sends.length).toBe(0)
+    expect(answers[0]).toContain('сессия не готова')
+    expect(answers[0]).toContain('busy')
   })
 })

--- a/plugin/tests/telegram/command-scope.test.ts
+++ b/plugin/tests/telegram/command-scope.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  registerOwnerScopedCommands,
+  type CommandScopeApi,
+  type CommandSpec,
+} from '../../src/telegram/command-scope.js'
+import type { Logger } from '../../src/log.js'
+
+const log = { info() {}, warn() {}, error() {}, debug() {} } as unknown as Logger
+
+const CMDS: CommandSpec[] = [
+  { command: 'help', description: 'справка' },
+  { command: 'status', description: 'статус' },
+]
+
+// A fake bot.api that records every scope call.
+function fakeApi(): {
+  api: CommandScopeApi
+  deletes: Array<{ scope?: { type: string } } | undefined>
+  sets: Array<{ commands: readonly CommandSpec[]; scope: { type: string; chat_id: number | string } }>
+} {
+  const deletes: Array<{ scope?: { type: string } } | undefined> = []
+  const sets: Array<{ commands: readonly CommandSpec[]; scope: { type: string; chat_id: number | string } }> = []
+  const api: CommandScopeApi = {
+    deleteMyCommands: async (options) => {
+      deletes.push(options)
+      return true
+    },
+    setMyCommands: async (commands, options) => {
+      sets.push({ commands, scope: options.scope })
+      return true
+    },
+  }
+  return { api, deletes, sets }
+}
+
+describe('registerOwnerScopedCommands', () => {
+  test('clears default + all_private_chats, then registers per owner chat', async () => {
+    const { api, deletes, sets } = fakeApi()
+    await registerOwnerScopedCommands(api, CMDS, [164795011], log)
+
+    // Two deleteMyCommands: default (no arg) + all_private_chats.
+    expect(deletes.length).toBe(2)
+    expect(deletes[0]).toBeUndefined() // default scope = bare call
+    expect(deletes[1]).toEqual({ scope: { type: 'all_private_chats' } })
+
+    // One setMyCommands scoped to the owner chat.
+    expect(sets.length).toBe(1)
+    expect(sets[0]!.scope).toEqual({ type: 'chat', chat_id: 164795011 })
+    expect(sets[0]!.commands.map((c) => c.command)).toEqual(['help', 'status'])
+  })
+
+  test('FIX-11: registers ONLY positive DM ids; skips group / @channel ids', async () => {
+    const { api, sets } = fakeApi()
+    // A negative group id and an @channel string must NOT get the owner menu
+    // (that would expose it publicly). Only the positive DM ids register.
+    await registerOwnerScopedCommands(api, CMDS, [111, -100222, '@chan', 222], log)
+    expect(sets.map((s) => s.scope.chat_id)).toEqual([111, 222])
+    for (const s of sets) expect(s.scope.type).toBe('chat')
+  })
+
+  test('FIX-11: a failure of the FIRST deleteMyCommands still runs the second', async () => {
+    const deletes: Array<{ scope?: { type: string } } | undefined> = []
+    const sets: Array<number | string> = []
+    let call = 0
+    const api: CommandScopeApi = {
+      deleteMyCommands: async (options) => {
+        call += 1
+        deletes.push(options)
+        if (call === 1) throw new Error('default-scope offline') // first fails
+        return true
+      },
+      setMyCommands: async (_c, options) => {
+        sets.push(options.scope.chat_id)
+        return true
+      },
+    }
+    await registerOwnerScopedCommands(api, CMDS, [164795011], log)
+    // BOTH deletes were attempted (separate try/catch) despite the first throw.
+    expect(deletes.length).toBe(2)
+    expect(deletes[1]).toEqual({ scope: { type: 'all_private_chats' } })
+    expect(sets).toEqual([164795011])
+  })
+
+  test('a per-chat setMyCommands failure does not abort the rest', async () => {
+    const sets: Array<number | string> = []
+    const api: CommandScopeApi = {
+      deleteMyCommands: async () => true,
+      setMyCommands: async (_c, options) => {
+        if (options.scope.chat_id === 111) throw new Error('boom')
+        sets.push(options.scope.chat_id)
+        return true
+      },
+    }
+    // Must not throw despite the first chat failing.
+    await registerOwnerScopedCommands(api, CMDS, [111, 222], log)
+    expect(sets).toEqual([222])
+  })
+
+  test('a deleteMyCommands failure still proceeds to register', async () => {
+    const sets: Array<number | string> = []
+    const api: CommandScopeApi = {
+      deleteMyCommands: async () => {
+        throw new Error('offline')
+      },
+      setMyCommands: async (_c, options) => {
+        sets.push(options.scope.chat_id)
+        return true
+      },
+    }
+    await registerOwnerScopedCommands(api, CMDS, [164795011], log)
+    expect(sets).toEqual([164795011])
+  })
+})

--- a/plugin/tests/telegram/newq-confirm-ui.test.ts
+++ b/plugin/tests/telegram/newq-confirm-ui.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  NEWQ_PREFIX,
+  buildNewConfirmCard,
+  createNewqNonceGuard,
+  handleNewqCallback,
+  parseNewqCallback,
+  type ControlSender,
+  type NewqCallbackContext,
+  type NewqCallbackDeps,
+} from '../../src/telegram/newq-confirm-ui.js'
+import type { ControlCommandResult } from '../../src/commands/keys.js'
+import type { Logger } from '../../src/log.js'
+
+const log = { info() {}, warn() {}, error() {}, debug() {} } as unknown as Logger
+const ALLOWED = [164795011]
+const PANE = { paneTarget: '%1', socketPath: '/tmp/s' }
+
+function makeCtx(
+  data: string,
+  fromId: number | undefined,
+  chatId?: string,
+): {
+  ctx: NewqCallbackContext
+  answers: (string | undefined)[]
+  edits: string[]
+} {
+  const answers: (string | undefined)[] = []
+  const edits: string[] = []
+  const ctx: NewqCallbackContext = {
+    callbackQuery: { data },
+    from: { id: fromId },
+    ...(chatId !== undefined ? { chatId } : {}),
+    answerCallbackQuery: async (arg) => {
+      answers.push(arg?.text)
+    },
+    editMessageText: async (text) => {
+      edits.push(text)
+    },
+  }
+  return { ctx, answers, edits }
+}
+
+// A ControlSender fake that records the call and returns a scripted result.
+function fakeSender(result: ControlCommandResult): { calls: string[]; sender: ControlSender } {
+  const calls: string[] = []
+  const sender: ControlSender = async (_target, name) => {
+    calls.push(name)
+    return result
+  }
+  return { calls, sender }
+}
+
+describe('parseNewqCallback', () => {
+  test('accepts confirm / cancel (with + without nonce); rejects the rest', () => {
+    expect(parseNewqCallback(`${NEWQ_PREFIX}confirm`)).toEqual({ action: 'confirm', ts: null, nonce: null })
+    expect(parseNewqCallback(`${NEWQ_PREFIX}cancel`)).toEqual({ action: 'cancel', ts: null, nonce: null })
+    // Legacy bare-<ts> nonce still parses (ts + nonce both set).
+    expect(parseNewqCallback(`${NEWQ_PREFIX}confirm:1720000000000`)).toEqual({
+      action: 'confirm',
+      ts: 1720000000000,
+      nonce: '1720000000000',
+    })
+    // IT2-5: current `<ts>:<rand>` nonce — ts parsed for TTL, full string kept.
+    expect(parseNewqCallback(`${NEWQ_PREFIX}confirm:1720000000000:ab12cd`)).toEqual({
+      action: 'confirm',
+      ts: 1720000000000,
+      nonce: '1720000000000:ab12cd',
+    })
+    expect(parseNewqCallback(`${NEWQ_PREFIX}nope`)).toBeNull()
+    expect(parseNewqCallback('ccmd:compact')).toBeNull()
+    expect(parseNewqCallback(`${NEWQ_PREFIX}`)).toBeNull()
+    // A present-but-garbage nonce is fail-closed (rejected).
+    expect(parseNewqCallback(`${NEWQ_PREFIX}confirm:abc`)).toBeNull()
+    // @ts-expect-error runtime guard for non-string
+    expect(parseNewqCallback(undefined)).toBeNull()
+  })
+})
+
+describe('buildNewConfirmCard', () => {
+  test('two buttons: confirm carries a nonce, cancel is plain', () => {
+    const card = buildNewConfirmCard()
+    expect(card.text).toContain('Новый диалог')
+    const datas = card.inlineKeyboard.inline_keyboard.flat().map((b) => b.callback_data)
+    // IT2-5: confirm nonce is `<ts>:<rand>`.
+    expect(datas[0]).toMatch(/^newq:confirm:\d+:[a-z0-9]+$/)
+    expect(datas[1]).toBe(`${NEWQ_PREFIX}cancel`)
+  })
+})
+
+describe('handleNewqCallback', () => {
+  test('unauthorized user id → toast, NO clear, NO edit', async () => {
+    const { calls, sender } = fakeSender({ ok: true })
+    const deps: NewqCallbackDeps = { allowedUserIds: ALLOWED, tmuxKeysTarget: PANE, log, sendControl: sender }
+    const { ctx, answers, edits } = makeCtx(`${NEWQ_PREFIX}confirm`, 999)
+    await handleNewqCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    expect(edits.length).toBe(0)
+    expect(answers[0]).toContain('не авторизовано')
+  })
+
+  test('missing id is unauthorized (fail-closed)', async () => {
+    const { calls, sender } = fakeSender({ ok: true })
+    const deps: NewqCallbackDeps = { allowedUserIds: ALLOWED, tmuxKeysTarget: PANE, log, sendControl: sender }
+    const { ctx, answers } = makeCtx(`${NEWQ_PREFIX}confirm`, undefined)
+    await handleNewqCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    expect(answers[0]).toContain('не авторизовано')
+  })
+
+  test('confirm ok → clears + edits card to «контекст очищен»', async () => {
+    const { calls, sender } = fakeSender({ ok: true })
+    const deps: NewqCallbackDeps = { allowedUserIds: ALLOWED, tmuxKeysTarget: PANE, log, sendControl: sender }
+    const { ctx, answers, edits } = makeCtx(`${NEWQ_PREFIX}confirm`, ALLOWED[0]!)
+    await handleNewqCallback(ctx, deps)
+    expect(calls).toEqual(['clear'])
+    expect(answers[0]).toContain('Очищаю')
+    // FIX-14: buttons are stripped first (an «очищаю…» edit), then the result.
+    expect(edits.some((e) => e.includes('контекст очищен'))).toBe(true)
+  })
+
+  test('confirm busy → edits card to the busy failure message', async () => {
+    const { sender } = fakeSender({ ok: false, reason: 'busy' })
+    const deps: NewqCallbackDeps = { allowedUserIds: ALLOWED, tmuxKeysTarget: PANE, log, sendControl: sender }
+    const { ctx, edits } = makeCtx(`${NEWQ_PREFIX}confirm`, ALLOWED[0]!)
+    await handleNewqCallback(ctx, deps)
+    expect(edits.some((e) => e.includes('агент занят'))).toBe(true)
+  })
+
+  test('cancel → edits card to «Отменено», no clear', async () => {
+    const { calls, sender } = fakeSender({ ok: true })
+    const deps: NewqCallbackDeps = { allowedUserIds: ALLOWED, tmuxKeysTarget: PANE, log, sendControl: sender }
+    const { ctx, edits } = makeCtx(`${NEWQ_PREFIX}cancel`, ALLOWED[0]!)
+    await handleNewqCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    expect(edits[0]).toBe('Отменено')
+  })
+
+  test('confirm with no pane → toast + edit, no clear', async () => {
+    const { calls, sender } = fakeSender({ ok: true })
+    const deps: NewqCallbackDeps = { allowedUserIds: ALLOWED, log, sendControl: sender }
+    const { ctx, answers, edits } = makeCtx(`${NEWQ_PREFIX}confirm`, ALLOWED[0]!)
+    await handleNewqCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    expect(answers[0]).toContain('pane недоступен')
+    expect(edits[0]).toContain('pane недоступен')
+  })
+
+  // ─── FIX-14: nonce staleness + double-tap dedup ──────────────────────────
+
+  test('expired confirm nonce (>60s) → refused, NO clear', async () => {
+    const { calls, sender } = fakeSender({ ok: true })
+    const deps: NewqCallbackDeps = { allowedUserIds: ALLOWED, tmuxKeysTarget: PANE, log, sendControl: sender }
+    const staleTs = Date.now() - 120_000 // 2 min old
+    const { ctx, answers, edits } = makeCtx(`${NEWQ_PREFIX}confirm:${staleTs}`, ALLOWED[0]!)
+    await handleNewqCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    expect(answers[0]).toContain('устарел')
+    expect(edits.some((e) => e.includes('устарел'))).toBe(true)
+  })
+
+  test('fresh nonce → clears; a SECOND tap of the same nonce is refused', async () => {
+    const { calls, sender } = fakeSender({ ok: true })
+    const guard = createNewqNonceGuard()
+    const ts = Date.now()
+    const data = `${NEWQ_PREFIX}confirm:${ts}`
+    const deps: NewqCallbackDeps = {
+      allowedUserIds: ALLOWED,
+      tmuxKeysTarget: PANE,
+      log,
+      sendControl: sender,
+      nonceGuard: guard,
+    }
+    // First tap fires the clear.
+    const first = makeCtx(data, ALLOWED[0]!)
+    await handleNewqCallback(first.ctx, deps)
+    expect(calls).toEqual(['clear'])
+    // Second (double) tap of the SAME card is refused — clear runs only once.
+    const second = makeCtx(data, ALLOWED[0]!)
+    await handleNewqCallback(second.ctx, deps)
+    expect(calls).toEqual(['clear']) // still just one
+    expect(second.answers[0]).toContain('уже выполнено')
+  })
+
+  // IT2-5: two cards built in the SAME millisecond carry the same <ts> but a
+  // DIFFERENT <rand>, so their FULL nonces differ. Both first-taps must fire —
+  // the second card must NOT be swallowed as «уже выполнено».
+  test('two same-ms cards (same ts, different rand) → BOTH first taps fire', async () => {
+    const { calls, sender } = fakeSender({ ok: true })
+    const guard = createNewqNonceGuard()
+    const ts = Date.now()
+    const deps: NewqCallbackDeps = {
+      allowedUserIds: ALLOWED,
+      tmuxKeysTarget: PANE,
+      log,
+      sendControl: sender,
+      nonceGuard: guard,
+    }
+    const cardA = makeCtx(`${NEWQ_PREFIX}confirm:${ts}:aaaa1111`, ALLOWED[0]!)
+    const cardB = makeCtx(`${NEWQ_PREFIX}confirm:${ts}:bbbb2222`, ALLOWED[0]!)
+    await handleNewqCallback(cardA.ctx, deps)
+    await handleNewqCallback(cardB.ctx, deps)
+    // Distinct nonces → neither is deduped away → clear fired for BOTH.
+    expect(calls).toEqual(['clear', 'clear'])
+    expect(cardB.answers.some((a) => a?.includes('уже выполнено'))).toBe(false)
+  })
+
+  // ─── FIX-8: owner-DM scoping ─────────────────────────────────────────────
+
+  test('confirm from a NON-owner chat → refused, NO clear', async () => {
+    const { calls, sender } = fakeSender({ ok: true })
+    const deps: NewqCallbackDeps = {
+      allowedUserIds: ALLOWED,
+      tmuxKeysTarget: PANE,
+      log,
+      sendControl: sender,
+      ownerChatIds: [164795011],
+    }
+    // Tap arrives from a group chat (negative id) — not the owner DM.
+    const { ctx, answers } = makeCtx(`${NEWQ_PREFIX}confirm`, ALLOWED[0]!, '-1001234567890')
+    await handleNewqCallback(ctx, deps)
+    expect(calls.length).toBe(0)
+    expect(answers[0]).toContain('недоступно')
+  })
+
+  test('confirm from the owner DM → clears', async () => {
+    const { calls, sender } = fakeSender({ ok: true })
+    const deps: NewqCallbackDeps = {
+      allowedUserIds: ALLOWED,
+      tmuxKeysTarget: PANE,
+      log,
+      sendControl: sender,
+      ownerChatIds: [164795011],
+    }
+    const { ctx } = makeCtx(`${NEWQ_PREFIX}confirm`, ALLOWED[0]!, '164795011')
+    await handleNewqCallback(ctx, deps)
+    expect(calls).toEqual(['clear'])
+  })
+})


### PR DESCRIPTION
## Что

Индикатор загрузки контекста (KAI-style) + переработка команд управления каналом на надёжный state-aware send-keys.

- **Плашка контекста**: закреплённое сообщение с процентом (`115k / 200k (57%)`) + кнопки Сжать/Новый; обновляется по хукам SessionStart/Stop; строго в личке владельца, изолирована от пути доставки сообщений.
- **Надёжные команды**: `/compact` (в один тап) и `/new` (с подтверждением) через `sendControlCommand` — проверка состояния пейна (idle/busy/dialog), interrupt-if-busy, подтверждение факта выполнения по свежим меткам TUI. `/reset` убран (дубликат `/clear`). `/cc` текст+панель и `/status` (с контекстом) переведены на тот же путь.
- **Scope-меню**: команды регистрируются в scope владельца (личка), с очисткой глобального scope.
- **Инфра**: захват `transcript_path` из хуков (`SessionInfoStore`) + парсер контекста из транскрипта JSONL (`context-usage`).

## Качество

- Двойное ревью Codex GPT-5.5 + Fable (2 итерации фиксов): критичное — строгий idle-gate (нет blind-fire на unknown), защита confirm-fire от ложного «готово» (occurrence-delta), owner-DM scope (нет утечки в группы), per-pane сериализация.
- Живой смоук-тест против реального TUI **v2.1.200** (исправлен несуществующий маркер `Ctrl+Y to paste` для /clear).
- Тесты: **1789 pass** / 2 fail (2 — известные env-фейлы PyYAML, не связаны). Типы чистые.

🤖 Generated with [Claude Code](https://claude.com/claude-code)