### PR TITLE
Фикс: кнопка Сжать под Claude Code v2.1.201 (classifyPane busy-спиннер)

### DIFF
--- a/plugin/src/commands/keys.ts
+++ b/plugin/src/commands/keys.ts
@@ -425,7 +425,15 @@ export function classifyPane(text: string): PaneState {
   ) {
     return 'dialog'
   }
-  if (chrome.includes('esc to interrupt')) {
+  // v2.1.200 busy footer printed "esc to interrupt". v2.1.201 replaced it with a
+  // spinner line "✢ … (Nm Ns · ↓ Nk tokens)" that no longer prints that phrase,
+  // so a busy pane classified as 'unknown' and compact refused (regression
+  // 2026-07-06, foreshadowed by the radar's claude-code v2.1.201 bump). Detect
+  // BOTH markers; the spinner's "· ↓/↑ … tokens)" tail never appears idle/dialog.
+  if (
+    chrome.includes('esc to interrupt') ||
+    /·\s*[↓↑][\s\d.,]*k?\s*tokens?\)/i.test(chrome)
+  ) {
     return 'busy'
   }
   if (

--- a/plugin/tests/commands/keys-control.test.ts
+++ b/plugin/tests/commands/keys-control.test.ts
@@ -141,6 +141,17 @@ describe('classifyPane', () => {
     expect(classifyPane('')).toBe('unknown')
   })
 
+  // v2.1.201 (regression 2026-07-06): the busy footer dropped "esc to interrupt"
+  // in favour of a spinner line "✢ … (Nm Ns · ↓ Nk tokens)". Without matching it
+  // a busy pane classified as 'unknown' and the compact button refused.
+  test('v2.1.201 spinner (no "esc to interrupt") is still busy', () => {
+    expect(classifyPane('✢ Триггерю… (6m 7s · ↓ 14.5k tokens)')).toBe('busy')
+    expect(classifyPane('✶ Working… (12s · ↓ 800 tokens)')).toBe('busy')
+    expect(classifyPane('· Cogitating… (1m 3s · ↑ 2.1k tokens)')).toBe('busy')
+    // the spinner tail must NOT make a plain idle/bypass footer read as busy
+    expect(classifyPane('⏵⏵ bypass permissions on (shift+tab to cycle)')).toBe('idle')
+  })
+
   // FIX-5 (Fable M3): markers are anchored to the BOTTOM UI chrome, so the
   // agent's own transcript quoting "Do you want to proceed?" / "esc to
   // interrupt" (this very plugin discusses these strings) far above the


### PR DESCRIPTION
v2.1.201 убрал `esc to interrupt` из индикатора занятости → classifyPane возвращал 'unknown' → кнопка compact отказывала («не удалось определить состояние»). Теперь ловит и старый `esc to interrupt`, и новый спиннер `(Nm Ns · ↓ Nk tokens)`. Тесты 27/0 (+ случай v2.1.201). Регрессия предсказана радаром (claude-code v2.1.201 bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)