### PR TITLE
Фикс: zoom join-ссылки больше не ломаются редактором секретов

### DIFF
--- a/plugin/src/safety/redact.ts
+++ b/plugin/src/safety/redact.ts
@@ -73,6 +73,20 @@ const QUERY_TOKEN_RE =
 // would carry basic-auth credentials verbatim.
 const URL_USERINFO_RE = /(https?:\/\/[^/\s:@]+:)[^@/\s]+(@)/gi
 
+// Zoom join links: the `pwd=` query param on a zoom.us `/j/<id>` (meeting)
+// or `/w/<id>` (webinar) join URL is a PUBLIC join passcode — the link
+// exists to be shared with attendees, and QUERY_TOKEN_RE would mask the
+// passcode and break it (prince directive 2026-07-06). These URLs are
+// swapped out before the rules run and restored verbatim afterwards.
+// Tight shape: real zoom.us subdomain host, numeric meeting id, pwd param.
+const ZOOM_JOIN_URL_RE =
+  /https:\/\/[a-z0-9-]+\.zoom\.us\/[jw]\/\d{8,12}\?[^\s"'<>]*\bpwd=[^\s"'<>]+/gi
+
+// Placeholder wrapper for swapped-out Zoom links. NUL bytes cannot appear
+// in inbound Telegram text or model output, so round-tripping is safe and
+// the placeholder can never collide with real content.
+const ZOOM_PLACEHOLDER_RE = /\u0000ZOOMJOIN(\d+)\u0000/g
+
 // JWT anywhere (path, query, fragment, prose): three dot-separated
 // base64url segments, the first two starting with `eyJ` (= `{"`). The
 // generic rule never caught these reliably (dots break the char class),
@@ -237,6 +251,14 @@ export function redactSecrets(
   extras?: ReadonlyArray<string>,
 ): string {
   let out = text
+  // Zoom join links are swapped out FIRST and restored LAST: their pwd=
+  // param is a public join passcode, not a secret, and must survive every
+  // rule (incl. QUERY_TOKEN_RE) byte-identical. See ZOOM_JOIN_URL_RE.
+  const zoomLinks: string[] = []
+  out = out.replace(ZOOM_JOIN_URL_RE, (m) => {
+    zoomLinks.push(m)
+    return `\u0000ZOOMJOIN${zoomLinks.length - 1}\u0000`
+  })
   // Extras BEFORE patterns: caller-supplied exact substrings (e.g. webhook
   // tokens with no public shape) get masked first so the downstream generic
   // long-token rule doesn't partially eat them and leave a recoverable
@@ -265,5 +287,13 @@ export function redactSecrets(
   // final post-specific-rules text to compute URL ranges (offsets shift
   // as earlier rules rewrite the string).
   out = maskLongTokensOutsideUrls(out)
+  // Restore the swapped-out Zoom join links byte-identical. Runs after
+  // every rule so nothing can touch the passcode inside.
+  if (zoomLinks.length > 0) {
+    out = out.replace(
+      ZOOM_PLACEHOLDER_RE,
+      (whole, idx: string) => zoomLinks[Number(idx)] ?? whole,
+    )
+  }
   return out
 }

--- a/plugin/src/safety/redact.ts
+++ b/plugin/src/safety/redact.ts
@@ -82,10 +82,28 @@ const URL_USERINFO_RE = /(https?:\/\/[^/\s:@]+:)[^@/\s]+(@)/gi
 const ZOOM_JOIN_URL_RE =
   /https:\/\/[a-z0-9-]+\.zoom\.us\/[jw]\/\d{8,12}\?[^\s"'<>]*\bpwd=[^\s"'<>]+/gi
 
-// Placeholder wrapper for swapped-out Zoom links. NUL bytes cannot appear
-// in inbound Telegram text or model output, so round-tripping is safe and
-// the placeholder can never collide with real content.
+// Placeholder wrapper for swapped-out Zoom links. Raw NUL bytes are
+// stripped from the input before the swap runs (see redactSecrets), so a
+// placeholder in the output can only be one WE inserted - no collision or
+// index-injection from crafted input.
 const ZOOM_PLACEHOLDER_RE = /\u0000ZOOMJOIN(\d+)\u0000/g
+
+// Query params allowed to ride inside an exempted Zoom join link. Anything
+// else (token=, access_token=, ...) means the URL is NOT a plain join link -
+// the exemption is refused and the normal rules mask it (fail closed).
+// pwd = join passcode, uname = prefill display name, omn = one-meeting id.
+const ZOOM_ALLOWED_PARAMS = new Set(['pwd', 'uname', 'omn'])
+
+// True iff every query param name in the matched join URL is allowlisted.
+function isCleanZoomJoinUrl(url: string): boolean {
+  const qIdx = url.indexOf('?')
+  if (qIdx < 0) return false
+  for (const pair of url.slice(qIdx + 1).split('&')) {
+    const name = pair.split('=', 1)[0]?.toLowerCase() ?? ''
+    if (!ZOOM_ALLOWED_PARAMS.has(name)) return false
+  }
+  return true
+}
 
 // JWT anywhere (path, query, fragment, prose): three dot-separated
 // base64url segments, the first two starting with `eyJ` (= `{"`). The
@@ -250,12 +268,18 @@ export function redactSecrets(
   text: string,
   extras?: ReadonlyArray<string>,
 ): string {
-  let out = text
+  // Strip raw NUL bytes first: they never appear in legitimate Telegram
+  // text or model output, and this guarantees any ZOOM placeholder in the
+  // string below is one we inserted ourselves (no index injection).
+  let out = text.replace(/\u0000/g, '')
   // Zoom join links are swapped out FIRST and restored LAST: their pwd=
   // param is a public join passcode, not a secret, and must survive every
-  // rule (incl. QUERY_TOKEN_RE) byte-identical. See ZOOM_JOIN_URL_RE.
+  // rule (incl. QUERY_TOKEN_RE) byte-identical. Only links whose query
+  // params are ALL allowlisted qualify - a zoom-shaped URL carrying e.g.
+  // &token=... is left to the normal rules. See ZOOM_JOIN_URL_RE.
   const zoomLinks: string[] = []
   out = out.replace(ZOOM_JOIN_URL_RE, (m) => {
+    if (!isCleanZoomJoinUrl(m)) return m
     zoomLinks.push(m)
     return `\u0000ZOOMJOIN${zoomLinks.length - 1}\u0000`
   })

--- a/plugin/tests/safety/redact.test.ts
+++ b/plugin/tests/safety/redact.test.ts
@@ -440,4 +440,22 @@ describe('redactSecrets — Zoom join links (public passcode exemption)', () => 
     expect(out).toContain(join)
     expect(out).not.toContain(token)
   })
+
+  test('zoom-shaped URL smuggling a non-allowlisted param is NOT exempted', () => {
+    const smuggle =
+      'https://us02web.zoom.us/j/83269385955?pwd=x&access_token=REALSECRETVALUE12345'
+    const out = redactSecrets(smuggle)
+    expect(out).not.toContain('REALSECRETVALUE12345')
+    expect(out).toContain('[REDACTED]')
+  })
+
+  test('crafted placeholder in input cannot index into zoomLinks', () => {
+    const nul = String.fromCharCode(0)
+    const crafted = `${nul}ZOOMJOIN0${nul} and a real link ${join}`
+    const out = redactSecrets(crafted)
+    // raw NULs from input are stripped, so the crafted marker is inert text
+    expect(out).toContain('ZOOMJOIN0 and a real link')
+    expect(out).toContain(join)
+    expect(out).not.toContain(nul)
+  })
 })

--- a/plugin/tests/safety/redact.test.ts
+++ b/plugin/tests/safety/redact.test.ts
@@ -400,3 +400,44 @@ describe('redactSecrets — HTML-neutral marker', () => {
     expect(out).not.toContain('<redacted>')
   })
 })
+
+describe('redactSecrets — Zoom join links (public passcode exemption)', () => {
+  const join =
+    'https://us02web.zoom.us/j/83269385955?pwd=ylrXDjig1u7We2mblEbWHsAzl8dsbU.1'
+
+  test('zoom join URL survives byte-identical, placeholder fully removed', () => {
+    const out = redactSecrets(`Ссылка: ${join} — жми`)
+    expect(out).toContain(join)
+    expect(out).not.toContain('[REDACTED]')
+    expect(out).not.toContain(String.fromCharCode(0))
+  })
+
+  test('idempotent: double pass keeps the link intact', () => {
+    const once = redactSecrets(join)
+    expect(redactSecrets(once)).toBe(once)
+  })
+
+  test('subdomain /w/ webinar link survives; bare-host link fails closed', () => {
+    const sub =
+      'https://us02web.zoom.us/w/98765432101?pwd=AbCdEf123456.7&uname=x'
+    expect(redactSecrets(sub)).toContain(sub)
+    // bare zoom.us has no subdomain — outside the tight host shape, so the
+    // passcode is still masked (fail closed for unexpected shapes)
+    const bare = 'https://zoom.us/w/98765432101?pwd=AbCdEf123456.7'
+    expect(redactSecrets(bare)).toContain('pwd=[REDACTED]')
+  })
+
+  test('pwd on non-zoom URLs is still masked', () => {
+    const other = 'https://evil.example.com/j/83269385955?pwd=supersecret123'
+    const out = redactSecrets(other)
+    expect(out).toContain('pwd=[REDACTED]')
+    expect(out).not.toContain('supersecret123')
+  })
+
+  test('secrets NEXT TO a zoom link are still masked', () => {
+    const token = '1234567890:AAHdqTcvbXHK4-KpB7avjkkwcHM4dJq0Fx8'
+    const out = redactSecrets(`join ${join} and the bot token ${token}`)
+    expect(out).toContain(join)
+    expect(out).not.toContain(token)
+  })
+})


### PR DESCRIPTION
Директива принца 2026-07-06: `pwd=` в zoom.us join-ссылке — публичный код входа, фильтр превращал ссылку в `pwd=[REDACTED]` и она не открывалась.

Решение: placeholder-swap — Zoom join URL (жёсткая форма: сабдомен `*.zoom.us`, путь `/j/<id>` или `/w/<id>`, числовой id 8-12 цифр, параметр pwd) вырезается ДО прогона правил и восстанавливается байт-в-байт ПОСЛЕ. Всё вне этой формы (bare-host, чужие домены, pwd на не-zoom URL) маскируется как раньше — fail closed.

Тесты: +5 (byte-identical, идемпотентность, fail-closed для bare-host, не-zoom pwd, секреты рядом со ссылкой). Redact suite 52/52; полный suite 1911 pass + 2 pre-existing fail (hooks-sentinel, PyYAML отсутствует в системном python — не связано).

🤖 Generated with [Claude Code](https://claude.com/claude-code)