### PR TITLE
Пин: expandable-список задач + сброс снапшота при старте сессии

### DIFF
--- a/plugin/src/safety/html-validator.ts
+++ b/plugin/src/safety/html-validator.ts
@@ -67,7 +67,10 @@ const TAG_ATTR_ALLOWLIST: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ['code', new Set(['class'])],
   ['pre', new Set<string>()],
   ['tg-spoiler', new Set<string>()],
-  ['blockquote', new Set<string>()],
+  // `expandable` is Telegram's collapsible-quote flag (Bot API 7.9+); it is a
+  // valueless boolean attribute, not a styling/URL vector, so whitelisting it
+  // on the already-allowed <blockquote> does not widen the XSS surface.
+  ['blockquote', new Set(['expandable'])],
   ['b', new Set<string>()],
   ['strong', new Set<string>()],
   ['i', new Set<string>()],

--- a/plugin/src/status/context-hud.ts
+++ b/plugin/src/status/context-hud.ts
@@ -124,33 +124,40 @@ export function renderStatusTasks(todos: ReadonlyArray<TodoItem>): string {
   const filled = Math.max(0, Math.min(BAR_SEGMENTS, Math.round((done / total) * BAR_SEGMENTS)))
   const bar = BAR_FILLED.repeat(filled) + BAR_EMPTY.repeat(BAR_SEGMENTS - filled)
 
-  const lines: string[] = [`<b>Задачи</b> ${bar} ${done}/${total}`]
-  for (const t of inProgress) lines.push(taskLine(t))
-  for (const t of pending.slice(0, TASKS_MAX_PENDING)) lines.push(taskLine(t))
+  // The header (bar + count) stays OUTSIDE the collapsible quote so progress is
+  // always visible when collapsed; the per-task detail goes INSIDE an
+  // <blockquote expandable>, so the pin reads «progress — tap to expand the list».
+  const header = `<b>Задачи</b> ${bar} ${done}/${total}`
+
+  const detail: string[] = []
+  for (const t of inProgress) detail.push(taskLine(t))
+  for (const t of pending.slice(0, TASKS_MAX_PENDING)) detail.push(taskLine(t))
   if (pending.length > TASKS_MAX_PENDING) {
-    lines.push(`<i>+${pending.length - TASKS_MAX_PENDING} ещё…</i>`)
+    detail.push(`<i>+${pending.length - TASKS_MAX_PENDING} ещё…</i>`)
   }
   const visibleDone = completed.slice(-TASKS_MAX_DONE)
   const hiddenDone = completed.length - visibleDone.length
-  if (hiddenDone > 0) lines.push(`<i>+${hiddenDone} завершено ранее</i>`)
-  for (const t of visibleDone) lines.push(taskLine(t))
+  if (hiddenDone > 0) detail.push(`<i>+${hiddenDone} завершено ранее</i>`)
+  for (const t of visibleDone) detail.push(taskLine(t))
 
   // Total-budget pass: the per-category caps bound pending/completed but not
-  // in-progress, and escaping expands after the per-line cut. Keep the header
-  // always; drop overflowing lines and mark the cut with a tail.
+  // in-progress, and escaping expands after the per-line cut. The header is
+  // always kept (counted first); drop overflowing detail lines, mark the cut.
   const out: string[] = []
-  let used = 0
+  let used = header.length
   let dropped = 0
-  for (const line of lines) {
-    if (out.length === 0 || used + 1 + line.length <= TASKS_MAX_CHARS) {
+  for (const line of detail) {
+    if (used + 1 + line.length <= TASKS_MAX_CHARS) {
       out.push(line)
-      used += (out.length === 1 ? 0 : 1) + line.length
+      used += 1 + line.length
     } else {
       dropped++
     }
   }
   if (dropped > 0) out.push(`<i>+${dropped} строк скрыто</i>`)
-  return out.join('\n')
+
+  if (out.length === 0) return header
+  return `${header}\n<blockquote expandable>${out.join('\n')}</blockquote>`
 }
 
 // «план» is the only mode worth naming; every other Claude Code permission
@@ -341,6 +348,11 @@ export class ContextHud {
     if (!this.enabled || !this.isOwner(chatId)) return Promise.resolve()
     return this.runSerialized(chatId, async () => {
       try {
+        // A new session starts with a clean task list: drop any snapshot left
+        // over from a prior session so the pin never shows stale milestones
+        // (renderStatusTasks returns '' for an empty list → the section is
+        // omitted until the agent emits fresh TodoWrite/TaskCreate events).
+        this.work.delete(chatId)
         const { text, keyboard } = await this.renderCurrent(chatId)
         const ensured = await this.ensureMessage(chatId, text, keyboard)
         if (ensured === undefined) return

--- a/plugin/tests/safety/html-validator.test.ts
+++ b/plugin/tests/safety/html-validator.test.ts
@@ -57,6 +57,11 @@ describe('validateTelegramHtml — valid passes', () => {
     const r = validateTelegramHtml('<blockquote>quote</blockquote>')
     expect(r.downgraded).toBe(false)
   })
+
+  test('passes <blockquote expandable> (collapsible-quote attribute)', () => {
+    const r = validateTelegramHtml('<blockquote expandable>quote</blockquote>')
+    expect(r.downgraded).toBe(false)
+  })
 })
 
 describe('validateTelegramHtml — invalid downgrades', () => {

--- a/plugin/tests/status/context-hud.test.ts
+++ b/plugin/tests/status/context-hud.test.ts
@@ -637,6 +637,24 @@ describe('renderStatusTasks', () => {
     expect(text).toContain('☑ d3')
     expect(text).toContain('<i>+2 завершено ранее</i>')
   })
+
+  test('detail lives in an expandable blockquote; header stays outside', () => {
+    const text = renderStatusTasks([
+      todo('1', 'completed', 'done-a'),
+      todo('2', 'in_progress', 'now', 'Doing X'),
+      todo('3', 'pending', 'later'),
+    ])
+    const qi = text.indexOf('<blockquote expandable>')
+    expect(qi).toBeGreaterThan(-1)
+    // header (bar + count) is before the quote, not inside it
+    expect(text.slice(0, qi)).toContain('<b>Задачи</b>')
+    expect(text.endsWith('</blockquote>')).toBe(true)
+    // per-task detail is inside the collapsible quote
+    const inside = text.slice(qi)
+    expect(inside).toContain('◐ Doing X')
+    expect(inside).toContain('◻ later')
+    expect(inside).toContain('☑ done-a')
+  })
 })
 
 describe('renderStatusTasks budget', () => {


### PR DESCRIPTION
По директиве принца (2026-07-05): (1) статус задач в пине должен обновляться после его сообщений — корень был не в перерисовке (bump уже на каждый inbound), а в том, что снапшот задач не сбрасывался на границе сессии → пин висел со старыми M1-M5; фикс: onSessionStart сбрасывает `work`. (2) задачи через выпадающий список — details задач теперь в `<blockquote expandable>`, шапка (прогресс-бар + счётчик) вне блока (свёрнуто прогресс, развёрнуто список).

html-validator: whitelisted valueless boolean attr `expandable` on `<blockquote>` (без этого весь пин бы downgrade-нулся в plain-text). +2 теста. Тесты 79 зелёные, tsc чист. Дуал-ревью Fable + Codex: SHIP.

Применится при следующем рестарте сессии (вместе с permission Option B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)