### PR TITLE
Гейт: точный детектор git-exec-surface — убрал ложные карточки, сохранив защиту от RCE

### DIFF
--- a/plugin/src/security/permission-policy.ts
+++ b/plugin/src/security/permission-policy.ts
@@ -399,24 +399,34 @@ function bashReferencesSecret(command: string): boolean {
 // visible command is still just "git push". These ALWAYS confirm and can
 // never appear in confirm_overrides (separate matcher, not in the built-in
 // substring list).
-// ANY `git -c <...>` (or its long form `--config`/`--config-env`) confirms:
-// quoting and include.path indirection make per-key matching leaky, and the
-// owner has accepted that only a clean `git push` auto-allows (Codex High
-// round 3 — tokenizing the shell is overkill; confirm-on-any-`-c` is the
-// minimal safe patch).
+// Short `-c` is git's GLOBAL config option ONLY when it precedes the
+// subcommand token (`git -c name=value <cmd>`). A `-c` AFTER the subcommand is
+// that subcommand's own flag and is benign — `git switch -c branch` (create),
+// `git commit -c HEAD` (reuse message), `git branch -c old new`, `git notes
+// add -c <obj>`. The old whole-command `-c` regex could not tell these apart
+// (it matched `-c` anywhere after the substring "git") and carded the owner on
+// every one, plus on non-git commands whose `-c` belongs to another program
+// while "git" only appears inside a string (`echo "git-exec-surface"; python3
+// -c …`). The detection is now POSITIONAL and command-anchored: split the
+// pipeline into segments, tokenize each git-bearing segment quote-aware, and a
+// global `-c` seen before the first non-option token is the surface (option B,
+// warchief 2026-07-08). The long forms (`--config`/`--config-env`,
+// `--upload-pack`/`--receive-pack`/`--exec`) never collide with benign
+// subcommand flags, so they keep their original position-independent semantics.
 //
 // `-c` is matched CASE-SENSITIVELY (lowercase only). git's `-C <dir>` (change
 // working directory) is a completely safe, extremely common flag that differs
-// from `-c <cfg>` (config injection) ONLY by case. The classifier lowercases
-// the command for substring matching, which collapsed `-C`→`-c` and raised a
-// confirm card on every `git -C …` — the single biggest false-positive in the
-// gate (2026-06-10). So gitExecSurface takes the RAW command and the `-c`
-// regex below has NO `/i` flag; `git` itself stays case-insensitive via the
-// explicit char classes, and the long forms keep `/i` (they are lowercase).
+// from `-c <cfg>` (config injection) ONLY by case. gitExecSurface takes the RAW
+// (case-preserved) command so `-C` never collapses onto `-c`; the long forms
+// keep `/i` (they are lowercase). GIT_DASH_C_RE survives only as the
+// conservative whole-command fallback for shell-indirection cases (see below).
 const GIT_DASH_C_RE = /[Gg][Ii][Tt]\b[^\n]*?\s-c(\s|=|["'])/
-const GIT_CONFIG_LONG_RE = /\bgit\b[^\n]*?--config(\s|=|-env)/i
+// `--exec` (transport exec alias) matches ONLY as the whole option — a trailing
+// `[\w-]` (i.e. `--exec-path`) is excluded: bare `--exec-path` merely PRINTS
+// git's exec path and is benign; `--exec-path=<path>` is handled as an explicit
+// surface in isLongExecSurfaceToken (Codex Sol r10).
 const GIT_FLAG_RE =
-  /\bgit\b[^\n]*?(--config-env|--upload-pack|--receive-pack|--exec)\b/i
+  /\bgit\b[^\n]*?(--config-env\b|--upload-pack\b|--receive-pack\b|--exec(?![\w-]))/i
 const GIT_HOOKS_WRITE_RE = /(\.git\/hooks\/|core\.hookspath)/i
 // Git config/exec indirection via environment variables — these reroute how
 // git push authenticates or which local program it runs, so a downgraded
@@ -478,38 +488,425 @@ export function segmentBashQuoteAware(command: string): string[] | null {
   return segs.map((s) => s.trim()).filter((s) => s.length > 0)
 }
 
-/** Any git config/exec flag in a segment. `-c` is case-sensitive (see RE); the
- *  long forms are case-insensitive. Operates on the RAW (case-preserved) text. */
-function gitFlagPresent(s: string): boolean {
-  return GIT_DASH_C_RE.test(s) || GIT_CONFIG_LONG_RE.test(s) || GIT_FLAG_RE.test(s)
+/** Position-independent ALWAYS-surface long forms: `--config-env`, the
+ *  transport-exec flags (`--upload-pack`/`--receive-pack`/`--exec`). NOTE: bare
+ *  `--config` is NOT here — it is the long form of `-c` and is dangerous only
+ *  WITH a config-assignment value (`git help --config` merely lists variables),
+ *  so config-family is value-gated in segmentGitExecSurface, not matched raw
+ *  (Codex Sol r11). Case-insensitive (the flags are lowercase). */
+function gitLongFormPresent(s: string): boolean {
+  return GIT_FLAG_RE.test(s)
+}
+
+/** True if a git-bearing segment carries a long-form config/exec flag. Keeps
+ *  the original segment/indirection semantics: pipeline neighbours can't be
+ *  blamed for git's flags, but shell indirection falls back to the whole-command
+ *  scan (fail-closed). */
+function gitLongFormSurface(rawCommand: string): boolean {
+  if (!gitLongFormPresent(rawCommand)) return false
+  // Indirection ($var/$(…)/`…`/wrapper fns) can route argv INTO git from
+  // elsewhere → conservative whole-command scan (a flag is already present).
+  if (/[$`]/.test(rawCommand)) return true
+  const segs = segmentBashQuoteAware(rawCommand)
+  if (segs === null) return true // unbalanced quotes → fail-closed
+  return segs.some((s) => /\bgit\b/i.test(s) && gitLongFormPresent(s))
+}
+
+/**
+ * Quote-aware argv tokenizer for ONE pipeline segment (top-level operators are
+ * already split by segmentBashQuoteAware). Splits on unquoted whitespace and
+ * returns each token's DEQUOTED value (surrounding quotes removed, `\` unescaped
+ * outside single quotes). The dequoted form lets the scan tell a real `git`
+ * command word from a quoted string literal such as `"'git-exec-surface'"`.
+ * Returns null on unbalanced quoting so the caller can fail closed.
+ */
+function tokenizeQuoteAware(segment: string): string[] | null {
+  const tokens: string[] = []
+  let deq = ''
+  let has = false // token exists (even if it dequotes to empty, e.g. "")
+  let quote: "'" | '"' | null = null
+  const flush = () => {
+    if (has) tokens.push(deq)
+    deq = ''
+    has = false
+  }
+  for (let i = 0; i < segment.length; i++) {
+    const ch = segment[i] as string
+    if (quote === "'") {
+      if (ch === "'") { quote = null; continue }
+      deq += ch; has = true; continue
+    }
+    if (quote === '"') {
+      if (ch === '\\') {
+        const nx = segment[i + 1]
+        if (nx !== undefined) { deq += nx; has = true; i++; continue }
+        deq += ch; has = true; continue
+      }
+      if (ch === '"') { quote = null; continue }
+      deq += ch; has = true; continue
+    }
+    if (ch === "'" || ch === '"') { quote = ch; has = true; continue }
+    if (ch === '\\') {
+      const nx = segment[i + 1]
+      if (nx !== undefined) { deq += nx; has = true; i++; continue }
+      continue
+    }
+    if (ch === ' ' || ch === '\t' || ch === '\r' || ch === '\n') { flush(); continue }
+    deq += ch; has = true
+  }
+  if (quote !== null) return null
+  flush()
+  return tokens
+}
+
+// git resolves an UNAMBIGUOUS long-option PREFIX to the full option, so
+// `--upl`/`--upload` == `--upload-pack`, `--rec`/`--receive` == `--receive-pack`.
+// ALWAYS-surface targets: they name a program to run / are the exec-env config
+// form, so they are a surface regardless of value (no benign
+// `git help --upload-pack`-style collision). `config` (the plain long form of
+// `-c`) is deliberately EXCLUDED here — it is value-gated (see config-family).
+const LONG_EXEC_PREFIX_TARGETS = ['upload-pack', 'receive-pack']
+
+/** A DEQUOTED token that is an ALWAYS-surface long exec flag (regardless of
+ *  value): `--exec` (run program, exact — `--exec-path` bare is NOT it),
+ *  `--exec-path=<nonempty>` (reroutes git's exec search path → RCE),
+ *  `--config-env` and its `--config-e…` prefixes (exec-env config), and the
+ *  `--upload-pack`/`--receive-pack` transport programs (down to 2-char
+ *  prefixes). Prefix abbreviations & fragment-rejoined forms are handled since
+ *  we match on the DEQUOTED name (Codex Sol r8/r10/r11). */
+function isAlwaysLongExecSurface(tok: string): boolean {
+  if (!tok.startsWith('--')) return false
+  // `--exec-path=<nonempty>` reroutes git's executable search path (RCE); bare
+  // `--exec-path` (no value, just prints) stays benign.
+  if (/^--exec-path=.+/.test(tok)) return true
+  const name = (tok.slice(2).split('=')[0] as string).toLowerCase()
+  if (name === 'exec') return true
+  // `--config-env` and its prefixes PAST "config" (`config-`, `config-e`, …);
+  // these resolve unambiguously to config-env (exec-env), always a surface.
+  if (name.length >= 7 && 'config-env'.startsWith(name)) return true
+  // Minimum 2 chars for the transport programs: git resolves `--up`==upload-pack
+  // etc.; no benign git long option is a 2-char prefix of these (verified vs
+  // --no-pager/--paginate/--oneline/--author/--amend/--all/--recurse-submodules/
+  // --reference). ACCEPTED RESIDUAL (documented): 1-char prefixes (`--u`) and
+  // deeper per-subcommand abbreviation ambiguity need git's full parse-options
+  // tables — infeasible in a heuristic.
+  if (name.length < 2) return false
+  return LONG_EXEC_PREFIX_TARGETS.some((t) => t.startsWith(name))
+}
+
+/** A DEQUOTED token that is the CONFIG-FAMILY long form of `-c`: `--config` and
+ *  its prefixes that resolve to `config` (`--c`/`--co`/`--con`/`--conf`/
+ *  `--confi`/`--config`) — NOT `--config-env`/`--config-e…` (those are
+ *  always-surface). Config-family sets git config only for `git clone`; it is a
+ *  surface there with any nonempty value, benign elsewhere (Codex Sol r13). */
+function isConfigFamilyToken(tok: string): boolean {
+  if (!tok.startsWith('--')) return false
+  const name = (tok.slice(2).split('=')[0] as string).toLowerCase()
+  return name.length >= 1 && 'config'.startsWith(name)
+}
+
+/** The value carried by a `-c`/`--config`-family token: the glued `=<value>`
+ *  tail if present, else the NEXT token. Returns undefined when there is no
+ *  value (bare flag at end of argv). */
+function consumedFlagValue(tok: string, next: string | undefined): string | undefined {
+  const eq = tok.indexOf('=')
+  if (eq >= 0) return tok.slice(eq + 1)
+  return next
+}
+
+/**
+ * SHORT `-c` config surface, POSITION/SUBCOMMAND model (Codex Sol r13 — replaces
+ * the leaky value-shape heuristic; git accepts URL-scoped / exotic config keys
+ * that no value regex can enumerate). There is NO benign config-set `-c`, so a
+ * `-c` with any nonempty consumed value is a surface exactly in the two
+ * config-setting positions:
+ *   - GLOBAL `-c` (before the subcommand): always config injection —
+ *     `git -c <key>=<value> <sub>`.
+ *   - `-c` when the SUBCOMMAND is `clone` (`git clone -c <key>=<value>`): sets
+ *     config pre-fetch.
+ * Any OTHER subcommand's `-c` is that subcommand's own flag (create branch,
+ * reuse message, combined diff) → benign: `git switch -c feature[=x]`,
+ * `git commit -c HEAD`, `git branch -c old[=name]`, `git log -c`,
+ * `git show -c HEAD`. `-C` (uppercase, change-dir) is never `-c`.
+ */
+function shortDashCConfig(tok: string, next: string | undefined, isGlobal: boolean, isCloneSub: boolean): boolean {
+  let val: string | undefined
+  if (tok === '-c') val = next
+  else if (tok.length > 2 && tok[0] === '-' && tok[1] === 'c') val = tok.slice(2)
+  if (val === undefined || val.length === 0) return false
+  return isGlobal || isCloneSub
+}
+
+/** True if a token is a real `git` command word (bare or path-qualified),
+ *  not a substring like `git-exec-surface` nor a quoted string literal. */
+function isGitToken(tok: string): boolean {
+  return tok === 'git' || /(?:^|\/)git$/.test(tok)
+}
+
+// git top-level options that consume the NEXT token as a SEPARATE value. Used
+// ONLY to skip over an option's value when locating the subcommand (so
+// `git -C /r clone …` reads `clone`, not `/r`, as the subcommand).
+const GIT_VALUE_GLOBAL_FLAGS = new Set([
+  '-C', '--git-dir', '--work-tree', '--namespace', '--super-prefix',
+  '--attr-source', '--shallow-file',
+])
+
+// Subcommands for which bare `-u` is the short alias of `--upload-pack` (selects
+// the executed transport program). For push/add/branch/… `-u` means something
+// else entirely (set-upstream, update), so the `-u` surface is scoped to these.
+const GIT_UPLOAD_PACK_U_SUBCOMMANDS = new Set(['clone', 'fetch', 'ls-remote', 'pull'])
+
+/** Index of the subcommand token in a git invocation: the first token after the
+ *  git token that is not an option and is not a value consumed by a preceding
+ *  separate-value global. Returns toks.length if none (bare `git` / only
+ *  options). A `-c` seen at index < this is a GLOBAL `-c`. */
+function gitSubcommandIndex(toks: string[], gitAt: number): number {
+  let i = gitAt + 1
+  while (i < toks.length) {
+    const tok = toks[i] as string
+    if (tok.length === 0) { i++; continue }
+    if (tok[0] !== '-') return i
+    if (tok === '-c' || GIT_VALUE_GLOBAL_FLAGS.has(tok)) { i += 2; continue }
+    i++
+  }
+  return toks.length
+}
+
+/**
+ * True if a git-bearing segment carries a git exec surface, using a
+ * POSITION-INDEPENDENT value-shape model (Codex Sol r7 — `git clone -c k=v`
+ * sets config AFTER the subcommand, and long transport flags come after it too,
+ * so the old "global before subcommand" boundary leaked). We require a real
+ * `git` token (dequoted exactly `git`/`.../git`) so a quoted string
+ * (`"git-exec-surface"`) is ignored and prefix wrappers (`env`, `sudo`, `xargs`,
+ * `command`, …) are still handled, then scan EVERY token after it for:
+ *   - a SHORT `-c` config surface — dotted key, `=` optional when GLOBAL
+ *     (pre-subcommand), `=` required when post-subcommand (see shortDashCConfig), or
+ *   - a LONG exec-surface flag (`--config`/`--config-env`, `--upload-pack`,
+ *     `--receive-pack`, `--exec`, incl. prefix abbreviations / fragment-rejoined
+ *     ones) anywhere, before OR after the subcommand, or
+ *   - a bare `-u` (`--upload-pack` alias) when the subcommand is fetch-family
+ *     (clone/fetch/ls-remote/pull) — scoped so `git push -u` / `git add -u`
+ *     stay benign (Codex Sol r8).
+ */
+function segmentGitExecSurface(segment: string): boolean {
+  const toks = tokenizeQuoteAware(segment)
+  if (toks === null) return true // weird quoting we can't tokenize → fail-closed
+  // ACCEPTED RESIDUAL (Codex Sol r3, deliberately not fixed): this scans for a
+  // `git` token in ANY position, not only the command position. So a `git` that
+  // is DATA to another command (`printf '%s\n' git -c user.name=x`) is treated
+  // as a command word and over-cards (confirms) even though git never runs.
+  // Fully closing it needs shell command-position parsing (rabbit hole); the
+  // over-card is harmless (safe-side false positive), so it stays.
+  let gitAt = -1
+  for (let g = 0; g < toks.length; g++) {
+    if (isGitToken(toks[g] as string)) { gitAt = g; break }
+  }
+  if (gitAt < 0) return false
+  const subIdx = gitSubcommandIndex(toks, gitAt)
+  const subcommand = subIdx < toks.length ? (toks[subIdx] as string) : ''
+  const fetchFamily = GIT_UPLOAD_PACK_U_SUBCOMMANDS.has(subcommand)
+  const isCloneSub = subcommand === 'clone'
+  for (let i = gitAt + 1; i < toks.length; i++) {
+    const tok = toks[i] as string
+    // Short `-c`: config surface when GLOBAL (pre-subcommand) or under `clone`.
+    if (shortDashCConfig(tok, toks[i + 1], i < subIdx, isCloneSub)) return true
+    if (isAlwaysLongExecSurface(tok)) return true
+    // Long config-family (`--config`/`--conf`/…) sets config ONLY for `clone`;
+    // any nonempty value there → surface, regardless of key shape (URL-scoped
+    // keys included). `git help --config` (not clone) stays benign.
+    if (isCloneSub && isConfigFamilyToken(tok)) {
+      const val = consumedFlagValue(tok, toks[i + 1])
+      if (val !== undefined && val.length > 0) return true
+    }
+    // `-u` == --upload-pack for fetch-family, separate (`-u /x`) OR stuck
+    // (`-u/x`). push/add/branch are not fetch-family, so their `-u` is benign.
+    if (fetchFamily && (tok === '-u' || (tok.startsWith('-u') && tok.length > 2))) return true
+  }
+  return false
+}
+
+const ANSI_C_SIMPLE: Record<string, string> = {
+  n: '\n', t: '\t', r: '\r', a: '\x07', b: '\b', f: '\f', v: '\v',
+  e: '\x1b', E: '\x1b', '\\': '\\', "'": "'", '"': '"', '?': '?',
+}
+
+/**
+ * Decode a bash ANSI-C `$'…'` body starting at `start` (just past the opening
+ * `'`). Handles `\xHH` hex, `\NNN` octal (1–3 digits), `\uHHHH`/`\UHHHHHHHH`
+ * and the standard escapes. Returns [decodedBytes, indexAfterClosingQuote,
+ * closed]. `closed=false` means the `'` was never found (unterminated).
+ */
+function decodeAnsiCBody(s: string, start: number): [string, number, boolean] {
+  let out = ''
+  let i = start
+  while (i < s.length) {
+    const c = s[i] as string
+    if (c === "'") return [out, i + 1, true]
+    if (c === '\\') {
+      const e = s[i + 1]
+      if (e === undefined) { out += '\\'; i++; continue }
+      if (e === 'x') {
+        const m = /^[0-9a-fA-F]{1,2}/.exec(s.slice(i + 2))
+        if (m) { out += String.fromCharCode(parseInt(m[0], 16)); i += 2 + m[0].length; continue }
+        out += 'x'; i += 2; continue
+      }
+      if (e === 'u' || e === 'U') {
+        const width = e === 'u' ? 4 : 8
+        const m = new RegExp(`^[0-9a-fA-F]{1,${width}}`).exec(s.slice(i + 2))
+        if (m) { out += String.fromCodePoint(parseInt(m[0], 16)); i += 2 + m[0].length; continue }
+        out += e; i += 2; continue
+      }
+      if (e >= '0' && e <= '7') {
+        const m = /^[0-7]{1,3}/.exec(s.slice(i + 1))
+        if (m) { out += String.fromCharCode(parseInt(m[0], 8) & 0xff); i += 1 + m[0].length; continue }
+      }
+      if (e in ANSI_C_SIMPLE) { out += ANSI_C_SIMPLE[e]; i += 2; continue }
+      out += e; i += 2; continue // unknown escape → keep the char
+    }
+    out += c; i++
+  }
+  return [out, i, false] // unterminated
+}
+
+/**
+ * Collapse bash quote/backslash concatenation AND ANSI-C encoding for the
+ * fail-closed indirection branch, so an encoded/fragmented `git`/`-c`/long-flag
+ * surfaces: `$'\x67\x69\x74'`→`git`, `-'c'`→`-c`, `-\c`→`-c`, `'g'it`→`git`,
+ * `--upload'-pack'`→`--upload-pack`. `$'…'` is decoded first (its escapes are
+ * special); an UNTERMINATED `$'…` is left verbatim so the caller can fail
+ * closed on the surviving `$'` marker. Not a full shell parse — just enough to
+ * defeat fragment splitting and ANSI-C encoding of the markers.
+ */
+function flattenIndirection(s: string): string {
+  let out = ''
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i] as string
+    if (ch === '$' && s[i + 1] === "'") {
+      const [decoded, next, closed] = decodeAnsiCBody(s, i + 2)
+      if (!closed) { out += s.slice(i); break } // unterminated → keep $' marker
+      out += decoded
+      i = next - 1 // for-loop ++ lands on the char after the closing quote
+      continue
+    }
+    if (ch === '\\') {
+      const nx = s[i + 1]
+      if (nx !== undefined) { out += nx; i++; continue }
+      continue // trailing backslash dropped
+    }
+    if (ch === "'" || ch === '"') continue // drop quote chars → fragments join
+    out += ch
+  }
+  return out
+}
+
+/** git config/exec surface: value-shape `-c name=value` + long exec flags on the
+ *  clean path (position-independent per segment), broad fail-closed under
+ *  shell indirection. */
+function gitGlobalDashCSurface(command: string): boolean {
+  // Shell indirection ($var/$(…)/`…`/wrapper fns) can route argv into git from
+  // another segment, and git may be GLUED inside a substitution/assignment
+  // (`x=$(git …`, `` `git …` ``) so it isn't even a clean token — positional
+  // tokenization is untrustworthy here. This branch runs ONLY when `$`/backtick
+  // is present, i.e. argv genuinely cannot be resolved, so we broadly FAIL
+  // CLOSED (Codex Sol HIGH r4): if a `git` word appears anywhere AND any config/
+  // exec-surface marker is present in the raw text, confirm. Over-confirming is
+  // accepted on the safe side — a benign `x=$(git switch -c "$b")` also confirms
+  // under indirection; we deliberately do not try to exempt it.
+  if (/[$`]/.test(command)) {
+    // bash reconstructs a token by concatenating adjacent quoted/unquoted/
+    // backslash fragments (`-'c'`→`-c`, `-\c`→`-c`, `'g'it`→`git`,
+    // `--upload'-pack'`→`--upload-pack`), which the RAW regexes miss. Build a
+    // FLATTENED view that drops quote chars and backslash-escapes so those
+    // fragments join, then run the git-word + marker checks on it (Codex Sol
+    // HIGH r5). This is the fail-closed indirection branch, so the resulting
+    // over-confirm (e.g. a benign `grep -c git` inside `$(…)`) is ACCEPTED on
+    // the safe side — we do not try to exempt it.
+    const flat = flattenIndirection(command)
+    const lc = flat.toLowerCase()
+    const flatToks = tokenizeQuoteAware(flat) ?? []
+    const marker =
+      GIT_DASH_C_RE.test(flat) || // `git … -c`
+      /-c(?:\s|=|$)/.test(flat) || // any short `-c` config marker (quotes dropped)
+      gitLongFormPresent(flat) || // --config-env / --upload-pack / --receive-pack
+      flatToks.some(isAlwaysLongExecSurface) || // + prefix abbreviations (`--upl=…`)
+      // Config-family (`--config …`/`--conf=…`) WITH a value → fail-closed under
+      // indirection (can't resolve the subcommand; safe-side, Codex Sol r13).
+      flatToks.some((t, idx) => {
+        if (!isConfigFamilyToken(t)) return false
+        const v = consumedFlagValue(t, flatToks[idx + 1])
+        return v !== undefined && v.length > 0
+      }) ||
+      // A dotted config-key assignment (`alias.pwn=`, `core.sshCommand=`,
+      // `user.name=`) — catches a variable-held `-c` whose flag we can't see but
+      // whose config payload is literal (`c=-c; git "$c" alias.pwn='!id' pwn`).
+      // Deliberately narrow: a DOTTED key + `=`, so `--author=`, `FOO=bar`, and
+      // `git checkout "$b"` (no dotted-key=) do NOT trip it (Codex Sol r7).
+      /\b[A-Za-z][\w-]*\.[\w.-]*=/.test(flat) ||
+      GIT_ENV_INDIRECTION_RE.test(lc) ||
+      GIT_HOOKS_WRITE_RE.test(lc)
+    if (!marker) return false
+    // A config/exec marker is present. Confirm if a git word appears in the
+    // decoded+flattened text, OR if an un-resolved ANSI-C `$'…'` remains (it
+    // could encode `git`/`-c` we couldn't fully decode) — fail closed, do NOT
+    // return false past it. This over-confirms a benign marker+`$'` with no git
+    // (accepted safe-side for the unresolvable indirection branch).
+    return /\bgit\b/.test(flat) || /\$'/.test(command)
+  }
+  const segs = segmentBashQuoteAware(command)
+  if (segs === null) return true // unbalanced quotes → fail-closed
+  return segs.some(segmentGitExecSurface)
+}
+
+/**
+ * Remove backslash-newline line continuations QUOTE-AWARE, mirroring bash:
+ * bash joins `\<newline>` OUTSIDE quotes and INSIDE double quotes, but PRESERVES
+ * it inside single quotes (no processing there). An escaped backslash (`\\`)
+ * consumes both backslashes so a following newline stays literal (parity).
+ */
+function stripLineContinuations(command: string): string {
+  let out = ''
+  let quote: "'" | '"' | null = null
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i] as string
+    if (quote === "'") {
+      out += ch
+      if (ch === "'") quote = null
+      continue
+    }
+    if (ch === "'" && quote === null) { quote = "'"; out += ch; continue }
+    if (ch === '"') { quote = quote === '"' ? null : '"'; out += ch; continue }
+    if (ch === '\\') {
+      const nx = command[i + 1]
+      // `\<newline>` (outside quotes or in double quotes) → line continuation.
+      if (nx === '\n') { i++; continue }
+      if (nx === '\r' && command[i + 2] === '\n') { i += 2; continue }
+      // Any other escaped char (incl. escaped backslash / escaped quote) — keep
+      // both so parity and quote state stay correct.
+      if (nx !== undefined) { out += ch + nx; i++; continue }
+      out += ch
+      continue
+    }
+    out += ch
+  }
+  return out
 }
 
 function gitExecSurface(rawCommand: string): boolean {
-  const lower = rawCommand.toLowerCase()
+  // bash removes backslash-newline line continuations before word splitting, so
+  // `git -\<newline>c …` is really `git -c …`. Strip them FIRST so
+  // segmentation/tokenization see the joined argv (Codex edge: the split `-`+`c`
+  // otherwise slips the positional scan). Quote-aware: single-quoted content is
+  // left untouched (bash preserves `\<newline>` inside single quotes).
+  const command = stripLineContinuations(rawCommand)
+  const lower = command.toLowerCase()
   // Hook-path writes and env indirection are segment-independent and
   // case-insensitive (GIT_SSH_COMMAND= etc. are uppercase env vars).
   if (GIT_HOOKS_WRITE_RE.test(lower) || GIT_ENV_INDIRECTION_RE.test(lower)) return true
-  // Fast path: if no config/exec flag appears ANYWHERE, no segmentation can
-  // create one (segments are substrings) — definitively safe. Match on the RAW
-  // command so `-c` keeps its case (`git -C` change-dir must NOT trip here).
-  if (!gitFlagPresent(rawCommand)) return false
-  // A flag matched somewhere. We only narrow to per-segment scanning (to
-  // suppress a pipeline neighbour's flag, e.g. `git show X | grep -c Y`) when
-  // there is NO shell indirection. Indirection ($var, $(...), `...`, arrays,
-  // wrapper functions) can route argv INTO git from another segment (Codex
-  // Critical: `g(){ git "$@"; }; g -c core.sshCommand=evil fetch`), so we fall
-  // back to the whole-command scan — at least as strict as the pre-segment
-  // behaviour. (Residual, pre-existing in that behaviour too: a flag that
-  // appears textually BEFORE git via a variable — `c='-c …'; git $c` — is not
-  // caught here; closing that needs real argv resolution, out of scope.)
-  if (/[$`]/.test(rawCommand)) {
-    return gitFlagPresent(rawCommand)
-  }
-  const segs = segmentBashQuoteAware(rawCommand)
-  if (segs === null) return true // unbalanced quotes → fail-closed
-  // Indirection-free, balanced: the flag can only belong to git if a
-  // git-bearing segment literally carries it.
-  return segs.some((s) => /\bgit\b/i.test(s) && gitFlagPresent(s))
+  // Position-independent long forms keep their original semantics.
+  if (gitLongFormSurface(command)) return true
+  // Short `-c` is git's global config option ONLY before the subcommand.
+  return gitGlobalDashCSurface(command)
 }
 
 // ── systemctl: verb-aware confirm (live FPs 2026-06-10) ─────────────────

--- a/plugin/tests/security/permission-policy.test.ts
+++ b/plugin/tests/security/permission-policy.test.ts
@@ -857,3 +857,596 @@ describe('git-exec-surface round 3 — any git -c confirms (Codex High r3)', () 
     expect(classify('Bash', { command: 'git commit -m fix' }, OVR).tier).toBe('allow')
   })
 })
+
+describe('git-exec-surface `-c` is POSITIONAL — subcommand -c is benign, global -c confirms (option B, 2026-07-08)', () => {
+  const surfaced = (cmd: string) =>
+    (classify('Bash', { command: cmd }, VARIANT1).matchedRule ?? '').includes('git-exec-surface')
+
+  // ── MUST NOT confirm: -c belongs to the subcommand, not to git ──────────
+  test('git switch -c (create branch) does not confirm', () => {
+    expect(surfaced('git switch -c feature/x')).toBe(false)
+    expect(classify('Bash', { command: 'git switch -c feature/x' }, VARIANT1).tier).toBe('allow')
+  })
+  test('git commit -c HEAD (reuse message) does not confirm', () => {
+    expect(surfaced('git commit -c HEAD --amend')).toBe(false)
+  })
+  test('git branch -c oldname newname (copy branch) does not confirm', () => {
+    expect(surfaced('git branch -c oldname newname')).toBe(false)
+  })
+  test('git -C dir switch -c topic — subcommand -c after global -C dir is benign', () => {
+    expect(surfaced('git -C /repo switch -c topic')).toBe(false)
+    expect(classify('Bash', { command: 'git -C /repo switch -c topic' }, VARIANT1).tier).toBe('allow')
+  })
+  test('git -C /some/dir status — case-sensitivity preserved (uppercase -C is not -c)', () => {
+    expect(surfaced('git -C /some/dir status')).toBe(false)
+    expect(classify('Bash', { command: 'git -C /some/dir status' }, VARIANT1).tier).toBe('allow')
+  })
+  test('non-git command whose -c belongs to python; "git" only inside a string', () => {
+    expect(surfaced('echo "\'git-exec-surface\'"; python3 -c "import yaml; print(1)"')).toBe(false)
+  })
+  test('git in seg 1, python -c in seg 2 — the -c is not attributed to git', () => {
+    expect(surfaced('git show HEAD:file | python3 -c "import sys"')).toBe(false)
+  })
+
+  // ── MUST STILL confirm: real global config/exec surfaces ────────────────
+  test('git -c core.sshCommand=evil push (global config) still confirms', () => {
+    expect(surfaced('git -c core.sshCommand=evil push')).toBe(true)
+  })
+  test('git -c credential.helper=... fetch still confirms', () => {
+    expect(surfaced('git -c credential.helper=/tmp/x fetch')).toBe(true)
+  })
+  test('git -C /repo -c core.hooksPath=/tmp push — global -c after -C dir still confirms', () => {
+    expect(surfaced('git -C /repo -c core.hooksPath=/tmp push')).toBe(true)
+  })
+  test('git --config-env=core.sshCommand=X push (long form) still confirms', () => {
+    expect(surfaced('git --config-env=core.sshCommand=X push')).toBe(true)
+  })
+  test('GIT_SSH_COMMAND=/tmp/evil git push (env indirection) still confirms', () => {
+    expect(classify('Bash', { command: 'GIT_SSH_COMMAND=/tmp/evil git push' }, VARIANT1).tier).toBe('confirm')
+  })
+  test('git clone --upload-pack=/tmp/evil (transport exec) still confirms', () => {
+    expect(surfaced('git clone --upload-pack=/tmp/evil host:repo')).toBe(true)
+  })
+  test('wrapper-fn indirection ($ present → fail-closed whole-command scan) still confirms', () => {
+    expect(surfaced('g(){ git "$@"; }; g -c core.sshCommand=evil fetch')).toBe(true)
+  })
+  test('unbalanced quotes around git -c → fail-closed confirm', () => {
+    expect(surfaced('git -c core.sshCommand=evil "unterminated push')).toBe(true)
+  })
+})
+
+describe('git-exec-surface fix-loop — command-prefix wrappers, line-continuation, quoted -c under indirection (Codex+Fable review 2026-07-09)', () => {
+  const surfaced = (cmd: string) =>
+    (classify('Bash', { command: cmd }, VARIANT1).matchedRule ?? '').includes('git-exec-surface')
+
+  // FINDING 1 — a global `-c` behind ANY command-prefix wrapper still confirms
+  // (positional scan must find the git token, not anchor on the first token).
+  test('command git -c … push confirms', () => {
+    expect(surfaced('command git -c core.sshCommand=evil push')).toBe(true)
+  })
+  test('exec git -c … push confirms', () => {
+    expect(surfaced('exec git -c core.sshCommand=evil push')).toBe(true)
+  })
+  test('env git -c … push confirms', () => {
+    expect(surfaced('env git -c core.sshCommand=evil push')).toBe(true)
+  })
+  test('env X=1 git -c … push confirms', () => {
+    expect(surfaced('env X=1 git -c core.sshCommand=evil push')).toBe(true)
+  })
+  test('sudo git -c … push confirms (via the sudo builtin, which fires first — still not a silent allow)', () => {
+    // The `sudo ` builtin confirm masks git-exec-surface here; what matters is
+    // it confirms rather than silently allowing.
+    expect(classify('Bash', { command: 'sudo git -c core.sshCommand=evil push' }, VARIANT1).tier).toBe('confirm')
+  })
+  test('nice git -c … push confirms', () => {
+    expect(surfaced('nice git -c core.sshCommand=evil push')).toBe(true)
+  })
+  test('nohup git -c … push confirms', () => {
+    expect(surfaced('nohup git -c core.sshCommand=evil push')).toBe(true)
+  })
+  test('stdbuf -o0 git -c … push confirms', () => {
+    expect(surfaced('stdbuf -o0 git -c core.sshCommand=evil push')).toBe(true)
+  })
+  test('xargs git -c … confirms', () => {
+    expect(surfaced('xargs git -c core.sshCommand=evil')).toBe(true)
+  })
+  test('wrapper with global -C dir then -c still confirms (value-flag consumption anchored on git token)', () => {
+    expect(surfaced('command git -C /r -c core.sshCommand=evil push')).toBe(true)
+  })
+  test('but a wrapper prefix does NOT over-confirm a benign subcommand -c', () => {
+    expect(surfaced('command git switch -c feature/x')).toBe(false)
+    expect(surfaced('env X=1 git commit -c HEAD --amend')).toBe(false)
+  })
+
+  // FINDING 2 — backslash-newline line continuation splitting `-c`.
+  test('git -\\<newline>c … push (bash joins to git -c) confirms', () => {
+    expect(surfaced('git -\\\nc core.sshCommand=evil push')).toBe(true)
+  })
+  test('line continuation does not break a benign subcommand -c', () => {
+    // `git switch -\<nl>c br` joins to `git switch -c br` — still benign.
+    expect(surfaced('git switch -\\\nc feature/x')).toBe(false)
+  })
+
+  // FINDING 3 — quoted `-c` under $/backtick indirection must not slip.
+  test("g(){ git \"$@\"; }; g '-c' … fetch (quoted -c under indirection) confirms", () => {
+    expect(surfaced('g(){ git "$@"; }; g \'-c\' core.sshCommand=evil fetch')).toBe(true)
+  })
+  test('unquoted -c under indirection still confirms (unchanged)', () => {
+    expect(surfaced('g(){ git "$@"; }; g -c core.sshCommand=evil fetch')).toBe(true)
+  })
+  test('indirection with git in $(…) and a real -c still confirms', () => {
+    expect(surfaced('$(git -c core.sshCommand=evil push)')).toBe(true)
+  })
+  test('benign $() with git and no -c does not confirm', () => {
+    expect(classify('Bash', { command: 'B=$(git rev-parse --abbrev-ref HEAD); echo $B' }, VARIANT1).tier).toBe('allow')
+  })
+})
+
+describe('git-exec-surface round-3 tightening — ANSI-C quoting + quote-aware line continuation (Codex Sol r3)', () => {
+  const surfaced = (cmd: string) =>
+    (classify('Bash', { command: cmd }, VARIANT1).matchedRule ?? '').includes('git-exec-surface')
+
+  // CLOSE #1 — ANSI-C quoting decodes to a real `-c`; presence in a git command
+  // fails closed (the $ path can't decode `$'…'`).
+  test("git $'-c' user.name=x status (ANSI-C quoted -c) confirms", () => {
+    expect(surfaced("git $'-c' user.name=x status")).toBe(true)
+  })
+  test("git $'\\x2d\\x63' user.name=x status (hex ANSI-C -c) confirms", () => {
+    expect(surfaced("git $'\\x2d\\x63' user.name=x status")).toBe(true)
+  })
+
+  // CLOSE #2 — backslash-newline stripping is quote-aware: single-quoted content
+  // is preserved (bash does no continuation removal inside single quotes), so a
+  // single-quoted `-\<nl>c` stays literal and is NOT a global -c.
+  test("git '-\\<newline>c' … (single-quoted) is NOT transformed into -c → benign", () => {
+    expect(surfaced("git '-\\\nc' feature/x")).toBe(false)
+  })
+  test('git -\\<newline>c … (unquoted) still joins to -c → confirms', () => {
+    expect(surfaced('git -\\\nc user.name=x status')).toBe(true)
+  })
+})
+
+describe('git-exec-surface round-4 — git glued in command substitution / assignment under indirection (Codex Sol r4)', () => {
+  const surfaced = (cmd: string) =>
+    (classify('Bash', { command: cmd }, VARIANT1).matchedRule ?? '').includes('git-exec-surface')
+
+  // HIGH — git glued as `x=$(git …`: the token is `x=$(git`, not `git`, so the
+  // old token-dequote git-presence test missed it. The broad `\bgit\b` + marker
+  // fail-closed now catches the whole class.
+  test("x=$(git '-c' …) (quoted -c inside command substitution) confirms", () => {
+    expect(surfaced("x=$(git '-c' core.sshCommand=/tmp/evil fetch origin)")).toBe(true)
+  })
+  test("x=$(git $'-c' …) (ANSI-C -c inside command substitution) confirms", () => {
+    expect(surfaced("x=$(git $'-c' core.sshCommand=/tmp/evil fetch origin)")).toBe(true)
+  })
+  test('`git -c … push` in backticks confirms', () => {
+    expect(surfaced('`git -c core.sshCommand=x push`')).toBe(true)
+  })
+  test('accepted safe-side: x=$(git switch -c "$b") confirms under indirection (unresolvable argv)', () => {
+    expect(surfaced('x=$(git switch -c "$b")')).toBe(true)
+  })
+  test('but a substitution with git and NO config marker stays allow', () => {
+    expect(classify('Bash', { command: 'x=$(git rev-parse HEAD); echo $x' }, VARIANT1).tier).toBe('allow')
+  })
+})
+
+describe('git-exec-surface round-5 — value-flag completeness + indirection fragment concatenation (Codex Sol r5)', () => {
+  const surfaced = (cmd: string) =>
+    (classify('Bash', { command: cmd }, VARIANT1).matchedRule ?? '').includes('git-exec-surface')
+
+  // FINDING A — separate-value globals that precede a real `-c` must be
+  // consumed on the CLEAN positional path, else the value reads as the
+  // subcommand and the following global `-c` is missed.
+  test('git --attr-source HEAD -c … fetch (attr-source consumes HEAD) confirms', () => {
+    expect(surfaced('git --attr-source HEAD -c core.sshCommand=/tmp/evil fetch origin')).toBe(true)
+  })
+  test('git --shallow-file /tmp/shallow -c … fetch confirms', () => {
+    expect(surfaced('git --shallow-file /tmp/shallow -c core.sshCommand=/tmp/evil fetch origin')).toBe(true)
+  })
+  test('and those flags alone (no -c) do NOT over-confirm on the clean path', () => {
+    expect(surfaced('git --attr-source HEAD log --oneline -1')).toBe(false)
+  })
+
+  // FINDING B — bash fragment concatenation under indirection ($/backtick).
+  test("x=$(git -'c' …) — split -'c' rejoins to -c → confirms", () => {
+    expect(surfaced("x=$(git -'c' core.sshCommand=/tmp/evil fetch origin)")).toBe(true)
+  })
+  test('x=$(git -\\c …) — backslash-split -\\c rejoins to -c → confirms', () => {
+    expect(surfaced('x=$(git -\\c core.sshCommand=/tmp/evil fetch origin)')).toBe(true)
+  })
+  test("x=$(git clone --upload'-pack'=… ) — split long flag rejoins → confirms", () => {
+    expect(surfaced("x=$(git clone --upload'-pack'=/tmp/evil ssh://host/repo)")).toBe(true)
+  })
+  test("x=$('g'it -c … ) — split command word 'g'it rejoins to git → confirms", () => {
+    expect(surfaced("x=$('g'it -c core.sshCommand=/tmp/evil fetch origin)")).toBe(true)
+  })
+})
+
+describe('git-exec-surface round-6 — fragmented long-form (clean) + ANSI-C command word (indirection) (Codex Sol r6)', () => {
+  const surfaced = (cmd: string) =>
+    (classify('Bash', { command: cmd }, VARIANT1).matchedRule ?? '').includes('git-exec-surface')
+
+  // FINDING 1 — CLEAN path: a fragmented LONG-form config/exec flag dequotes to
+  // a real global exec surface before the subcommand.
+  test("git --config'-env'=… ls-remote (fragmented --config-env, RCE) confirms", () => {
+    expect(surfaced("X=id git --config'-env'=core.sshCommand=X ls-remote ssh://example.invalid/repo")).toBe(true)
+  })
+  test("git --up'load'-pack=/x clone host:r (fragmented --upload-pack) confirms", () => {
+    expect(surfaced("git --up'load'-pack=/x clone host:r")).toBe(true)
+  })
+  test("git --con'fig'-env=… fetch (fragmented --config-env) confirms", () => {
+    expect(surfaced("git --con'fig'-env=core.sshCommand=X fetch origin")).toBe(true)
+  })
+  test('benign long options that are NOT exec surfaces do not confirm on the clean path', () => {
+    expect(surfaced('git --no-pager log --oneline -1')).toBe(false)
+    expect(surfaced('git --paginate diff')).toBe(false)
+  })
+
+  // FINDING 2 — indirection: ANSI-C-encoded command word / flag.
+  test("$'\\x67\\x69\\x74' -c … (hex ANSI-C git) under indirection confirms", () => {
+    expect(surfaced("X=id $'\\x67\\x69\\x74' -c core.sshCommand=X ls-remote ssh://example.invalid/repo")).toBe(true)
+  })
+  test("$'\\147\\151\\164' -c … (octal ANSI-C git) under indirection confirms", () => {
+    expect(surfaced("X=id $'\\147\\151\\164' -c core.sshCommand=X ls-remote ssh://example.invalid/repo")).toBe(true)
+  })
+  test("x=$($'\\x67\\x69\\x74' -c … ) inside command substitution confirms", () => {
+    expect(surfaced("x=$($'\\x67\\x69\\x74' -c core.sshCommand=/tmp/evil fetch origin)")).toBe(true)
+  })
+  test('benign ANSI-C with no git and no config marker (printf $\\n) does not confirm', () => {
+    expect(classify('Bash', { command: "printf $'\\n'" }, VARIANT1).tier).toBe('allow')
+  })
+})
+
+describe('git-exec-surface round-7 — position-independent value-shape model (Codex Sol r7, terminal for clean path)', () => {
+  const surfaced = (cmd: string) =>
+    (classify('Bash', { command: cmd }, VARIANT1).matchedRule ?? '').includes('git-exec-surface')
+
+  // FINDING 1 — `-c` config AFTER the subcommand (git clone -c … sets pre-fetch
+  // config → RCE). The old "global before subcommand" walk missed it.
+  test('git clone -c core.sshCommand=x repo (subcommand -c config) confirms', () => {
+    expect(surfaced('git clone -c core.sshCommand=/tmp/evil ssh://host/repo')).toBe(true)
+  })
+  // FINDING 2 — fragmented long transport flag AFTER the subcommand. `git push`
+  // is itself a builtin confirm, so to prove the surface fires INDEPENDENTLY we
+  // downgrade `git push` and require git-exec-surface to still stand.
+  const OVR_PUSH: PermissionPolicy = { default_tier: 'allow', confirm_overrides: { builtin_rules: ['git push'] } }
+  test("git push --receive'-pack'=/x origin (fragmented, after subcommand) still confirms even when git push is downgraded", () => {
+    const v = classify('Bash', { command: "git push --receive'-pack'=/tmp/evil origin main" }, OVR_PUSH)
+    expect(v.tier).toBe('confirm')
+    expect(v.matchedRule).toContain('git-exec-surface')
+  })
+  test('git push --receive-pack=/x origin (plain, after subcommand) still confirms when git push is downgraded', () => {
+    const v = classify('Bash', { command: 'git push --receive-pack=/tmp/evil origin' }, OVR_PUSH)
+    expect(v.tier).toBe('confirm')
+    expect(v.matchedRule).toContain('git-exec-surface')
+  })
+  test('git clone --upload-pack=/x host:r (after subcommand) confirms', () => {
+    expect(surfaced('git clone --upload-pack=/tmp/evil host:r')).toBe(true)
+  })
+
+  // Prior global/pre-subcommand cases still confirm under the new model.
+  test('git -c k=v push (global -c) confirms', () => {
+    expect(surfaced('git -c core.sshCommand=/tmp/evil push')).toBe(true)
+  })
+  test('git --attr-source HEAD -c core.sshCommand=x fetch confirms', () => {
+    expect(surfaced('git --attr-source HEAD -c core.sshCommand=/tmp/evil fetch origin')).toBe(true)
+  })
+  test('command git -c k=v push (wrapper prefix) confirms', () => {
+    expect(surfaced('command git -c core.sshCommand=/tmp/evil push')).toBe(true)
+  })
+
+  // FINDING 3 — variable-held `-c` with a literal dotted config-key payload.
+  test("c=-c; git \"$c\" alias.pwn='!id' pwn (variable -c, dotted-key config) confirms", () => {
+    expect(surfaced("c=-c; git \"$c\" alias.pwn='!/usr/bin/id' pwn")).toBe(true)
+  })
+
+  // MUST-NOT — the value-shape model keeps every clean-path FP fix intact.
+  test('subcommand -c with a non-config value stays benign', () => {
+    expect(surfaced('git switch -c feature/x')).toBe(false)
+    expect(surfaced('git commit -c HEAD')).toBe(false)
+    expect(surfaced('git commit -c HEAD --amend')).toBe(false)
+    expect(surfaced('git branch -c old new')).toBe(false)
+    expect(surfaced('git log -c')).toBe(false)
+    expect(surfaced('git show -c HEAD')).toBe(false)
+  })
+  test('non-config git invocations stay benign', () => {
+    expect(surfaced('git -C /path status')).toBe(false)
+    expect(surfaced('git --no-pager log')).toBe(false)
+    expect(surfaced('git --paginate diff')).toBe(false)
+    expect(surfaced('echo "\'git-exec-surface\'"; python3 -c "import yaml"')).toBe(false)
+  })
+  test('benign indirection without a dotted-key config assignment stays allow', () => {
+    expect(classify('Bash', { command: 'git checkout "$branch"' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'git log --author="$me"' }, VARIANT1).tier).toBe('allow')
+  })
+})
+
+describe('git-exec-surface round-8 — transport-exec aliases & long-prefix abbreviations (Codex Sol r8, final)', () => {
+  const surfaced = (cmd: string) =>
+    (classify('Bash', { command: cmd }, VARIANT1).matchedRule ?? '').includes('git-exec-surface')
+
+  // FIX 1 — unambiguous long-option prefix abbreviations of the exec surfaces.
+  test('git clone --upload=/x host:r (--upload == --upload-pack) confirms', () => {
+    expect(surfaced('git clone --upload=/tmp/evil host:r')).toBe(true)
+  })
+  test('git clone --upl=/x host:r (--upl abbreviation) confirms', () => {
+    expect(surfaced('git clone --upl=/tmp/evil host:r')).toBe(true)
+  })
+  test('git fetch --rec=/x origin (--rec == --receive-pack family prefix) confirms', () => {
+    expect(surfaced('git fetch --rec=/tmp/evil origin')).toBe(true)
+  })
+  test('git --conf=... fetch (non-clone --config) is git-rejected → benign under the r13 position model', () => {
+    // git has NO global `--config` (only `-c`/`--config-env`); `--config` sets
+    // config ONLY for `clone`. On `fetch` it is an unknown option → git errors,
+    // nothing runs (Codex Sol r13 — precise subcommand model). The real clone
+    // surface `git clone --conf core.sshCommand=x` is covered in round-13.
+    expect(surfaced('git --conf=core.sshCommand=/tmp/evil fetch origin')).toBe(false)
+  })
+
+  // FIX 2 — `-u` is --upload-pack ONLY for fetch-family subcommands.
+  test('git clone -u /x ssh://host/repo (fetch-family -u) confirms', () => {
+    expect(surfaced('git clone -u /tmp/evil ssh://host/repo')).toBe(true)
+  })
+  test('git fetch -u /x origin (fetch-family -u) confirms', () => {
+    expect(surfaced('git fetch -u /tmp/evil origin')).toBe(true)
+  })
+  test('git pull -u /x origin (fetch-family -u) confirms', () => {
+    expect(surfaced('git pull -u /tmp/evil origin')).toBe(true)
+  })
+
+  // CRITICAL MUST-NOT — `-u` on non-fetch subcommands is a totally different,
+  // extremely common flag and must NOT confirm.
+  test('git push -u origin main does NOT confirm (set-upstream, not upload-pack)', () => {
+    expect(surfaced('git push -u origin main')).toBe(false)
+    expect(classify('Bash', { command: 'git push -u origin main' }, VARIANT1).matchedRule ?? '').not.toContain('git-exec-surface')
+  })
+  test('git push -u origin HEAD does NOT confirm', () => {
+    expect(surfaced('git push -u origin HEAD')).toBe(false)
+  })
+  test('git add -u / git add -u . does NOT confirm', () => {
+    expect(classify('Bash', { command: 'git add -u' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'git add -u .' }, VARIANT1).tier).toBe('allow')
+  })
+  test('git branch -u origin/main does NOT confirm (set-upstream)', () => {
+    expect(classify('Bash', { command: 'git branch -u origin/main' }, VARIANT1).tier).toBe('allow')
+  })
+  test('long-prefix matcher does not trip benign long options', () => {
+    expect(surfaced('git --no-pager log')).toBe(false)
+    expect(surfaced('git --paginate diff')).toBe(false)
+    expect(surfaced('git log --oneline -5')).toBe(false)
+    expect(classify('Bash', { command: 'git log --author=me' }, VARIANT1).tier).toBe('allow')
+    expect(surfaced('git commit --amend --all')).toBe(false)
+    expect(surfaced('git clone --recurse-submodules host:r')).toBe(false)
+    expect(surfaced('git clone --reference /x host:r')).toBe(false)
+  })
+
+  // Indirection: long-prefix abbreviation runs on the flattened+decoded text.
+  test('x=$(git clone --upl=/x host:r) under indirection confirms', () => {
+    expect(surfaced('x=$(git clone --upl=/tmp/evil host:r)')).toBe(true)
+  })
+})
+
+describe('git-exec-surface round-9 — dotted-key discriminator + stuck -u + 2-char prefix (Codex Sol r9, definitively final)', () => {
+  const surfaced = (cmd: string) =>
+    (classify('Bash', { command: cmd }, VARIANT1).matchedRule ?? '').includes('git-exec-surface')
+
+  // FIX 1 (CRITICAL) — a `-c` value with `=` but NO dot is a benign branch name,
+  // not a config key. This kills the round-7 false positive.
+  test('git switch -c feature=x (branch name with =) does NOT confirm', () => {
+    expect(surfaced('git switch -c feature=x')).toBe(false)
+    expect(classify('Bash', { command: 'git switch -c feature=x' }, VARIANT1).tier).toBe('allow')
+  })
+  test('git branch -c old=name copied (branch name with =) does NOT confirm', () => {
+    expect(surfaced('git branch -c old=name copied')).toBe(false)
+  })
+  test('git commit -c HEAD / git switch -c feature/x stay benign', () => {
+    expect(surfaced('git commit -c HEAD')).toBe(false)
+    expect(surfaced('git switch -c feature/x')).toBe(false)
+  })
+  test('real DOTTED -c config still confirms', () => {
+    expect(surfaced('git -c core.sshCommand=/tmp/evil push')).toBe(true)
+    expect(surfaced('git clone -c core.sshCommand=/tmp/evil repo')).toBe(true)
+    expect(surfaced('git -c credential.helper=/tmp/x fetch')).toBe(true)
+  })
+
+  // FIX 2 — stuck short `-u<value>` for fetch-family.
+  test('git clone -u/tmp/evil ssh://host/repo (stuck -u) confirms', () => {
+    expect(surfaced('git clone -u/tmp/evil ssh://host/repo')).toBe(true)
+  })
+  test('git fetch -u/x origin (stuck -u) confirms', () => {
+    expect(surfaced('git fetch -u/tmp/evil origin')).toBe(true)
+  })
+  test('stuck -u regression guard: push/add/branch stay benign', () => {
+    expect(surfaced('git push -u origin main')).toBe(false)
+    expect(classify('Bash', { command: 'git add -u' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'git add -u .' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'git branch -u origin/main' }, VARIANT1).tier).toBe('allow')
+  })
+
+  // FIX 3 — 2-char long-option prefix.
+  test('git clone --up=/x ssh://host/repo (--up == --upload-pack) confirms', () => {
+    expect(surfaced('git clone --up=/tmp/evil ssh://host/repo')).toBe(true)
+  })
+  test('threshold-2 does not newly trip the benign long-option set', () => {
+    expect(surfaced('git --no-pager log')).toBe(false)
+    expect(surfaced('git --paginate diff')).toBe(false)
+    expect(surfaced('git log --oneline -5')).toBe(false)
+    expect(classify('Bash', { command: 'git log --author=me' }, VARIANT1).tier).toBe('allow')
+    expect(surfaced('git commit --amend --all')).toBe(false)
+    expect(surfaced('git clone --recurse-submodules host:r')).toBe(false)
+    expect(surfaced('git clone --reference /x host:r')).toBe(false)
+  })
+})
+
+describe('git-exec-surface round-10 — --exec-path=<path> + global -c dotted key without = (Codex Sol r10, final)', () => {
+  const surfaced = (cmd: string) =>
+    (classify('Bash', { command: cmd }, VARIANT1).matchedRule ?? '').includes('git-exec-surface')
+
+  // FIX 1 — --exec-path with a value is RCE; bare --exec-path is benign.
+  test('git --exec-path=/tmp/evil pwn confirms', () => {
+    expect(surfaced('git --exec-path=/tmp/evil pwn')).toBe(true)
+  })
+  test('bare git --exec-path does NOT confirm', () => {
+    expect(surfaced('git --exec-path')).toBe(false)
+    expect(classify('Bash', { command: 'git --exec-path' }, VARIANT1).tier).toBe('allow')
+  })
+  test('--exec-path=<path> under indirection confirms', () => {
+    expect(surfaced('x=$(git --exec-path=/tmp/evil pwn)')).toBe(true)
+  })
+
+  // FIX 2 — a GLOBAL (pre-subcommand) -c with a dotted key confirms even WITHOUT
+  // `=` (git sets it boolean-true); post-subcommand -c stays `=`-required.
+  test('git -c core.hooksPath commit (global dotted -c, no =) confirms', () => {
+    expect(surfaced('git -c core.hooksPath commit')).toBe(true)
+  })
+  test('git -c core.sshCommand fetch (global dotted -c, no =) confirms', () => {
+    expect(surfaced('git -c core.sshCommand fetch')).toBe(true)
+  })
+  test('git -c core.sshCommand=x push (global dotted -c, with =) still confirms', () => {
+    expect(surfaced('git -c core.sshCommand=/tmp/evil push')).toBe(true)
+  })
+  test('MUST STAY BENIGN: branch-name -c cases (post-subcommand, no dotted-key=)', () => {
+    expect(classify('Bash', { command: 'git switch -c feature' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'git switch -c feature=x' }, VARIANT1).tier).toBe('allow')
+    expect(surfaced('git commit -c HEAD')).toBe(false)
+    expect(surfaced('git branch -c old new')).toBe(false)
+    expect(surfaced('git branch -c old=name copied')).toBe(false)
+  })
+})
+
+describe('git-exec-surface round-11 — --config is value-gated like -c (Codex Sol r11, FP fix)', () => {
+  const surfaced = (cmd: string) =>
+    (classify('Bash', { command: cmd }, VARIANT1).matchedRule ?? '').includes('git-exec-surface')
+
+  // FP FIX — `git help --config` lists config variables, benign. `--config`
+  // (and its `config`-resolving prefixes) is the long form of `-c` and needs a
+  // dotted config value to be a surface.
+  test('git help --config does NOT confirm', () => {
+    expect(surfaced('git help --config')).toBe(false)
+    expect(classify('Bash', { command: 'git help --config' }, VARIANT1).tier).toBe('allow')
+  })
+  test('git help --config (trailing space) does NOT confirm', () => {
+    expect(classify('Bash', { command: 'git help --config ' }, VARIANT1).tier).toBe('allow')
+  })
+  test('git help --conf / git help --co do NOT confirm', () => {
+    expect(surfaced('git help --conf')).toBe(false)
+    expect(surfaced('git help --co')).toBe(false)
+  })
+
+  // MUST-CONFIRM — real --config config injection surfaces.
+  test('git clone --config core.sshCommand=x repo (separate value) confirms', () => {
+    expect(surfaced('git clone --config core.sshCommand=/tmp/evil repo')).toBe(true)
+  })
+  test('git clone --config=core.sshCommand=x repo (glued value) confirms', () => {
+    expect(surfaced('git clone --config=core.sshCommand=/tmp/evil repo')).toBe(true)
+  })
+  test('git clone --conf core.sshCommand=x repo (prefix + value) confirms', () => {
+    expect(surfaced('git clone --conf core.sshCommand=/tmp/evil repo')).toBe(true)
+  })
+
+  // Always-surface long forms remain unconditional.
+  test('git --config-env=core.sshCommand=X push still confirms (always-surface)', () => {
+    expect(surfaced('git --config-env=core.sshCommand=X push')).toBe(true)
+  })
+  test('git clone --up=/x host:r still confirms (transport program)', () => {
+    expect(surfaced('git clone --up=/tmp/evil host:r')).toBe(true)
+  })
+  test('git push --receive-pack=/x origin still confirms even when git push is downgraded', () => {
+    const OVR_PUSH: PermissionPolicy = { default_tier: 'allow', confirm_overrides: { builtin_rules: ['git push'] } }
+    const v = classify('Bash', { command: 'git push --receive-pack=/tmp/evil origin' }, OVR_PUSH)
+    expect(v.tier).toBe('confirm')
+    expect(v.matchedRule).toContain('git-exec-surface')
+  })
+
+  // Prior benign guards intact under the new split.
+  test('prior benign cases still do not confirm', () => {
+    expect(classify('Bash', { command: 'git switch -c feature=x' }, VARIANT1).tier).toBe('allow')
+    expect(surfaced('git commit -c HEAD')).toBe(false)
+    expect(surfaced('git -C /path status')).toBe(false)
+    expect(surfaced('git push -u origin main')).toBe(false)
+    expect(classify('Bash', { command: 'git add -u' }, VARIANT1).tier).toBe('allow')
+    expect(surfaced('git --exec-path')).toBe(false)
+    expect(surfaced('git --no-pager log')).toBe(false)
+    expect(surfaced('git log --oneline -5')).toBe(false)
+  })
+})
+
+describe('git-exec-surface round-12 — global -c is unconditional (URL-scoped config-key RCE) (Codex Sol r12, final)', () => {
+  const surfaced = (cmd: string) =>
+    (classify('Bash', { command: cmd }, VARIANT1).matchedRule ?? '').includes('git-exec-surface')
+
+  // FINDING — URL-scoped config key (`credential.<URL>.helper=!cmd`) is RCE; its
+  // `:`/`/` chars fail the dotted-key regex, so a GLOBAL `-c` must not require it.
+  test('git -c credential.https://host.helper=!id fetch (URL-scoped key) confirms', () => {
+    expect(surfaced("git -c 'credential.https://github.com.helper=!id' fetch https://github.com/private/repo")).toBe(true)
+  })
+  test('global -c with any nonempty value confirms (no benign global -c exists)', () => {
+    expect(surfaced('git -c core.sshCommand=/tmp/evil push')).toBe(true)
+    expect(surfaced('git -c core.hooksPath commit')).toBe(true)
+    expect(surfaced('git -c foo=bar push')).toBe(true) // git-rejected but safe-side
+  })
+
+  // MUST-STAY-BENIGN — post-subcommand `-c` rule unchanged (branch names etc.).
+  test('post-subcommand -c (branch names / message reuse) stays benign', () => {
+    expect(classify('Bash', { command: 'git switch -c feature=x' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'git switch -c feature' }, VARIANT1).tier).toBe('allow')
+    expect(surfaced('git commit -c HEAD')).toBe(false)
+    expect(surfaced('git commit -c HEAD --amend')).toBe(false)
+    expect(surfaced('git branch -c old new')).toBe(false)
+    expect(surfaced('git branch -c old=name copied')).toBe(false)
+    expect(surfaced('git log -c')).toBe(false)
+    expect(surfaced('git show -c HEAD')).toBe(false)
+    expect(surfaced('git -C /path status')).toBe(false)
+    expect(surfaced('git help --config')).toBe(false)
+  })
+})
+
+describe('git-exec-surface round-13 — config family is POSITION/SUBCOMMAND gated, not value-shape (Codex Sol r13, terminal)', () => {
+  const surfaced = (cmd: string) =>
+    (classify('Bash', { command: cmd }, VARIANT1).matchedRule ?? '').includes('git-exec-surface')
+
+  // MUST-CONFIRM — long-form `--config` under clone with a URL-scoped key.
+  test("git clone --config='credential.https://host.helper=!id' url (URL-scoped, long) confirms", () => {
+    expect(surfaced("git clone --config='credential.https://github.com.helper=!id' https://github.com/private/repo")).toBe(true)
+  })
+  test('git clone --config=core.sshCommand=x r (glued) confirms', () => {
+    expect(surfaced('git clone --config=core.sshCommand=/tmp/evil r')).toBe(true)
+  })
+  test('git clone --config core.sshCommand=x r (separate) confirms', () => {
+    expect(surfaced('git clone --config core.sshCommand=/tmp/evil r')).toBe(true)
+  })
+  test("git clone -c 'credential.https://host.helper=!id' url (URL-scoped, short) confirms", () => {
+    expect(surfaced("git clone -c 'credential.https://github.com.helper=!id' https://github.com/private/repo")).toBe(true)
+  })
+  test('git clone -c core.sshCommand=x r confirms', () => {
+    expect(surfaced('git clone -c core.sshCommand=/tmp/evil r')).toBe(true)
+  })
+  test("git -c 'credential.https://h.helper=!id' fetch url (global, URL-scoped) confirms", () => {
+    expect(surfaced("git -c 'credential.https://h.helper=!id' fetch https://h/r")).toBe(true)
+  })
+  test('other always-surfaces intact', () => {
+    expect(surfaced('git -c core.sshCommand=/tmp/evil push')).toBe(true)
+    expect(surfaced('git --config-env=core.sshCommand=X push')).toBe(true)
+    expect(surfaced('git --exec-path=/tmp/evil pwn')).toBe(true)
+    expect(surfaced('git clone -u/tmp/evil ssh://host/repo')).toBe(true)
+  })
+
+  // MUST-STAY-BENIGN — non-clone `-c`/`--config` and everyday commands.
+  test('non-clone -c and --config plus everyday commands stay benign', () => {
+    expect(classify('Bash', { command: 'git switch -c feature=x' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'git switch -c feature' }, VARIANT1).tier).toBe('allow')
+    expect(surfaced('git commit -c HEAD')).toBe(false)
+    expect(surfaced('git commit -c HEAD --amend')).toBe(false)
+    expect(surfaced('git branch -c old new')).toBe(false)
+    expect(surfaced('git branch -c old=name copied')).toBe(false)
+    expect(classify('Bash', { command: 'git checkout -b x' }, VARIANT1).tier).toBe('allow')
+    expect(surfaced('git log -c')).toBe(false)
+    expect(surfaced('git show -c HEAD')).toBe(false)
+    expect(surfaced('git help --config')).toBe(false)
+    expect(classify('Bash', { command: 'git help --config ' }, VARIANT1).tier).toBe('allow')
+    expect(surfaced('git -C /path status')).toBe(false)
+    expect(surfaced('git push -u origin main')).toBe(false)
+    expect(classify('Bash', { command: 'git add -u' }, VARIANT1).tier).toBe('allow')
+    expect(classify('Bash', { command: 'git config user.name x' }, VARIANT1).tier).toBe('allow')
+  })
+})


### PR DESCRIPTION
## Что и зачем

Вождь 2026-07-09: убрать confirm-карточки гейта на обычных командах — он всё равно жмёт Allow. Первый подход (снести последние два confirm-детектора `git-exec-surface` + `pipe-interpreter`) **отклонён двойным ревью**: Codex GPT-5.6 Sol дал BLOCK — эти детекторы ловят RCE-через-индирекцию (`curl|sh`, `git -c core.sshCommand=evil`), а silent-allow открыл бы обход lexical deny-спайна. Fable дал SHIP, но пропустил это — цена двойного кросс-family ревью.

Вместо сноса — сделал детектор `git-exec-surface` **точным**: убрал ложные срабатывания, сохранив (и усилив) защиту.

## Ложные срабатывания устранены

`git switch -c`, `git commit -c HEAD`, `git branch -c old new`, `git log -c`, `git show -c HEAD`, `git checkout -b`, git-в-строке рядом с `python3 -c`, `git -C /path`, `git help --config`, `git push -u`, `git add -u` — больше **не** поднимают карточку.

## Защита от RCE усилена (позиционно-независимая value/subcommand модель)

- **короткий `-c`**: config-инъекция = глобальный `-c` с любым значением ЛИБО `-c`/`--config` под `clone` (любой ключ, включая URL-scoped `credential.https://...helper=!id`); после сабкоманды benign (имена веток, даже с `=`)
- **длинные exec-флаги**: `--config-env`, `--upload-pack`/`--receive-pack` (+ префикс-аббревиатуры), `--exec`, `--exec-path=<val>` — position-independent, ловят фрагментацию кавычками (`--receive'-pack'`)
- **git-алиасы**: `-u`/`-u<val>` для fetch-семейства = `--upload-pack`
- **индирекция** (`$`/backtick): flatten + ANSI-C decode + fail-closed маркеры
- **сохранены**: `GIT_SSH_COMMAND=` env-config и `.git/hooks` гарды, весь deny-спайн (secrets, own-channel systemctl, force-push) — не переопределяемы

## Ревью

Двойное ревью Codex GPT-5.6 Sol + Fable. **13 кругов** adversarial-упрочнения — каждый круг Codex находил либо реальную дыру (`git clone -c`, фрагментированный `--receive-pack`, ANSI-C `$'git'`, URL-scoped ключи), либо ложный срабат моего же рефактора (`git help --config`), и то, и другое устранялось. Финальный вердикт: **Codex SHIP, 0 находок**.

- `bun test` (plugin/): **2049 pass / 0 fail** (полный прогон 2221/0)
- `bun run typecheck`: 0 ошибок

## Задокументированный остаток

1-символьные сокращения опций git (`--u`) и глубокая per-subcommand неоднозначность аббревиатур требуют полного парсера `parse-options` git — неразрешимо в эвристике, присутствует в baseline v1.1.0. Эксплойт требует специально обфусцированной инъекции.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
