### PR TITLE
HUD: убрать кнопку «Новый диалог» с закреплённой карточки

### DIFF
--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -331,9 +331,9 @@ export const AppConfigSchema = z.object({
     allowed_user_ids: z.array(z.number().int().positive()).optional(),
   }).optional(),
   // Context HUD (wave 3B) — a single pinned Telegram message in the owner's
-  // chat that shows context-window usage (bar + percentage) plus two action
-  // buttons (Сжать / Новый диалог), refreshed after each turn (SessionStart /
-  // Stop hooks). Default ON.
+  // chat that shows context-window usage (bar + percentage) plus the «Сжать»
+  // action button, refreshed after each turn (SessionStart / Stop hooks).
+  // Default ON.
   //
   // The whole block is OPTIONAL (no `.default({})`) so `hud` reads as
   // `hud?: { enabled: boolean }` on the inferred type — existing full-config

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -503,8 +503,8 @@ const sessionInfoStore = new SessionInfoStore()
 // message delivery.
 // FIX-8 (both reviews): owner chats come from resolveOwnerChatIds (owner_chat_ids
 // / allowed_user_ids = positive DM ids), NEVER allowed_chat_ids — which in
-// multichat also lists group ids. A HUD with destructive buttons must never be
-// pinned in a public group, and its control callbacks drive the single global
+// multichat also lists group ids. A HUD with session-driving controls must
+// never be pinned in a public group, and its callbacks drive the single global
 // DM pane.
 const hudOwnerChatIds: ReadonlyArray<number | string> = resolveOwnerChatIds(config)
 const hudApi: HudTelegramApi = {
@@ -910,7 +910,8 @@ bot.on('callback_query:data', async ctx => {
     }
     return
   }
-  // Context HUD panel (hud:*) — the two buttons on the pinned HUD message.
+  // Context HUD panel (hud:*) — callbacks of the pinned HUD message («Сжать»
+  // plus legacy hud:new from stale pre-removal markup).
   // Same fail-closed allowlist auth as kkey:/ccmd:/newq: (config
   // .allowed_user_ids). `hud:compact` drives the reliable /compact injection;
   // `hud:new` posts the SAME /new confirm card whose newq:* buttons the branch

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -489,7 +489,7 @@ const statusManager = new StatusManager({
 const sessionInfoStore = new SessionInfoStore()
 
 // Context HUD (wave 3B) — the single pinned Telegram message in the owner's
-// chat showing context-window usage + Сжать / Новый диалог buttons. Driven by
+// chat showing context-window usage + the «Сжать» button. Driven by
 // the SessionStart / Stop hooks (wired through the webhook deps below) and the
 // `hud:` callback branch further down. Owner chats: allowed_chat_ids, falling
 // back to allowed_user_ids (in a DM the chat id equals the user id). The HUD

--- a/plugin/src/status/context-hud.ts
+++ b/plugin/src/status/context-hud.ts
@@ -1,7 +1,7 @@
 // Context HUD (wave 3B) — a single PINNED Telegram message in the owner's chat
 // that shows how full the model's context window is (a 10-segment unicode bar +
-// percentage) plus two action buttons: «Сжать» (/compact) and «Новый диалог»
-// (confirm-then-/clear). It is the KAI-style always-visible indicator, refreshed
+// percentage) plus one action button: «Сжать» (/compact). It is the
+// KAI-style always-visible indicator, refreshed
 // after every turn from the SessionStart / Stop hook events — there are NO
 // timers or polling; the HUD only moves when a hook fires.
 //
@@ -58,11 +58,14 @@ function escapeHtml(s: string): string {
 
 // Build the HUD's inline keyboard. Static (never changes) so the edit path can
 // re-send the same markup on every refresh and let Telegram no-op it.
+// «Новый диалог» removed per prince directive 2026-07-04 — clearing context is
+// too destructive for a one-tap pinned button; /new stays as the command path.
+// The hud:new callback handler is kept so a stale pinned card (pre-removal
+// markup) still resolves to the confirm flow instead of a dead tap.
 export function buildHudKeyboard(): InlineKeyboardLike {
   return {
     inline_keyboard: [
       [{ text: '🗜 Сжать', callback_data: `${HUD_PREFIX}compact` }],
-      [{ text: '🧹 Новый диалог', callback_data: `${HUD_PREFIX}new` }],
     ],
   }
 }

--- a/plugin/src/status/context-hud.ts
+++ b/plugin/src/status/context-hud.ts
@@ -32,7 +32,8 @@ import type { TodoItem } from '../schemas.js'
 import type { EditOpts, InlineKeyboardLike, SendMessageOpts } from '../channel/tools.js'
 import type { Logger } from '../log.js'
 
-// The callback prefix for the HUD's two buttons. Distinct from kkey:/ccmd:/
+// The callback prefix for the HUD's callbacks (compact button + legacy new
+// from stale pre-removal markup). Distinct from kkey:/ccmd:/
 // newq:/pgate:/ask: by construction so it never collides in the shared
 // bot.on('callback_query:data') router.
 export const HUD_PREFIX = 'hud:'
@@ -662,7 +663,8 @@ export class ContextHud {
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Callback handler for the HUD's two buttons (hud:compact / hud:new).
+// Callback handler for the HUD's callbacks (hud:compact — the card's only
+// button — plus legacy hud:new from stale pre-removal markup).
 //
 // Fail-closed auth FIRST (config.allowed_user_ids — the SAME allowlist that
 // guards every other session-driving control), then parse, then act:

--- a/plugin/tests/status/context-hud.test.ts
+++ b/plugin/tests/status/context-hud.test.ts
@@ -212,15 +212,16 @@ describe('renderHud', () => {
     expect(escaped).toContain('<i>a&lt;b&gt;&amp;c</i>')
   })
 
-  test('keyboard shape: Сжать / Новый диалог with hud: callbacks', () => {
+  test('keyboard shape: single Сжать row, no Новый диалог button', () => {
     const { keyboard } = renderHud({ usedTokens: 0 }, WINDOW)
     expect(keyboard).toEqual(buildHudKeyboard())
     const rows = keyboard.inline_keyboard
-    expect(rows.length).toBe(2)
+    expect(rows.length).toBe(1)
     expect(rows[0]![0]!.callback_data).toBe(`${HUD_PREFIX}compact`)
-    expect(rows[1]![0]!.callback_data).toBe(`${HUD_PREFIX}new`)
     expect(rows[0]![0]!.text).toContain('Сжать')
-    expect(rows[1]![0]!.text).toContain('Новый диалог')
+    const flat = JSON.stringify(keyboard)
+    expect(flat).not.toContain('Новый диалог')
+    expect(flat).not.toContain(`${HUD_PREFIX}new`)
   })
 })
 

--- a/plugin/tests/status/context-hud.test.ts
+++ b/plugin/tests/status/context-hud.test.ts
@@ -217,6 +217,7 @@ describe('renderHud', () => {
     expect(keyboard).toEqual(buildHudKeyboard())
     const rows = keyboard.inline_keyboard
     expect(rows.length).toBe(1)
+    expect(rows[0]).toHaveLength(1)
     expect(rows[0]![0]!.callback_data).toBe(`${HUD_PREFIX}compact`)
     expect(rows[0]![0]!.text).toContain('Сжать')
     const flat = JSON.stringify(keyboard)


### PR DESCRIPTION
## Что

С закреплённой статус-карточки (context HUD) убрана кнопка «Новый диалог». Остаётся одна кнопка «Сжать». Директива принца 2026-07-04: «Кнопка новый диалог осталась».

## Почему

Очистка контекста — разрушительное действие, ему не место в one-tap кнопке на постоянном закрепе. Путь через команду `/new` (с карточкой подтверждения) сохраняется.

## Как

- `buildHudKeyboard()`: убран ряд `hud:new`, остался `hud:compact`
- Обработчик `hud:new` в `handleHudCallback` СОХРАНЁН: устаревший закреп со старой клавиатурой продолжает вести в confirm-flow, а не в мёртвый тап
- Комментарии про «две кнопки» обновлены (config.ts, server.ts, заголовок context-hud.ts)
- Тест формы клавиатуры переписан: один ряд, отсутствие «Новый диалог»/`hud:new` в markup

## Проверка

- `tsc --noEmit` чисто
- `bun test` — 1852 pass; 2 fail в `tests/chats/hooks-sentinel.test.ts` pre-existing (падают на чистом main, к диффу отношения не имеют)
- HUD-тесты: 45/45

🤖 Generated with [Claude Code](https://claude.com/claude-code)