### PR TITLE
Статус-пин: контекст + задачи в одном закрепе, якорь внизу над tmux mirror

### DIFF
--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -507,6 +507,11 @@ const hudApi: HudTelegramApi = {
     telegramApi.editMessageText(chatId, messageId, text, opts),
   pinChatMessage: (chatId, messageId, opts) =>
     bot.api.pinChatMessage(chatId, messageId, opts).then(() => undefined),
+  // bump() legs (status pin): delete goes through the safe wrapper (rate
+  // limiting); unpin carries no user text and is adapted from grammY like pin.
+  deleteMessage: (chatId, messageId) => telegramApi.deleteMessage(chatId, messageId),
+  unpinChatMessage: (chatId, messageId) =>
+    bot.api.unpinChatMessage(chatId, messageId).then(() => undefined),
 }
 const contextHud = new ContextHud({
   api: hudApi,
@@ -1160,6 +1165,9 @@ const handlerDeps: HandlerDeps = {
   watcher: inboundWatcher,
   // Optional /mirror control surface — undefined when tmux_mirror.enabled=false.
   ...(tmuxMirror !== null ? { tmuxMirror } : {}),
+  // Status pin (2026-07-04): re-anchor the pinned card on every inbound owner
+  // message, sequenced before the tmux-mirror bump inside handlers.ts.
+  contextHud,
   // /keys — deterministic keystrokes into the agent pane (DM allowlist only).
   ...(tmuxKeysTarget !== undefined ? { tmuxKeys: { target: tmuxKeysTarget } } : {}),
   // Session facts (transcript_path + model) for /status context usage.

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -1183,6 +1183,21 @@ const handlerDeps: HandlerDeps = {
   askUserQuestionUi,
 }
 
+// Status pin (2026-07-04, review HIGH #1): every HUD bump re-pins the fresh
+// card, and each pin drops a permanent «закрепил сообщение» service bubble
+// into the chat (disable_notification mutes only the push). Delete OUR OWN
+// pin service messages immediately — gated on the sender being THIS bot, so
+// the warchief's manual pins are never touched. Best-effort: a failed delete
+// just leaves one bubble behind.
+bot.on('message:pinned_message', ctx => {
+  if (botIdentity.id === 0 || ctx.message.from?.id !== botIdentity.id) return
+  void ctx.deleteMessage().catch((err: unknown) => {
+    log.warn('pin service-message delete failed (ignored)', {
+      chat_id: String(ctx.chat.id),
+      error: err instanceof Error ? err.message : String(err),
+    })
+  })
+})
 bot.on('message:text', ctx => handleInboundText(ctx, handlerDeps))
 bot.on('message:photo', ctx => handleInboundPhoto(ctx, handlerDeps))
 bot.on('message:document', ctx => handleInboundDocument(ctx, handlerDeps))

--- a/plugin/src/status/context-hud.ts
+++ b/plugin/src/status/context-hud.ts
@@ -21,7 +21,7 @@
 // that message instead of spamming a fresh one; if the user deleted it we
 // recreate it exactly once.
 
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { classifyEditError } from '../safety/telegram-edit-classifier.js'
@@ -389,10 +389,18 @@ export class ContextHud {
         const old = this.messageIds.get(chatId) ?? this.loadPersisted(chatId)
         if (old !== undefined) {
           this.messageIds.delete(chatId)
-          let deleted = false
+          // `retired` = the old card can no longer hold a pin (deleted, or
+          // unpinned in place). Only a retired old card may be replaced —
+          // otherwise sending a fresh pinned card could yield TWO pins
+          // (codex review 2026-07-04, HIGH #1).
+          let retired = false
           try {
             await this.api.deleteMessage(chatId, old)
-            deleted = true
+            retired = true
+            // Deliberate persistence cleanup (codex MED #3): the persisted id
+            // now points at a deleted message. Drop it so a crash between
+            // here and sendFresh can't resurrect the stale id later.
+            this.clearPersisted(chatId)
           } catch (err) {
             this.log.warn('context hud bump delete failed (will unpin instead)', {
               chat_id: chatId,
@@ -400,9 +408,10 @@ export class ContextHud {
               error: err instanceof Error ? err.message : String(err),
             })
           }
-          if (!deleted) {
+          if (!retired) {
             try {
               await this.api.unpinChatMessage(chatId, old)
+              retired = true
             } catch (err) {
               this.log.warn('context hud bump unpin failed (ignored)', {
                 chat_id: chatId,
@@ -410,6 +419,14 @@ export class ContextHud {
                 error: err instanceof Error ? err.message : String(err),
               })
             }
+          }
+          if (!retired) {
+            // BOTH legs failed — the old card may still be pinned somewhere.
+            // Bail out and keep pointing at it: a stale position beats a
+            // second pinned card (the one-pin invariant is the warchief's
+            // hard requirement). The next bump retries the whole sequence.
+            this.messageIds.set(chatId, old)
+            return
           }
         }
         // sendFresh persists the new id (overwriting the stale one) and pins.
@@ -573,6 +590,19 @@ export class ContextHud {
     // defensively so a surprising value can never escape the state dir.
     const safe = chatId.replace(/[^0-9A-Za-z_-]/g, '_')
     return join(this.stateDir, `context-hud-${safe}.json`)
+  }
+
+  // Remove the persisted id after a successful delete — a file pointing at a
+  // deleted message is worse than no file (bump/updateNow would edit a ghost).
+  private clearPersisted(chatId: string): void {
+    try {
+      rmSync(this.persistPath(chatId), { force: true })
+    } catch (err) {
+      this.log.warn('context hud clearPersisted failed (ignored)', {
+        chat_id: chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
   }
 
   private loadPersisted(chatId: string): number | undefined {

--- a/plugin/src/status/context-hud.ts
+++ b/plugin/src/status/context-hud.ts
@@ -26,6 +26,9 @@ import { join } from 'node:path'
 
 import { classifyEditError } from '../safety/telegram-edit-classifier.js'
 import { readContextUsage as realReadContextUsage, type ContextUsage } from './context-usage.js'
+import { applyTaskCreateToMap, applyTaskUpdateToMap } from './task-mirror.js'
+import type { TaskMirrorEvent } from '../hooks/claude-events.js'
+import type { TodoItem } from '../schemas.js'
 import type { EditOpts, InlineKeyboardLike, SendMessageOpts } from '../channel/tools.js'
 import type { Logger } from '../log.js'
 
@@ -41,6 +44,10 @@ export const HUD_PREFIX = 'hud:'
 const BAR_SEGMENTS = 10
 const BAR_FILLED = '▰'
 const BAR_EMPTY = '▱'
+
+// bump() debounce window — collapses inbound-message bursts (multi-part voice,
+// albums) into a single delete+resend. Mirrors TmuxMirror.BUMP_DEBOUNCE_MS.
+const HUD_BUMP_DEBOUNCE_MS = 1500
 
 // Escape the model string for HTML parse mode. Model ids ("claude-opus-4-8")
 // carry no markup, but escape defensively so a surprising value can never break
@@ -60,6 +67,70 @@ export function buildHudKeyboard(): InlineKeyboardLike {
   }
 }
 
+// Work-status view rendered under the context line (status-pin wave, 2026-07-04).
+export interface HudWorkView {
+  todos: ReadonlyArray<TodoItem>
+  permissionMode?: string
+}
+
+// Caps for the tasks section. The HUD is a compact pinned card, not the full
+// TaskMirror body: all in-progress items, a handful of pending, the last
+// couple of completed. Item text is truncated on the RAW string BEFORE
+// escaping so an entity can never be sliced in half.
+const TASKS_MAX_PENDING = 5
+const TASKS_MAX_DONE = 2
+const TASK_LINE_CHARS = 80
+
+const TASK_ICONS = {
+  in_progress: '◐',
+  pending: '◻',
+  completed: '☑',
+} as const
+
+function taskLine(todo: TodoItem): string {
+  const raw = todo.status === 'in_progress' && todo.activeForm
+    ? todo.activeForm
+    : todo.content
+  const cut = raw.length > TASK_LINE_CHARS ? `${raw.slice(0, TASK_LINE_CHARS - 1)}…` : raw
+  return `${TASK_ICONS[todo.status]} ${escapeHtml(cut)}`
+}
+
+/**
+ * Render the compact «Задачи» section for the status pin: a 10-segment
+ * done/total bar + in-progress / pending / last-completed lines.
+ * Empty todos → empty string (the HUD omits the section entirely).
+ * PURE — exported for unit tests.
+ */
+export function renderStatusTasks(todos: ReadonlyArray<TodoItem>): string {
+  if (todos.length === 0) return ''
+  const inProgress = todos.filter((t) => t.status === 'in_progress')
+  const pending = todos.filter((t) => t.status === 'pending')
+  const completed = todos.filter((t) => t.status === 'completed')
+  const total = todos.length
+  const done = completed.length
+
+  const filled = Math.max(0, Math.min(BAR_SEGMENTS, Math.round((done / total) * BAR_SEGMENTS)))
+  const bar = BAR_FILLED.repeat(filled) + BAR_EMPTY.repeat(BAR_SEGMENTS - filled)
+
+  const lines: string[] = [`<b>Задачи</b> ${bar} ${done}/${total}`]
+  for (const t of inProgress) lines.push(taskLine(t))
+  for (const t of pending.slice(0, TASKS_MAX_PENDING)) lines.push(taskLine(t))
+  if (pending.length > TASKS_MAX_PENDING) {
+    lines.push(`<i>+${pending.length - TASKS_MAX_PENDING} ещё…</i>`)
+  }
+  const visibleDone = completed.slice(-TASKS_MAX_DONE)
+  const hiddenDone = completed.length - visibleDone.length
+  if (hiddenDone > 0) lines.push(`<i>+${hiddenDone} завершено ранее</i>`)
+  for (const t of visibleDone) lines.push(taskLine(t))
+  return lines.join('\n')
+}
+
+// «план» is the only mode worth naming; every other Claude Code permission
+// mode (default / acceptEdits / bypassPermissions) is just «выполнение».
+function modeLabel(permissionMode: string): string {
+  return permissionMode === 'plan' ? 'план' : 'выполнение'
+}
+
 /**
  * Render the HUD text + keyboard from a context-usage reading.
  *
@@ -68,18 +139,31 @@ export function buildHudKeyboard(): InlineKeyboardLike {
  * clamped percentage. An optional second line shows the model when known.
  * A null usage (no transcript / no usable turn yet) renders `🧠 <b>Контекст</b>: —`.
  *
+ * With a `work` view the card grows a mode line («режим: план» /
+ * «выполнение», only when the permission mode is known) and a compact
+ * «Задачи» section (renderStatusTasks) — the combined status pin the
+ * warchief asked for on 2026-07-04: ONE pinned message = context + work.
+ *
  * PURE — no I/O, no clock — so it is trivially unit-testable against fixed inputs.
  */
 export function renderHud(
   usage: { usedTokens: number } | null,
   windowTokens: number,
   model?: string,
+  work?: HudWorkView,
 ): { text: string; keyboard: InlineKeyboardLike } {
   const keyboard = buildHudKeyboard()
   const modelLine = model !== undefined && model.length > 0 ? `\n<i>${escapeHtml(model)}</i>` : ''
+  const modeLine =
+    work?.permissionMode !== undefined && work.permissionMode.length > 0
+      ? `\n<i>режим: ${modeLabel(work.permissionMode)}</i>`
+      : ''
+  const tasksBlock = work !== undefined ? renderStatusTasks(work.todos) : ''
+  const tasksSection = tasksBlock.length > 0 ? `\n\n${tasksBlock}` : ''
+  const tail = `${modelLine}${modeLine}${tasksSection}`
 
   if (usage === null) {
-    return { text: `🧠 <b>Контекст</b>: —${modelLine}`, keyboard }
+    return { text: `🧠 <b>Контекст</b>: —${tail}`, keyboard }
   }
 
   const windowK = Math.round(windowTokens / 1000)
@@ -91,7 +175,7 @@ export function renderHud(
   const filled = Math.max(0, Math.min(BAR_SEGMENTS, Math.round(pct / 10)))
   const bar = BAR_FILLED.repeat(filled) + BAR_EMPTY.repeat(BAR_SEGMENTS - filled)
 
-  const text = `🧠 <b>Контекст</b>: ${bar} ${pct}% (${usedK}k / ${windowK}k)${modelLine}`
+  const text = `🧠 <b>Контекст</b>: ${bar} ${pct}% (${usedK}k / ${windowK}k)${tail}`
   return { text, keyboard }
 }
 
@@ -109,12 +193,23 @@ export interface HudTelegramApi {
   sendMessage(chatId: string, text: string, opts: SendMessageOpts): Promise<{ message_id: number }>
   editMessageText(chatId: string, messageId: number, text: string, opts: EditOpts): Promise<void>
   pinChatMessage(chatId: string, messageId: number, opts: { disable_notification?: boolean }): Promise<void>
+  // bump() re-anchoring (status-pin wave): delete the old card (deleting a
+  // pinned message also removes its pin), unpin as the fallback when delete
+  // is refused (bots cannot delete own messages older than 48h). Both carry
+  // no user text — adapted from grammY at the composition root like pin.
+  deleteMessage(chatId: string, messageId: number): Promise<void>
+  unpinChatMessage(chatId: string, messageId: number): Promise<void>
 }
 
 // Read-only view of the SessionInfoStore the HUD consumes. Satisfied by
 // `SessionInfoStore.get`.
 export interface SessionInfoReader {
-  get(chatId?: string): { transcriptPath?: string; sessionId?: string; model?: string }
+  get(chatId?: string): {
+    transcriptPath?: string
+    sessionId?: string
+    model?: string
+    permissionMode?: string
+  }
 }
 
 // Injectable transcript reader — defaults to the real `readContextUsage`. Tests
@@ -156,6 +251,14 @@ export class ContextHud {
   private readonly readUsage: ReadContextUsageFn
   // In-memory message-id cache per chat (mirrors the on-disk persistence).
   private readonly messageIds = new Map<string, number>()
+  // Latest work-status view per chat (todos synthesised from TodoWrite /
+  // TaskCreate / TaskUpdate hook events). Kept ACROSS turns — a Stop hook
+  // does not clear it, so the pinned card keeps showing «что сделали» until
+  // the next task replaces the snapshot.
+  private readonly work = new Map<string, { todos: ReadonlyArray<TodoItem>; taskMap: Map<string, TodoItem> }>()
+  // bump() debounce per chat — a burst of inbound messages collapses to one
+  // delete+resend (same rationale as TmuxMirror.BUMP_DEBOUNCE_MS).
+  private readonly lastBumpAt = new Map<string, number>()
   // FIX-9 (both reviews): per-chat serialization. A concurrent SessionStart +
   // Stop (both firing before the first send persists an id) would each see an
   // empty cache and sendFresh → TWO pinned HUDs. Chaining every HUD operation
@@ -236,6 +339,90 @@ export class ContextHud {
     await this.updateNow(chatId)
   }
 
+  // Todo events (TodoWrite / TaskCreate / TaskUpdate, mapped by
+  // toTodoWriteEvent in the webhook) — update the work view and refresh the
+  // card in place. `todo_session_stop` deliberately does NOT clear the view:
+  // the pinned card keeps the last milestones visible across turns.
+  onTodoEvent(chatId: string, event: TaskMirrorEvent): Promise<void> {
+    if (!this.enabled || !this.isOwner(chatId)) return Promise.resolve()
+    if (event.kind === 'todo_session_stop') return Promise.resolve()
+    let state = this.work.get(chatId)
+    if (state === undefined) {
+      state = { todos: [], taskMap: new Map<string, TodoItem>() }
+      this.work.set(chatId, state)
+    }
+    switch (event.kind) {
+      case 'todo_write':
+        // TodoWrite payloads ARE the full list — replace wholesale and drop
+        // the incremental map so a mid-session tool switch starts clean.
+        state.taskMap.clear()
+        state.todos = event.todos
+        break
+      case 'task_create':
+        applyTaskCreateToMap(state.taskMap, event)
+        state.todos = Array.from(state.taskMap.values())
+        break
+      case 'task_update':
+        applyTaskUpdateToMap(state.taskMap, event)
+        state.todos = Array.from(state.taskMap.values())
+        break
+    }
+    return this.updateNow(chatId)
+  }
+
+  // Re-anchor the pinned card at the BOTTOM of the chat (just above the tmux
+  // mirror — the handlers fire this BEFORE TmuxMirror.bump on every inbound
+  // owner message). Deletes the old message — which also removes its pin, so
+  // the one-pin invariant holds — and sends+pins a fresh one. When Telegram
+  // refuses the delete (bots cannot delete own messages older than 48h) we
+  // fall back to unpinChatMessage so two pins can never coexist. Debounced
+  // and serialized per chat; best-effort like every other HUD op.
+  bump(chatId: string): Promise<void> {
+    if (!this.enabled || !this.isOwner(chatId)) return Promise.resolve()
+    const now = Date.now()
+    const last = this.lastBumpAt.get(chatId)
+    if (last !== undefined && now - last < HUD_BUMP_DEBOUNCE_MS) return Promise.resolve()
+    this.lastBumpAt.set(chatId, now)
+    return this.runSerialized(chatId, async () => {
+      try {
+        const { text, keyboard } = await this.renderCurrent(chatId)
+        const old = this.messageIds.get(chatId) ?? this.loadPersisted(chatId)
+        if (old !== undefined) {
+          this.messageIds.delete(chatId)
+          let deleted = false
+          try {
+            await this.api.deleteMessage(chatId, old)
+            deleted = true
+          } catch (err) {
+            this.log.warn('context hud bump delete failed (will unpin instead)', {
+              chat_id: chatId,
+              message_id: old,
+              error: err instanceof Error ? err.message : String(err),
+            })
+          }
+          if (!deleted) {
+            try {
+              await this.api.unpinChatMessage(chatId, old)
+            } catch (err) {
+              this.log.warn('context hud bump unpin failed (ignored)', {
+                chat_id: chatId,
+                message_id: old,
+                error: err instanceof Error ? err.message : String(err),
+              })
+            }
+          }
+        }
+        // sendFresh persists the new id (overwriting the stale one) and pins.
+        await this.sendFresh(chatId, text, keyboard)
+      } catch (err) {
+        this.log.warn('context hud bump failed (ignored)', {
+          chat_id: chatId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    })
+  }
+
   // Read the latest usage and reconcile the HUD message. Best-effort: never
   // throws. Creates the message if none exists yet (e.g. Stop before any
   // SessionStart), otherwise edits it in place. Serialized per chat.
@@ -274,7 +461,13 @@ export class ContextHud {
         usage = null
       }
     }
-    return renderHud(usage, this.windowTokens, info.model)
+    const work: HudWorkView = {
+      todos: this.work.get(chatId)?.todos ?? [],
+      ...(info.permissionMode !== undefined && info.permissionMode.length > 0
+        ? { permissionMode: info.permissionMode }
+        : {}),
+    }
+    return renderHud(usage, this.windowTokens, info.model, work)
   }
 
   // Resolve the HUD message id for a chat: in-memory cache → persisted file →

--- a/plugin/src/status/context-hud.ts
+++ b/plugin/src/status/context-hud.ts
@@ -80,6 +80,11 @@ export interface HudWorkView {
 const TASKS_MAX_PENDING = 5
 const TASKS_MAX_DONE = 2
 const TASK_LINE_CHARS = 80
+// Total section budget (post-escape chars). Keeps the card far under the
+// 4096 sendMessage cap even with many in-progress items and markup-heavy
+// subjects (escaping expands & → &amp; AFTER the per-line cut) — review
+// 2026-07-04 LOW #3.
+const TASKS_MAX_CHARS = 1500
 
 const TASK_ICONS = {
   in_progress: '◐',
@@ -91,7 +96,10 @@ function taskLine(todo: TodoItem): string {
   const raw = todo.status === 'in_progress' && todo.activeForm
     ? todo.activeForm
     : todo.content
-  const cut = raw.length > TASK_LINE_CHARS ? `${raw.slice(0, TASK_LINE_CHARS - 1)}…` : raw
+  // Truncate on CODE POINTS (Array.from), not UTF-16 units — a .slice cut
+  // can split a surrogate pair and render U+FFFD (review 2026-07-04 LOW #4).
+  const cps = Array.from(raw)
+  const cut = cps.length > TASK_LINE_CHARS ? `${cps.slice(0, TASK_LINE_CHARS - 1).join('')}…` : raw
   return `${TASK_ICONS[todo.status]} ${escapeHtml(cut)}`
 }
 
@@ -122,7 +130,23 @@ export function renderStatusTasks(todos: ReadonlyArray<TodoItem>): string {
   const hiddenDone = completed.length - visibleDone.length
   if (hiddenDone > 0) lines.push(`<i>+${hiddenDone} завершено ранее</i>`)
   for (const t of visibleDone) lines.push(taskLine(t))
-  return lines.join('\n')
+
+  // Total-budget pass: the per-category caps bound pending/completed but not
+  // in-progress, and escaping expands after the per-line cut. Keep the header
+  // always; drop overflowing lines and mark the cut with a tail.
+  const out: string[] = []
+  let used = 0
+  let dropped = 0
+  for (const line of lines) {
+    if (out.length === 0 || used + 1 + line.length <= TASKS_MAX_CHARS) {
+      out.push(line)
+      used += (out.length === 1 ? 0 : 1) + line.length
+    } else {
+      dropped++
+    }
+  }
+  if (dropped > 0) out.push(`<i>+${dropped} строк скрыто</i>`)
+  return out.join('\n')
 }
 
 // «план» is the only mode worth naming; every other Claude Code permission

--- a/plugin/src/status/session-info.ts
+++ b/plugin/src/status/session-info.ts
@@ -20,6 +20,10 @@ export interface SessionInfo {
   transcriptPath?: string
   sessionId?: string
   model?: string
+  // Claude Code permission mode from the latest hook payload that carried one
+  // ('default' | 'plan' | 'acceptEdits' | 'bypassPermissions'). The status pin
+  // renders «план» vs «выполнение» from it.
+  permissionMode?: string
 }
 
 export class SessionInfoStore {
@@ -36,6 +40,7 @@ export class SessionInfoStore {
     if (info.transcriptPath) next.transcriptPath = info.transcriptPath
     if (info.sessionId) next.sessionId = info.sessionId
     if (info.model) next.model = info.model
+    if (info.permissionMode) next.permissionMode = info.permissionMode
     if (key !== undefined) this.byChat.set(key, next)
     // `latest` always tracks the most recent event so a single-session caller
     // (no chatId passed to get()) still sees the freshest transcript/model.

--- a/plugin/src/status/task-mirror.ts
+++ b/plugin/src/status/task-mirror.ts
@@ -95,6 +95,69 @@ function parseCreatedTaskId(toolResult: unknown): string | null {
   return match ? (match[1] ?? null) : null
 }
 
+// ─────────────────────────────────────────────────────────────────────
+// Pure task-map appliers — shared by TaskMirror and the ContextHud work
+// section so both surfaces synthesise IDENTICAL todo snapshots from the
+// same TaskCreate/TaskUpdate event stream. Exported for reuse + tests.
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Apply a `task_create` event to a task map (see TaskMirror.applyTaskCreate
+ * docs for the provisional-id → harness-id reconciliation contract).
+ */
+export function applyTaskCreateToMap(
+  taskMap: Map<string, TodoItem>,
+  event: Extract<TaskMirrorEvent, { kind: 'task_create' }>,
+): void {
+  const realId =
+    event.toolResult !== undefined ? parseCreatedTaskId(event.toolResult) : null
+  const provisionalId = event.toolUseId
+  const provisional = taskMap.get(provisionalId)
+  const item: TodoItem = {
+    id: realId ?? provisional?.id ?? provisionalId,
+    content: event.input.subject,
+    status: provisional?.status ?? 'pending',
+    ...(event.input.activeForm !== undefined
+      ? { activeForm: event.input.activeForm }
+      : provisional?.activeForm !== undefined
+        ? { activeForm: provisional.activeForm }
+        : {}),
+  }
+  taskMap.delete(provisionalId)
+  if (realId !== null && realId !== provisionalId) {
+    taskMap.delete(realId)
+  }
+  taskMap.set(item.id ?? provisionalId, item)
+}
+
+/**
+ * Apply a `task_update` event to a task map. `status: 'deleted'` removes the
+ * entry; a missing target synthesises a minimal placeholder (webhook drops).
+ */
+export function applyTaskUpdateToMap(
+  taskMap: Map<string, TodoItem>,
+  event: Extract<TaskMirrorEvent, { kind: 'task_update' }>,
+): void {
+  const id = event.input.taskId
+  if (event.input.status === 'deleted') {
+    taskMap.delete(id)
+    return
+  }
+  const existing = taskMap.get(id)
+  const status = event.input.status ?? existing?.status ?? 'pending'
+  const next: TodoItem = {
+    id,
+    content: event.input.subject ?? existing?.content ?? `task ${id}`,
+    status,
+    ...(event.input.activeForm !== undefined
+      ? { activeForm: event.input.activeForm }
+      : existing?.activeForm !== undefined
+        ? { activeForm: existing.activeForm }
+        : {}),
+  }
+  taskMap.set(id, next)
+}
+
 export class TaskMirror {
   private readonly telegramApi: TelegramApiForProgress
   private readonly config: AppConfig
@@ -180,29 +243,9 @@ export class TaskMirror {
     entry: ChatTaskEntry,
     event: Extract<TaskMirrorEvent, { kind: 'task_create' }>,
   ): void {
-    const realId =
-      event.toolResult !== undefined ? parseCreatedTaskId(event.toolResult) : null
-    const provisionalId = event.toolUseId
-    const provisional = entry.taskMap.get(provisionalId)
-    const item: TodoItem = {
-      id: realId ?? provisional?.id ?? provisionalId,
-      content: event.input.subject,
-      status: provisional?.status ?? 'pending',
-      ...(event.input.activeForm !== undefined
-        ? { activeForm: event.input.activeForm }
-        : provisional?.activeForm !== undefined
-          ? { activeForm: provisional.activeForm }
-          : {}),
-    }
-    // Drop the provisional entry, insert under the canonical id. This re-keys
-    // the Map without dropping anything else; insertion-order semantics mean
-    // the task moves to the tail on reconciliation, which is the right place
-    // visually (most recently activated).
-    entry.taskMap.delete(provisionalId)
-    if (realId !== null && realId !== provisionalId) {
-      entry.taskMap.delete(realId)
-    }
-    entry.taskMap.set(item.id ?? provisionalId, item)
+    // Re-keying (provisional → canonical id) moves the task to the Map tail on
+    // reconciliation — the right place visually (most recently activated).
+    applyTaskCreateToMap(entry.taskMap, event)
   }
 
   /**
@@ -215,27 +258,7 @@ export class TaskMirror {
     entry: ChatTaskEntry,
     event: Extract<TaskMirrorEvent, { kind: 'task_update' }>,
   ): void {
-    const id = event.input.taskId
-    // Drop 'deleted' before constructing the TodoItem -- the rendered TodoItem
-    // type accepts only pending/in_progress/completed, and the schema-coerced
-    // 'deleted' value would not narrow correctly otherwise.
-    if (event.input.status === 'deleted') {
-      entry.taskMap.delete(id)
-      return
-    }
-    const existing = entry.taskMap.get(id)
-    const status = event.input.status ?? existing?.status ?? 'pending'
-    const next: TodoItem = {
-      id,
-      content: event.input.subject ?? existing?.content ?? `task ${id}`,
-      status,
-      ...(event.input.activeForm !== undefined
-        ? { activeForm: event.input.activeForm }
-        : existing?.activeForm !== undefined
-          ? { activeForm: existing.activeForm }
-          : {}),
-    }
-    entry.taskMap.set(id, next)
+    applyTaskUpdateToMap(entry.taskMap, event)
   }
 
   /**

--- a/plugin/src/telegram/handlers.ts
+++ b/plugin/src/telegram/handlers.ts
@@ -149,6 +149,11 @@ export interface HandlerDeps {
   // when tmux_mirror.enabled=false at startup the mirror instance is
   // never created and the OOB handler replies «disabled in config».
   tmuxMirror?: TmuxMirrorControl
+  // Context HUD / status pin (2026-07-04): bump() re-anchors the pinned
+  // status card at the bottom of the chat on every inbound owner message —
+  // sequenced BEFORE tmuxMirror.bump so the card lands ABOVE the mirror.
+  // Optional so older tests compile; the HUD gates on owner internally.
+  contextHud?: { bump(chatId: string): Promise<void> }
   // /keys target — resolved tmux pane of the agent session (server.ts wiring).
   tmuxKeys?: { target: TmuxKeysTarget }
   // Session facts (transcript_path + model) learned from Claude hook events,
@@ -291,16 +296,39 @@ function maybeTriggerWatcher(ctx: Context, deps: HandlerDeps): void {
 // Bug #3 (TASK-4): use `isSideEffectAllowed` so a non-addressed group
 // message never re-anchors the mirror.
 function maybeBumpMirror(ctx: Context, deps: HandlerDeps): void {
-  if (!deps.tmuxMirror?.bump) return
+  const hasMirror = deps.tmuxMirror?.bump !== undefined
+  const hasHud = deps.contextHud !== undefined
+  if (!hasMirror && !hasHud) return
   if (!isSideEffectAllowed(ctx, deps.config, deps.policy)) return
   const chatNum = ctx.chat?.id
   if (chatNum === undefined) return
-  void deps.tmuxMirror.bump().catch((err) => {
-    deps.log.warn('tmux mirror bump error (ignored)', {
-      chat_id: String(chatNum),
-      error: err instanceof Error ? err.message : String(err),
-    })
-  })
+  const chatId = String(chatNum)
+  // Sequence matters (status-pin wave, 2026-07-04): the pinned status card
+  // re-anchors FIRST, the tmux mirror second, so the chat bottom always reads
+  // «status card above, mirror below». Each leg is best-effort — a HUD
+  // failure must never rob the mirror of its bump, and vice versa.
+  void (async () => {
+    if (hasHud) {
+      try {
+        await deps.contextHud!.bump(chatId)
+      } catch (err) {
+        deps.log.warn('context hud bump error (ignored)', {
+          chat_id: chatId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+    if (hasMirror) {
+      try {
+        await deps.tmuxMirror!.bump!()
+      } catch (err) {
+        deps.log.warn('tmux mirror bump error (ignored)', {
+          chat_id: chatId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+  })()
 }
 
 // FIX-D M1 (2026-05-27): chat-type detection from a stringified Telegram

--- a/plugin/src/webhook/server.ts
+++ b/plugin/src/webhook/server.ts
@@ -189,6 +189,19 @@ export interface ContextHudForWebhook {
   onTodoEvent?(chatId: string, event: TaskMirrorEvent): Promise<void> | void
 }
 
+// Fire a HUD entry point without EVER letting it disturb the hook 200 path.
+// `Promise.resolve(fn()).catch()` alone is not enough: fn() runs before the
+// wrap, so a synchronous throw would escape (codex review 2026-07-04, HIGH #2).
+function fireHud(log: Logger, fn: () => Promise<void> | void): void {
+  try {
+    void Promise.resolve(fn()).catch(() => {})
+  } catch (err) {
+    log.warn('context hud dispatch threw synchronously (ignored)', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
 // Structural surface for the AskUserQuestion Telegram UI handler (TASK-2).
 // We accept any object exposing `startQuestion(requestId)` so the webhook
 // layer is decoupled from the concrete implementation in
@@ -577,15 +590,17 @@ async function handleRequest(
     // Context HUD (wave 3B): drive the pinned indicator on the session
     // lifecycle. SessionStart (re)pins + refreshes; Stop refreshes the
     // percentage after a turn. COMPLETELY isolated from the 200 path: the HUD
-    // methods swallow + log internally, and we still `void`+`.catch` here so a
-    // synchronous throw (defensive) can never escape into the hook response.
-    // The HUD gates on the owner chat internally, so a non-owner chatId is a
-    // safe no-op.
+    // methods swallow + log internally. fireHud additionally guards against a
+    // SYNCHRONOUS throw — `Promise.resolve(fn()).catch()` alone evaluates
+    // fn() BEFORE the wrap, so a sync throw would 500 the hook response
+    // (codex review 2026-07-04, HIGH #2). The HUD gates on the owner chat
+    // internally, so a non-owner chatId is a safe no-op.
     if (deps.contextHud) {
+      const hud = deps.contextHud
       if (payload.hook_event_name === 'SessionStart') {
-        void Promise.resolve(deps.contextHud.onSessionStart(payload.chatId)).catch(() => {})
+        fireHud(log, () => hud.onSessionStart(payload.chatId))
       } else if (payload.hook_event_name === 'Stop') {
-        void Promise.resolve(deps.contextHud.onStop(payload.chatId)).catch(() => {})
+        fireHud(log, () => hud.onStop(payload.chatId))
       }
     }
 
@@ -665,9 +680,8 @@ async function handleRequest(
           }
         }
         if (deps.contextHud?.onTodoEvent) {
-          void Promise.resolve(
-            deps.contextHud.onTodoEvent(payload.chatId, todoEvent),
-          ).catch(() => {})
+          const hud = deps.contextHud
+          fireHud(log, () => hud.onTodoEvent?.(payload.chatId, todoEvent))
         }
       }
     }

--- a/plugin/src/webhook/server.ts
+++ b/plugin/src/webhook/server.ts
@@ -38,7 +38,11 @@ import {
 import { resolvePermissionGateAllowedUserIds } from '../config.js'
 import type { PermissionGateRelay } from '../channel/permission-gate-relay.js'
 import { sendChannelNotification, normalizeMeta } from '../channel/notify.js'
-import { toActivityEvent, toTodoWriteEvent } from '../hooks/claude-events.js'
+import {
+  toActivityEvent,
+  toTodoWriteEvent,
+  type TaskMirrorEvent,
+} from '../hooks/claude-events.js'
 import type {
   AskUserQuestionRelay,
   AskUserQuestionResult,
@@ -161,7 +165,12 @@ export interface StatusManagerForWebhook {
 export interface SessionInfoRecorder {
   record(
     chatId: string | undefined,
-    info: { transcriptPath?: string; sessionId?: string; model?: string },
+    info: {
+      transcriptPath?: string
+      sessionId?: string
+      model?: string
+      permissionMode?: string
+    },
   ): void
 }
 
@@ -170,9 +179,14 @@ export interface SessionInfoRecorder {
 // points are best-effort inside the HUD (they swallow + log, never throw), so
 // the webhook fires them fire-and-forget and never blocks the 200. Optional —
 // when absent the hook path is unchanged (no HUD).
+//
+// Status-pin wave (2026-07-04): `onTodoEvent` feeds the HUD's «Задачи»
+// section from the SAME TaskMirrorEvent stream TaskMirror consumes. Optional
+// on the interface so older stubs/tests remain valid.
 export interface ContextHudForWebhook {
   onSessionStart(chatId: string): Promise<void> | void
   onStop(chatId: string): Promise<void> | void
+  onTodoEvent?(chatId: string, event: TaskMirrorEvent): Promise<void> | void
 }
 
 // Structural surface for the AskUserQuestion Telegram UI handler (TASK-2).
@@ -533,7 +547,12 @@ async function handleRequest(
     // the context HUD can read them. transcript_path + session_id ride on every
     // hook; model is present only on SessionStart. Pure in-memory record.
     if (deps.sessionInfo) {
-      const info: { transcriptPath?: string; sessionId?: string; model?: string } = {
+      const info: {
+        transcriptPath?: string
+        sessionId?: string
+        model?: string
+        permissionMode?: string
+      } = {
         transcriptPath: payload.transcript_path,
         sessionId: payload.session_id,
       }
@@ -543,6 +562,14 @@ async function handleRequest(
         && payload.model.length > 0
       ) {
         info.model = payload.model
+      }
+      // permission_mode rides on any hook that carries it (schema-optional).
+      // The status pin renders «план» / «выполнение» from the latest value.
+      if (
+        typeof payload.permission_mode === 'string'
+        && payload.permission_mode.length > 0
+      ) {
+        info.permissionMode = payload.permission_mode
       }
       deps.sessionInfo.record(payload.chatId, info)
     }
@@ -621,17 +648,26 @@ async function handleRequest(
     // PR-A2 (2026-05-20): TaskMirror handles TodoWrite + Stop hooks. The
     // mapper returns null for every other event, so the cost when no
     // TodoWrite is in flight is one schema test per hook — negligible.
-    if (taskMirror) {
+    // Status-pin wave (2026-07-04): the SAME mapped event also feeds the
+    // context HUD's «Задачи» section — fire-and-forget, never blocks the 200.
+    if (taskMirror || deps.contextHud?.onTodoEvent) {
       const todoEvent = toTodoWriteEvent(payload, log)
       if (todoEvent !== null) {
-        try {
-          await taskMirror.recordEvent(payload.chatId, todoEvent)
-        } catch (err) {
-          log.warn('hook event task mirror update failed (ignored)', {
-            chat_id: payload.chatId,
-            hook: payload.hook_event_name,
-            error: err instanceof Error ? err.message : String(err),
-          })
+        if (taskMirror) {
+          try {
+            await taskMirror.recordEvent(payload.chatId, todoEvent)
+          } catch (err) {
+            log.warn('hook event task mirror update failed (ignored)', {
+              chat_id: payload.chatId,
+              hook: payload.hook_event_name,
+              error: err instanceof Error ? err.message : String(err),
+            })
+          }
+        }
+        if (deps.contextHud?.onTodoEvent) {
+          void Promise.resolve(
+            deps.contextHud.onTodoEvent(payload.chatId, todoEvent),
+          ).catch(() => {})
         }
       }
     }

--- a/plugin/tests/status/context-hud.test.ts
+++ b/plugin/tests/status/context-hud.test.ts
@@ -10,11 +10,14 @@ import {
   handleHudCallback,
   parseHudCallback,
   renderHud,
+  renderStatusTasks,
   type HudCallbackContext,
   type HudCallbackDeps,
   type HudTelegramApi,
   type SessionInfoReader,
 } from '../../src/status/context-hud.js'
+import type { TaskMirrorEvent } from '../../src/hooks/claude-events.js'
+import type { TodoItem } from '../../src/schemas.js'
 import type { ControlCommandResult } from '../../src/commands/keys.js'
 import type { ControlSender } from '../../src/telegram/newq-confirm-ui.js'
 import type { EditOpts, InlineKeyboardLike, SendMessageOpts } from '../../src/channel/tools.js'
@@ -69,10 +72,14 @@ class FakeApi implements HudTelegramApi {
   sent: SendRecord[] = []
   edited: EditRecord[] = []
   pinned: PinRecord[] = []
+  deleted: Array<{ chatId: string; messageId: number }> = []
+  unpinned: Array<{ chatId: string; messageId: number }> = []
   nextId = 100
   sendError: unknown
   editError: unknown
   pinError: unknown
+  deleteError: unknown
+  unpinError: unknown
 
   async sendMessage(
     chatId: string,
@@ -103,11 +110,22 @@ class FakeApi implements HudTelegramApi {
     this.pinned.push({ chatId, messageId, opts })
     if (this.pinError) throw this.pinError
   }
+
+  async deleteMessage(chatId: string, messageId: number): Promise<void> {
+    if (this.deleteError) throw this.deleteError
+    this.deleted.push({ chatId, messageId })
+  }
+
+  async unpinChatMessage(chatId: string, messageId: number): Promise<void> {
+    if (this.unpinError) throw this.unpinError
+    this.unpinned.push({ chatId, messageId })
+  }
 }
 
 function fakeSession(info: {
   transcriptPath?: string
   model?: string
+  permissionMode?: string
 }): SessionInfoReader {
   return { get: () => info }
 }
@@ -557,5 +575,195 @@ describe('handleHudCallback', () => {
     expect(calls.length).toBe(0)
     expect(cards.length).toBe(0)
     expect(answers[0]).toContain('недоступно')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// Status pin (2026-07-04): renderStatusTasks + work view + bump + todos
+// ─────────────────────────────────────────────────────────────────────
+
+function todo(id: string, status: TodoItem['status'], content: string, activeForm?: string): TodoItem {
+  return { id, status, content, ...(activeForm !== undefined ? { activeForm } : {}) }
+}
+
+describe('renderStatusTasks', () => {
+  test('empty list → empty string (section omitted)', () => {
+    expect(renderStatusTasks([])).toBe('')
+  })
+
+  test('bar reflects done/total and header carries the count', () => {
+    const todos = [
+      todo('1', 'completed', 'a'),
+      todo('2', 'completed', 'b'),
+      todo('3', 'completed', 'c'),
+      todo('4', 'in_progress', 'd'),
+      todo('5', 'pending', 'e'),
+    ]
+    const text = renderStatusTasks(todos)
+    expect(text).toContain('<b>Задачи</b>')
+    expect(text).toContain('3/5')
+    expect((text.match(/▰/g) ?? []).length).toBe(6) // round(3/5*10)
+    expect((text.match(/▱/g) ?? []).length).toBe(4)
+  })
+
+  test('in-progress uses activeForm; content is escaped and truncated', () => {
+    const long = 'x'.repeat(120)
+    const text = renderStatusTasks([
+      todo('1', 'in_progress', 'raw', 'Working <on> & stuff'),
+      todo('2', 'pending', long),
+    ])
+    expect(text).toContain('◐ Working &lt;on&gt; &amp; stuff')
+    expect(text).toContain('…')
+    expect(text).not.toContain(long)
+  })
+
+  test('pending capped at 5 with a «+N ещё…» tail', () => {
+    const todos = Array.from({ length: 7 }, (_, i) => todo(String(i), 'pending', `p${i}`))
+    const text = renderStatusTasks(todos)
+    expect((text.match(/◻/g) ?? []).length).toBe(5)
+    expect(text).toContain('<i>+2 ещё…</i>')
+  })
+
+  test('completed shows the last 2 with a hidden-count line', () => {
+    const todos = [
+      ...Array.from({ length: 4 }, (_, i) => todo(String(i), 'completed', `d${i}`)),
+      todo('x', 'in_progress', 'now'),
+    ]
+    const text = renderStatusTasks(todos)
+    expect((text.match(/☑/g) ?? []).length).toBe(2)
+    expect(text).toContain('☑ d2')
+    expect(text).toContain('☑ d3')
+    expect(text).toContain('<i>+2 завершено ранее</i>')
+  })
+})
+
+describe('renderHud work view', () => {
+  test('permissionMode plan → «режим: план»; other → «выполнение»; absent → no line', () => {
+    const plan = renderHud({ usedTokens: 0 }, WINDOW, 'm', { todos: [], permissionMode: 'plan' })
+    expect(plan.text).toContain('<i>режим: план</i>')
+    const exec = renderHud({ usedTokens: 0 }, WINDOW, 'm', { todos: [], permissionMode: 'acceptEdits' })
+    expect(exec.text).toContain('<i>режим: выполнение</i>')
+    const none = renderHud({ usedTokens: 0 }, WINDOW, 'm', { todos: [] })
+    expect(none.text).not.toContain('режим:')
+  })
+
+  test('todos append a «Задачи» section; empty todos omit it', () => {
+    const withTasks = renderHud({ usedTokens: 0 }, WINDOW, undefined, {
+      todos: [todo('1', 'in_progress', 'работаю')],
+    })
+    expect(withTasks.text).toContain('\n\n<b>Задачи</b>')
+    expect(withTasks.text).toContain('◐ работаю')
+    const without = renderHud({ usedTokens: 0 }, WINDOW)
+    expect(without.text).not.toContain('Задачи')
+  })
+})
+
+describe('ContextHud bump', () => {
+  test('existing message: delete old → send fresh → pin; persisted id updated', async () => {
+    const api = new FakeApi()
+    const dir = stateDir()
+    const hud = makeHud(api, { dir })
+    await hud.onSessionStart(OWNER)
+    const oldId = api.sent[0]!.message_id
+
+    await hud.bump(OWNER)
+    expect(api.deleted).toEqual([{ chatId: OWNER, messageId: oldId }])
+    expect(api.unpinned.length).toBe(0)
+    expect(api.sent.length).toBe(2)
+    const newId = api.sent[1]!.message_id
+    expect(newId).not.toBe(oldId)
+    expect(api.pinned.map((p) => p.messageId)).toContain(newId)
+    const persisted = JSON.parse(
+      readFileSync(join(dir, `context-hud-${OWNER}.json`), 'utf8'),
+    ) as { message_id: number }
+    expect(persisted.message_id).toBe(newId)
+  })
+
+  test('delete refused (older than 48h) → unpin fallback, fresh message still sent', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.onSessionStart(OWNER)
+    const oldId = api.sent[0]!.message_id
+    api.deleteError = new Error('400: message can\'t be deleted')
+
+    await hud.bump(OWNER)
+    expect(api.unpinned).toEqual([{ chatId: OWNER, messageId: oldId }])
+    expect(api.sent.length).toBe(2)
+  })
+
+  test('debounce: a second bump within the window is a no-op', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.onSessionStart(OWNER)
+    await hud.bump(OWNER)
+    await hud.bump(OWNER)
+    expect(api.deleted.length).toBe(1)
+    expect(api.sent.length).toBe(2)
+  })
+
+  test('no prior message → just sends + pins (no delete/unpin)', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.bump(OWNER)
+    expect(api.deleted.length).toBe(0)
+    expect(api.unpinned.length).toBe(0)
+    expect(api.sent.length).toBe(1)
+    expect(api.pinned.length).toBe(1)
+  })
+
+  test('non-owner chat → complete no-op', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.bump('-1001234567890')
+    await hud.bump('99999')
+    expect(api.sent.length).toBe(0)
+  })
+})
+
+describe('ContextHud onTodoEvent', () => {
+  test('todo_write refreshes the card with a tasks section', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.onSessionStart(OWNER)
+
+    const event: TaskMirrorEvent = {
+      kind: 'todo_write',
+      todos: [todo('1', 'in_progress', 'шаг один'), todo('2', 'pending', 'шаг два')],
+    }
+    await hud.onTodoEvent(OWNER, event)
+    const last = api.edited[api.edited.length - 1]!
+    expect(last.text).toContain('<b>Задачи</b>')
+    expect(last.text).toContain('◐ шаг один')
+    expect(last.text).toContain('◻ шаг два')
+    expect(last.text).toContain('0/2')
+  })
+
+  test('task_create + task_update accumulate; todo_session_stop keeps the view', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.onSessionStart(OWNER)
+
+    await hud.onTodoEvent(OWNER, {
+      kind: 'task_create',
+      toolUseId: 'tu1',
+      input: { subject: 'собрать фичу' },
+      toolResult: 'Task #7 created successfully',
+    })
+    await hud.onTodoEvent(OWNER, {
+      kind: 'task_update',
+      toolUseId: 'tu2',
+      input: { taskId: '7', status: 'completed' },
+    })
+    let last = api.edited[api.edited.length - 1]!
+    expect(last.text).toContain('☑ собрать фичу')
+    expect(last.text).toContain('1/1')
+
+    const editsBefore = api.edited.length
+    await hud.onTodoEvent(OWNER, { kind: 'todo_session_stop' })
+    expect(api.edited.length).toBe(editsBefore) // stop never clears/re-renders
+    // A later refresh still carries the last snapshot.
+    await hud.updateNow(OWNER)
+    last = api.edited[api.edited.length - 1] ?? last
+    expect(last.text).toContain('☑ собрать фичу')
   })
 })

--- a/plugin/tests/status/context-hud.test.ts
+++ b/plugin/tests/status/context-hud.test.ts
@@ -691,6 +691,22 @@ describe('ContextHud bump', () => {
     expect(api.sent.length).toBe(2)
   })
 
+  test('delete AND unpin both fail → bump aborts, old card kept (one-pin invariant)', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.onSessionStart(OWNER)
+    const oldId = api.sent[0]!.message_id
+    api.deleteError = new Error('400: message can\'t be deleted')
+    api.unpinError = new Error('network')
+
+    await hud.bump(OWNER)
+    expect(api.sent.length).toBe(1) // NO replacement sent — two pins impossible
+    // The old id survives: a later refresh edits the SAME card.
+    await hud.updateNow(OWNER)
+    const lastEdit = api.edited[api.edited.length - 1]!
+    expect(lastEdit.messageId).toBe(oldId)
+  })
+
   test('debounce: a second bump within the window is a no-op', async () => {
     const api = new FakeApi()
     const hud = makeHud(api)

--- a/plugin/tests/status/context-hud.test.ts
+++ b/plugin/tests/status/context-hud.test.ts
@@ -637,6 +637,23 @@ describe('renderStatusTasks', () => {
   })
 })
 
+describe('renderStatusTasks budget', () => {
+  test('total budget: a flood of long in-progress items stays bounded', () => {
+    const todos = Array.from({ length: 40 }, (_, i) =>
+      todo(String(i), 'in_progress', `<${'очень длинная задача с разметкой & сущностями '.repeat(2)}${i}>`))
+    const text = renderStatusTasks(todos)
+    expect(text.length).toBeLessThan(1700)
+    expect(text).toContain('строк скрыто')
+  })
+
+  test('truncation never splits a surrogate pair', () => {
+    const raw = '𝕏'.repeat(100) // astral-plane chars (2 UTF-16 units each)
+    const text = renderStatusTasks([todo('1', 'pending', raw)])
+    expect(text).not.toContain('\uFFFD')
+    expect(text).toContain('…')
+  })
+})
+
 describe('renderHud work view', () => {
   test('permissionMode plan → «режим: план»; other → «выполнение»; absent → no line', () => {
     const plan = renderHud({ usedTokens: 0 }, WINDOW, 'm', { todos: [], permissionMode: 'plan' })

--- a/plugin/tests/webhook/server.test.ts
+++ b/plugin/tests/webhook/server.test.ts
@@ -1044,3 +1044,66 @@ describe('POST /hooks/agent — memoryWriter branch (Phase 8 T7)', () => {
     expect(mcp.calls.length).toBe(1)
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────
+// Status pin (2026-07-04): permission_mode capture + HUD todo dispatch
+// ─────────────────────────────────────────────────────────────────────
+
+describe('POST /hooks/agent — status-pin wiring', () => {
+  test('permission_mode is recorded; TodoWrite reaches contextHud.onTodoEvent', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const mcp = makeMcpStub()
+    const recorded: Array<{ chatId: string | undefined; info: Record<string, unknown> }> = []
+    const todoEvents: Array<{ chatId: string; event: { kind: string } }> = []
+    const h = await startWebhookServer(enabledConfig(), {
+      mcpServer: mcp.server,
+      config: enabledConfig(),
+      statePaths: paths,
+      log: createLogger('test'),
+      sessionInfo: {
+        record: (chatId, info) => {
+          recorded.push({ chatId, info: info as Record<string, unknown> })
+        },
+      },
+      contextHud: {
+        onSessionStart: () => {},
+        onStop: () => {},
+        onTodoEvent: (chatId, event) => {
+          todoEvents.push({ chatId, event })
+        },
+      },
+    })
+    if (!h) throw new Error('expected handle')
+    handle = h
+
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        chatId: 164795011,
+        hook_event_name: 'PostToolUse',
+        session_id: 's1',
+        transcript_path: '/tmp/t.jsonl',
+        cwd: '/tmp',
+        permission_mode: 'plan',
+        tool_name: 'TodoWrite',
+        tool_use_id: 'u1',
+        tool_input: {
+          todos: [{ content: 'шаг', status: 'in_progress', activeForm: 'делаю шаг' }],
+        },
+        tool_result: 'ok',
+      }),
+    })
+    expect(resp.status).toBe(200)
+    expect(recorded.length).toBe(1)
+    expect(recorded[0]!.info.permissionMode).toBe('plan')
+    // fire-and-forget dispatch — give the microtask queue one tick
+    await new Promise((r) => setTimeout(r, 10))
+    expect(todoEvents.length).toBe(1)
+    expect(todoEvents[0]!.chatId).toBe('164795011')
+    expect(todoEvents[0]!.event.kind).toBe('todo_write')
+  })
+})

--- a/plugin/tests/webhook/server.test.ts
+++ b/plugin/tests/webhook/server.test.ts
@@ -1050,6 +1050,55 @@ describe('POST /hooks/agent — memoryWriter branch (Phase 8 T7)', () => {
 // ─────────────────────────────────────────────────────────────────────
 
 describe('POST /hooks/agent — status-pin wiring', () => {
+  test('a synchronously-throwing HUD never breaks the 200 path', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const mcp = makeMcpStub()
+    const h = await startWebhookServer(enabledConfig(), {
+      mcpServer: mcp.server,
+      config: enabledConfig(),
+      statePaths: paths,
+      log: createLogger('test'),
+      contextHud: {
+        onSessionStart: () => {
+          throw new Error('sync boom')
+        },
+        onStop: () => {
+          throw new Error('sync boom')
+        },
+        onTodoEvent: () => {
+          throw new Error('sync boom')
+        },
+      },
+    })
+    if (!h) throw new Error('expected handle')
+    handle = h
+
+    for (const body of [
+      { hook_event_name: 'SessionStart', model: 'fable', source: 'startup' },
+      {
+        hook_event_name: 'PostToolUse', tool_name: 'TodoWrite', tool_use_id: 'u1',
+        tool_input: { todos: [{ content: 'x', status: 'pending' }] }, tool_result: 'ok',
+      },
+      { hook_event_name: 'Stop' },
+    ]) {
+      const resp = await fetch(url(h, '/hooks/agent'), {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${WEBHOOK_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          chatId: 164795011,
+          session_id: 's1',
+          transcript_path: '/tmp/t.jsonl',
+          cwd: '/tmp',
+          ...body,
+        }),
+      })
+      expect(resp.status).toBe(200)
+    }
+  })
+
   test('permission_mode is recorded; TodoWrite reaches contextHud.onTodoEvent', async () => {
     process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
     const mcp = makeMcpStub()


### PR DESCRIPTION
## Что это
По директиве принца (2026-07-04): закреплённое сообщение всегда ровно ОДНО (актуальное) и живёт внизу чата над tmux mirror, не улетая в историю.

## Как работает
- **Одна карточка «Статус»** = контекст-бар (▰▱ % окна) + <i>режим: план/выполнение</i> (permission_mode из хуков) + секция «Задачи» (бар done/total + ◐/◻/☑) из тех же TodoWrite/TaskCreate/TaskUpdate событий, что у TaskMirror (общие pure-хелперы applyTask*ToMap).
- **bump()**: на каждое входящее сообщение владельца старая карточка удаляется (delete снимает пин автоматически; unpin-фолбэк для >48ч; при провале ОБОИХ — отмена замены, инвариант одного пина важнее позиции) и свежая отправляется+закрепляется НАД зеркалом (hud bump строго перед mirror bump). Дебаунс 1500мс, сериализация на чат, всё best-effort.
- Сервисные пузыри «закрепил сообщение» от собственных пинов бота удаляются сразу (ручные пины принца не трогаются).
- Между сообщениями принца — edit на месте, без перезакрепов.

## Dual review (Codex GPT-5.5 + Fable 5) — применено
- HIGH: двойной провал delete+unpin → отмена замены (не два пина)
- HIGH: sync-throw изоляция HUD-диспатча в webhook (fireHud)
- HIGH: чистка сервисных «закрепил» (иначе пузырь на каждый bump)
- MED: persisted id чистится сразу после успешного delete
- LOW: общий бюджет секции задач 1500 (не пробиваем 4096), обрезка по code points

## Тесты
1808 pass / 2 fail — оба падения pre-existing на main (tests/chats/hooks-sentinel). Новые: renderStatusTasks (бар/капы/бюджет/суррогаты), renderHud(work), bump (замена/48ч-фолбэк/двойной провал/дебаунс/не-владелец), onTodoEvent (todo_write/incremental/stop), webhook (permission_mode запись, доставка в HUD, sync-throw → 200). typecheck clean.

## Деплой
После merge: task_mirror.enabled=false в live-конфиге (карточка заменяет отдельное сообщение «Задачи»), рестарт channel-silvana (разрешение принца получено).

🤖 Generated with [Claude Code](https://claude.com/claude-code)