### PR TITLE
Версионирование плагина: v1.1.0, manifest, CHANGELOG, процесс релизов

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "dashi-channel",
+  "displayName": "Dashi Channel — Telegram bridge for Claude Code",
+  "version": "1.1.0",
+  "description": "Telegram channel plugin for Claude Code: personal DM bridge + public multichat, permission relay, confirm-panel keys, context HUD with a single pinned status card, rich messages (Bot API 10.1), Guest Mode, voice transcription, terminal mirror, secret redaction.",
+  "author": { "name": "qwwiwi" },
+  "repository": "https://github.com/qwwiwi/dashi-plugin-claude-code",
+  "license": "Apache-2.0",
+  "keywords": ["telegram", "channel", "mcp", "bridge", "bot"]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to the dashi-channel plugin are documented here.
+
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning:
+[Semantic Versioning](https://semver.org). The single source of truth for the
+current version is `.claude-plugin/plugin.json`; `plugin/package.json` is kept
+in lockstep (enforced by `plugin/tests/version-sync.test.ts`), and the MCP
+server identity reads `package.json` at runtime. Release process:
+`docs/RELEASING.md`.
+
+Versions before 1.0.0 were not tracked — the project shipped ~60 merged PRs
+between 2026-05-14 and 2026-06-14 without a version discipline. 1.0.0
+retroactively marks the state of `main` on 2026-06-14.
+
+## [1.1.0] — 2026-07-04
+
+### Added
+- **Rich messages** (PR #86): DM replies auto-upgrade to Telegram Bot API 10.1
+  `sendRichMessage` — raw markdown rendered server-side (tables, headings,
+  task-lists, math, `<details>`, footnotes), 32 KB in a single message.
+  Transparent HTML fallback, session capability latch, killswitch
+  `TELEGRAM_RICH_MESSAGES=0`, per-chat opt-out.
+- **Guest Mode** (PR #96): one-shot @-mention answers in chats the bot is not
+  a member of, via `answerGuestQuery`; fail-closed allowlist gate on the
+  caller's user id.
+- **Context HUD + state-aware controls** (PR #94): pinned context-% HUD,
+  reliable `/compact`, `/new`, `/status` driven through the TUI, owner-scoped
+  command menu, AskUserQuestion relayed as Telegram inline buttons.
+- **Single pinned status card** (PR #95): one pinned message combining
+  context %, mode, and task list, re-anchored above the tmux mirror on every
+  inbound message; service bubbles auto-deleted.
+
+### Fixed
+- HUD dialog no longer renders a stray second button row (PR #97).
+
+## [1.0.0] — 2026-06-14
+
+Retroactive baseline — first stable state, in production for the whole agent
+fleet (silvana, kaelthas, garrosh, arthas). Highlights accumulated since
+2026-05-14:
+
+- Telegram DM bridge: inbound injection into a tmux-hosted Claude Code
+  session, `reply`/`edit_message`/`react`/`download_attachment` MCP tools.
+- Multichat: public group/supergroup sessions with an outbox delivery path.
+- Permission gate + relay: sensitive tool calls confirmed via Telegram.
+- Confirm-panel keys (PRs #79–#84): one-tap button keypad for native TUI
+  dialogs, OOB slash commands, backspace/passthrough handling.
+- Terminal mirror, voice-message transcription, photo/document intake.
+- Secret redaction on every outbound path; bot-token scrubbing.
+- `doctor` self-diagnostics (fleet checks, bridge checks, socket checks).
+- Session auto-restart watchdog.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,81 @@
+# Releasing — version discipline for dashi-channel
+
+How plugin versions work in this repo and the exact steps to cut a release.
+
+## Where the version lives (official Claude Code semantics)
+
+Claude Code resolves a plugin's version in this order (first match wins):
+
+1. `version` in `.claude-plugin/plugin.json` — **our source of truth**
+2. `version` in a marketplace entry (we don't set one)
+3. Git commit SHA (only when neither declares a version)
+
+Consequences:
+
+- `/plugin update` is a no-op until the `plugin.json` version is bumped —
+  pushing commits alone does NOT update marketplace installs.
+- Git tags are **not** read by Claude Code; we tag purely for humans and
+  `gh release`.
+- Our fleet runs the plugin as a development channel
+  (`claude --dangerously-load-development-channels server:dashi-channel`
+  with the launchd working dir at `plugin/`), so live agents pick up code on
+  session restart regardless of the version field. The version is still
+  meaningful: MCP identity, diagnostics, changelog anchoring, and any future
+  marketplace distribution.
+
+## The three declaration sites (must never drift)
+
+| Site | Role | Sync mechanism |
+|---|---|---|
+| `.claude-plugin/plugin.json` | Claude Code plugin version (source of truth) | bumped by hand |
+| `plugin/package.json` | Bun package version | bumped by hand, equality enforced by `plugin/tests/version-sync.test.ts` |
+| `Server(...)` identity in `plugin/src/server.ts` | MCP protocol identity | imports `pkg.version` from package.json — never hardcode |
+
+## Semver rules for this plugin
+
+- **MAJOR** — breaking changes for operators or agents: renamed/removed env
+  vars or config keys, changed MCP tool names/schemas, changed state-file
+  formats without migration, changed launchd/tmux contract.
+- **MINOR** — new features, new MCP tools/commands, new config options with
+  safe defaults (rich messages, guest mode, HUD are all MINOR-class).
+- **PATCH** — bug fixes, false-positive gate fixes, docs, dependency bumps
+  with no behavior change.
+
+One release may bundle several merged PRs; the highest-class change decides
+the bump.
+
+## Release steps
+
+1. Branch `chore/release-vX.Y.Z` (or bump as part of the feature PR when the
+   release is a single PR).
+2. Bump `version` in **both** `.claude-plugin/plugin.json` and
+   `plugin/package.json`.
+3. Add a `## [X.Y.Z] — YYYY-MM-DD` section at the top of `CHANGELOG.md`
+   (Keep a Changelog: Added / Changed / Fixed / Removed; reference PR
+   numbers).
+4. Verify from `plugin/`:
+   ```bash
+   bun test            # includes tests/version-sync.test.ts
+   bun run typecheck
+   ```
+   and from the repo root:
+   ```bash
+   claude plugin validate .
+   ```
+5. Double review (Codex + second-family model) — required before any commit
+   in this repo.
+6. PR to `main`, merge.
+7. Tag and publish the release from the merge commit:
+   ```bash
+   git tag vX.Y.Z && git push origin vX.Y.Z
+   gh release create vX.Y.Z --title "vX.Y.Z" --notes "<changelog section>"
+   ```
+8. Fleet rollout (when the change should go live): restart the affected
+   channel sessions — the dev-channel path loads code from the working tree,
+   not from the version field.
+
+## History note
+
+Versions before 1.0.0 were not tracked (2026-05-14 → 2026-06-14, ~60 merged
+PRs). 1.0.0 is a retroactive baseline pinned to the 2026-06-14 state of
+`main`; 1.1.0 is the first release cut under this process.

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashi-channel",
-  "version": "0.0.1",
+  "version": "1.1.0",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -20,6 +20,8 @@ import { execSync } from 'child_process'
 import { homedir } from 'os'
 import { isAbsolute, join, resolve as resolvePath } from 'path'
 
+import pkg from '../package.json'
+
 import {
   RuntimeEnvSchema,
   getStatePaths,
@@ -452,7 +454,9 @@ const richLatch = createRichLatch()
 const telegramApi = createSafeTelegramApi(rateLimitedTelegramApi, log, apiSecrets, richLatch)
 
 const mcp = new Server(
-  { name: 'dashi-channel', version: '1.0.0' },
+  // Single version source: package.json (kept in lockstep with the repo-root
+  // .claude-plugin/plugin.json by tests/version-sync.test.ts).
+  { name: 'dashi-channel', version: pkg.version },
   {
     capabilities: {
       tools: {},

--- a/plugin/tests/version-sync.test.ts
+++ b/plugin/tests/version-sync.test.ts
@@ -1,0 +1,47 @@
+// Version discipline: the plugin has exactly one user-facing version and it
+// must be identical everywhere it is declared. Claude Code resolves the
+// plugin version from the repo-root .claude-plugin/plugin.json (and `/plugin
+// update` only fires on a bump there), while the MCP server identity in
+// src/server.ts reads plugin/package.json. A drift between the two would ship
+// a plugin that reports one version to Claude Code and another over MCP.
+import { describe, expect, test } from 'bun:test'
+import { join } from 'path'
+
+const PLUGIN_DIR = join(import.meta.dir, '..')
+const REPO_ROOT = join(PLUGIN_DIR, '..')
+
+// Strict semver core: MAJOR.MINOR.PATCH, no leading zeros, no pre-release —
+// releases of this plugin are always plain stable versions.
+const SEMVER_CORE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/
+
+async function readJson(path: string): Promise<Record<string, unknown>> {
+  const raw = await Bun.file(path).text()
+  return JSON.parse(raw) as Record<string, unknown>
+}
+
+describe('version sync', () => {
+  test('plugin.json and package.json declare the same semver version', async () => {
+    const manifest = await readJson(join(REPO_ROOT, '.claude-plugin', 'plugin.json'))
+    const pkg = await readJson(join(PLUGIN_DIR, 'package.json'))
+
+    expect(typeof manifest.version).toBe('string')
+    expect(typeof pkg.version).toBe('string')
+    expect(manifest.version as string).toMatch(SEMVER_CORE)
+    expect(pkg.version).toBe(manifest.version)
+  })
+
+  test('manifest name matches the package name', async () => {
+    const manifest = await readJson(join(REPO_ROOT, '.claude-plugin', 'plugin.json'))
+    const pkg = await readJson(join(PLUGIN_DIR, 'package.json'))
+    expect(manifest.name).toBe('dashi-channel')
+    expect(pkg.name).toBe(manifest.name)
+  })
+
+  test('server identity has no hardcoded version literal', async () => {
+    // The MCP Server(...) identity must read pkg.version, not a string —
+    // that is what keeps the third declaration site from drifting.
+    const src = await Bun.file(join(PLUGIN_DIR, 'src', 'server.ts')).text()
+    expect(src).toMatch(/version:\s*pkg\.version/)
+    expect(src).not.toMatch(/name: 'dashi-channel',\s*version:\s*'/)
+  })
+})


### PR DESCRIPTION
## Что

Вводит дисциплину версий для dashi-channel (до этого: package.json `0.0.1`, MCP-identity `1.0.0` хардкодом, 0 тегов, 0 CHANGELOG на ~97 PR).

- `.claude-plugin/plugin.json` — официальный манифест Claude Code, версия **1.1.0** (source of truth; `/plugin update` реагирует только на bump этого поля). `claude plugin validate --strict` пройден.
- `plugin/package.json` → 1.1.0; identity в `server.ts` теперь `pkg.version` — один источник.
- `plugin/tests/version-sync.test.ts` — равенство manifest ↔ package.json, semver-формат, отсутствие хардкода в identity.
- `CHANGELOG.md` (Keep a Changelog): 1.1.0 — rich messages #86, Guest Mode #96, context HUD #94, статус-пин #95, фикс #97; 1.0.0 — ретро-базлайн состояния main на 2026-06-14.
- `docs/RELEASING.md` — semver-правила для этого плагина и пошаговый процесс релиза (bump → CHANGELOG → тесты/validate → двойное ревью → PR → тег + gh release).

## Проверки

- `bun test` — version-sync 3/3; полный сьют 1903 pass, 2 fail в `hooks-sentinel` **воспроизводятся на чистом main** (pre-existing, не из этого PR)
- `bun run typecheck` — чисто
- `claude plugin validate . --strict` — passed
- `bun build src/server.ts` — JSON-импорт резолвится; Codex прогнал `bun run src/server.ts --help` — дошло до pid-lock, рантайм цел

## Ревью

Двойное: Codex GPT-5.5 (2 minor: хрупкость теста, число PR — оба закрыты в этом же PR) + Fable 5 (нашла те же пункты, исправлено).

После мержа: тег `v1.1.0` + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)