### PR TITLE
Задачи в пине: узкие фидеры, lifecycle-фиксы и зеркало реальности из tmux-пейна

### DIFF
--- a/plugin/scripts/patch-claude-settings.ts
+++ b/plugin/scripts/patch-claude-settings.ts
@@ -20,7 +20,8 @@
 //     [--helper /abs/path/to/post-hook.ts]
 
 import { readFileSync, writeFileSync, renameSync, existsSync, unlinkSync } from 'fs'
-import { dirname, resolve as pathResolve } from 'path'
+import { homedir } from 'os'
+import { dirname, join, resolve as pathResolve } from 'path'
 import { fileURLToPath } from 'url'
 
 const MARKER = 'dashi-channel-hook'
@@ -336,8 +337,66 @@ function writeAtomic(path: string, contents: string): void {
   }
 }
 
+// ─── wide-feeder narrowing warning (review 2026-07-09 SHOULD-fix) ──────
+// Re-running the patch over an OLD wide install (a `.*` PreToolUse/PostToolUse
+// dashi feeder) silently narrows the feeder set. That is correct for the
+// current surfaces, but a fleet install whose plugin config still enables the
+// per-tool consumers (status / progress reporters) would silently lose their
+// event stream. Detect the narrowing + the enabled consumers and WARN loudly.
+
+/** True when the pre-patch settings carry one of OUR feeders on a wide surface. */
+export function hasWideDashiFeeder(settings: SettingsShape): boolean {
+  const hooks = settings.hooks ?? {}
+  const isOurs = (e: HookEntry | undefined): boolean =>
+    e !== undefined && (e.marker === MARKER || isLegacyDashiEntry(e))
+  for (const e of hooks.PreToolUse ?? []) {
+    if (isOurs(e)) return true // PreToolUse feeder no longer installed at all
+  }
+  for (const e of hooks.PostToolUse ?? []) {
+    if (isOurs(e) && (e.matcher === undefined || e.matcher === '.*' || e.matcher === '')) {
+      return true // unscoped PostToolUse feeder — fired on every tool
+    }
+  }
+  return false
+}
+
+// Best-effort read of the PLUGIN config (not the Claude settings being
+// patched) to see whether the per-tool consumers are enabled. Mirrors the
+// loadConfig path resolution: TELEGRAM_CONFIG_FILE, else
+// <TELEGRAM_STATE_DIR|~/.claude/channels/dashi-telegram-canary>/config.json.
+// Both status.enabled and progress.enabled default to FALSE in the schema, so
+// only an explicit `true` in config.json counts.
+function pluginConsumersEnabled(env: NodeJS.ProcessEnv): boolean {
+  try {
+    const stateRoot =
+      env.TELEGRAM_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'dashi-telegram-canary')
+    const configPath = env.TELEGRAM_CONFIG_FILE ?? join(stateRoot, 'config.json')
+    if (!existsSync(configPath)) return false
+    const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as {
+      status?: { enabled?: unknown }
+      progress?: { enabled?: unknown }
+    }
+    return parsed.status?.enabled === true || parsed.progress?.enabled === true
+  } catch {
+    return false
+  }
+}
+
+function warnIfNarrowing(settings: SettingsShape, env: NodeJS.ProcessEnv): void {
+  if (!hasWideDashiFeeder(settings)) return
+  if (!pluginConsumersEnabled(env)) return
+  process.stderr.write(
+    'WARNING: narrowing the dashi-channel hook feeders (dropping the wide ' +
+      'PreToolUse/PostToolUse `.*` feeder) while the plugin config has ' +
+      'status.enabled/progress.enabled=true — those surfaces consume the ' +
+      'per-tool event stream and will stop updating per tool call. Disable ' +
+      'them in config.json or keep a wide feeder manually.\n',
+  )
+}
+
 export function patchSettingsFile(opts: PatchOptions): void {
   const settings = readSettings(opts.settingsPath)
+  warnIfNarrowing(settings, process.env)
   const patched = applyPatch(settings, opts)
   const out = `${JSON.stringify(patched, null, 2)}\n`
   if (out.includes('TELEGRAM_WEBHOOK_TOKEN=')) {

--- a/plugin/scripts/patch-claude-settings.ts
+++ b/plugin/scripts/patch-claude-settings.ts
@@ -41,19 +41,42 @@ const REMINDER_MARKER = 'dashi-channel-reminder-hook'
 // the legacy entry in place + append the marked one, firing the hook
 // twice (review §6).
 const HELPER_PATH_FINGERPRINT = 'post-hook.ts'
+
+// All hook events we TOUCH — we filter our own (marker / legacy / gate) entries
+// out of each and rebuild. PreToolUse is iterated so the permission-gate hook
+// still installs there, even though it no longer carries a notification feeder.
 const HOOK_EVENTS = [
   'SessionStart',
   'UserPromptSubmit',
   'PreToolUse',
   'PostToolUse',
+  'SessionEnd',
   'Stop',
 ] as const
 
 type HookEvent = (typeof HOOK_EVENTS)[number]
 
+// NARROW canonical notification-feeder set (2026-07-09). The feeder spawns a
+// `bun` process + HTTP POST for every event it fires on; a `.*` PreToolUse /
+// PostToolUse feeder therefore paid that cost on EVERY tool call — far too much
+// on a 7.8 GB VPS, and the status/progress surfaces that once consumed the
+// per-tool stream are disabled. The surfaces still in use (pinned context HUD +
+// task mirror) need only: session lifecycle (SessionStart / SessionEnd),
+// per-turn context refresh (UserPromptSubmit / Stop), and the task tools
+// (PostToolUse scoped to TaskCreate|TaskUpdate|TodoWrite).
+const FEEDER_EVENTS: ReadonlySet<HookEvent> = new Set<HookEvent>([
+  'SessionStart',
+  'UserPromptSubmit',
+  'PostToolUse',
+  'SessionEnd',
+  'Stop',
+])
+
+// Claude Code hook matchers accept `|`-separated EXACT tool names. Scoping the
+// PostToolUse feeder to the three task tools is what keeps the feeder off the
+// hot path (Bash/Read/Edit/… no longer fire it).
 const MATCHER_BY_EVENT: Partial<Record<HookEvent, string>> = {
-  PreToolUse: '.*',
-  PostToolUse: '.*',
+  PostToolUse: 'TaskCreate|TaskUpdate|TodoWrite',
 }
 
 export interface PatchOptions {
@@ -180,11 +203,12 @@ export function applyPatch(settings: SettingsShape, opts: PatchOptions): Setting
   const hooks: NonNullable<SettingsShape['hooks']> = { ...(settings.hooks ?? {}) }
   const withGate = opts.permissionGateHelperPath !== undefined
   for (const event of HOOK_EVENTS) {
-    const next = buildEntryFor(event, opts)
     const existing = hooks[event] ?? []
     // Drop anything that's clearly ours: notification marker, legacy
     // markerless notification entry, OR the gate marker (re-added below for
-    // PreToolUse). Unrelated entries survive untouched.
+    // PreToolUse). Unrelated entries survive untouched. This also STRIPS a
+    // previously-installed `.*` PreToolUse/PostToolUse feeder (same MARKER), so
+    // re-running the patch migrates an old wide install to the narrow set.
     const filtered = existing.filter(
       (e) =>
         !e ||
@@ -193,9 +217,14 @@ export function applyPatch(settings: SettingsShape, opts: PatchOptions): Setting
           e.marker !== REMINDER_MARKER &&
           !isLegacyDashiEntry(e)),
     )
-    const rebuilt = [...filtered, next]
+    const rebuilt = [...filtered]
+    // The notification feeder is added ONLY for the narrow FEEDER_EVENTS set.
+    // PreToolUse is iterated (for the gate below) but no longer gets a feeder.
+    if (FEEDER_EVENTS.has(event)) {
+      rebuilt.push(buildEntryFor(event, opts))
+    }
     // The gate hook lives on PreToolUse only, and is registered FIRST so its
-    // deny verdict is evaluated before the notification mirror runs.
+    // deny verdict is evaluated before any later hook runs.
     if (event === 'PreToolUse' && withGate) {
       rebuilt.unshift(buildGateEntry(opts))
     }
@@ -205,7 +234,13 @@ export function applyPatch(settings: SettingsShape, opts: PatchOptions): Setting
     if (event === 'UserPromptSubmit' && opts.reminderHelperPath !== undefined) {
       rebuilt.push(buildReminderEntry(opts))
     }
-    hooks[event] = rebuilt
+    // Don't leave an empty array behind (e.g. PreToolUse with no gate): drop
+    // the key so the patched settings stay clean.
+    if (rebuilt.length > 0) {
+      hooks[event] = rebuilt
+    } else {
+      delete hooks[event]
+    }
   }
   return { ...settings, hooks }
 }

--- a/plugin/scripts/sync-multichat-hooks.sh
+++ b/plugin/scripts/sync-multichat-hooks.sh
@@ -26,6 +26,16 @@
 #     (tmux kill-session -t multichat-<chat_id>; the router respawns on the
 #     next inbound message).
 #
+# Task-feeder note (2026-07-09): child multichat sessions deliberately carry
+# NO context-HUD / task-mirror notification feeders. Those surfaces are
+# owner-DM only (a group/supergroup chat id is negative and never gets a pinned
+# HUD), and the master DM session's feeders are installed separately by
+# scripts/patch-claude-settings.ts — which now uses the NARROW canonical set
+# (SessionStart, UserPromptSubmit, PostToolUse=TaskCreate|TaskUpdate|TodoWrite,
+# SessionEnd, Stop), no `.*` PreToolUse/PostToolUse. The per-chat hooks synced
+# below (persona / policy-gate / outbox / hot-memory) are the ONLY hooks a
+# child workspace runs; do NOT add wide notification feeders here.
+#
 # Usage:
 #   scripts/sync-multichat-hooks.sh [--deploy-dir /abs/path]
 # Default deploy dir: ~/.claude-lab/thrall/.claude/chats/hooks

--- a/plugin/src/hooks/claude-events.ts
+++ b/plugin/src/hooks/claude-events.ts
@@ -79,8 +79,14 @@ export type ActivityStatusEvent =
 // thread, todo list) keep independent lifecycles.
 // ─────────────────────────────────────────────────────────────────────
 
+// Every TaskMirror event carries the `sessionId` it belongs to. Harness task
+// numbering restarts at #1 on every new session, so the mirror MUST namespace
+// its snapshot by session — a task event whose sessionId differs from the
+// current snapshot's is a new session and resets the surface. Sourced from the
+// hook payload's `session_id` (always present per ClaudeHookCommonShape).
 export interface TodoWriteEvent {
   readonly kind: 'todo_write'
+  readonly sessionId: string
   readonly todos: ReadonlyArray<TodoItem>
   readonly chatId?: string
 }
@@ -94,27 +100,44 @@ export interface TodoWriteEvent {
 // (Phase 2 — for now the provisional id stays).
 export interface TaskCreateEvent {
   readonly kind: 'task_create'
+  readonly sessionId: string
   readonly toolUseId: string
   readonly input: TaskCreateInput
-  // Populated on PostToolUse when the harness has materialised the task; null
-  // on PreToolUse. Format: usually `Task #<n> created` — TaskMirror runs the
-  // same regex extract as the warchief's terminal renderer.
+  // Populated on PostToolUse when the harness has materialised the task.
+  // Format: usually `Task #<n> created` — TaskMirror runs the same regex
+  // extract as the warchief's terminal renderer. We map ONLY the PostToolUse
+  // pass (see toTodoWriteEvent): a provisional PreToolUse create would race the
+  // permission gate on the same event and, if rejected, leave a phantom task.
   readonly toolResult?: unknown
   readonly chatId?: string
 }
 
 export interface TaskUpdateEvent {
   readonly kind: 'task_update'
+  readonly sessionId: string
   readonly toolUseId: string
   readonly input: TaskUpdateInput
   readonly chatId?: string
 }
 
-// Session-stop signal for TaskMirror specifically. Renamed from the
-// ActivityStatusEvent variant so the TaskMirror dispatcher does not
-// accidentally consume a non-todo Stop hook.
-export interface TodoSessionStopEvent {
-  readonly kind: 'todo_session_stop'
+// Session lifecycle signals for the task surfaces. SessionStart resets the
+// snapshot when the session id changes (a genuine new session) and preserves
+// it otherwise (compact / resume keep the same id). SessionEnd — a REAL Claude
+// Code hook, unlike Stop which is turn-end — finalizes the surface. Stop no
+// longer maps to any TaskMirrorEvent: it must NOT finalize tasks.
+export interface TaskSessionStartEvent {
+  readonly kind: 'session_start'
+  readonly sessionId: string
+  // SessionStart fires for startup / resume / clear / compact. The mirror uses
+  // `sessionId` (not source) as the reset key; source rides along for the HUD.
+  readonly source?: 'startup' | 'resume' | 'clear' | 'compact'
+  readonly chatId?: string
+}
+
+export interface TaskSessionEndEvent {
+  readonly kind: 'session_end'
+  readonly sessionId: string
+  readonly reason?: string
   readonly chatId?: string
 }
 
@@ -122,7 +145,22 @@ export type TaskMirrorEvent =
   | TodoWriteEvent
   | TaskCreateEvent
   | TaskUpdateEvent
-  | TodoSessionStopEvent
+  | TaskSessionStartEvent
+  | TaskSessionEndEvent
+
+// The subset of TaskMirrorEvent that mutates the task snapshot (as opposed to
+// the session lifecycle signals). The context HUD's `onTodoEvent` consumes
+// ONLY these; lifecycle events reach the HUD through its dedicated
+// onSessionStart / onSessionEnd entry points instead.
+export type TaskMutationEvent = TodoWriteEvent | TaskCreateEvent | TaskUpdateEvent
+
+export function isTaskMutationEvent(event: TaskMirrorEvent): event is TaskMutationEvent {
+  return (
+    event.kind === 'todo_write' ||
+    event.kind === 'task_create' ||
+    event.kind === 'task_update'
+  )
+}
 
 /**
  * Convert a validated Claude hook payload to an ActivityStatusEvent.
@@ -170,6 +208,9 @@ export function toActivityEvent(payload: ClaudeHookPayload): ActivityStatusEvent
     }
     case 'Stop':
       return { kind: 'session_stop', ...chatIdProp }
+    case 'SessionEnd':
+      // Real session end also closes the transient status bubble.
+      return { kind: 'session_stop', ...chatIdProp }
     case 'UserPromptSubmit':
       return { kind: 'reasoning', ...chatIdProp }
     case 'SessionStart':
@@ -180,17 +221,21 @@ export function toActivityEvent(payload: ClaudeHookPayload): ActivityStatusEvent
 /**
  * Convert a validated Claude hook payload to a TaskMirrorEvent.
  *
- * Returns non-null ONLY for events TaskMirror cares about:
- *   - PostToolUse with tool_name === 'TodoWrite' → parses tool_input via
- *     TodoWriteInputSchema. On parse failure, logs a warning and returns
- *     null (graceful degradation — the rolling activity thread still
- *     renders correctly because toActivityEvent handles the same payload
- *     independently).
- *   - Stop → returns `{ kind: 'todo_session_stop' }` so TaskMirror can
- *     finalize and evict its per-chat entry.
+ * Returns non-null ONLY for events the task surfaces care about:
+ *   - SessionStart → `session_start` lifecycle event (carries source). The
+ *     mirror resets its snapshot when the session id changes and preserves it
+ *     on compact / resume of the same id.
+ *   - SessionEnd → `session_end` lifecycle event. This is the REAL session end
+ *     — the mirror finalizes here, never on Stop.
+ *   - PostToolUse TodoWrite → `todo_write` (full-list snapshot).
+ *   - PostToolUse TaskCreate → `task_create` with `toolResult`. We map ONLY
+ *     the PostToolUse pass: a provisional PreToolUse create runs concurrently
+ *     with the permission gate on the same event, so a rejected create would
+ *     leave a phantom task in the mirror.
+ *   - PostToolUse TaskUpdate → `task_update`.
  *
- * Every other hook event returns null so the caller can short-circuit
- * before touching TaskMirror.
+ * Stop returns null on purpose (it is turn-end, not session-end). Every other
+ * hook event returns null so the caller can short-circuit.
  */
 export function toTodoWriteEvent(
   payload: ClaudeHookPayload,
@@ -203,10 +248,30 @@ export function toTodoWriteEvent(
     payload.chatId !== undefined && payload.chatId !== ''
       ? { chatId: payload.chatId }
       : {}
+  // session_id is required on every hook payload (ClaudeHookCommonShape); the
+  // mirror namespaces its snapshot by it so a new session starts a clean list.
+  const sessionId = payload.session_id
 
-  if (payload.hook_event_name === 'Stop') {
-    return { kind: 'todo_session_stop', ...chatIdProp }
+  if (payload.hook_event_name === 'SessionStart') {
+    const event: TaskSessionStartEvent = {
+      kind: 'session_start',
+      sessionId,
+      ...(payload.source !== undefined ? { source: payload.source } : {}),
+      ...chatIdProp,
+    }
+    return event
   }
+
+  if (payload.hook_event_name === 'SessionEnd') {
+    const event: TaskSessionEndEvent = {
+      kind: 'session_end',
+      sessionId,
+      ...(typeof payload.reason === 'string' ? { reason: payload.reason } : {}),
+      ...chatIdProp,
+    }
+    return event
+  }
+
   if (payload.hook_event_name === 'PostToolUse' && payload.tool_name === 'TodoWrite') {
     const parsed = TodoWriteInputSchema.safeParse(payload.tool_input)
     if (!parsed.success) {
@@ -215,16 +280,13 @@ export function toTodoWriteEvent(
       })
       return null
     }
-    return { kind: 'todo_write', todos: parsed.data.todos, ...chatIdProp }
+    return { kind: 'todo_write', sessionId, todos: parsed.data.todos, ...chatIdProp }
   }
 
-  // TaskCreate -- emit on PreToolUse so the milestone shows up the moment the
-  // warchief sees it spawn, and again on PostToolUse with `toolResult` so
-  // TaskMirror can reconcile the provisional id with the harness-assigned one.
-  if (
-    (payload.hook_event_name === 'PreToolUse' || payload.hook_event_name === 'PostToolUse') &&
-    payload.tool_name === 'TaskCreate'
-  ) {
+  // TaskCreate -- PostToolUse ONLY. The harness has assigned the real id by
+  // then (carried in `tool_result`) and the create has cleared the permission
+  // gate, so we never record a task that a rejected PreToolUse would orphan.
+  if (payload.hook_event_name === 'PostToolUse' && payload.tool_name === 'TaskCreate') {
     const parsed = TaskCreateInputSchema.safeParse(payload.tool_input)
     if (!parsed.success) {
       log?.warn('TaskCreate tool_input failed schema validation (ignored)', {
@@ -234,11 +296,12 @@ export function toTodoWriteEvent(
     }
     const event: TaskCreateEvent = {
       kind: 'task_create',
+      sessionId,
       toolUseId: payload.tool_use_id,
       input: parsed.data,
       ...chatIdProp,
     }
-    return payload.hook_event_name === 'PostToolUse' && payload.tool_result !== undefined
+    return payload.tool_result !== undefined
       ? { ...event, toolResult: payload.tool_result }
       : event
   }
@@ -256,6 +319,7 @@ export function toTodoWriteEvent(
     }
     return {
       kind: 'task_update',
+      sessionId,
       toolUseId: payload.tool_use_id,
       input: parsed.data,
       ...chatIdProp,

--- a/plugin/src/schemas.ts
+++ b/plugin/src/schemas.ts
@@ -260,12 +260,27 @@ export const ClaudeSessionStartSchema = z
   })
   .passthrough()
 
+// SessionEnd is a REAL Claude Code hook event (unlike Stop, which is turn-end).
+// It fires once when the session actually terminates (clear / logout /
+// prompt_input_exit / other). The task surfaces (TaskMirror, context HUD)
+// finalize on THIS event, never on Stop. `reason` is an open string because
+// the harness may add reasons across versions; passthrough keeps unknown
+// fields riding through.
+export const ClaudeSessionEndSchema = z
+  .object({
+    ...ClaudeHookCommonShape,
+    hook_event_name: z.literal('SessionEnd'),
+    reason: z.string().optional(),
+  })
+  .passthrough()
+
 export const ClaudeHookPayloadSchema = z.discriminatedUnion('hook_event_name', [
   ClaudePreToolUseSchema,
   ClaudePostToolUseSchema,
   ClaudeStopSchema,
   ClaudeUserPromptSubmitSchema,
   ClaudeSessionStartSchema,
+  ClaudeSessionEndSchema,
 ])
 export type ClaudeHookPayload = z.infer<typeof ClaudeHookPayloadSchema>
 

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -51,6 +51,8 @@ import { StatusManager } from './status/status-manager.js'
 import { ProgressReporter } from './status/progress-reporter.js'
 import { TaskMirror } from './status/task-mirror.js'
 import { TmuxMirror } from './status/tmux-mirror.js'
+import { defaultTmuxExec } from './status/pane-capture.js'
+import { TaskRealityMirror } from './status/task-reality-mirror.js'
 import { SessionInfoStore } from './status/session-info.js'
 import {
   ContextHud,
@@ -606,6 +608,48 @@ if (config.tmux_mirror.enabled) {
     process.once('SIGINT', shutdownMirror)
     process.once('SIGTERM', shutdownMirror)
   }
+}
+
+// Env gate for the M3 reconciler (behaviour-changing surface, off by default).
+// Accepts `1` / `true` / `yes` / `on` (case-insensitive).
+function resolveTaskReconcilerEnabled(): boolean {
+  const v = (process.env.JARVIS_TASK_RECONCILER ?? '').trim().toLowerCase()
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on'
+}
+
+// TaskRealityMirror (M3, 2026-07-09) — reconciles the tool-event stream with
+// the REAL task list Claude Code renders in the tmux pane, so the context HUD
+// «Задачи» section and the TaskMirror message reflect reality even when the
+// agent forgets to call the task tools. Default-OFF: opt in with
+// JARVIS_TASK_RECONCILER=1 (behaviour-changing surface, warchief-gated, like
+// tmux_mirror). Reuses the tmux_mirror pane target/socket (the agent's task
+// list renders in that same pane) and captures a wider window (200 lines) so a
+// long list is always in view. Owner-DM-gated; each sink also gates internally.
+let taskRealityMirror: TaskRealityMirror | undefined
+if (resolveTaskReconcilerEnabled()) {
+  const paneTarget = config.tmux_mirror.pane_target || 'channel-thrall:0.0'
+  const ownerSet = new Set(hudOwnerChatIds.map(String))
+  taskRealityMirror = new TaskRealityMirror({
+    exec: defaultTmuxExec,
+    capture: {
+      paneTarget,
+      ...(config.tmux_mirror.socket_name ? { socketName: config.tmux_mirror.socket_name } : {}),
+      lineCount: 200,
+    },
+    log,
+    sinks: [contextHud, taskMirror],
+    // Owner DM only (positive numeric chat id in the owner set) — the pane is
+    // the single global DM session; a group chat must never be reconciled.
+    isOwnerChat: (chatId: string): boolean => {
+      if (!ownerSet.has(chatId)) return false
+      const n = Number(chatId)
+      return Number.isInteger(n) && n > 0
+    },
+  })
+  log.info('task reality mirror configured', { pane_target: paneTarget })
+  const shutdownReality = (): void => taskRealityMirror?.stop()
+  process.once('SIGINT', shutdownReality)
+  process.once('SIGTERM', shutdownReality)
 }
 
 // InboundWatcher (PR-A3, 2026-05-20) — auto-reply «Тралл занят» when the
@@ -1384,6 +1428,7 @@ try {
     contextHud,
     progressReporter,
     taskMirror,
+    ...(taskRealityMirror !== undefined ? { taskRealityMirror } : {}),
     watcher: inboundWatcher,
     ...(memoryWriter !== undefined ? { memoryWriter } : {}),
     // PRX-1 TASK-3 (2026-05-27): AskUserQuestion HTTP relay routes.

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -559,14 +559,21 @@ const progressReporter = new ProgressReporter({ telegramApi, config, log })
 // through redact + HTML validation before leaving the process.
 const taskMirror = new TaskMirror({ telegramApi, config, log, stateDir: statePaths.root })
 
+// Default pane target when tmux_mirror.pane_target is unset. Overridable via
+// JARVIS_PANE_TARGET (review 2026-07-09 SHOULD-fix: the hardcoded
+// `channel-thrall:0.0` fallback breaks on any other host); the historical
+// value stays the default — the canonical session for this plugin on Thrall.
+function resolveDefaultPaneTarget(): string {
+  return (process.env.JARVIS_PANE_TARGET ?? '').trim() || 'channel-thrall:0.0'
+}
+
 // TmuxMirror (2026-05-20) — read-only mirror of the agent's terminal pane
 // into ONE rolling Telegram message. Default-OFF in config; the warchief
 // opts in explicitly. When enabled without an explicit pane_target we
-// fall back to `channel-thrall:0.0` — the canonical session for this
-// plugin on Thrall VPS.
+// fall back to resolveDefaultPaneTarget().
 let tmuxMirror: TmuxMirror | null = null
 if (config.tmux_mirror.enabled) {
-  const target = config.tmux_mirror.pane_target || 'channel-thrall:0.0'
+  const target = config.tmux_mirror.pane_target || resolveDefaultPaneTarget()
   const mirrorChatId = String(config.allowed_chat_ids[0] ?? '')
   if (mirrorChatId === '') {
     log.warn('tmux mirror enabled but no allowed_chat_ids configured — skipping')
@@ -627,7 +634,7 @@ function resolveTaskReconcilerEnabled(): boolean {
 // long list is always in view. Owner-DM-gated; each sink also gates internally.
 let taskRealityMirror: TaskRealityMirror | undefined
 if (resolveTaskReconcilerEnabled()) {
-  const paneTarget = config.tmux_mirror.pane_target || 'channel-thrall:0.0'
+  const paneTarget = config.tmux_mirror.pane_target || resolveDefaultPaneTarget()
   const ownerSet = new Set(hudOwnerChatIds.map(String))
   taskRealityMirror = new TaskRealityMirror({
     exec: defaultTmuxExec,

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -555,7 +555,7 @@ const progressReporter = new ProgressReporter({ telegramApi, config, log })
 // showing Claude's TodoWrite milestones. Independent of the two surfaces
 // above; uses the same safe-wrapped telegramApi so every text/edit goes
 // through redact + HTML validation before leaving the process.
-const taskMirror = new TaskMirror({ telegramApi, config, log })
+const taskMirror = new TaskMirror({ telegramApi, config, log, stateDir: statePaths.root })
 
 // TmuxMirror (2026-05-20) — read-only mirror of the agent's terminal pane
 // into ONE rolling Telegram message. Default-OFF in config; the warchief

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -645,6 +645,9 @@ if (resolveTaskReconcilerEnabled()) {
     },
     log,
     sinks: [contextHud, taskMirror],
+    // Session-epoch persistence (active + tombstones) — survives restarts so
+    // late lifecycle stragglers can't roll the epoch back (review r3 #1).
+    stateDir: statePaths.root,
     // Owner DM only (positive numeric chat id in the owner set) — the pane is
     // the single global DM session; a group chat must never be reconciled.
     isOwnerChat: (chatId: string): boolean => {

--- a/plugin/src/status/context-hud.ts
+++ b/plugin/src/status/context-hud.ts
@@ -329,6 +329,8 @@ export class ContextHud {
   // tasks nor the bucketed freshness label changed, skipping the refresh keeps
   // editMessageText traffic at zero instead of a no-op edit per tick.
   private readonly lastReconciledRender = new Map<string, string>()
+  // Chats whose persisted epoch state has been restored this process lifetime.
+  private readonly epochsRestored = new Set<string>()
   // bump() debounce per chat — a burst of inbound messages collapses to one
   // delete+resend (same rationale as TmuxMirror.BUMP_DEBOUNCE_MS).
   private readonly lastBumpAt = new Map<string, number>()
@@ -392,7 +394,20 @@ export class ContextHud {
   onSessionStart(chatId: string, opts: { sessionId?: string; source?: string } = {}): Promise<void> {
     if (!this.enabled || !this.isOwner(chatId)) return Promise.resolve()
     const { sessionId, source } = opts
+    this.restoreEpochs(chatId)
     const prev = this.sessionIds.get(chatId)
+    // Rollback guard (review 2026-07-10 #2): a SessionStart naming an ENDED id
+    // while a DIFFERENT session is tracked is a late/replayed straggler — it
+    // must NOT displace the active session or clear its snapshot. Resume of an
+    // ended id is valid only when no different session is tracked.
+    if (
+      sessionId !== undefined &&
+      prev !== undefined &&
+      prev !== sessionId &&
+      this.endedSessions.get(chatId)?.has(sessionId) === true
+    ) {
+      return Promise.resolve()
+    }
     const sessionChanged = sessionId !== undefined && prev !== undefined && prev !== sessionId
     if (source === 'clear' || sessionChanged) {
       // Genuine reset: drop the prior snapshot so the pin never shows stale
@@ -410,6 +425,7 @@ export class ContextHud {
     if (sessionId !== undefined) {
       this.sessionIds.set(chatId, sessionId)
       this.endedSessions.get(chatId)?.delete(sessionId)
+      this.persistEpoch(chatId)
     }
     return this.runSerialized(chatId, async () => {
       try {
@@ -448,11 +464,13 @@ export class ContextHud {
   // late task event naming it is dropped instead of clearing the active state.
   async onSessionEnd(chatId: string, opts: { sessionId?: string } = {}): Promise<void> {
     if (!this.enabled || !this.isOwner(chatId)) return
+    this.restoreEpochs(chatId)
     const { sessionId } = opts
     const prev = this.sessionIds.get(chatId)
     if (sessionId !== undefined) {
       // Tombstone even a late end for a session we've moved past — its
-      // stragglers must be dropped too.
+      // stragglers must be dropped too. Bound 64 oldest-first (review
+      // 2026-07-10 #2), persisted so tombstones survive a restart.
       let set = this.endedSessions.get(chatId)
       if (set === undefined) {
         set = new Set()
@@ -460,11 +478,12 @@ export class ContextHud {
       }
       set.delete(sessionId)
       set.add(sessionId)
-      while (set.size > 8) {
+      while (set.size > 64) {
         const oldest = set.values().next().value
         if (oldest === undefined) break
         set.delete(oldest)
       }
+      this.persistEpoch(chatId)
     }
     // Ignore a late SessionEnd for a session we've already moved past.
     if (sessionId !== undefined && prev !== undefined && prev !== sessionId) return
@@ -484,6 +503,7 @@ export class ContextHud {
     if (event.kind === 'session_start' || event.kind === 'session_end') {
       return Promise.resolve()
     }
+    this.restoreEpochs(chatId)
     // Drop late stragglers from an ENDED session — they must not clear the
     // active session's snapshot or resurrect the dead id (review 2026-07-09 #2).
     if (this.endedSessions.get(chatId)?.has(event.sessionId) === true) {
@@ -780,32 +800,87 @@ export class ContextHud {
     }
   }
 
-  private loadPersisted(chatId: string): number | undefined {
+  // Full persisted shape (schema-versioned; v2 adds the epoch block).
+  private loadPersistedFull(chatId: string): {
+    messageId?: number
+    epoch?: { active?: string; ended?: ReadonlyArray<string> }
+  } {
     try {
       const raw = readFileSync(this.persistPath(chatId), 'utf8')
       const parsed: unknown = JSON.parse(raw)
-      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-        const id = (parsed as { message_id?: unknown }).message_id
-        if (typeof id === 'number' && Number.isInteger(id) && id > 0) return id
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {}
+      const obj = parsed as Record<string, unknown>
+      const out: { messageId?: number; epoch?: { active?: string; ended?: ReadonlyArray<string> } } = {}
+      const id = obj.message_id
+      if (typeof id === 'number' && Number.isInteger(id) && id > 0) out.messageId = id
+      if (typeof obj.epoch === 'object' && obj.epoch !== null && !Array.isArray(obj.epoch)) {
+        const e = obj.epoch as Record<string, unknown>
+        const active = typeof e.active === 'string' && e.active.length > 0 ? e.active : undefined
+        const ended = Array.isArray(e.ended)
+          ? e.ended.filter((s): s is string => typeof s === 'string' && s.length > 0).slice(-64)
+          : undefined
+        out.epoch = {
+          ...(active !== undefined ? { active } : {}),
+          ...(ended !== undefined ? { ended } : {}),
+        }
       }
+      return out
     } catch {
-      // Missing file / malformed JSON → treat as "no persisted id".
+      return {} // missing file / malformed JSON → nothing persisted
     }
-    return undefined
   }
 
-  private persist(chatId: string, messageId: number): void {
+  private loadPersisted(chatId: string): number | undefined {
+    return this.loadPersistedFull(chatId).messageId
+  }
+
+  // Restore persisted epoch state (tracked session + ended tombstones) ONCE
+  // per chat (review 2026-07-10 #2: HUD epoch state was runtime-only, so a
+  // restart forgot every tombstone and a dead session's stragglers could
+  // clear the active snapshot). Runtime state is never clobbered.
+  private restoreEpochs(chatId: string): void {
+    if (this.epochsRestored.has(chatId)) return
+    this.epochsRestored.add(chatId)
+    const epoch = this.loadPersistedFull(chatId).epoch
+    if (epoch === undefined) return
+    if (epoch.active !== undefined && !this.sessionIds.has(chatId)) {
+      this.sessionIds.set(chatId, epoch.active)
+    }
+    if (epoch.ended !== undefined && !this.endedSessions.has(chatId)) {
+      this.endedSessions.set(chatId, new Set(epoch.ended))
+    }
+  }
+
+  private writePersisted(chatId: string, messageId: number | undefined): void {
     try {
       mkdirSync(this.stateDir, { recursive: true, mode: 0o700 })
-      writeFileSync(this.persistPath(chatId), JSON.stringify({ message_id: messageId }), {
-        mode: 0o600,
-      })
+      const active = this.sessionIds.get(chatId)
+      const ended = this.endedSessions.get(chatId)
+      const body = {
+        v: 2,
+        ...(messageId !== undefined ? { message_id: messageId } : {}),
+        epoch: {
+          ...(active !== undefined ? { active } : {}),
+          ...(ended !== undefined && ended.size > 0 ? { ended: [...ended] } : {}),
+        },
+      }
+      writeFileSync(this.persistPath(chatId), JSON.stringify(body), { mode: 0o600 })
     } catch (err) {
       this.log.warn('context hud persist failed (ignored)', {
         chat_id: chatId,
         error: err instanceof Error ? err.message : String(err),
       })
     }
+  }
+
+  private persist(chatId: string, messageId: number): void {
+    this.writePersisted(chatId, messageId)
+  }
+
+  // Refresh ONLY the epoch block, preserving the persisted message id.
+  private persistEpoch(chatId: string): void {
+    const messageId = this.messageIds.get(chatId) ?? this.loadPersistedFull(chatId).messageId
+    this.writePersisted(chatId, messageId)
   }
 }
 

--- a/plugin/src/status/context-hud.ts
+++ b/plugin/src/status/context-hud.ts
@@ -27,6 +27,7 @@ import { join } from 'node:path'
 import { classifyEditError } from '../safety/telegram-edit-classifier.js'
 import { readContextUsage as realReadContextUsage, type ContextUsage } from './context-usage.js'
 import { applyTaskCreateToMap, applyTaskUpdateToMap } from './task-mirror.js'
+import { renderFreshnessHeader, type TaskFreshness } from './task-freshness.js'
 import type { TaskMirrorEvent } from '../hooks/claude-events.js'
 import type { TodoItem } from '../schemas.js'
 import type { EditOpts, InlineKeyboardLike, SendMessageOpts } from '../channel/tools.js'
@@ -75,6 +76,9 @@ export function buildHudKeyboard(): InlineKeyboardLike {
 export interface HudWorkView {
   todos: ReadonlyArray<TodoItem>
   permissionMode?: string
+  // M3 reality mirror: when present, the «Задачи» header carries a freshness
+  // indicator («сверено … / ДАННЫЕ УСТАРЕЛИ / НЕ СВЕРЕНО / сессия завершена»).
+  freshness?: TaskFreshness
 }
 
 // Caps for the tasks section. The HUD is a compact pinned card, not the full
@@ -113,7 +117,10 @@ function taskLine(todo: TodoItem): string {
  * Empty todos → empty string (the HUD omits the section entirely).
  * PURE — exported for unit tests.
  */
-export function renderStatusTasks(todos: ReadonlyArray<TodoItem>): string {
+export function renderStatusTasks(
+  todos: ReadonlyArray<TodoItem>,
+  freshness?: TaskFreshness,
+): string {
   if (todos.length === 0) return ''
   const inProgress = todos.filter((t) => t.status === 'in_progress')
   const pending = todos.filter((t) => t.status === 'pending')
@@ -127,7 +134,12 @@ export function renderStatusTasks(todos: ReadonlyArray<TodoItem>): string {
   // The header (bar + count) stays OUTSIDE the collapsible quote so progress is
   // always visible when collapsed; the per-task detail goes INSIDE an
   // <blockquote expandable>, so the pin reads «progress — tap to expand the list».
-  const header = `<b>Задачи</b> ${bar} ${done}/${total}`
+  // M3: when a freshness indicator is supplied the bold «Задачи» label is
+  // replaced by the freshness label (+ optional subline), so the pin shows how
+  // recently the list was reconciled against the real pane.
+  const fh = freshness !== undefined ? renderFreshnessHeader(freshness) : { label: '<b>Задачи</b>' }
+  const header = `${fh.label} ${bar} ${done}/${total}`
+  const subLine = 'sub' in fh && fh.sub !== undefined ? `\n${fh.sub}` : ''
 
   const detail: string[] = []
   for (const t of inProgress) detail.push(taskLine(t))
@@ -144,7 +156,7 @@ export function renderStatusTasks(todos: ReadonlyArray<TodoItem>): string {
   // in-progress, and escaping expands after the per-line cut. The header is
   // always kept (counted first); drop overflowing detail lines, mark the cut.
   const out: string[] = []
-  let used = header.length
+  let used = header.length + subLine.length
   let dropped = 0
   for (const line of detail) {
     if (used + 1 + line.length <= TASKS_MAX_CHARS) {
@@ -156,8 +168,8 @@ export function renderStatusTasks(todos: ReadonlyArray<TodoItem>): string {
   }
   if (dropped > 0) out.push(`<i>+${dropped} строк скрыто</i>`)
 
-  if (out.length === 0) return header
-  return `${header}\n<blockquote expandable>${out.join('\n')}</blockquote>`
+  if (out.length === 0) return `${header}${subLine}`
+  return `${header}${subLine}\n<blockquote expandable>${out.join('\n')}</blockquote>`
 }
 
 // «план» is the only mode worth naming; every other Claude Code permission
@@ -193,7 +205,7 @@ export function renderHud(
     work?.permissionMode !== undefined && work.permissionMode.length > 0
       ? `\n<i>режим: ${modeLabel(work.permissionMode)}</i>`
       : ''
-  const tasksBlock = work !== undefined ? renderStatusTasks(work.todos) : ''
+  const tasksBlock = work !== undefined ? renderStatusTasks(work.todos, work.freshness) : ''
   const tasksSection = tasksBlock.length > 0 ? `\n\n${tasksBlock}` : ''
   const tail = `${modelLine}${modeLine}${tasksSection}`
 
@@ -291,6 +303,12 @@ export class ContextHud {
   // does not clear it, so the pinned card keeps showing «что сделали» until
   // the next task replaces the snapshot.
   private readonly work = new Map<string, { todos: ReadonlyArray<TodoItem>; taskMap: Map<string, TodoItem> }>()
+  // M3 reality mirror: the reconciled view (real pane-verified list + freshness)
+  // per chat. When present it SUPERSEDES the event-only `work` snapshot in the
+  // render — the pin then reflects the harness's real task list. Fed by
+  // TaskRealityMirror.applyReconciledView; the raw onTodoEvent path is bypassed
+  // when the reconciler is wired (server.ts), so the two never fight.
+  private readonly reconciled = new Map<string, { todos: ReadonlyArray<TodoItem>; freshness: TaskFreshness }>()
   // Per-chat session id, tracked from SessionStart + task events. Used to decide
   // when to CLEAR the task snapshot: a genuine session change clears it; a
   // compact (same id) preserves it. SessionStart fires for startup / resume /
@@ -367,6 +385,9 @@ export class ContextHud {
       // milestones (renderStatusTasks returns '' for an empty list → the
       // section is omitted until fresh TodoWrite/TaskCreate events arrive).
       this.work.delete(chatId)
+      // M3: also drop the reconciled view; TaskRealityMirror re-pushes a fresh
+      // «НЕ СВЕРЕНО» view for the new session immediately after.
+      this.reconciled.delete(chatId)
     }
     // Compact / resume / first-ever start (same or unknown id) preserve the
     // snapshot. Track the latest known id for the next comparison.
@@ -453,6 +474,23 @@ export class ContextHud {
         state.todos = Array.from(state.taskMap.values())
         break
     }
+    return this.updateNow(chatId)
+  }
+
+  // M3 reality mirror: adopt the reconciled (pane-verified) task view + its
+  // freshness indicator and refresh the pin in place. This SUPERSEDES the
+  // event-only `work` snapshot in the render, so the pin reflects the harness's
+  // real task list even when the agent skipped the task tools. Best-effort +
+  // serialized like every other HUD op; gates on owner + enabled.
+  applyReconciledView(
+    chatId: string,
+    view: { sessionId: string; todos: ReadonlyArray<TodoItem>; freshness: TaskFreshness },
+  ): Promise<void> {
+    if (!this.enabled || !this.isOwner(chatId)) return Promise.resolve()
+    this.reconciled.set(chatId, { todos: view.todos, freshness: view.freshness })
+    // Keep the tracked session id coherent so a later onSessionStart correctly
+    // detects a genuine change.
+    this.sessionIds.set(chatId, view.sessionId)
     return this.updateNow(chatId)
   }
 
@@ -564,12 +602,15 @@ export class ContextHud {
         usage = null
       }
     }
-    const work: HudWorkView = {
-      todos: this.work.get(chatId)?.todos ?? [],
-      ...(info.permissionMode !== undefined && info.permissionMode.length > 0
+    // M3: the reconciled (pane-verified) view wins over the event-only snapshot.
+    const rv = this.reconciled.get(chatId)
+    const permissionMode =
+      info.permissionMode !== undefined && info.permissionMode.length > 0
         ? { permissionMode: info.permissionMode }
-        : {}),
-    }
+        : {}
+    const work: HudWorkView = rv !== undefined
+      ? { todos: rv.todos, freshness: rv.freshness, ...permissionMode }
+      : { todos: this.work.get(chatId)?.todos ?? [], ...permissionMode }
     return renderHud(usage, this.windowTokens, info.model, work)
   }
 

--- a/plugin/src/status/context-hud.ts
+++ b/plugin/src/status/context-hud.ts
@@ -313,8 +313,22 @@ export class ContextHud {
   // when to CLEAR the task snapshot: a genuine session change clears it; a
   // compact (same id) preserves it. SessionStart fires for startup / resume /
   // clear / compact, so source alone can't tell «new session» from «compacted
-  // same session» — the id does.
+  // same session» — the id does. KEPT across SessionEnd (review 2026-07-09 #2):
+  // deleting it on end made the next startup's sessionChanged=false, so a
+  // brand-new session inherited the dead session's task snapshot.
   private readonly sessionIds = new Map<string, string>()
+  // Per-chat tombstones of ENDED session ids (bounded). A late task event
+  // naming an ended session is dropped — pre-fix it cleared the active
+  // session's work and adopted the dead id. SessionStart with the same id
+  // (resume) un-tombstones. The reconciler's applyReconciledView is exempt:
+  // it manages its own lifecycle and must be able to deliver the frozen
+  // «сессия завершена» view right after SessionEnd.
+  private readonly endedSessions = new Map<string, Set<string>>()
+  // Dedup for reconciler-driven refreshes: hash of the last applied reconciled
+  // «Задачи» render per chat. The reconciler ticks every 20s; when neither the
+  // tasks nor the bucketed freshness label changed, skipping the refresh keeps
+  // editMessageText traffic at zero instead of a no-op edit per tick.
+  private readonly lastReconciledRender = new Map<string, string>()
   // bump() debounce per chat — a burst of inbound messages collapses to one
   // delete+resend (same rationale as TmuxMirror.BUMP_DEBOUNCE_MS).
   private readonly lastBumpAt = new Map<string, number>()
@@ -388,10 +402,15 @@ export class ContextHud {
       // M3: also drop the reconciled view; TaskRealityMirror re-pushes a fresh
       // «НЕ СВЕРЕНО» view for the new session immediately after.
       this.reconciled.delete(chatId)
+      this.lastReconciledRender.delete(chatId)
     }
     // Compact / resume / first-ever start (same or unknown id) preserve the
-    // snapshot. Track the latest known id for the next comparison.
-    if (sessionId !== undefined) this.sessionIds.set(chatId, sessionId)
+    // snapshot. Track the latest known id for the next comparison. A resume
+    // of an ENDED session legitimizes it again (drop the tombstone).
+    if (sessionId !== undefined) {
+      this.sessionIds.set(chatId, sessionId)
+      this.endedSessions.get(chatId)?.delete(sessionId)
+    }
     return this.runSerialized(chatId, async () => {
       try {
         const { text, keyboard } = await this.renderCurrent(chatId)
@@ -423,15 +442,32 @@ export class ContextHud {
 
   // SessionEnd (the REAL session end, unlike Stop): refresh the pinned card.
   // We keep the last task snapshot visible (the next SessionStart with a new id
-  // clears it) but forget the tracked session id so a brand-new session is
-  // correctly treated as a change. Best-effort, serialized like the others.
+  // clears it) and KEEP the tracked session id (review 2026-07-09 #2:
+  // forgetting it made the next startup's sessionChanged=false, so a brand-new
+  // session showed the dead session's tasks). The ended id is tombstoned so a
+  // late task event naming it is dropped instead of clearing the active state.
   async onSessionEnd(chatId: string, opts: { sessionId?: string } = {}): Promise<void> {
     if (!this.enabled || !this.isOwner(chatId)) return
     const { sessionId } = opts
     const prev = this.sessionIds.get(chatId)
+    if (sessionId !== undefined) {
+      // Tombstone even a late end for a session we've moved past — its
+      // stragglers must be dropped too.
+      let set = this.endedSessions.get(chatId)
+      if (set === undefined) {
+        set = new Set()
+        this.endedSessions.set(chatId, set)
+      }
+      set.delete(sessionId)
+      set.add(sessionId)
+      while (set.size > 8) {
+        const oldest = set.values().next().value
+        if (oldest === undefined) break
+        set.delete(oldest)
+      }
+    }
     // Ignore a late SessionEnd for a session we've already moved past.
     if (sessionId !== undefined && prev !== undefined && prev !== sessionId) return
-    this.sessionIds.delete(chatId)
     await this.updateNow(chatId)
   }
 
@@ -446,6 +482,11 @@ export class ContextHud {
   onTodoEvent(chatId: string, event: TaskMirrorEvent): Promise<void> {
     if (!this.enabled || !this.isOwner(chatId)) return Promise.resolve()
     if (event.kind === 'session_start' || event.kind === 'session_end') {
+      return Promise.resolve()
+    }
+    // Drop late stragglers from an ENDED session — they must not clear the
+    // active session's snapshot or resurrect the dead id (review 2026-07-09 #2).
+    if (this.endedSessions.get(chatId)?.has(event.sessionId) === true) {
       return Promise.resolve()
     }
     const prev = this.sessionIds.get(chatId)
@@ -491,6 +532,13 @@ export class ContextHud {
     // Keep the tracked session id coherent so a later onSessionStart correctly
     // detects a genuine change.
     this.sessionIds.set(chatId, view.sessionId)
+    // Reconciler-tick dedup: the mirror ticks every 20s and the freshness label
+    // is minute-bucketed, so most ticks change NOTHING in the rendered section.
+    // Skip the whole refresh when the rendered «Задачи» section is identical to
+    // the previously applied one — no editMessageText per tick.
+    const renderKey = `${view.sessionId}|${renderStatusTasks(view.todos, view.freshness)}`
+    if (this.lastReconciledRender.get(chatId) === renderKey) return Promise.resolve()
+    this.lastReconciledRender.set(chatId, renderKey)
     return this.updateNow(chatId)
   }
 

--- a/plugin/src/status/context-hud.ts
+++ b/plugin/src/status/context-hud.ts
@@ -291,6 +291,12 @@ export class ContextHud {
   // does not clear it, so the pinned card keeps showing «что сделали» until
   // the next task replaces the snapshot.
   private readonly work = new Map<string, { todos: ReadonlyArray<TodoItem>; taskMap: Map<string, TodoItem> }>()
+  // Per-chat session id, tracked from SessionStart + task events. Used to decide
+  // when to CLEAR the task snapshot: a genuine session change clears it; a
+  // compact (same id) preserves it. SessionStart fires for startup / resume /
+  // clear / compact, so source alone can't tell «new session» from «compacted
+  // same session» — the id does.
+  private readonly sessionIds = new Map<string, string>()
   // bump() debounce per chat — a burst of inbound messages collapses to one
   // delete+resend (same rationale as TmuxMirror.BUMP_DEBOUNCE_MS).
   private readonly lastBumpAt = new Map<string, number>()
@@ -344,15 +350,29 @@ export class ContextHud {
 
   // SessionStart: ensure the HUD message exists and is pinned, then refresh it.
   // The whole method is best-effort — it never throws. Serialized per chat.
-  onSessionStart(chatId: string): Promise<void> {
+  //
+  // Task snapshot handling: SessionStart fires for startup, resume, clear AND
+  // compact. A compact keeps the SAME session id, so clearing the task list on
+  // every SessionStart would wipe the milestones the warchief is watching every
+  // time the context is auto-compacted. We therefore clear ONLY on a genuine
+  // session change (new id) or an explicit `source === 'clear'`; a compact with
+  // the same id preserves the snapshot.
+  onSessionStart(chatId: string, opts: { sessionId?: string; source?: string } = {}): Promise<void> {
     if (!this.enabled || !this.isOwner(chatId)) return Promise.resolve()
+    const { sessionId, source } = opts
+    const prev = this.sessionIds.get(chatId)
+    const sessionChanged = sessionId !== undefined && prev !== undefined && prev !== sessionId
+    if (source === 'clear' || sessionChanged) {
+      // Genuine reset: drop the prior snapshot so the pin never shows stale
+      // milestones (renderStatusTasks returns '' for an empty list → the
+      // section is omitted until fresh TodoWrite/TaskCreate events arrive).
+      this.work.delete(chatId)
+    }
+    // Compact / resume / first-ever start (same or unknown id) preserve the
+    // snapshot. Track the latest known id for the next comparison.
+    if (sessionId !== undefined) this.sessionIds.set(chatId, sessionId)
     return this.runSerialized(chatId, async () => {
       try {
-        // A new session starts with a clean task list: drop any snapshot left
-        // over from a prior session so the pin never shows stale milestones
-        // (renderStatusTasks returns '' for an empty list → the section is
-        // omitted until the agent emits fresh TodoWrite/TaskCreate events).
-        this.work.delete(chatId)
         const { text, keyboard } = await this.renderCurrent(chatId)
         const ensured = await this.ensureMessage(chatId, text, keyboard)
         if (ensured === undefined) return
@@ -373,19 +393,45 @@ export class ContextHud {
     })
   }
 
-  // Stop / end-of-turn: refresh the percentage. No pin (that is SessionStart's
-  // job); updateNow self-heals a deleted message once.
+  // Stop / end-of-turn: refresh the percentage. Stop carries model /
+  // permission_mode for the pinned card but must NOT finalize task state. No
+  // pin (that is SessionStart's job); updateNow self-heals a deleted message.
   async onStop(chatId: string): Promise<void> {
+    await this.updateNow(chatId)
+  }
+
+  // SessionEnd (the REAL session end, unlike Stop): refresh the pinned card.
+  // We keep the last task snapshot visible (the next SessionStart with a new id
+  // clears it) but forget the tracked session id so a brand-new session is
+  // correctly treated as a change. Best-effort, serialized like the others.
+  async onSessionEnd(chatId: string, opts: { sessionId?: string } = {}): Promise<void> {
+    if (!this.enabled || !this.isOwner(chatId)) return
+    const { sessionId } = opts
+    const prev = this.sessionIds.get(chatId)
+    // Ignore a late SessionEnd for a session we've already moved past.
+    if (sessionId !== undefined && prev !== undefined && prev !== sessionId) return
+    this.sessionIds.delete(chatId)
     await this.updateNow(chatId)
   }
 
   // Todo events (TodoWrite / TaskCreate / TaskUpdate, mapped by
   // toTodoWriteEvent in the webhook) — update the work view and refresh the
-  // card in place. `todo_session_stop` deliberately does NOT clear the view:
-  // the pinned card keeps the last milestones visible across turns.
+  // card in place. Session lifecycle events are handled by onSessionStart /
+  // onSessionEnd, not here; if one slips through it is ignored.
+  //
+  // A task event whose sessionId differs from the tracked one signals a new
+  // session (we may have missed SessionStart) — reset the stale snapshot and
+  // adopt the new id so the pin never blends two sessions' task lists.
   onTodoEvent(chatId: string, event: TaskMirrorEvent): Promise<void> {
     if (!this.enabled || !this.isOwner(chatId)) return Promise.resolve()
-    if (event.kind === 'todo_session_stop') return Promise.resolve()
+    if (event.kind === 'session_start' || event.kind === 'session_end') {
+      return Promise.resolve()
+    }
+    const prev = this.sessionIds.get(chatId)
+    if (prev !== undefined && prev !== event.sessionId) {
+      this.work.delete(chatId)
+    }
+    this.sessionIds.set(chatId, event.sessionId)
     let state = this.work.get(chatId)
     if (state === undefined) {
       state = { todos: [], taskMap: new Map<string, TodoItem>() }

--- a/plugin/src/status/pane-capture.ts
+++ b/plugin/src/status/pane-capture.ts
@@ -1,0 +1,145 @@
+// pane-capture — the SINGLE shared `tmux capture-pane` + ANSI-strip code path.
+//
+// Both the rolling TmuxMirror (human-facing terminal mirror) and the
+// TaskRealityMirror (task-list reconciler) need to read the agent's pane and
+// clean it. This module owns that primitive so neither surface duplicates the
+// capture-pane argv or the ANSI/control stripping — a review hard-requirement
+// for M3 (do NOT duplicate capture-pane logic). TmuxMirror re-exports the
+// `TmuxExec` / `TmuxExecResult` seams from here for backward-compat.
+//
+// Deliberately I/O-thin: `capturePaneText` runs ONE exec and returns cleaned
+// text; `resolvePaneCwd` runs ONE `display-message` and returns the pane's
+// working directory (best-effort, for reconciler provenance). Neither throws —
+// a dead pane / missing tmux surfaces as `ok:false` / `null`, and the caller
+// decides how to degrade.
+
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+// Test seam: production wraps `tmux <args>`; tests inject a deterministic stub.
+// Args are exactly the argv AFTER the `tmux` binary. Shared with TmuxMirror.
+export interface TmuxExecResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+export type TmuxExec = (args: readonly string[]) => Promise<TmuxExecResult>
+
+// Default production exec: spawn `tmux` with an ARGV ARRAY (no shell, so pane
+// targets / socket names can't inject). Never throws — a non-zero exit is
+// returned so the caller renders the failure instead of crashing the loop.
+// Shared by TmuxMirror and TaskRealityMirror.
+const execFileAsync = promisify(execFile)
+export async function defaultTmuxExec(args: readonly string[]): Promise<TmuxExecResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync('tmux', args as string[], {
+      maxBuffer: 4 * 1024 * 1024,
+      encoding: 'utf8',
+      timeout: 5000,
+    })
+    return { stdout, stderr, exitCode: 0 }
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; code?: number; message?: string }
+    return {
+      stdout: e.stdout ?? '',
+      stderr: e.stderr ?? e.message ?? 'tmux exec failed',
+      exitCode: typeof e.code === 'number' ? e.code : 1,
+    }
+  }
+}
+
+// Strip ANSI / vt control sequences and bare control characters. Keep
+// newlines + tabs. Patterns:
+//   • CSI:  ESC [ ... terminator-letter
+//   • OSC:  ESC ] ... BEL  OR  ESC ] ... ST (ESC \)
+//   • DCS/PM/APC/SOS: ESC (P|^|_|X) ... ST
+//   • two-byte: ESC + single char in @-Z, \, -, _
+// Stripping happens BEFORE any HTML escaping so leftover characters can't blow
+// up Telegram's HTML parser. ST is `ESC \`; both BEL and ST terminate OSC.
+const ANSI_RE =
+  // eslint-disable-next-line no-control-regex
+  /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][\s\S]*?(?:\x07|\x1b\\)|[P^_X][\s\S]*?\x1b\\|[@-Z\\\-_])/g
+// eslint-disable-next-line no-control-regex
+const CTRL_RE = /[\x00-\x08\x0B-\x0C\x0E-\x1F\x7F]/g
+
+/** Remove ANSI escapes + bare control chars, preserving `\n` and `\t`. */
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, '').replace(CTRL_RE, '')
+}
+
+export interface PaneCaptureConfig {
+  /** tmux target, `session:window.pane` (e.g. `channel-thrall:0.0`). */
+  paneTarget: string
+  /** tmux socket name (`tmux -L <name>`). Empty = default socket. */
+  socketName?: string
+  /** `-S -N`: capture the N most-recent lines. */
+  lineCount: number
+}
+
+export interface PaneCaptureResult {
+  /** true when the capture-pane exec returned exit 0. */
+  ok: boolean
+  /** ANSI-stripped pane text (empty on failure). */
+  text: string
+  exitCode: number
+  /** stderr / failure reason when `ok` is false. */
+  error?: string
+}
+
+function socketArgs(socketName: string | undefined): string[] {
+  return socketName ? ['-L', socketName] : []
+}
+
+/**
+ * Capture the pane and strip ANSI. ONE exec. Never throws — a failed capture
+ * (session gone, tmux missing) returns `{ ok:false, text:'' }`.
+ */
+export async function capturePaneText(
+  exec: TmuxExec,
+  cfg: PaneCaptureConfig,
+): Promise<PaneCaptureResult> {
+  const result = await exec([
+    ...socketArgs(cfg.socketName),
+    'capture-pane',
+    '-p',
+    '-t',
+    cfg.paneTarget,
+    '-S',
+    `-${cfg.lineCount}`,
+  ])
+  if (result.exitCode !== 0) {
+    return {
+      ok: false,
+      text: '',
+      exitCode: result.exitCode,
+      error: result.stderr.trim() || `tmux exited ${result.exitCode}`,
+    }
+  }
+  return { ok: true, text: stripAnsi(result.stdout), exitCode: 0 }
+}
+
+/**
+ * Resolve the pane's current working directory (`#{pane_current_path}`) for
+ * reconciler provenance. Best-effort — returns null when the pane is gone or
+ * tmux errors, so the caller can degrade to skipping the cwd cross-check.
+ */
+export async function resolvePaneCwd(
+  exec: TmuxExec,
+  cfg: PaneCaptureConfig,
+): Promise<string | null> {
+  try {
+    const result = await exec([
+      ...socketArgs(cfg.socketName),
+      'display-message',
+      '-p',
+      '-t',
+      cfg.paneTarget,
+      '#{pane_current_path}',
+    ])
+    if (result.exitCode !== 0) return null
+    const cwd = stripAnsi(result.stdout).trim()
+    return cwd.length > 0 ? cwd : null
+  } catch {
+    return null
+  }
+}

--- a/plugin/src/status/task-freshness.ts
+++ b/plugin/src/status/task-freshness.ts
@@ -27,6 +27,13 @@ export type TaskFreshness =
    * reconciliation. No growing age — the label never changes after this.
    */
   | { readonly kind: 'ended'; readonly reconciledAtLabel: string | null }
+  /**
+   * Reconciliation stopped WITHOUT a clean session end (hard-TTL eviction of
+   * an orphaned session). Frozen terminal state — the surface must never keep
+   * saying «сверено недавно» for data nobody updates any more
+   * (review 2026-07-10 #7).
+   */
+  | { readonly kind: 'expired' }
 
 /** The rendered two-part header: a bold label line + an optional italic subline. */
 export interface FreshnessHeader {
@@ -79,5 +86,7 @@ export function renderFreshnessHeader(f: TaskFreshness): FreshnessHeader {
             ? `<b>Задачи</b> · <i>сессия завершена · сверено ${f.reconciledAtLabel} UTC</i>`
             : '<b>Задачи</b> · <i>сессия завершена</i>',
       }
+    case 'expired':
+      return { label: '<b>Задачи</b> · <i>данные не обновляются</i>' }
   }
 }

--- a/plugin/src/status/task-freshness.ts
+++ b/plugin/src/status/task-freshness.ts
@@ -1,0 +1,83 @@
+// task-freshness — the «свежесть сверки» indicator shared by the two task
+// surfaces (context HUD pin + TaskMirror message). PURE: no clock, no I/O.
+//
+// The TaskRealityMirror derives a `TaskFreshness` value from the reconciled
+// state + turn-active window and hands it to each surface's render path. Both
+// surfaces render the SAME header wording so the warchief reads one consistent
+// «сверено / УСТАРЕЛИ / НЕ СВЕРЕНО / завершено» language everywhere.
+//
+// Bucketing matters for edit-churn: the label embeds a coarse relative age
+// («меньше минуты» / «N мин»), so within one minute bucket the rendered text is
+// byte-identical and the surface's existing hash-dedup suppresses the Telegram
+// edit; crossing a bucket changes the text and lets the edit through. That is
+// exactly the «edit only when content hash changes OR the age crosses a minute
+// bucket» rule from the M3 brief — no extra throttle needed in the surfaces.
+
+/** Discriminated freshness state. Ages are raw ms; the renderer buckets them. */
+export type TaskFreshness =
+  /** A valid pane snapshot confirms the list. `reconciledAgeMs` = now − lastReconciled. */
+  | { readonly kind: 'fresh'; readonly reconciledAgeMs: number }
+  /** Active turn, reconciliation failing > 90s. Shows both ages. */
+  | { readonly kind: 'stale'; readonly reconciledAgeMs: number; readonly eventAgeMs: number }
+  /** No valid pane snapshot has ever been reconciled — tool events only. */
+  | { readonly kind: 'unverified' }
+  /**
+   * Session ended: frozen. `reconciledAtLabel` is a pre-formatted `HH:MM`
+   * (UTC) string, or null when the session ended without any successful
+   * reconciliation. No growing age — the label never changes after this.
+   */
+  | { readonly kind: 'ended'; readonly reconciledAtLabel: string | null }
+
+/** The rendered two-part header: a bold label line + an optional italic subline. */
+export interface FreshnessHeader {
+  /** First line — replaces the surfaces' default `<b>Задачи</b>` label. */
+  label: string
+  /** Optional second line (stale ages / unverified subtitle). */
+  sub?: string
+}
+
+/** Bucket a duration into coarse Russian relative age: «меньше минуты» / «N мин». */
+export function bucketAge(ms: number): string {
+  if (ms < 60_000) return 'меньше минуты'
+  const mins = Math.floor(ms / 60_000)
+  return `${mins} мин`
+}
+
+/** Format an epoch-ms instant as `HH:MM` in UTC (frozen session-end label). */
+export function formatUtcHm(epochMs: number): string {
+  const d = new Date(epochMs)
+  const hh = String(d.getUTCHours()).padStart(2, '0')
+  const mm = String(d.getUTCMinutes()).padStart(2, '0')
+  return `${hh}:${mm}`
+}
+
+/**
+ * Render the freshness state into a label (+ optional subline). Exact strings
+ * are contractually stable (M3 brief §4) — tests assert on them verbatim.
+ */
+export function renderFreshnessHeader(f: TaskFreshness): FreshnessHeader {
+  switch (f.kind) {
+    case 'fresh': {
+      const age = bucketAge(f.reconciledAgeMs)
+      const phrase = f.reconciledAgeMs < 60_000 ? 'сверено меньше минуты назад' : `сверено ${age} назад`
+      return { label: `<b>Задачи</b> · <i>${phrase}</i>` }
+    }
+    case 'stale':
+      return {
+        label: '<b>Задачи — ДАННЫЕ УСТАРЕЛИ</b>',
+        sub: `<i>сверено ${bucketAge(f.reconciledAgeMs)} назад · событие ${bucketAge(f.eventAgeMs)} назад</i>`,
+      }
+    case 'unverified':
+      return {
+        label: '<b>Задачи — НЕ СВЕРЕНО</b>',
+        sub: '<i>Показаны только события инструментов</i>',
+      }
+    case 'ended':
+      return {
+        label:
+          f.reconciledAtLabel !== null
+            ? `<b>Задачи</b> · <i>сессия завершена · сверено ${f.reconciledAtLabel} UTC</i>`
+            : '<b>Задачи</b> · <i>сессия завершена</i>',
+      }
+  }
+}

--- a/plugin/src/status/task-mirror.ts
+++ b/plugin/src/status/task-mirror.ts
@@ -30,7 +30,7 @@
 //   * `recordEvent` is serialized per chat and its try/catch swallows every
 //     throw so the webhook 200 path is never blocked.
 
-import { mkdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from 'node:fs'
+import { mkdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import type { AppConfig } from '../config.js'
@@ -69,12 +69,25 @@ export interface TaskMirrorDeps {
   stateDir?: string
 }
 
+// Session-epoch state persisted alongside the snapshot (review 2026-07-10 #2:
+// epoch state lost on restart let a dead session's stragglers switch epochs).
+interface PersistedEpoch {
+  active?: string
+  retired?: ReadonlyArray<string>
+}
+
 // On-disk snapshot persisted per chat under `task-mirror-<chatId>.json`. Lets a
 // plugin restart pick up the SAME rolling message (edit in place) and the SAME
 // session namespace, instead of spamming a fresh message on the next event.
+//
+// Schema-versioned: `v: 2` adds the epoch block and allows EPOCH-ONLY files
+// (no messageId — written by finalize/dropOrphan so tombstones survive a
+// restart even after the message state is gone). v1 files (no `v`) load fine.
 interface PersistedTaskState {
+  v?: number
   sessionId?: string
-  messageId: number
+  // Absent in epoch-only (post-finalize) snapshots.
+  messageId?: number
   todos: ReadonlyArray<TodoItem>
   // true when `todos` had NOT yet been rendered into the remote message at
   // persist time (throttled edit pending / edit rejected). On hydration a
@@ -84,8 +97,10 @@ interface PersistedTaskState {
   dirty?: boolean
   // Absolute epoch ms of the entry's last activity. Without it an ancient
   // orphan looked freshly-active after every restart and was finalized
-  // gracefully instead of dropped (review 2026-07-09 #3c).
+  // gracefully instead of dropped (review 2026-07-09 #3c). Legacy v1 files
+  // fall back to the snapshot file's mtime (review 2026-07-10 #6).
   lastActivityMs?: number
+  epoch?: PersistedEpoch
 }
 
 // Per-chat lifecycle entry. Field-for-field parallel to ChatProgressEntry,
@@ -227,6 +242,9 @@ export class TaskMirror {
   // treated as "newer", finalizing/clearing the active session's snapshot and
   // adopting the dead id. SessionStart with the same id (resume) un-retires.
   private readonly retiredSessions = new Map<string, Set<string>>()
+  // Chats whose persisted epoch state has been restored this process lifetime
+  // (restoreEpochs is once-per-chat; runtime state is never clobbered).
+  private readonly epochsRestored = new Set<string>()
 
   constructor(deps: TaskMirrorDeps) {
     this.telegramApi = deps.telegramApi
@@ -468,18 +486,42 @@ export class TaskMirror {
   // longer finalizes on Stop, so idleness is normal). TTL now bites ONLY as
   // orphan cleanup on a session change (see ensureSessionForMutation).
   private hydrate(chatId: string): ChatTaskEntry | undefined {
+    this.restoreEpochs(chatId)
     const mem = this.chats.get(chatId)
     if (mem) return mem
     const persisted = this.loadPersisted(chatId)
     if (!persisted) return undefined
-    const entry = this.reconstructEntry(chatId, persisted)
+    // Epoch-only snapshot (post-finalize): tombstones restored above, but
+    // there is no message state to rebuild.
+    if (persisted.messageId === undefined) return undefined
+    const entry = this.reconstructEntry(chatId, { ...persisted, messageId: persisted.messageId })
     this.chats.set(chatId, entry)
     // Dirty snapshot: the persisted todos were never acked into the remote
     // message (throttled edit pending / rejected at crash time). Replay ONE
     // edit now — reconstructEntry left lastRenderedText unset so the flush is
-    // not suppressed by the idempotency gate (review 2026-07-09 #3a).
+    // not suppressed by the idempotency gate (review 2026-07-09 #3a). The
+    // startFlush convergence loop (review 2026-07-10 #5) guarantees a mutation
+    // racing this replay still gets its own follow-up edit.
     if (persisted.dirty === true) this.scheduleFlush(entry)
     return entry
+  }
+
+  // Restore persisted session-epoch state (active + retired) ONCE per chat
+  // (review 2026-07-10 #2: epoch state was runtime-only, so a restart forgot
+  // every tombstone and a dead session's stragglers switched epochs again).
+  // Runtime state, when already present, is never clobbered.
+  private restoreEpochs(chatId: string): void {
+    if (this.epochsRestored.has(chatId)) return
+    this.epochsRestored.add(chatId)
+    const persisted = this.loadPersisted(chatId)
+    const epoch = persisted?.epoch
+    if (epoch === undefined) return
+    if (epoch.active !== undefined && !this.activeSessions.has(chatId)) {
+      this.activeSessions.set(chatId, epoch.active)
+    }
+    if (epoch.retired !== undefined && !this.retiredSessions.has(chatId)) {
+      this.retiredSessions.set(chatId, new Set(epoch.retired.slice(-TaskMirror.MAX_RETIRED)))
+    }
   }
 
   private getOrCreate(chatId: string): ChatTaskEntry {
@@ -507,7 +549,10 @@ export class TaskMirror {
   // post-restore edit isn't throttled. lastActivityMs restores the ABSOLUTE
   // persisted timestamp (clamped to now) so an ancient orphan is recognized as
   // such after a restart instead of looking freshly active.
-  private reconstructEntry(chatId: string, persisted: PersistedTaskState): ChatTaskEntry {
+  private reconstructEntry(
+    chatId: string,
+    persisted: PersistedTaskState & { messageId: number },
+  ): ChatTaskEntry {
     const taskMap = new Map<string, TodoItem>()
     persisted.todos.forEach((t, i) => {
       taskMap.set(t.id ?? `restored-${i}`, t)
@@ -535,7 +580,11 @@ export class TaskMirror {
 
   // ─── session lifecycle ────────────────────────────────────────────────
 
-  // Bounded tombstone bookkeeping (review 2026-07-09 #2).
+  // Bounded tombstone bookkeeping (review 2026-07-09 #2; bound raised to 64
+  // per review 2026-07-10 #2 — at 8, a burst of short sessions evicted older
+  // tombstones and their late stragglers could switch epochs again).
+  private static readonly MAX_RETIRED = 64
+
   private retire(chatId: string, sessionId: string): void {
     let set = this.retiredSessions.get(chatId)
     if (set === undefined) {
@@ -544,8 +593,8 @@ export class TaskMirror {
     }
     set.delete(sessionId) // re-add moves to the tail (freshest)
     set.add(sessionId)
-    while (set.size > 8) {
-      const oldest = set.values().next().value
+    while (set.size > TaskMirror.MAX_RETIRED) {
+      const oldest = set.values().next().value // oldest-first eviction
       if (oldest === undefined) break
       set.delete(oldest)
     }
@@ -556,14 +605,29 @@ export class TaskMirror {
   }
 
   // SessionStart: mark the session ACTIVE for the chat (independent of any
-  // task entry existing), un-retire it (a resume of an ended session is
-  // legitimate), then reset the snapshot on a genuine session change and
-  // preserve it on compact / resume (same id).
+  // task entry existing), then reset the snapshot on a genuine session change
+  // and preserve it on compact / resume (same id).
+  //
+  // Rollback guard (review 2026-07-10 #2): a SessionStart naming a RETIRED id
+  // while a DIFFERENT session is active is a late/replayed straggler — it
+  // must NOT displace the active session. Resume of a retired id is valid
+  // ONLY when no different session is active.
   private async handleSessionStart(chatId: string, sessionId: string): Promise<void> {
-    this.retiredSessions.get(chatId)?.delete(sessionId) // resume legitimizes
+    this.restoreEpochs(chatId)
+    if (this.isRetired(chatId, sessionId)) {
+      const active = this.activeSessions.get(chatId)
+      if (active !== undefined && active !== sessionId) {
+        this.log.debug('task mirror dropped late SessionStart for retired session', {
+          chat_id: chatId,
+        })
+        return
+      }
+      this.retiredSessions.get(chatId)?.delete(sessionId) // genuine resume
+    }
     const active = this.activeSessions.get(chatId)
     if (active !== undefined && active !== sessionId) this.retire(chatId, active)
     this.activeSessions.set(chatId, sessionId)
+    this.persistEpochState(chatId)
 
     const existing = this.hydrate(chatId)
     if (!existing) return
@@ -580,18 +644,26 @@ export class TaskMirror {
   // session that is NOT the active one only tombstones it — it must never
   // finalize the active session's mirror.
   private async handleSessionEnd(chatId: string, sessionId: string): Promise<void> {
+    this.restoreEpochs(chatId)
     const active = this.activeSessions.get(chatId)
     if (active !== undefined && active !== sessionId) {
       this.retire(chatId, sessionId) // late end from a retired session
+      this.persistEpochState(chatId)
       return
     }
     this.retire(chatId, sessionId)
     this.activeSessions.delete(chatId)
 
     const existing = this.hydrate(chatId)
-    if (!existing) return
-    if (existing.sessionId !== undefined && existing.sessionId !== sessionId) return
-    await this.finalize(chatId, existing)
+    if (!existing) {
+      this.persistEpochState(chatId)
+      return
+    }
+    if (existing.sessionId !== undefined && existing.sessionId !== sessionId) {
+      this.persistEpochState(chatId)
+      return
+    }
+    await this.finalize(chatId, existing) // finalize persists the epoch-only snapshot
   }
 
   // A task mutation arrived. Returns false when the event must be DROPPED
@@ -599,6 +671,7 @@ export class TaskMirror {
   // different session than the current snapshot (missed SessionStart) and
   // adopts the event's session as active.
   private async ensureSessionForMutation(chatId: string, sessionId: string): Promise<boolean> {
+    this.restoreEpochs(chatId)
     if (this.isRetired(chatId, sessionId)) return false // late event from a dead session
     const active = this.activeSessions.get(chatId)
     if (active !== undefined && active !== sessionId) {
@@ -663,19 +736,30 @@ export class TaskMirror {
     if (text === undefined || text === entry.lastRenderedText) return
     delete entry.desiredText
 
-    entry.flushPromise = this.executeFlush(entry, text).finally(() => {
+    // Convergence loop (review 2026-07-10 #5): after a SUCCESSFUL flush,
+    // re-run scheduleFlush unconditionally — it re-renders from the CURRENT
+    // todos and no-ops when rendered == lastRenderedText, so a mutation (or a
+    // dirty-hydration replay) that raced this in-flight op always gets its own
+    // follow-up edit. Bounded: each iteration only fires on an actual content
+    // difference, and the just-advanced lastEditAtMs throttles it. After a
+    // FAILED flush we keep the old semantics (reschedule only when a newer
+    // desiredText is pending) so a permanently failing edit cannot tight-loop
+    // — the next event retries.
+    entry.flushPromise = this.executeFlush(entry, text).then((ok) => {
       entry.flushPromise = null
-      if (
-        !entry.stopped &&
-        entry.desiredText !== undefined &&
-        entry.desiredText !== entry.lastRenderedText
-      ) {
+      if (entry.stopped) return
+      if (ok) {
+        this.scheduleFlush(entry)
+        return
+      }
+      if (entry.desiredText !== undefined && entry.desiredText !== entry.lastRenderedText) {
         this.scheduleFlush(entry)
       }
     })
   }
 
-  private async executeFlush(entry: ChatTaskEntry, text: string): Promise<void> {
+  // Returns true when the Telegram op landed (send succeeded / edit succeeded).
+  private async executeFlush(entry: ChatTaskEntry, text: string): Promise<boolean> {
     if (entry.messageId === undefined) {
       try {
         const sent = await this.telegramApi.sendMessage(entry.chatId, text, HTML_OPTS)
@@ -690,13 +774,14 @@ export class TaskMirror {
             message_id: sent.message_id,
           })
         }
+        return true
       } catch (err) {
         this.log.warn('task mirror sendMessage failed (ignored)', {
           chat_id: entry.chatId,
           error: err instanceof Error ? err.message : String(err),
         })
+        return false
       }
-      return
     }
     try {
       await this.telegramApi.editMessageText(entry.chatId, entry.messageId, text, HTML_OPTS)
@@ -705,12 +790,14 @@ export class TaskMirror {
         entry.lastEditAtMs = this.now()
         this.persistEntry(entry)
       }
+      return true
     } catch (err) {
       this.log.warn('task mirror editMessageText failed (ignored)', {
         chat_id: entry.chatId,
         message_id: entry.messageId,
         error: err instanceof Error ? err.message : String(err),
       })
+      return false
     }
   }
 
@@ -760,7 +847,10 @@ export class TaskMirror {
     }
 
     this.chats.delete(chatId)
-    this.clearPersisted(chatId)
+    // Message state is gone, but the epoch (active + retired tombstones) must
+    // SURVIVE the restart — write an epoch-only snapshot instead of deleting
+    // the file (review 2026-07-10 #2).
+    this.persistEpochState(chatId, { dropMessageState: true })
   }
 
   /**
@@ -779,7 +869,7 @@ export class TaskMirror {
       chat_id: chatId,
     })
     this.chats.delete(chatId)
-    this.clearPersisted(chatId)
+    this.persistEpochState(chatId, { dropMessageState: true }) // epoch survives
   }
 
   /**
@@ -823,6 +913,15 @@ export class TaskMirror {
     return join(this.stateDir as string, `task-mirror-${safe}.json`)
   }
 
+  private currentEpoch(chatId: string): PersistedEpoch {
+    const active = this.activeSessions.get(chatId)
+    const retired = this.retiredSessions.get(chatId)
+    return {
+      ...(active !== undefined ? { active } : {}),
+      ...(retired !== undefined && retired.size > 0 ? { retired: [...retired] } : {}),
+    }
+  }
+
   private persistEntry(entry: ChatTaskEntry): void {
     if (this.stateDir === undefined) return
     if (entry.messageId === undefined) return
@@ -832,15 +931,50 @@ export class TaskMirror {
     // rendering the persisted todos reproduces the last successfully-sent text.
     const dirty = this.safeRender(entry.todos, entry.freshness) !== entry.lastRenderedText
     const snapshot: PersistedTaskState = {
+      v: 2,
       ...(entry.sessionId !== undefined ? { sessionId: entry.sessionId } : {}),
       messageId: entry.messageId,
       todos: entry.todos,
       dirty,
       lastActivityMs: entry.lastActivityMs,
+      epoch: this.currentEpoch(entry.chatId),
     }
+    this.writePersisted(entry.chatId, snapshot)
+  }
+
+  // Persist the CURRENT epoch state for a chat (review 2026-07-10 #2: epoch
+  // state was lost on restart). Three shapes:
+  //   • a live in-memory entry with a message → full persistEntry (epoch rides
+  //     along);
+  //   • no live entry but a NOT-yet-hydrated on-disk snapshot → MERGE: keep
+  //     the message state on disk, refresh only the epoch block (clobbering
+  //     it here would erase the restorable message before hydration);
+  //   • `dropMessageState` (finalize / dropOrphan) → EPOCH-ONLY overwrite: the
+  //     message is finalized/orphaned and must never be re-hydrated, but the
+  //     tombstones survive the restart.
+  private persistEpochState(chatId: string, opts: { dropMessageState?: boolean } = {}): void {
+    if (this.stateDir === undefined) return
+    const epoch = this.currentEpoch(chatId)
+    if (opts.dropMessageState !== true) {
+      const mem = this.chats.get(chatId)
+      if (mem !== undefined && mem.messageId !== undefined && !mem.stopped) {
+        this.persistEntry(mem)
+        return
+      }
+      const onDisk = this.loadPersisted(chatId)
+      if (onDisk !== undefined && onDisk.messageId !== undefined) {
+        this.writePersisted(chatId, { ...onDisk, v: 2, epoch })
+        return
+      }
+    }
+    this.writePersisted(chatId, { v: 2, todos: [], epoch })
+  }
+
+  private writePersisted(chatId: string, snapshot: PersistedTaskState): void {
+    if (this.stateDir === undefined) return
     try {
       mkdirSync(this.stateDir, { recursive: true, mode: 0o700 })
-      const path = this.persistPath(entry.chatId)
+      const path = this.persistPath(chatId)
       const tmp = `${path}.tmp.${process.pid}.${Date.now()}`
       writeFileSync(tmp, JSON.stringify(snapshot), { mode: 0o600 })
       try {
@@ -855,7 +989,7 @@ export class TaskMirror {
       }
     } catch (err) {
       this.log.warn('task mirror persist failed (ignored)', {
-        chat_id: entry.chatId,
+        chat_id: chatId,
         error: err instanceof Error ? err.message : String(err),
       })
     }
@@ -873,9 +1007,18 @@ export class TaskMirror {
       const parsed: unknown = JSON.parse(raw)
       if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return undefined
       const obj = parsed as Record<string, unknown>
-      const messageId = obj.messageId
-      if (typeof messageId !== 'number' || !Number.isInteger(messageId) || messageId <= 0) {
-        return undefined
+      // v2 allows EPOCH-ONLY snapshots without a messageId; a present-but-
+      // malformed messageId still quarantines the whole file.
+      let messageId: number | undefined
+      if (obj.messageId !== undefined) {
+        if (
+          typeof obj.messageId !== 'number' ||
+          !Number.isInteger(obj.messageId) ||
+          obj.messageId <= 0
+        ) {
+          return undefined
+        }
+        messageId = obj.messageId
       }
       // Schema-validate EVERY todo (review 2026-07-09 #3b). Pre-fix a snapshot
       // like `{todos:[null]}` passed the Array.isArray check, then threw at
@@ -896,33 +1039,47 @@ export class TaskMirror {
       }
       const sessionId = typeof obj.sessionId === 'string' ? obj.sessionId : undefined
       const dirty = obj.dirty === true
-      const lastActivityMs =
+      // Legacy (pre-lastActivityMs) snapshots must NOT fabricate freshness
+      // (review 2026-07-10 #6): fall back to the snapshot FILE's mtime — the
+      // moment it was last written — and, failing even that, to 0
+      // (expired-unknown ⇒ silent orphan drop on the next session change).
+      let lastActivityMs =
         typeof obj.lastActivityMs === 'number' && Number.isFinite(obj.lastActivityMs)
           ? obj.lastActivityMs
           : undefined
+      if (lastActivityMs === undefined) {
+        try {
+          lastActivityMs = statSync(this.persistPath(chatId)).mtimeMs
+        } catch {
+          lastActivityMs = 0
+        }
+      }
+      // Epoch block (v2). Validated defensively: strings only, bounded.
+      let epoch: PersistedEpoch | undefined
+      if (typeof obj.epoch === 'object' && obj.epoch !== null && !Array.isArray(obj.epoch)) {
+        const e = obj.epoch as Record<string, unknown>
+        const active = typeof e.active === 'string' && e.active.length > 0 ? e.active : undefined
+        const retired = Array.isArray(e.retired)
+          ? e.retired.filter((s): s is string => typeof s === 'string' && s.length > 0).slice(-64)
+          : undefined
+        epoch = {
+          ...(active !== undefined ? { active } : {}),
+          ...(retired !== undefined ? { retired } : {}),
+        }
+      }
       return {
         ...(sessionId !== undefined ? { sessionId } : {}),
-        messageId,
+        ...(messageId !== undefined ? { messageId } : {}),
         todos,
         dirty,
-        ...(lastActivityMs !== undefined ? { lastActivityMs } : {}),
+        lastActivityMs,
+        ...(epoch !== undefined ? { epoch } : {}),
       }
     } catch {
       return undefined // malformed JSON → treat as no snapshot
     }
   }
 
-  private clearPersisted(chatId: string): void {
-    if (this.stateDir === undefined) return
-    try {
-      rmSync(this.persistPath(chatId), { force: true })
-    } catch (err) {
-      this.log.warn('task mirror clearPersisted failed (ignored)', {
-        chat_id: chatId,
-        error: err instanceof Error ? err.message : String(err),
-      })
-    }
-  }
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/plugin/src/status/task-mirror.ts
+++ b/plugin/src/status/task-mirror.ts
@@ -674,11 +674,18 @@ export class TaskMirror {
     this.restoreEpochs(chatId)
     if (this.isRetired(chatId, sessionId)) return false // late event from a dead session
     const active = this.activeSessions.get(chatId)
-    if (active !== undefined && active !== sessionId) {
+    const displaced = active !== undefined && active !== sessionId
+    if (displaced) {
       // Unknown (not retired) session — a missed SessionStart for a newer one.
       this.retire(chatId, active)
     }
     this.activeSessions.set(chatId, sessionId)
+    if (displaced || active === undefined) {
+      // Persist the epoch transition SYNCHRONOUSLY, BEFORE the awaited
+      // finalize/send below (review 2026-07-10 r3 #5): a crash mid-finalize
+      // must restore «s2 active, s1 retired», not the pre-displacement epoch.
+      this.persistEpochState(chatId)
+    }
 
     const existing = this.hydrate(chatId)
     if (!existing) return true

--- a/plugin/src/status/task-mirror.ts
+++ b/plugin/src/status/task-mirror.ts
@@ -39,6 +39,7 @@ import type { TaskMirrorEvent } from '../hooks/claude-events.js'
 import type { TodoItem } from '../schemas.js'
 import type { TelegramApiForProgress } from './telegram-api.js'
 import { escapeHtml } from '../format/html.js'
+import { renderFreshnessHeader, type TaskFreshness } from './task-freshness.js'
 
 // Telegram editMessageText cap (4096 chars). Default render budget below it
 // — the spec asks for ~3500-char headroom (see plan §3 file 4).
@@ -97,6 +98,10 @@ interface ChatTaskEntry {
   // after every mutation so `scheduleFlush` keeps using the existing renderer.
   // Insertion-order Map keeps the visual ordering stable across renders.
   taskMap: Map<string, TodoItem>
+  // M3 reality mirror: freshness indicator for the «Задачи» header. Set by
+  // applyReconciledView; undefined in the legacy event-only path (header stays
+  // the plain «Задачи»).
+  freshness?: TaskFreshness
   // Last text we actually sent / edited. Idempotency gate.
   lastRenderedText?: string
   // Timestamp of the last successful send or edit. Used for throttle.
@@ -296,6 +301,60 @@ export class TaskMirror {
     }
   }
 
+  /**
+   * M3 reality mirror entry point. Publishes a reconciled (pane-verified) task
+   * list + freshness indicator into the rolling message. The reconciled list is
+   * the FULL authoritative list, so it replaces the snapshot wholesale (clears
+   * the incremental taskMap). Serialized per chat like recordEvent; never throws.
+   *
+   * When the reconciler is wired (server.ts), the raw recordEvent path is
+   * bypassed and this is the sole driver — so the two never fight over `todos`.
+   * An empty list before any message exists is NOT materialised (we don't post
+   * an empty «задач нет» card for a fresh session with no tasks yet).
+   */
+  async applyReconciledView(
+    chatId: string,
+    view: { sessionId: string; todos: ReadonlyArray<TodoItem>; freshness: TaskFreshness },
+  ): Promise<void> {
+    if (!this.config.task_mirror.enabled) return
+    await this.runSerialized(chatId, () => this.applyReconciledViewInner(chatId, view))
+  }
+
+  private async applyReconciledViewInner(
+    chatId: string,
+    view: { sessionId: string; todos: ReadonlyArray<TodoItem>; freshness: TaskFreshness },
+  ): Promise<void> {
+    try {
+      await this.ensureSessionForMutation(chatId, view.sessionId)
+      const entry = this.getOrCreate(chatId)
+      if (entry.stopped) return
+      entry.sessionId = view.sessionId
+      entry.lastActivityMs = this.now()
+      // Reconciled list is the full authoritative snapshot.
+      entry.taskMap.clear()
+      entry.todos = view.todos
+      entry.freshness = view.freshness
+      // Don't create an empty card for a fresh session with no tasks yet; wait
+      // until a task actually appears. Once a message exists we keep editing it
+      // (a freshness change on a non-empty list still updates in place).
+      if (entry.messageId === undefined && view.todos.length === 0) return
+      if (entry.messageId !== undefined) this.persistEntry(entry)
+      this.scheduleFlush(entry)
+      if (entry.messageId === undefined && entry.flushPromise !== null) {
+        try {
+          await entry.flushPromise
+        } catch {
+          /* already logged inside executeFlush */
+        }
+      }
+    } catch (err) {
+      this.log.warn('task mirror applyReconciledView failed (ignored)', {
+        chat_id: chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
   // Serialize an operation per chat. The returned promise resolves when THIS op
   // completes; the next call for the same chat waits for it. `fn` swallows its
   // own errors (recordEventInner try/catch), so the chain never rejects.
@@ -479,7 +538,7 @@ export class TaskMirror {
    */
   private scheduleFlush(entry: ChatTaskEntry): void {
     if (entry.stopped) return
-    const text = this.safeRender(entry.todos)
+    const text = this.safeRender(entry.todos, entry.freshness)
     if (!text || text === entry.lastRenderedText) return
     entry.desiredText = text
 
@@ -636,14 +695,14 @@ export class TaskMirror {
    * the safety margin renderTodoList reserves.
    */
   private renderFinal(entry: ChatTaskEntry): string {
-    const block = this.safeRender(entry.todos)
+    const block = this.safeRender(entry.todos, entry.freshness)
     if (!block) return ''
     return `${block}\n<i>сессия завершена</i>`
   }
 
-  private safeRender(todos: ReadonlyArray<TodoItem>): string {
+  private safeRender(todos: ReadonlyArray<TodoItem>, freshness?: TaskFreshness): string {
     try {
-      return renderTodoList(todos, this.config.task_mirror.collapse_completed_after)
+      return renderTodoList(todos, this.config.task_mirror.collapse_completed_after, undefined, freshness)
     } catch (err) {
       this.log.warn('task mirror render failed (ignored)', {
         error: err instanceof Error ? err.message : String(err),
@@ -759,9 +818,17 @@ export function renderTodoList(
   todos: ReadonlyArray<TodoItem>,
   collapseCompletedAfter: number,
   maxChars: number = DEFAULT_MAX_CHARS,
+  freshness?: TaskFreshness,
 ): string {
+  // M3: the bold «Задачи» header is replaced by the reconciliation-freshness
+  // label (+ optional subline) when a freshness value is supplied.
+  const fh = freshness !== undefined ? renderFreshnessHeader(freshness) : { label: '<b>Задачи</b>' }
+  const headerLabel = fh.label
+  const headerSub = 'sub' in fh && fh.sub !== undefined ? fh.sub : undefined
+
   if (todos.length === 0) {
-    return '<b>Задачи</b>\n<i>задач нет</i>'
+    const subLine = headerSub !== undefined ? `\n${headerSub}` : ''
+    return `${headerLabel}${subLine}\n<i>задач нет</i>`
   }
 
   let doneCount = 0
@@ -787,7 +854,7 @@ export function renderTodoList(
     }
   }
 
-  const header = '<b>Задачи</b>'
+  const headerLines = headerSub !== undefined ? [headerLabel, headerSub] : [headerLabel]
   const counts = `${doneCount} done / ${inProgressCount} in progress / ${pendingCount} pending`
 
   // Show only the last N completed items; older ones collapse into a tail
@@ -798,7 +865,7 @@ export function renderTodoList(
     : []
   const hiddenCompletedCount = completed.length - visibleCompleted.length
 
-  const lines: string[] = [header, counts, '']
+  const lines: string[] = [...headerLines, counts, '']
   for (const t of inProgress) lines.push(`${ICONS.in_progress} ${escapeTodoLine(t)}`)
   for (const t of pending) lines.push(`${ICONS.pending} ${escapeTodoLine(t)}`)
   if (hiddenCompletedCount > 0) {
@@ -812,8 +879,8 @@ export function renderTodoList(
   // Over budget. Truncation pass: drop trailing pending lines first, then
   // completed. Always keep header + counts + at least the in-progress block.
   const safeBudget = maxChars - TRUNCATE_MARGIN
-  // Header block (header + counts + blank line) is mandatory.
-  const headerBlock = [header, counts, ''].join('\n')
+  // Header block (header + optional freshness subline + counts + blank line) is mandatory.
+  const headerBlock = [...headerLines, counts, ''].join('\n')
   const inProgressBlock = inProgress
     .map((t) => `${ICONS.in_progress} ${escapeTodoLine(t)}`)
     .join('\n')

--- a/plugin/src/status/task-mirror.ts
+++ b/plugin/src/status/task-mirror.ts
@@ -36,7 +36,7 @@ import { join } from 'node:path'
 import type { AppConfig } from '../config.js'
 import type { Logger } from '../log.js'
 import type { TaskMirrorEvent } from '../hooks/claude-events.js'
-import type { TodoItem } from '../schemas.js'
+import { TodoItemSchema, type TodoItem } from '../schemas.js'
 import type { TelegramApiForProgress } from './telegram-api.js'
 import { escapeHtml } from '../format/html.js'
 import { renderFreshnessHeader, type TaskFreshness } from './task-freshness.js'
@@ -76,6 +76,16 @@ interface PersistedTaskState {
   sessionId?: string
   messageId: number
   todos: ReadonlyArray<TodoItem>
+  // true when `todos` had NOT yet been rendered into the remote message at
+  // persist time (throttled edit pending / edit rejected). On hydration a
+  // dirty snapshot forces one replay edit; otherwise the restored
+  // lastRenderedText would suppress it and the remote message would stay
+  // stale forever (review 2026-07-09 #3a).
+  dirty?: boolean
+  // Absolute epoch ms of the entry's last activity. Without it an ancient
+  // orphan looked freshly-active after every restart and was finalized
+  // gracefully instead of dropped (review 2026-07-09 #3c).
+  lastActivityMs?: number
 }
 
 // Per-chat lifecycle entry. Field-for-field parallel to ChatProgressEntry,
@@ -207,6 +217,16 @@ export class TaskMirror {
   // recordEvent for a chat is chained through this settled (never-rejecting)
   // promise — mirrors ContextHud.runSerialized.
   private readonly chatLocks: Map<string, Promise<void>>
+  // Per-chat ACTIVE session id, tracked from SessionStart/SessionEnd
+  // INDEPENDENTLY of whether a task entry exists (review 2026-07-09 #2:
+  // handleSessionStart previously stored nothing when no tasks existed, so the
+  // new session wasn't authoritative until its first mutation).
+  private readonly activeSessions = new Map<string, string>()
+  // Per-chat tombstones: session ids that received SessionEnd (bounded). A
+  // LATE event naming a retired session must be DROPPED — pre-fix it was
+  // treated as "newer", finalizing/clearing the active session's snapshot and
+  // adopting the dead id. SessionStart with the same id (resume) un-retires.
+  private readonly retiredSessions = new Map<string, Set<string>>()
 
   constructor(deps: TaskMirrorDeps) {
     this.telegramApi = deps.telegramApi
@@ -256,8 +276,11 @@ export class TaskMirror {
       }
 
       // Task mutation. Reset the mirror first if this event belongs to a
-      // different session than the current snapshot.
-      await this.ensureSessionForMutation(chatId, event.sessionId)
+      // different session than the current snapshot; DROP it entirely when it
+      // names a retired (ended) session — a late straggler must not resurrect
+      // a dead session or clear the active one (review 2026-07-09 #2).
+      const accepted = await this.ensureSessionForMutation(chatId, event.sessionId)
+      if (!accepted) return
       const entry = this.getOrCreate(chatId)
       if (entry.stopped) return
       entry.sessionId = event.sessionId
@@ -325,9 +348,22 @@ export class TaskMirror {
     view: { sessionId: string; todos: ReadonlyArray<TodoItem>; freshness: TaskFreshness },
   ): Promise<void> {
     try {
-      await this.ensureSessionForMutation(chatId, view.sessionId)
+      const accepted = await this.ensureSessionForMutation(chatId, view.sessionId)
+      if (!accepted) return // retired session — drop
       const entry = this.getOrCreate(chatId)
       if (entry.stopped) return
+      // Restart guard (review 2026-07-09 #10): right after a plugin restart the
+      // reconciler knows nothing yet (empty, unverified) while the entry may
+      // hold a RESTORED populated message. Applying the empty view would edit
+      // the live card down to «задач нет» — skip it; the reconciler pushes a
+      // real view as soon as events/pane arrive.
+      if (
+        view.todos.length === 0 &&
+        view.freshness.kind === 'unverified' &&
+        entry.todos.length > 0
+      ) {
+        return
+      }
       entry.sessionId = view.sessionId
       entry.lastActivityMs = this.now()
       // Reconciled list is the full authoritative snapshot.
@@ -438,6 +474,11 @@ export class TaskMirror {
     if (!persisted) return undefined
     const entry = this.reconstructEntry(chatId, persisted)
     this.chats.set(chatId, entry)
+    // Dirty snapshot: the persisted todos were never acked into the remote
+    // message (throttled edit pending / rejected at crash time). Replay ONE
+    // edit now — reconstructEntry left lastRenderedText unset so the flush is
+    // not suppressed by the idempotency gate (review 2026-07-09 #3a).
+    if (persisted.dirty === true) this.scheduleFlush(entry)
     return entry
   }
 
@@ -459,23 +500,32 @@ export class TaskMirror {
     return entry
   }
 
-  // Rebuild an entry from its persisted snapshot. lastRenderedText is set so the
-  // idempotency gate holds (an identical follow-up event is a no-op); lastEditAt
-  // is 0 so the first post-restore edit isn't throttled.
+  // Rebuild an entry from its persisted snapshot. For a CLEAN snapshot,
+  // lastRenderedText is set so the idempotency gate holds (an identical
+  // follow-up event is a no-op); for a DIRTY one it is left unset so the
+  // hydration replay edit goes through. lastEditAt is 0 so the first
+  // post-restore edit isn't throttled. lastActivityMs restores the ABSOLUTE
+  // persisted timestamp (clamped to now) so an ancient orphan is recognized as
+  // such after a restart instead of looking freshly active.
   private reconstructEntry(chatId: string, persisted: PersistedTaskState): ChatTaskEntry {
     const taskMap = new Map<string, TodoItem>()
     persisted.todos.forEach((t, i) => {
       taskMap.set(t.id ?? `restored-${i}`, t)
     })
+    const now = this.now()
+    const lastActivityMs =
+      persisted.lastActivityMs !== undefined ? Math.min(persisted.lastActivityMs, now) : now
     return {
       chatId,
       messageId: persisted.messageId,
       ...(persisted.sessionId !== undefined ? { sessionId: persisted.sessionId } : {}),
-      startedAtMs: this.now(),
-      lastActivityMs: this.now(),
+      startedAtMs: now,
+      lastActivityMs,
       todos: persisted.todos,
       taskMap,
-      lastRenderedText: this.safeRender(persisted.todos),
+      ...(persisted.dirty === true
+        ? {}
+        : { lastRenderedText: this.safeRender(persisted.todos) }),
       lastEditAtMs: 0,
       flushPromise: null,
       pendingTimer: null,
@@ -485,10 +535,36 @@ export class TaskMirror {
 
   // ─── session lifecycle ────────────────────────────────────────────────
 
-  // SessionStart: reset the snapshot on a genuine session change, preserve it
-  // on compact / resume (same id). Fires before any task event of the new
-  // session, so the next mutation starts on a clean entry.
+  // Bounded tombstone bookkeeping (review 2026-07-09 #2).
+  private retire(chatId: string, sessionId: string): void {
+    let set = this.retiredSessions.get(chatId)
+    if (set === undefined) {
+      set = new Set()
+      this.retiredSessions.set(chatId, set)
+    }
+    set.delete(sessionId) // re-add moves to the tail (freshest)
+    set.add(sessionId)
+    while (set.size > 8) {
+      const oldest = set.values().next().value
+      if (oldest === undefined) break
+      set.delete(oldest)
+    }
+  }
+
+  private isRetired(chatId: string, sessionId: string): boolean {
+    return this.retiredSessions.get(chatId)?.has(sessionId) === true
+  }
+
+  // SessionStart: mark the session ACTIVE for the chat (independent of any
+  // task entry existing), un-retire it (a resume of an ended session is
+  // legitimate), then reset the snapshot on a genuine session change and
+  // preserve it on compact / resume (same id).
   private async handleSessionStart(chatId: string, sessionId: string): Promise<void> {
+    this.retiredSessions.get(chatId)?.delete(sessionId) // resume legitimizes
+    const active = this.activeSessions.get(chatId)
+    if (active !== undefined && active !== sessionId) this.retire(chatId, active)
+    this.activeSessions.set(chatId, sessionId)
+
     const existing = this.hydrate(chatId)
     if (!existing) return
     if (existing.sessionId === undefined) {
@@ -499,24 +575,44 @@ export class TaskMirror {
     await this.resetForNewSession(chatId, existing)
   }
 
-  // SessionEnd (the REAL session end): finalize the surface. A late SessionEnd
-  // that names a session we've already moved past is ignored so it can't kill
-  // the new session's mirror.
+  // SessionEnd (the REAL session end): finalize the surface and TOMBSTONE the
+  // session so late events naming it are dropped. A late SessionEnd naming a
+  // session that is NOT the active one only tombstones it — it must never
+  // finalize the active session's mirror.
   private async handleSessionEnd(chatId: string, sessionId: string): Promise<void> {
+    const active = this.activeSessions.get(chatId)
+    if (active !== undefined && active !== sessionId) {
+      this.retire(chatId, sessionId) // late end from a retired session
+      return
+    }
+    this.retire(chatId, sessionId)
+    this.activeSessions.delete(chatId)
+
     const existing = this.hydrate(chatId)
     if (!existing) return
     if (existing.sessionId !== undefined && existing.sessionId !== sessionId) return
     await this.finalize(chatId, existing)
   }
 
-  // A task mutation arrived: reset if it belongs to a different session than
-  // the current snapshot (e.g. we missed the SessionStart hook).
-  private async ensureSessionForMutation(chatId: string, sessionId: string): Promise<void> {
+  // A task mutation arrived. Returns false when the event must be DROPPED
+  // (retired session). Otherwise resets the entry if the event belongs to a
+  // different session than the current snapshot (missed SessionStart) and
+  // adopts the event's session as active.
+  private async ensureSessionForMutation(chatId: string, sessionId: string): Promise<boolean> {
+    if (this.isRetired(chatId, sessionId)) return false // late event from a dead session
+    const active = this.activeSessions.get(chatId)
+    if (active !== undefined && active !== sessionId) {
+      // Unknown (not retired) session — a missed SessionStart for a newer one.
+      this.retire(chatId, active)
+    }
+    this.activeSessions.set(chatId, sessionId)
+
     const existing = this.hydrate(chatId)
-    if (!existing) return
-    if (existing.sessionId === undefined) return // adopted by the mutation
-    if (existing.sessionId === sessionId) return
+    if (!existing) return true
+    if (existing.sessionId === undefined) return true // adopted by the mutation
+    if (existing.sessionId === sessionId) return true
     await this.resetForNewSession(chatId, existing)
+    return true
   }
 
   // Reset on session change. If the old snapshot is fresh, finalize it
@@ -693,10 +789,15 @@ export class TaskMirror {
    * session-end signal). Same DEFAULT_MAX_CHARS budget applies — if the
    * snapshot already pushes against the cap, the marker still fits inside
    * the safety margin renderTodoList reserves.
+   *
+   * When the reality mirror already stamped an `ended` freshness header
+   * («Задачи · сессия завершена · сверено HH:MM UTC»), the footer marker is
+   * SKIPPED — otherwise the card would say «сессия завершена» twice.
    */
   private renderFinal(entry: ChatTaskEntry): string {
     const block = this.safeRender(entry.todos, entry.freshness)
     if (!block) return ''
+    if (entry.freshness?.kind === 'ended') return block
     return `${block}\n<i>сессия завершена</i>`
   }
 
@@ -725,10 +826,17 @@ export class TaskMirror {
   private persistEntry(entry: ChatTaskEntry): void {
     if (this.stateDir === undefined) return
     if (entry.messageId === undefined) return
+    // dirty = the current todos have NOT been acked into the remote message
+    // yet (throttled edit pending / edit failed). Computed structurally so
+    // every persist site gets it right: the snapshot is clean exactly when
+    // rendering the persisted todos reproduces the last successfully-sent text.
+    const dirty = this.safeRender(entry.todos, entry.freshness) !== entry.lastRenderedText
     const snapshot: PersistedTaskState = {
       ...(entry.sessionId !== undefined ? { sessionId: entry.sessionId } : {}),
       messageId: entry.messageId,
       todos: entry.todos,
+      dirty,
+      lastActivityMs: entry.lastActivityMs,
     }
     try {
       mkdirSync(this.stateDir, { recursive: true, mode: 0o700 })
@@ -769,12 +877,35 @@ export class TaskMirror {
       if (typeof messageId !== 'number' || !Number.isInteger(messageId) || messageId <= 0) {
         return undefined
       }
-      const todos = Array.isArray(obj.todos) ? (obj.todos as ReadonlyArray<TodoItem>) : []
+      // Schema-validate EVERY todo (review 2026-07-09 #3b). Pre-fix a snapshot
+      // like `{todos:[null]}` passed the Array.isArray check, then threw at
+      // `t.id` inside reconstructEntry on EVERY subsequent webhook event — a
+      // permanent wedge. An invalid snapshot is quarantined (ignored) and the
+      // mirror continues fresh.
+      if (!Array.isArray(obj.todos)) return undefined
+      const todos: TodoItem[] = []
+      for (const rawItem of obj.todos) {
+        const item = TodoItemSchema.safeParse(rawItem)
+        if (!item.success) {
+          this.log.warn('task mirror persisted snapshot invalid — quarantined, starting fresh', {
+            chat_id: chatId,
+          })
+          return undefined
+        }
+        todos.push(item.data)
+      }
       const sessionId = typeof obj.sessionId === 'string' ? obj.sessionId : undefined
+      const dirty = obj.dirty === true
+      const lastActivityMs =
+        typeof obj.lastActivityMs === 'number' && Number.isFinite(obj.lastActivityMs)
+          ? obj.lastActivityMs
+          : undefined
       return {
         ...(sessionId !== undefined ? { sessionId } : {}),
         messageId,
         todos,
+        dirty,
+        ...(lastActivityMs !== undefined ? { lastActivityMs } : {}),
       }
     } catch {
       return undefined // malformed JSON → treat as no snapshot

--- a/plugin/src/status/task-mirror.ts
+++ b/plugin/src/status/task-mirror.ts
@@ -16,10 +16,22 @@
 //   * Throttle via `edit_throttle_ms`. First send bypasses throttle, subsequent
 //     edits within the window defer onto a single timer slot.
 //   * Idempotency: same rendered text → no Telegram round-trip.
-//   * TTL eviction on `session_ttl_ms` of idleness — protects against lost
-//     `session_stop` hooks the way ProgressReporter does.
-//   * `recordEvent` is fire-and-forget; top-level try/catch swallows every
+//   * Session namespacing: the snapshot is keyed on the harness `sessionId`.
+//     A SessionStart with a new id (or a task event carrying one) resets the
+//     mirror; compact / resume of the same id preserve it. The mirror finalizes
+//     ONLY on SessionEnd (the real session end) — NEVER on Stop (turn-end).
+//   * TTL (`session_ttl_ms`) is orphan cleanup ONLY: a same-session snapshot is
+//     never expired for idleness; the TTL merely decides whether a session
+//     change drops the old snapshot silently (stale orphan) or finalizes it
+//     with a marker (fresh handoff).
+//   * Persistence: `{sessionId, messageId, todos}` is written per chat under the
+//     plugin state dir, so a plugin restart restores the rolling message
+//     instead of spamming a fresh one.
+//   * `recordEvent` is serialized per chat and its try/catch swallows every
 //     throw so the webhook 200 path is never blocked.
+
+import { mkdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 
 import type { AppConfig } from '../config.js'
 import type { Logger } from '../log.js'
@@ -50,6 +62,19 @@ export interface TaskMirrorDeps {
   now?: () => number
   setTimer?: (cb: () => void, ms: number) => NodeJS.Timeout
   clearTimer?: (handle: NodeJS.Timeout) => void
+  // Plugin state dir. When set, the mirror persists `{sessionId, messageId,
+  // todos}` per chat so a plugin restart restores the rolling message instead
+  // of losing the snapshot. Omitted in unit tests that don't exercise restart.
+  stateDir?: string
+}
+
+// On-disk snapshot persisted per chat under `task-mirror-<chatId>.json`. Lets a
+// plugin restart pick up the SAME rolling message (edit in place) and the SAME
+// session namespace, instead of spamming a fresh message on the next event.
+interface PersistedTaskState {
+  sessionId?: string
+  messageId: number
+  todos: ReadonlyArray<TodoItem>
 }
 
 // Per-chat lifecycle entry. Field-for-field parallel to ChatProgressEntry,
@@ -57,8 +82,11 @@ export interface TaskMirrorDeps {
 interface ChatTaskEntry {
   chatId: string
   messageId?: number
+  // Session this snapshot belongs to. Harness task ids restart at #1 every
+  // session, so a mutation whose event.sessionId differs resets the mirror.
+  sessionId?: string
   startedAtMs: number
-  // Updated on every recordEvent. Used by TTL eviction in getOrCreate.
+  // Updated on every recordEvent. Used by TTL orphan cleanup on session change.
   lastActivityMs: number
   // Latest TodoWrite snapshot from Claude. Replaced wholesale on each event
   // — TodoWrite is itself the full list, so we never merge incrementally.
@@ -81,7 +109,8 @@ interface ChatTaskEntry {
   // Single-slot throttle timer. Non-null while waiting for the throttle
   // window to elapse before publishing.
   pendingTimer: NodeJS.Timeout | null
-  // True once todo_session_stop has been processed. Idempotency guard.
+  // True once the entry has been finalized (session end) or dropped (orphan /
+  // session change). Idempotency + orphan guard for late in-flight flushes.
   stopped: boolean
 }
 
@@ -165,7 +194,14 @@ export class TaskMirror {
   private readonly now: () => number
   private readonly setTimer: (cb: () => void, ms: number) => NodeJS.Timeout
   private readonly clearTimer: (handle: NodeJS.Timeout) => void
+  private readonly stateDir: string | undefined
   private readonly chats: Map<string, ChatTaskEntry>
+  // Per-chat serialization. Session transitions (finalize old → start new) and
+  // throttled flushes must not interleave across concurrent webhook requests,
+  // or a late old-session edit could race the new session's snapshot. Every
+  // recordEvent for a chat is chained through this settled (never-rejecting)
+  // promise — mirrors ContextHud.runSerialized.
+  private readonly chatLocks: Map<string, Promise<void>>
 
   constructor(deps: TaskMirrorDeps) {
     this.telegramApi = deps.telegramApi
@@ -174,32 +210,52 @@ export class TaskMirror {
     this.now = deps.now ?? (() => Date.now())
     this.setTimer = deps.setTimer ?? ((cb, ms) => setTimeout(cb, ms))
     this.clearTimer = deps.clearTimer ?? ((h) => clearTimeout(h))
+    this.stateDir = deps.stateDir
     this.chats = new Map()
+    this.chatLocks = new Map()
   }
 
   /**
    * Main entry point. Called by the webhook handler for every Claude hook
-   * that mapped to a TaskMirrorEvent. Never throws — top-level try/catch
-   * swallows any failure so the webhook 200 path stays open.
+   * that mapped to a TaskMirrorEvent. Never throws — the inner handler's
+   * try/catch swallows any failure so the webhook 200 path stays open.
    *
-   * Three input shapes:
-   *   - `todo_write`: full list snapshot (legacy TodoWrite tool). Replaces
-   *     `todos` wholesale AND clears `taskMap` so a mid-session switch from
-   *     TodoWrite to TaskCreate/Update starts cleanly.
-   *   - `task_create` / `task_update`: incremental events from the newer
-   *     TaskCreate/TaskUpdate tools. Mutate `taskMap`, then synthesise the
-   *     `todos` array from it.
-   *   - `todo_session_stop`: terminal signal, handled separately.
+   * Serialized per chat so a session transition and its flushes can't
+   * interleave with a concurrent event for the same chat.
    */
   async recordEvent(chatId: string, event: TaskMirrorEvent): Promise<void> {
     if (!this.config.task_mirror.enabled) return
+    await this.runSerialized(chatId, () => this.recordEventInner(chatId, event))
+  }
+
+  /**
+   * Serialized body. Five input shapes:
+   *   - `session_start`: reset the snapshot when the session id changes
+   *     (genuine new session); preserve it on compact / resume of the same id.
+   *   - `session_end`: finalize the surface (marker + evict). The REAL session
+   *     end — Stop no longer reaches here.
+   *   - `todo_write`: full list snapshot (legacy TodoWrite tool). Replaces
+   *     `todos` wholesale AND clears `taskMap`.
+   *   - `task_create` / `task_update`: incremental events. Mutate `taskMap`,
+   *     then synthesise the `todos` array from it.
+   */
+  private async recordEventInner(chatId: string, event: TaskMirrorEvent): Promise<void> {
     try {
-      if (event.kind === 'todo_session_stop') {
-        await this.handleStop(chatId)
+      if (event.kind === 'session_start') {
+        await this.handleSessionStart(chatId, event.sessionId)
         return
       }
+      if (event.kind === 'session_end') {
+        await this.handleSessionEnd(chatId, event.sessionId)
+        return
+      }
+
+      // Task mutation. Reset the mirror first if this event belongs to a
+      // different session than the current snapshot.
+      await this.ensureSessionForMutation(chatId, event.sessionId)
       const entry = this.getOrCreate(chatId)
       if (entry.stopped) return
+      entry.sessionId = event.sessionId
       entry.lastActivityMs = this.now()
 
       switch (event.kind) {
@@ -217,13 +273,44 @@ export class TaskMirror {
           entry.todos = Array.from(entry.taskMap.values())
           break
       }
+      // Persist eagerly once the message exists so a restart mid-session
+      // restores the latest todos even if the throttled edit hasn't landed.
+      if (entry.messageId !== undefined) this.persistEntry(entry)
       this.scheduleFlush(entry)
+      // Materialise the FIRST send inside the lock so a following serialized
+      // event edits the same message instead of double-sending. Deferred
+      // (throttled) edits keep messageId already set, so we do NOT await them
+      // and throttling is preserved.
+      if (entry.messageId === undefined && entry.flushPromise !== null) {
+        try {
+          await entry.flushPromise
+        } catch {
+          /* already logged inside executeFlush */
+        }
+      }
     } catch (err) {
       this.log.warn('task mirror recordEvent failed (ignored)', {
         chat_id: chatId,
         error: err instanceof Error ? err.message : String(err),
       })
     }
+  }
+
+  // Serialize an operation per chat. The returned promise resolves when THIS op
+  // completes; the next call for the same chat waits for it. `fn` swallows its
+  // own errors (recordEventInner try/catch), so the chain never rejects.
+  private runSerialized(chatId: string, fn: () => Promise<void>): Promise<void> {
+    const prior = this.chatLocks.get(chatId) ?? Promise.resolve()
+    const result = prior.then(fn, fn)
+    const settled: Promise<void> = result.then(
+      () => undefined,
+      () => undefined,
+    )
+    this.chatLocks.set(chatId, settled)
+    void settled.then(() => {
+      if (this.chatLocks.get(chatId) === settled) this.chatLocks.delete(chatId)
+    })
+    return result
   }
 
   /**
@@ -280,20 +367,24 @@ export class TaskMirror {
   // Internals
   // ─────────────────────────────────────────────────────────────────────
 
+  // Return the in-memory entry, restoring it from disk first if the process
+  // just restarted. Unlike the old getOrCreate, this NEVER expires an entry by
+  // TTL — an active same-session snapshot must survive idle gaps (the mirror no
+  // longer finalizes on Stop, so idleness is normal). TTL now bites ONLY as
+  // orphan cleanup on a session change (see ensureSessionForMutation).
+  private hydrate(chatId: string): ChatTaskEntry | undefined {
+    const mem = this.chats.get(chatId)
+    if (mem) return mem
+    const persisted = this.loadPersisted(chatId)
+    if (!persisted) return undefined
+    const entry = this.reconstructEntry(chatId, persisted)
+    this.chats.set(chatId, entry)
+    return entry
+  }
+
   private getOrCreate(chatId: string): ChatTaskEntry {
-    const existing = this.chats.get(chatId)
-    if (existing) {
-      const idle = this.now() - existing.lastActivityMs
-      if (idle > this.config.task_mirror.session_ttl_ms) {
-        this.log.debug('task mirror entry TTL expired, starting fresh thread', {
-          chat_id: chatId,
-          idle_ms: idle,
-        })
-        this.chats.delete(chatId)
-      } else {
-        return existing
-      }
-    }
+    const existing = this.hydrate(chatId)
+    if (existing) return existing
     const entry: ChatTaskEntry = {
       chatId,
       startedAtMs: this.now(),
@@ -307,6 +398,78 @@ export class TaskMirror {
     }
     this.chats.set(chatId, entry)
     return entry
+  }
+
+  // Rebuild an entry from its persisted snapshot. lastRenderedText is set so the
+  // idempotency gate holds (an identical follow-up event is a no-op); lastEditAt
+  // is 0 so the first post-restore edit isn't throttled.
+  private reconstructEntry(chatId: string, persisted: PersistedTaskState): ChatTaskEntry {
+    const taskMap = new Map<string, TodoItem>()
+    persisted.todos.forEach((t, i) => {
+      taskMap.set(t.id ?? `restored-${i}`, t)
+    })
+    return {
+      chatId,
+      messageId: persisted.messageId,
+      ...(persisted.sessionId !== undefined ? { sessionId: persisted.sessionId } : {}),
+      startedAtMs: this.now(),
+      lastActivityMs: this.now(),
+      todos: persisted.todos,
+      taskMap,
+      lastRenderedText: this.safeRender(persisted.todos),
+      lastEditAtMs: 0,
+      flushPromise: null,
+      pendingTimer: null,
+      stopped: false,
+    }
+  }
+
+  // ─── session lifecycle ────────────────────────────────────────────────
+
+  // SessionStart: reset the snapshot on a genuine session change, preserve it
+  // on compact / resume (same id). Fires before any task event of the new
+  // session, so the next mutation starts on a clean entry.
+  private async handleSessionStart(chatId: string, sessionId: string): Promise<void> {
+    const existing = this.hydrate(chatId)
+    if (!existing) return
+    if (existing.sessionId === undefined) {
+      existing.sessionId = sessionId
+      return
+    }
+    if (existing.sessionId === sessionId) return // compact / resume — preserve
+    await this.resetForNewSession(chatId, existing)
+  }
+
+  // SessionEnd (the REAL session end): finalize the surface. A late SessionEnd
+  // that names a session we've already moved past is ignored so it can't kill
+  // the new session's mirror.
+  private async handleSessionEnd(chatId: string, sessionId: string): Promise<void> {
+    const existing = this.hydrate(chatId)
+    if (!existing) return
+    if (existing.sessionId !== undefined && existing.sessionId !== sessionId) return
+    await this.finalize(chatId, existing)
+  }
+
+  // A task mutation arrived: reset if it belongs to a different session than
+  // the current snapshot (e.g. we missed the SessionStart hook).
+  private async ensureSessionForMutation(chatId: string, sessionId: string): Promise<void> {
+    const existing = this.hydrate(chatId)
+    if (!existing) return
+    if (existing.sessionId === undefined) return // adopted by the mutation
+    if (existing.sessionId === sessionId) return
+    await this.resetForNewSession(chatId, existing)
+  }
+
+  // Reset on session change. If the old snapshot is fresh, finalize it
+  // gracefully (final «сессия завершена» edit) so the warchief sees the handoff;
+  // if it is past the TTL it is a stale orphan and dropped silently.
+  private async resetForNewSession(chatId: string, existing: ChatTaskEntry): Promise<void> {
+    const idle = this.now() - existing.lastActivityMs
+    if (idle > this.config.task_mirror.session_ttl_ms) {
+      this.dropOrphan(chatId, existing)
+    } else {
+      await this.finalize(chatId, existing)
+    }
   }
 
   /**
@@ -365,6 +528,7 @@ export class TaskMirror {
           entry.messageId = sent.message_id
           entry.lastRenderedText = text
           entry.lastEditAtMs = this.now()
+          this.persistEntry(entry)
         } else {
           this.log.warn('task mirror send completed after stop (orphan)', {
             chat_id: entry.chatId,
@@ -384,6 +548,7 @@ export class TaskMirror {
       if (!entry.stopped) {
         entry.lastRenderedText = text
         entry.lastEditAtMs = this.now()
+        this.persistEntry(entry)
       }
     } catch (err) {
       this.log.warn('task mirror editMessageText failed (ignored)', {
@@ -395,19 +560,19 @@ export class TaskMirror {
   }
 
   /**
-   * Eviction handler — mirrors ProgressReporter.handleStop. Cancels timers,
-   * awaits any in-flight flush, posts a final edit (if a message exists)
-   * with the latest snapshot AND a «сессия завершена» marker line, then
-   * deletes the entry.
+   * Finalize a session. Cancels timers, awaits any in-flight flush, posts a
+   * final edit (if a message exists) with the latest snapshot AND a «сессия
+   * завершена» marker line, then evicts the entry and clears its persisted
+   * snapshot. Called on SessionEnd and on a fresh session change — NEVER on
+   * Stop (Stop is turn-end, not session-end).
    *
-   * Why the marker: without it, if the last TodoWrite snapshot was already
-   * rendered the idempotency gate (`text === lastRenderedText`) skips the
-   * final edit — the warchief never sees a visual «session ended» signal.
-   * Appending a non-empty marker line guarantees the final text differs.
+   * Why the marker: without it, if the last snapshot was already rendered the
+   * idempotency gate (`text === lastRenderedText`) skips the final edit — the
+   * warchief never sees a visual «session ended» signal. Appending a non-empty
+   * marker line guarantees the final text differs.
    */
-  private async handleStop(chatId: string): Promise<void> {
-    const entry = this.chats.get(chatId)
-    if (!entry || entry.stopped) return
+  private async finalize(chatId: string, entry: ChatTaskEntry): Promise<void> {
+    if (entry.stopped) return
     entry.stopped = true
 
     if (entry.pendingTimer !== null) {
@@ -440,6 +605,26 @@ export class TaskMirror {
     }
 
     this.chats.delete(chatId)
+    this.clearPersisted(chatId)
+  }
+
+  /**
+   * Drop a stale orphan (a snapshot whose session changed AND that is past the
+   * TTL — a long-dead session we never got a clean SessionEnd for). Silent: no
+   * «сессия завершена» edit, since the old message is long stale. Cancels the
+   * throttle timer and marks the entry stopped so any in-flight flush no-ops.
+   */
+  private dropOrphan(chatId: string, entry: ChatTaskEntry): void {
+    entry.stopped = true
+    if (entry.pendingTimer !== null) {
+      this.clearTimer(entry.pendingTimer)
+      entry.pendingTimer = null
+    }
+    this.log.debug('task mirror orphan dropped on session change (TTL elapsed)', {
+      chat_id: chatId,
+    })
+    this.chats.delete(chatId)
+    this.clearPersisted(chatId)
   }
 
   /**
@@ -464,6 +649,88 @@ export class TaskMirror {
         error: err instanceof Error ? err.message : String(err),
       })
       return ''
+    }
+  }
+
+  // ─── persistence ──────────────────────────────────────────────────────
+  // Best-effort, same pattern as ContextHud: a persistence failure NEVER
+  // disturbs the surface (the mirror keeps working from memory). Files are
+  // written atomically (temp + rename in the same dir) so a partial write can't
+  // corrupt the snapshot. No-op when no state dir was configured.
+
+  private persistPath(chatId: string): string {
+    const safe = chatId.replace(/[^0-9A-Za-z_-]/g, '_')
+    return join(this.stateDir as string, `task-mirror-${safe}.json`)
+  }
+
+  private persistEntry(entry: ChatTaskEntry): void {
+    if (this.stateDir === undefined) return
+    if (entry.messageId === undefined) return
+    const snapshot: PersistedTaskState = {
+      ...(entry.sessionId !== undefined ? { sessionId: entry.sessionId } : {}),
+      messageId: entry.messageId,
+      todos: entry.todos,
+    }
+    try {
+      mkdirSync(this.stateDir, { recursive: true, mode: 0o700 })
+      const path = this.persistPath(entry.chatId)
+      const tmp = `${path}.tmp.${process.pid}.${Date.now()}`
+      writeFileSync(tmp, JSON.stringify(snapshot), { mode: 0o600 })
+      try {
+        renameSync(tmp, path)
+      } catch (err) {
+        try {
+          unlinkSync(tmp)
+        } catch {
+          /* ignore */
+        }
+        throw err
+      }
+    } catch (err) {
+      this.log.warn('task mirror persist failed (ignored)', {
+        chat_id: entry.chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  private loadPersisted(chatId: string): PersistedTaskState | undefined {
+    if (this.stateDir === undefined) return undefined
+    let raw: string
+    try {
+      raw = readFileSync(this.persistPath(chatId), 'utf8')
+    } catch {
+      return undefined // missing file → no persisted snapshot
+    }
+    try {
+      const parsed: unknown = JSON.parse(raw)
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return undefined
+      const obj = parsed as Record<string, unknown>
+      const messageId = obj.messageId
+      if (typeof messageId !== 'number' || !Number.isInteger(messageId) || messageId <= 0) {
+        return undefined
+      }
+      const todos = Array.isArray(obj.todos) ? (obj.todos as ReadonlyArray<TodoItem>) : []
+      const sessionId = typeof obj.sessionId === 'string' ? obj.sessionId : undefined
+      return {
+        ...(sessionId !== undefined ? { sessionId } : {}),
+        messageId,
+        todos,
+      }
+    } catch {
+      return undefined // malformed JSON → treat as no snapshot
+    }
+  }
+
+  private clearPersisted(chatId: string): void {
+    if (this.stateDir === undefined) return
+    try {
+      rmSync(this.persistPath(chatId), { force: true })
+    } catch (err) {
+      this.log.warn('task mirror clearPersisted failed (ignored)', {
+        chat_id: chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
     }
   }
 }

--- a/plugin/src/status/task-reality-mirror.ts
+++ b/plugin/src/status/task-reality-mirror.ts
@@ -1,0 +1,578 @@
+// TaskRealityMirror — the M3 wiring layer that makes the task surfaces reflect
+// the harness's REAL task list even when the agent forgets to call task tools.
+//
+// It fuses two truth sources per chat:
+//   (a) the plugin's own tool-event stream (TodoWrite / TaskCreate / TaskUpdate)
+//       already flowing through the webhook, and
+//   (b) validated snapshots of the task list Claude Code renders directly in the
+//       tmux pane (captured via the shared pane-capture code path).
+//
+// The pure fusion + freshness logic lives in the M2 `task-reconciler` module;
+// this file owns ONLY the stateful orchestration the pure layer forbids itself:
+// per-chat state, the session binding, the turn-active window, the capture
+// timer (20s cadence, 5s coalesce, immediate on SessionStart / UserPromptSubmit
+// / Stop), and pushing the reconciled view + freshness indicator into the
+// surfaces (context HUD pin + TaskMirror). Every method is best-effort and must
+// never throw into the webhook 200 path.
+//
+// Degradation: when no pane is capturable (tmux absent, session gone, wrong
+// pane), reconciliation produces no valid snapshot and the view renders
+// «НЕ СВЕРЕНО» (events only) — the surfaces still show the optimistic list.
+
+import type { Logger } from '../log.js'
+import type { TodoItem } from '../schemas.js'
+import type { TaskMirrorEvent, TaskMutationEvent } from '../hooks/claude-events.js'
+import { isTaskMutationEvent } from '../hooks/claude-events.js'
+import { applyTaskCreateToMap, applyTaskUpdateToMap } from './task-mirror.js'
+import {
+  capturePaneText,
+  resolvePaneCwd,
+  type PaneCaptureConfig,
+  type TmuxExec,
+} from './pane-capture.js'
+import {
+  deriveHealth,
+  initialReconciledState,
+  normalizeDescription,
+  parsePaneTaskList,
+  reconcileTaskState,
+  validateSnapshot,
+  type PaneProvenance,
+  type PaneSnapshot,
+  type ReconciledState,
+  type ReconciledTask,
+  type SessionBinding,
+  type ToolTaskEvent,
+} from './task-reconciler.js'
+import { formatUtcHm, type TaskFreshness } from './task-freshness.js'
+
+// ─────────────────────────────────────────────────────────────────────
+// Sink contract — the surfaces the reconciled view is pushed into.
+// ─────────────────────────────────────────────────────────────────────
+
+/** The reconciled task view a surface renders (reconciled list + freshness). */
+export interface ReconciledView {
+  sessionId: string
+  todos: ReadonlyArray<TodoItem>
+  freshness: TaskFreshness
+}
+
+/** A surface that can render a reconciled view (context HUD, TaskMirror). */
+export interface ReconciledViewSink {
+  applyReconciledView(chatId: string, view: ReconciledView): void | Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Options.
+// ─────────────────────────────────────────────────────────────────────
+
+export interface TaskRealityMirrorOptions {
+  exec: TmuxExec
+  /** Pane the agent's task list renders in (reused from tmux_mirror config). */
+  capture: PaneCaptureConfig
+  log: Logger
+  /** Surfaces to feed. Order is irrelevant; each is best-effort. */
+  sinks: ReadonlyArray<ReconciledViewSink>
+  /** Periodic capture cadence while a session is active. Default 20s. */
+  captureIntervalMs?: number
+  /** Coalesce window: triggers within this collapse to one capture. Default 5s. */
+  coalesceWindowMs?: number
+  /** Orphan-timer TTL: an idle non-active session parks its timer past this. Default 10min. */
+  ttlMs?: number
+  /** Owner-chat gate — the reconciler acts ONLY for owner DM chats. */
+  isOwnerChat?: (chatId: string) => boolean
+  now?: () => number
+  setTimer?: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>
+  clearTimer?: (handle: ReturnType<typeof setTimeout>) => void
+}
+
+interface ChatRec {
+  chatId: string
+  sessionId: string
+  binding: SessionBinding
+  state: ReconciledState
+  // Event-derived TodoItem map (same appliers the surfaces use) — kept so we
+  // can emit ONLY the changed tasks as ToolTaskEvents (re-emitting unchanged
+  // tasks would reset their updatedAt and wrongly out-rank pane snapshots).
+  eventMap: Map<string, TodoItem>
+  turnActive: boolean
+  ended: boolean
+  lastActivityMs: number
+  periodicTimer: ReturnType<typeof setTimeout> | null
+  coalesceTimer: ReturnType<typeof setTimeout> | null
+  lastCaptureAt: number
+  capturing: boolean
+}
+
+const DEFAULT_CAPTURE_INTERVAL_MS = 20_000
+const DEFAULT_COALESCE_WINDOW_MS = 5_000
+const DEFAULT_TTL_MS = 10 * 60 * 1000
+
+export class TaskRealityMirror {
+  private readonly exec: TmuxExec
+  private readonly capture: PaneCaptureConfig
+  private readonly log: Logger
+  private readonly sinks: ReadonlyArray<ReconciledViewSink>
+  private readonly captureIntervalMs: number
+  private readonly coalesceWindowMs: number
+  private readonly ttlMs: number
+  private readonly isOwnerChat: (chatId: string) => boolean
+  private readonly now: () => number
+  private readonly setTimer: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>
+  private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
+  private readonly recs = new Map<string, ChatRec>()
+
+  constructor(opts: TaskRealityMirrorOptions) {
+    this.exec = opts.exec
+    this.capture = opts.capture
+    this.log = opts.log
+    this.sinks = opts.sinks
+    this.captureIntervalMs = opts.captureIntervalMs ?? DEFAULT_CAPTURE_INTERVAL_MS
+    this.coalesceWindowMs = opts.coalesceWindowMs ?? DEFAULT_COALESCE_WINDOW_MS
+    this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS
+    this.isOwnerChat = opts.isOwnerChat ?? ((): boolean => true)
+    this.now = opts.now ?? ((): number => Date.now())
+    this.setTimer = opts.setTimer ?? ((cb, ms): ReturnType<typeof setTimeout> => setTimeout(cb, ms))
+    this.clearTimer = opts.clearTimer ?? ((h): void => clearTimeout(h))
+  }
+
+  // ─── lifecycle entry points (called from the webhook dispatcher) ──────
+
+  /** SessionStart: (re)bind, reset on a session change, arm the timer, capture now. */
+  onSessionStart(chatId: string, opts: { sessionId: string; cwd?: string }): void {
+    if (!this.isOwnerChat(chatId)) return
+    try {
+      const rec = this.ensureRec(chatId, opts.sessionId, opts.cwd)
+      this.ensureSession(rec, opts.sessionId)
+      rec.ended = false
+      rec.lastActivityMs = this.now()
+      this.pushView(rec)
+      this.ensureTicking(rec)
+      this.triggerCapture(rec, true)
+    } catch (err) {
+      this.warn('onSessionStart', chatId, err)
+    }
+  }
+
+  /** UserPromptSubmit: a turn has begun — mark active, arm the timer, capture now. */
+  onUserPromptSubmit(chatId: string, opts: { sessionId: string; cwd?: string }): void {
+    if (!this.isOwnerChat(chatId)) return
+    try {
+      const rec = this.ensureRec(chatId, opts.sessionId, opts.cwd)
+      this.ensureSession(rec, opts.sessionId)
+      rec.ended = false
+      rec.turnActive = true
+      rec.lastActivityMs = this.now()
+      this.pushView(rec)
+      this.ensureTicking(rec)
+      this.triggerCapture(rec, true)
+    } catch (err) {
+      this.warn('onUserPromptSubmit', chatId, err)
+    }
+  }
+
+  /** Stop (turn-end): capture BEFORE closing the turn window, then go idle. */
+  onStop(chatId: string): void {
+    if (!this.isOwnerChat(chatId)) return
+    const rec = this.recs.get(chatId)
+    if (rec === undefined || rec.ended) return
+    try {
+      // Immediate capture while the turn is still "active" so a fresh list is
+      // reconciled before the HUD refreshes; the window closes right after.
+      this.triggerCapture(rec, true)
+      rec.turnActive = false
+      rec.lastActivityMs = this.now()
+      this.pushView(rec)
+    } catch (err) {
+      this.warn('onStop', chatId, err)
+    }
+  }
+
+  /**
+   * SessionEnd (the REAL end): freeze the surface. Consumes the LATEST
+   * reconciled state — does NOT capture (the pane may already be gone) — stops
+   * the timers, and pushes a frozen «сессия завершена» view.
+   */
+  onSessionEnd(chatId: string, opts: { sessionId: string }): void {
+    if (!this.isOwnerChat(chatId)) return
+    const rec = this.recs.get(chatId)
+    if (rec === undefined) return
+    // Ignore a late SessionEnd naming a session we've already moved past.
+    if (rec.sessionId !== opts.sessionId) return
+    try {
+      rec.ended = true
+      rec.turnActive = false
+      this.disarm(rec)
+      this.pushView(rec)
+    } catch (err) {
+      this.warn('onSessionEnd', chatId, err)
+    }
+  }
+
+  /** A task mutation event (TodoWrite / TaskCreate / TaskUpdate). */
+  onTaskEvent(chatId: string, event: TaskMirrorEvent, opts: { cwd?: string } = {}): void {
+    if (!this.isOwnerChat(chatId)) return
+    if (!isTaskMutationEvent(event)) return // lifecycle handled by the entry points above
+    try {
+      const rec = this.ensureRec(chatId, event.sessionId, opts.cwd)
+      this.ensureSession(rec, event.sessionId)
+      rec.lastActivityMs = this.now()
+      const now = this.now()
+      for (const te of this.deriveToolEvents(rec, event, now)) {
+        rec.state = reconcileTaskState(rec.state, { kind: 'event', event: te })
+      }
+      this.pushView(rec)
+    } catch (err) {
+      this.warn('onTaskEvent', chatId, err)
+    }
+  }
+
+  /** Stop every timer (process shutdown). */
+  stop(): void {
+    for (const rec of this.recs.values()) this.disarm(rec)
+  }
+
+  // ─── per-chat state ──────────────────────────────────────────────────
+
+  private ensureRec(chatId: string, sessionId: string, cwd?: string): ChatRec {
+    let rec = this.recs.get(chatId)
+    if (rec === undefined) {
+      rec = {
+        chatId,
+        sessionId,
+        binding: { sessionId, paneTarget: this.capture.paneTarget, cwd: cwd ?? '' },
+        state: initialReconciledState(sessionId),
+        eventMap: new Map(),
+        turnActive: false,
+        ended: false,
+        lastActivityMs: this.now(),
+        periodicTimer: null,
+        coalesceTimer: null,
+        // −∞ so the FIRST trigger always captures immediately (no 5s coalesce
+        // wait on a brand-new session).
+        lastCaptureAt: Number.NEGATIVE_INFINITY,
+        capturing: false,
+      }
+      this.recs.set(chatId, rec)
+    } else if (cwd !== undefined && cwd.length > 0 && rec.binding.cwd !== cwd) {
+      rec.binding = { ...rec.binding, cwd }
+    }
+    return rec
+  }
+
+  // Reset state on a genuine session change (harness task ids restart at #1).
+  private ensureSession(rec: ChatRec, sessionId: string): void {
+    if (rec.sessionId === sessionId) return
+    rec.sessionId = sessionId
+    rec.binding = { ...rec.binding, sessionId }
+    rec.state = initialReconciledState(sessionId)
+    rec.eventMap = new Map()
+    rec.ended = false
+    rec.turnActive = false
+  }
+
+  // ─── capture scheduling ──────────────────────────────────────────────
+
+  private ensureTicking(rec: ChatRec): void {
+    if (rec.ended) return
+    if (rec.periodicTimer !== null) return
+    this.scheduleTick(rec)
+  }
+
+  private scheduleTick(rec: ChatRec): void {
+    if (rec.ended) return
+    rec.periodicTimer = this.setTimer(() => this.onTick(rec), this.captureIntervalMs)
+  }
+
+  private onTick(rec: ChatRec): void {
+    rec.periodicTimer = null
+    if (rec.ended) return
+    const idle = this.now() - rec.lastActivityMs
+    if (!rec.turnActive && idle > this.ttlMs) {
+      // Orphan timer: a long-idle session with no SessionEnd. Park the timer
+      // (stop rearming) — a fresh UserPromptSubmit / SessionStart restarts it.
+      this.log.debug('task reality mirror timer parked (idle > ttl)', {
+        chat_id: rec.chatId,
+      })
+      return
+    }
+    this.triggerCapture(rec, false)
+    // Advance the freshness indicator (minute buckets) even if the capture is
+    // async / a no-op; the sinks dedup identical renders.
+    this.pushView(rec)
+    this.scheduleTick(rec)
+  }
+
+  // Coalesce triggers within `coalesceWindowMs` into a single capture.
+  private triggerCapture(rec: ChatRec, immediate: boolean): void {
+    if (rec.ended) return
+    const since = this.now() - rec.lastCaptureAt
+    if (immediate && since >= this.coalesceWindowMs) {
+      void this.doCapture(rec)
+      return
+    }
+    if (rec.coalesceTimer !== null) return
+    const wait = Math.max(0, this.coalesceWindowMs - since)
+    if (wait === 0) {
+      void this.doCapture(rec)
+      return
+    }
+    rec.coalesceTimer = this.setTimer(() => {
+      rec.coalesceTimer = null
+      void this.doCapture(rec)
+    }, wait)
+  }
+
+  private async doCapture(rec: ChatRec): Promise<void> {
+    if (rec.capturing || rec.ended) return
+    rec.capturing = true
+    rec.lastCaptureAt = this.now()
+    try {
+      const cap = await capturePaneText(this.exec, this.capture)
+      if (!cap.ok) {
+        // No pane / capture failed — no snapshot. Refresh the indicator only
+        // (health may transition to stale if a turn is active).
+        this.pushView(rec)
+        return
+      }
+      // Resolve the pane's cwd for provenance. When unobtainable, degrade by
+      // reusing the binding cwd so validateSnapshot skips the cross-check
+      // rather than false-flagging a mismatch (documented M3 degrade).
+      const paneCwd = await resolvePaneCwd(this.exec, this.capture)
+      const cwd = paneCwd ?? rec.binding.cwd
+      const provenance: PaneProvenance = {
+        sessionId: rec.binding.sessionId,
+        paneTarget: this.capture.paneTarget,
+        cwd,
+        capturedAt: this.now(),
+      }
+      const snapshot = parsePaneTaskList(cap.text, provenance)
+      if (snapshot === null) {
+        // No task list in the pane. While IDLE this is normal (the harness does
+        // not redraw the list between turns) — do NOT churn state; the last
+        // valid snapshot stays rendered as verified. deriveHealth handles the
+        // active-turn staleness case.
+        this.pushView(rec)
+        return
+      }
+      const verdict = validateSnapshot(snapshot, rec.binding)
+      // §5 positional-alias pre-pass: re-key moved tasks to the snapshot's
+      // ordinals by unique description so a genuine move is a merge, not a
+      // remove+add. Only meaningful when the snapshot is authoritative.
+      const base = verdict.authoritative ? realignOrdinals(rec.state, snapshot) : rec.state
+      rec.state = reconcileTaskState(base, { kind: 'snapshot', snapshot, verdict })
+      this.pushView(rec)
+    } catch (err) {
+      this.warn('doCapture', rec.chatId, err)
+    } finally {
+      rec.capturing = false
+    }
+  }
+
+  private disarm(rec: ChatRec): void {
+    if (rec.periodicTimer !== null) {
+      this.clearTimer(rec.periodicTimer)
+      rec.periodicTimer = null
+    }
+    if (rec.coalesceTimer !== null) {
+      this.clearTimer(rec.coalesceTimer)
+      rec.coalesceTimer = null
+    }
+  }
+
+  // ─── view push ───────────────────────────────────────────────────────
+
+  private pushView(rec: ChatRec): void {
+    const view: ReconciledView = {
+      sessionId: rec.sessionId,
+      todos: reconciledToTodos(rec.state),
+      freshness: this.computeFreshness(rec),
+    }
+    for (const sink of this.sinks) {
+      try {
+        const r = sink.applyReconciledView(rec.chatId, view)
+        if (r instanceof Promise) {
+          r.catch((err: unknown) => this.warn('sink.applyReconciledView', rec.chatId, err))
+        }
+      } catch (err) {
+        // Guard a SYNCHRONOUS throw from a sink so it can't escape into a hook.
+        this.warn('sink.applyReconciledView', rec.chatId, err)
+      }
+    }
+  }
+
+  private computeFreshness(rec: ChatRec): TaskFreshness {
+    const now = this.now()
+    if (rec.ended) {
+      return {
+        kind: 'ended',
+        reconciledAtLabel: rec.state.lastReconciledAt > 0 ? formatUtcHm(rec.state.lastReconciledAt) : null,
+      }
+    }
+    const health = deriveHealth(rec.state, now, rec.turnActive)
+    if (health === 'unverified') return { kind: 'unverified' }
+    if (health === 'stale') {
+      const eventAgeMs = rec.state.lastEventAt > 0 ? now - rec.state.lastEventAt : now - rec.state.lastReconciledAt
+      return { kind: 'stale', reconciledAgeMs: now - rec.state.lastReconciledAt, eventAgeMs }
+    }
+    return { kind: 'fresh', reconciledAgeMs: now - rec.state.lastReconciledAt }
+  }
+
+  // ─── tool-event derivation ───────────────────────────────────────────
+
+  // Apply the mutation to the event-derived map, then emit ToolTaskEvents for
+  // ONLY the tasks whose status/description actually changed (or are new). This
+  // keeps unchanged tasks from re-stamping `updatedAt` and wrongly out-ranking
+  // authoritative pane snapshots.
+  private deriveToolEvents(rec: ChatRec, event: TaskMutationEvent, now: number): ToolTaskEvent[] {
+    const pre = new Map(rec.eventMap)
+    applyEventToEventMap(rec.eventMap, event)
+    const out: ToolTaskEvent[] = []
+    for (const [id, item] of rec.eventMap) {
+      const prev = pre.get(id)
+      if (
+        prev !== undefined &&
+        prev.status === item.status &&
+        prev.content === item.content &&
+        prev.activeForm === item.activeForm
+      ) {
+        continue
+      }
+      const ordinal = numericOrdinal(id)
+      out.push({
+        ...(ordinal !== undefined ? { ordinal } : {}),
+        status: item.status,
+        description: item.content,
+        at: now,
+      })
+    }
+    return out
+  }
+
+  private warn(where: string, chatId: string, err: unknown): void {
+    this.log.warn(`task reality mirror ${where} failed (ignored)`, {
+      chat_id: chatId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Pure helpers (exported for tests).
+// ─────────────────────────────────────────────────────────────────────
+
+/** Numeric harness ordinal from a task id (`"3"` → 3), or undefined for non-numeric ids. */
+export function numericOrdinal(id: string): number | undefined {
+  return /^\d+$/.test(id) ? Number.parseInt(id, 10) : undefined
+}
+
+/** Apply a task mutation to an event-derived TodoItem map (same appliers the surfaces use). */
+export function applyEventToEventMap(map: Map<string, TodoItem>, event: TaskMutationEvent): void {
+  switch (event.kind) {
+    case 'todo_write': {
+      map.clear()
+      event.todos.forEach((t, i) => {
+        map.set(t.id !== undefined && t.id.length > 0 ? t.id : `todo-${i + 1}`, t)
+      })
+      return
+    }
+    case 'task_create':
+      applyTaskCreateToMap(map, event)
+      return
+    case 'task_update':
+      applyTaskUpdateToMap(map, event)
+      return
+  }
+}
+
+/** Project the reconciled state into the TodoItem list the surfaces render. */
+export function reconciledToTodos(state: ReconciledState): TodoItem[] {
+  return state.tasks.map((t) => {
+    const content = t.descriptionTruncated ? `${t.description}…` : t.description
+    const item: TodoItem = {
+      id: t.ordinal !== null ? String(t.ordinal) : t.key,
+      content,
+      status: t.status,
+    }
+    return item
+  })
+}
+
+/**
+ * §5 positional-alias re-association. The live harness renders NO ordinals —
+ * keys are positional — so a task that MOVES position looks like a
+ * removal-at-old + addition-at-new to the reconciler's canonical-key merge,
+ * which would churn the list. Before reconciling an authoritative snapshot,
+ * re-key each committed pane-confirmed task to the snapshot ordinal that
+ * uniquely matches its normalized description, but ONLY when the move is
+ * genuine (the task's old ordinal is not itself present in the snapshot — that
+ * would be a duplicate description, not a move). Genuine removals/regressions
+ * keep the reconciler's two-snapshot rule untouched.
+ *
+ * PURE — returns a new state; `state` is not mutated. Coupled to the M2
+ * canonical-key format `${sessionId}:#${ordinal}`.
+ */
+export function realignOrdinals(state: ReconciledState, snapshot: PaneSnapshot): ReconciledState {
+  const sessionId = state.sessionId
+  const keyOf = (ord: number): string => `${sessionId}:#${ord}`
+
+  // Committed pane-confirmed tasks that can "move": have an ordinal, are pane
+  // confirmed, and carry a non-truncated description we can match on.
+  const committed = state.tasks.filter(
+    (t): t is ReconciledTask & { ordinal: number } =>
+      t.ordinal !== null && t.paneConfirmed && !t.descriptionTruncated,
+  )
+  // description → unique committed task (null marks an ambiguous description).
+  const byDesc = new Map<string, (ReconciledTask & { ordinal: number }) | null>()
+  for (const t of committed) {
+    const d = normalizeDescription(t.description)
+    byDesc.set(d, byDesc.has(d) ? null : t)
+  }
+  const snapOrdinals = new Set(snapshot.tasks.map((s) => s.ordinal))
+
+  const remap = new Map<number, number>() // oldOrdinal → newOrdinal
+  const takenNew = new Set<number>()
+  for (const s of snapshot.tasks) {
+    if (s.descriptionTruncated) continue
+    const match = byDesc.get(normalizeDescription(s.description))
+    if (match === undefined || match === null) continue
+    const oldOrd = match.ordinal
+    if (oldOrd === s.ordinal) continue // already correctly placed
+    // Genuine SHIFT only: the task's old ordinal must be vacated in the new
+    // snapshot. If the old ordinal is still present, the description appears in
+    // two places (a positional SWAP or a duplicate) — ambiguous with positional
+    // keys, so we leave it to the reconciler's two-snapshot rule.
+    if (snapOrdinals.has(oldOrd)) continue
+    if (remap.has(oldOrd) || takenNew.has(s.ordinal)) continue
+    remap.set(oldOrd, s.ordinal)
+    takenNew.add(s.ordinal)
+  }
+  if (remap.size === 0) return state
+
+  // Apply the remap, then float the re-keyed tasks to the END so that if a
+  // re-key target collides with a soon-to-be-removed committed occupant, the
+  // re-keyed (correct) task wins the reconciler's by-key lookup.
+  const remapped = new Set<ReconciledTask>()
+  const mapped = state.tasks.map((t) => {
+    if (t.ordinal !== null && remap.has(t.ordinal)) {
+      const newOrd = remap.get(t.ordinal) as number
+      const nt: ReconciledTask = { ...t, ordinal: newOrd, key: keyOf(newOrd) }
+      remapped.add(nt)
+      return nt
+    }
+    return t
+  })
+  const tasks = [...mapped.filter((t) => !remapped.has(t)), ...mapped.filter((t) => remapped.has(t))]
+
+  // Re-key prevSnapshotFacts so the two-snapshot removal/regression rule stays
+  // coherent after the move.
+  const prevSnapshotFacts = new Map(state.prevSnapshotFacts)
+  for (const [oldOrd, newOrd] of remap) {
+    const oldKey = keyOf(oldOrd)
+    const facts = prevSnapshotFacts.get(oldKey)
+    prevSnapshotFacts.delete(oldKey)
+    if (facts !== undefined) prevSnapshotFacts.set(keyOf(newOrd), facts)
+  }
+
+  return { ...state, tasks, prevSnapshotFacts }
+}

--- a/plugin/src/status/task-reality-mirror.ts
+++ b/plugin/src/status/task-reality-mirror.ts
@@ -32,6 +32,9 @@
 // pane), reconciliation produces no valid snapshot and the view renders
 // «НЕ СВЕРЕНО» (events only) — the surfaces still show the optimistic list.
 
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
 import type { Logger } from '../log.js'
 import type { TodoItem } from '../schemas.js'
 import type { TaskMirrorEvent, TaskMutationEvent } from '../hooks/claude-events.js'
@@ -98,6 +101,11 @@ export interface TaskRealityMirrorOptions {
   ttlMs?: number
   /** Owner-chat gate — the reconciler acts ONLY for owner DM chats. */
   isOwnerChat?: (chatId: string) => boolean
+  /** Plugin state dir. When set, the session-epoch state (active + retired
+   *  tombstones) is persisted per chat (`task-reality-epoch-<chat>.json`) so a
+   *  plugin restart cannot be rolled back by late lifecycle stragglers
+   *  (review 2026-07-10 r3 #1). Omitted in unit tests that don't exercise it. */
+  stateDir?: string
   now?: () => number
   setTimer?: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>
   clearTimer?: (handle: ReturnType<typeof setTimeout>) => void
@@ -157,11 +165,18 @@ export class TaskRealityMirror {
   private readonly setTimer: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
   private readonly recs = new Map<string, ChatRec>()
+  private readonly stateDir: string | undefined
   // Per-chat tombstones: session ids that received SessionEnd. Late events
   // naming a tombstoned session are dropped — they must never finalize/clear
   // the ACTIVE session or resurrect the retired one. SessionStart with the
   // same id (a genuine resume) removes the tombstone.
   private readonly endedSessions = new Map<string, Set<string>>()
+  // Per-chat ACTIVE session id — survives rec eviction (unlike recs) and, via
+  // persistence, plugin restarts. Cleared by SessionEnd; kept by hard-TTL
+  // eviction (the session never ended, it just went silent).
+  private readonly activeSessions = new Map<string, string>()
+  // Chats whose persisted epoch state has been restored this process lifetime.
+  private readonly epochsRestored = new Set<string>()
 
   constructor(opts: TaskRealityMirrorOptions) {
     this.exec = opts.exec
@@ -172,6 +187,7 @@ export class TaskRealityMirror {
     this.coalesceWindowMs = opts.coalesceWindowMs ?? DEFAULT_COALESCE_WINDOW_MS
     this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS
     this.isOwnerChat = opts.isOwnerChat ?? ((): boolean => true)
+    this.stateDir = opts.stateDir
     this.now = opts.now ?? ((): number => Date.now())
     this.setTimer = opts.setTimer ?? ((cb, ms): ReturnType<typeof setTimeout> => setTimeout(cb, ms))
     this.clearTimer = opts.clearTimer ?? ((h): void => clearTimeout(h))
@@ -183,13 +199,16 @@ export class TaskRealityMirror {
   onSessionStart(chatId: string, opts: { sessionId: string; cwd?: string }): void {
     if (!this.isOwnerChat(chatId)) return
     try {
+      this.restoreEpochs(chatId)
       // Rollback guard (review 2026-07-10 #2): a SessionStart naming a
       // TOMBSTONED id while a DIFFERENT session is active is a late/replayed
       // straggler — it must NOT displace the active session. A resume of a
       // tombstoned id is valid only when no different session is active.
+      // «Active» comes from activeSessions (persisted, survives restart —
+      // review 2026-07-10 r3 #1), not the transient rec.
       if (this.isTombstoned(chatId, opts.sessionId)) {
-        const active = this.recs.get(chatId)
-        if (active !== undefined && !active.ended && active.sessionId !== opts.sessionId) {
+        const active = this.activeSessions.get(chatId)
+        if (active !== undefined && active !== opts.sessionId) {
           this.log.debug('task reality mirror dropped late SessionStart for tombstoned session', {
             chat_id: chatId,
           })
@@ -197,6 +216,7 @@ export class TaskRealityMirror {
         }
         // Genuine RESUME — the harness is alive again under the same id.
         this.untombstone(chatId, opts.sessionId)
+        this.persistEpochs(chatId)
       }
       const rec = this.ensureRec(chatId, opts.sessionId, opts.cwd)
       this.ensureSession(rec, opts.sessionId)
@@ -213,6 +233,7 @@ export class TaskRealityMirror {
   /** UserPromptSubmit: a turn has begun — mark active, arm the timer, capture now. */
   onUserPromptSubmit(chatId: string, opts: { sessionId: string; cwd?: string }): void {
     if (!this.isOwnerChat(chatId)) return
+    this.restoreEpochs(chatId)
     if (this.isTombstoned(chatId, opts.sessionId)) return // late event from a retired session
     try {
       const rec = this.ensureRec(chatId, opts.sessionId, opts.cwd)
@@ -255,7 +276,12 @@ export class TaskRealityMirror {
   onSessionEnd(chatId: string, opts: { sessionId: string }): void {
     if (!this.isOwnerChat(chatId)) return
     try {
+      this.restoreEpochs(chatId)
       this.tombstone(chatId, opts.sessionId)
+      if (this.activeSessions.get(chatId) === opts.sessionId) {
+        this.activeSessions.delete(chatId)
+      }
+      this.persistEpochs(chatId)
       const rec = this.recs.get(chatId)
       if (rec === undefined) return
       // Late end for a retired session: never touch the active rec.
@@ -273,6 +299,7 @@ export class TaskRealityMirror {
   onTaskEvent(chatId: string, event: TaskMirrorEvent, opts: { cwd?: string } = {}): void {
     if (!this.isOwnerChat(chatId)) return
     if (!isTaskMutationEvent(event)) return // lifecycle handled by the entry points above
+    this.restoreEpochs(chatId)
     if (this.isTombstoned(chatId, event.sessionId)) return // retired session — drop
     try {
       const rec = this.ensureRec(chatId, event.sessionId, opts.cwd)
@@ -291,6 +318,13 @@ export class TaskRealityMirror {
         // Removed PANE-CONFIRMED tasks get a versioned tombstone (review
         // 2026-07-10 #4): only a NEWER pane snapshot may resurrect them.
         for (const r of applied.removals) rec.eventRemovedAt.set(r.key, r.at)
+        // A TodoWrite that REINTRODUCES a removed key reasserts the task with
+        // full event authority — its tombstone must be CLEARED, or an
+        // equal-millisecond pane snapshot would delete the valid re-addition
+        // via enforceEventRemovals (review 2026-07-10 r3 #3).
+        for (const key of [...rec.eventRemovedAt.keys()]) {
+          if (rec.state.tasks.some((t) => t.key === key)) rec.eventRemovedAt.delete(key)
+        }
         while (rec.eventRemovedAt.size > 64) {
           const oldest = rec.eventRemovedAt.keys().next().value
           if (oldest === undefined) break
@@ -339,6 +373,7 @@ export class TaskRealityMirror {
         eventRemovedAt: new Map(),
       }
       this.recs.set(chatId, rec)
+      this.setActive(chatId, sessionId)
     } else if (cwd !== undefined && cwd.length > 0 && rec.binding.cwd !== cwd) {
       rec.binding = { ...rec.binding, cwd }
       // A binding change invalidates in-flight captures (their provenance was
@@ -361,6 +396,14 @@ export class TaskRealityMirror {
     rec.eventRemovedAt = new Map()
     rec.ended = false
     rec.turnActive = false
+    this.setActive(rec.chatId, sessionId)
+  }
+
+  // Track (and persist) the active session id for the chat.
+  private setActive(chatId: string, sessionId: string): void {
+    if (this.activeSessions.get(chatId) === sessionId) return
+    this.activeSessions.set(chatId, sessionId)
+    this.persistEpochs(chatId)
   }
 
   // Drop a rec entirely: timers disarmed, in-flight captures invalidated via
@@ -395,6 +438,77 @@ export class TaskRealityMirror {
 
   private isTombstoned(chatId: string, sessionId: string): boolean {
     return this.endedSessions.get(chatId)?.has(sessionId) === true
+  }
+
+  // ─── epoch persistence (review 2026-07-10 r3 #1) ─────────────────────
+  // The reality mirror's epoch state (active session + retired tombstones)
+  // was process-local: after a restart a late SessionStart for a session that
+  // ended PRE-restart displaced the restored active one. Persisted per chat
+  // in its own schema-versioned file with the same atomic tmp+rename pattern
+  // as TaskMirror. Best-effort: persistence failures never disturb the mirror.
+
+  private epochPath(chatId: string): string {
+    const safe = chatId.replace(/[^0-9A-Za-z_-]/g, '_')
+    return join(this.stateDir as string, `task-reality-epoch-${safe}.json`)
+  }
+
+  private persistEpochs(chatId: string): void {
+    if (this.stateDir === undefined) return
+    try {
+      mkdirSync(this.stateDir, { recursive: true, mode: 0o700 })
+      const active = this.activeSessions.get(chatId)
+      const retired = this.endedSessions.get(chatId)
+      const body = {
+        v: 1,
+        ...(active !== undefined ? { active } : {}),
+        retired: retired !== undefined ? [...retired] : [],
+      }
+      const path = this.epochPath(chatId)
+      const tmp = `${path}.tmp.${process.pid}.${Date.now()}`
+      writeFileSync(tmp, JSON.stringify(body), { mode: 0o600 })
+      try {
+        renameSync(tmp, path)
+      } catch (err) {
+        try {
+          unlinkSync(tmp)
+        } catch {
+          /* ignore */
+        }
+        throw err
+      }
+    } catch (err) {
+      this.warn('persistEpochs', chatId, err)
+    }
+  }
+
+  // Restore persisted epoch state ONCE per chat; runtime state is never
+  // clobbered. Called at the top of every lifecycle/event entry point so the
+  // tombstone checks always see post-restart truth.
+  private restoreEpochs(chatId: string): void {
+    if (this.epochsRestored.has(chatId)) return
+    this.epochsRestored.add(chatId)
+    if (this.stateDir === undefined) return
+    try {
+      const raw = readFileSync(this.epochPath(chatId), 'utf8')
+      const parsed: unknown = JSON.parse(raw)
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return
+      const obj = parsed as Record<string, unknown>
+      if (
+        typeof obj.active === 'string' &&
+        obj.active.length > 0 &&
+        !this.activeSessions.has(chatId)
+      ) {
+        this.activeSessions.set(chatId, obj.active)
+      }
+      if (Array.isArray(obj.retired) && !this.endedSessions.has(chatId)) {
+        const retired = obj.retired
+          .filter((s): s is string => typeof s === 'string' && s.length > 0)
+          .slice(-MAX_TOMBSTONES)
+        if (retired.length > 0) this.endedSessions.set(chatId, new Set(retired))
+      }
+    } catch {
+      // Missing file / malformed JSON → nothing persisted.
+    }
   }
 
   // ─── capture scheduling ──────────────────────────────────────────────
@@ -836,15 +950,28 @@ export function realignOrdinals(state: ReconciledState, snapshot: PaneSnapshot):
   }
   const snapOrdinals = new Set(snapshot.tasks.map((s) => s.ordinal))
 
-  // Full simultaneous permutation over unique exact descriptions (#8).
+  // A description participates in the permutation ONLY when it is unique on
+  // BOTH sides (review 2026-07-10 r3 #4): `byDesc` already nulls committed
+  // duplicates; this counts the SNAPSHOT side — committed [X#1, A#2] against
+  // snapshot [A#1, A#2] must not remap A (which copy is which is ambiguous).
+  const snapDescCount = new Map<string, number>()
+  for (const s of snapshot.tasks) {
+    if (s.descriptionTruncated) continue
+    const d = normalizeDescription(s.description)
+    snapDescCount.set(d, (snapDescCount.get(d) ?? 0) + 1)
+  }
+
+  // Full simultaneous permutation over descriptions unique on both sides (#8).
   const consumed = new Set<ReconciledTask>()
   const remap = new Map<number, number>() // mover oldOrdinal → newOrdinal
   const takenNew = new Set<number>()
   for (const s of snapshot.tasks) {
     if (s.descriptionTruncated) continue
-    const match = byDesc.get(normalizeDescription(s.description))
+    const d = normalizeDescription(s.description)
+    if (snapDescCount.get(d) !== 1) continue // duplicated in the snapshot — ambiguous
+    const match = byDesc.get(d)
     if (match === undefined || match === null) continue
-    if (consumed.has(match)) continue // duplicate description in the SNAPSHOT
+    if (consumed.has(match)) continue // defensive (unreachable with unique counts)
     consumed.add(match)
     if (match.ordinal === s.ordinal) continue // already correctly placed
     if (takenNew.has(s.ordinal)) continue

--- a/plugin/src/status/task-reality-mirror.ts
+++ b/plugin/src/status/task-reality-mirror.ts
@@ -119,17 +119,30 @@ interface ChatRec {
   coalesceTimer: ReturnType<typeof setTimeout> | null
   lastCaptureAt: number
   capturing: boolean
-  // Monotonic invalidation token. Bumped on session change, session end and
-  // eviction. doCapture snapshots it at entry and re-checks after every await;
-  // a mismatch means the work belongs to a retired binding and is discarded.
-  generation: number
+  // Monotonic OBSERVATION REVISION (review 2026-07-10 #3). Bumped on EVERY
+  // state mutation: tool events, session change/end, eviction, cwd rebind.
+  // doCapture snapshots it at entry and re-checks after every await; a
+  // mismatch means the pane text predates a state change (e.g. a TodoWrite
+  // landed during the cwd-resolution await) and the capture is discarded —
+  // otherwise old pane text would be stamped POST-event and committed,
+  // defeating both per-task recency and the stale-fact protection.
+  revision: number
+  // Event-sourced removal tombstones (review 2026-07-10 #4): canonical key →
+  // event time of the TodoWrite that authoritatively removed a PANE-CONFIRMED
+  // task. A pane snapshot NEWER than the tombstone clears it (pane is the
+  // higher authority — it may resurrect the task or confirm the removal); a
+  // stale/older pane snapshot may NOT resurrect it. Without tmux the
+  // tombstone wins outright. Cleared on session change.
+  eventRemovedAt: Map<string, number>
 }
 
 const DEFAULT_CAPTURE_INTERVAL_MS = 20_000
 const DEFAULT_COALESCE_WINDOW_MS = 5_000
 const DEFAULT_TTL_MS = 10 * 60 * 1000
-// Bounded per-chat memory of ended (tombstoned) session ids.
-const MAX_TOMBSTONES = 8
+// Bounded per-chat memory of ended (tombstoned) session ids. 64 (review
+// 2026-07-10 #2): at 8, a burst of short sessions evicted older tombstones and
+// their late stragglers became «unknown» again, able to switch epochs.
+const MAX_TOMBSTONES = 64
 
 export class TaskRealityMirror {
   private readonly exec: TmuxExec
@@ -170,9 +183,21 @@ export class TaskRealityMirror {
   onSessionStart(chatId: string, opts: { sessionId: string; cwd?: string }): void {
     if (!this.isOwnerChat(chatId)) return
     try {
-      // A SessionStart naming a tombstoned id is a genuine RESUME — the
-      // harness is alive again under the same id. Un-tombstone it.
-      this.untombstone(chatId, opts.sessionId)
+      // Rollback guard (review 2026-07-10 #2): a SessionStart naming a
+      // TOMBSTONED id while a DIFFERENT session is active is a late/replayed
+      // straggler — it must NOT displace the active session. A resume of a
+      // tombstoned id is valid only when no different session is active.
+      if (this.isTombstoned(chatId, opts.sessionId)) {
+        const active = this.recs.get(chatId)
+        if (active !== undefined && !active.ended && active.sessionId !== opts.sessionId) {
+          this.log.debug('task reality mirror dropped late SessionStart for tombstoned session', {
+            chat_id: chatId,
+          })
+          return
+        }
+        // Genuine RESUME — the harness is alive again under the same id.
+        this.untombstone(chatId, opts.sessionId)
+      }
       const rec = this.ensureRec(chatId, opts.sessionId, opts.cwd)
       this.ensureSession(rec, opts.sessionId)
       rec.ended = false
@@ -261,12 +286,24 @@ export class TaskRealityMirror {
         // 2026-07-09 #5: the per-task delta path lost removals in the
         // events-only degrade ⇒ ghosts forever without tmux).
         applyEventToEventMap(rec.eventMap, event) // keep the map coherent for later task_update matching
-        rec.state = applyTodoWriteToState(rec.state, event.todos, now)
+        const applied = applyTodoWriteToState(rec.state, event.todos, now)
+        rec.state = applied.state
+        // Removed PANE-CONFIRMED tasks get a versioned tombstone (review
+        // 2026-07-10 #4): only a NEWER pane snapshot may resurrect them.
+        for (const r of applied.removals) rec.eventRemovedAt.set(r.key, r.at)
+        while (rec.eventRemovedAt.size > 64) {
+          const oldest = rec.eventRemovedAt.keys().next().value
+          if (oldest === undefined) break
+          rec.eventRemovedAt.delete(oldest)
+        }
       } else {
         for (const te of this.deriveToolEvents(rec, event, now)) {
           rec.state = reconcileTaskState(rec.state, { kind: 'event', event: te })
         }
       }
+      // Every event application invalidates in-flight captures (their pane
+      // text predates this state change) — review 2026-07-10 #3.
+      rec.revision += 1
       this.pushView(rec)
     } catch (err) {
       this.warn('onTaskEvent', chatId, err)
@@ -298,35 +335,40 @@ export class TaskRealityMirror {
         // wait on a brand-new session).
         lastCaptureAt: Number.NEGATIVE_INFINITY,
         capturing: false,
-        generation: 0,
+        revision: 0,
+        eventRemovedAt: new Map(),
       }
       this.recs.set(chatId, rec)
     } else if (cwd !== undefined && cwd.length > 0 && rec.binding.cwd !== cwd) {
       rec.binding = { ...rec.binding, cwd }
+      // A binding change invalidates in-flight captures (their provenance was
+      // resolved against the old cwd) — review 2026-07-10 #3.
+      rec.revision += 1
     }
     return rec
   }
 
   // Reset state on a genuine session change (harness task ids restart at #1).
-  // Bumps the generation so any in-flight capture from the OLD session binding
+  // Bumps the revision so any in-flight capture from the OLD session binding
   // discards itself instead of committing old-pane output into the new state.
   private ensureSession(rec: ChatRec, sessionId: string): void {
     if (rec.sessionId === sessionId) return
-    rec.generation += 1
+    rec.revision += 1
     rec.sessionId = sessionId
     rec.binding = { ...rec.binding, sessionId }
     rec.state = initialReconciledState(sessionId)
     rec.eventMap = new Map()
+    rec.eventRemovedAt = new Map()
     rec.ended = false
     rec.turnActive = false
   }
 
   // Drop a rec entirely: timers disarmed, in-flight captures invalidated via
-  // the generation bump, entry removed from the map. Used by SessionEnd, the
+  // the revision bump, entry removed from the map. Used by SessionEnd, the
   // hard TTL and stop().
   private evict(rec: ChatRec): void {
     this.disarm(rec)
-    rec.generation += 1
+    rec.revision += 1
     if (this.recs.get(rec.chatId) === rec) this.recs.delete(rec.chatId)
   }
 
@@ -377,10 +419,16 @@ export class TaskRealityMirror {
       // missed Stop would otherwise leave turnActive=true and the timer would
       // poll tmux + cross age buckets + edit Telegram forever. A fresh
       // SessionStart / UserPromptSubmit rebuilds the rec from scratch.
+      //
+      // Terminal push FIRST (review 2026-07-10 #7): without it the surfaces
+      // would keep showing «сверено меньше минуты назад» forever for data
+      // nobody updates any more. One frozen «данные не обновляются» view goes
+      // out, THEN state is dropped and in-flight captures invalidated.
       this.log.debug('task reality mirror rec evicted (idle > ttl)', {
         chat_id: rec.chatId,
         idle_ms: idle,
       })
+      this.pushView(rec, { kind: 'expired' })
       this.evict(rec)
       return
     }
@@ -415,13 +463,18 @@ export class TaskRealityMirror {
     if (rec.capturing || rec.ended) return
     rec.capturing = true
     rec.lastCaptureAt = this.now()
-    // Generation snapshot: if the session changes / ends / evicts while any of
-    // the awaits below is pending, this capture's output belongs to a retired
-    // binding and MUST be discarded (review 2026-07-09 #4).
-    const gen = rec.generation
+    // Observation-revision snapshot (review 2026-07-10 #3): if ANY state
+    // mutation lands while one of the awaits below is pending (a tool event, a
+    // session change/end, a cwd rebind), the captured pane text predates that
+    // mutation and MUST be discarded — re-checked after EVERY await.
+    const rev = rec.revision
     try {
       const cap = await capturePaneText(this.exec, this.capture)
-      if (rec.generation !== gen || rec.ended) return
+      if (rec.revision !== rev || rec.ended) return
+      // Stamp capturedAt NOW — the moment capture-pane returned — so an event
+      // landing during the cwd resolution below can never be out-ranked by
+      // this (older) pane text (review 2026-07-10 #3).
+      const capturedAt = this.now()
       if (!cap.ok) {
         // No pane / capture failed — no snapshot. Refresh the indicator only
         // (health may transition to stale if a turn is active).
@@ -433,12 +486,12 @@ export class TaskRealityMirror {
       // is the one provenance check with real signal here; substituting the
       // binding cwd would make validation unconditionally pass and neuter it.
       const paneCwd = await resolvePaneCwd(this.exec, this.capture)
-      if (rec.generation !== gen || rec.ended) return
+      if (rec.revision !== rev || rec.ended) return
       const provenance: PaneProvenance = {
         sessionId: rec.binding.sessionId,
         paneTarget: this.capture.paneTarget,
         cwd: paneCwd ?? '',
-        capturedAt: this.now(),
+        capturedAt,
       }
       const snapshot = parsePaneTaskList(cap.text, provenance)
       if (snapshot === null) {
@@ -458,6 +511,12 @@ export class TaskRealityMirror {
       // remove+add. Only meaningful when the snapshot is authoritative.
       const base = verdict.authoritative ? realignOrdinals(rec.state, snapshot) : rec.state
       rec.state = reconcileTaskState(base, { kind: 'snapshot', snapshot, verdict })
+      // Event-removal tombstones (review 2026-07-10 #4): only a pane snapshot
+      // NEWER than the removing TodoWrite may resurrect (or finally confirm the
+      // absence of) a removed task; a stale one may not re-add it.
+      if (verdict.authoritative && rec.eventRemovedAt.size > 0) {
+        rec.state = enforceEventRemovals(rec.state, rec.eventRemovedAt, capturedAt)
+      }
       this.pushView(rec)
     } catch (err) {
       this.warn('doCapture', rec.chatId, err)
@@ -479,11 +538,11 @@ export class TaskRealityMirror {
 
   // ─── view push ───────────────────────────────────────────────────────
 
-  private pushView(rec: ChatRec): void {
+  private pushView(rec: ChatRec, freshnessOverride?: TaskFreshness): void {
     const view: ReconciledView = {
       sessionId: rec.sessionId,
       todos: reconciledToTodos(rec.state),
-      freshness: this.computeFreshness(rec),
+      freshness: freshnessOverride ?? this.computeFreshness(rec),
     }
     for (const sink of this.sinks) {
       try {
@@ -600,9 +659,13 @@ export function reconciledToTodos(state: ReconciledState): TodoItem[] {
  * Fold a TodoWrite payload into the reconciled state as an AUTHORITATIVE event
  * snapshot (review 2026-07-09 #5). TodoWrite is the harness's own full task
  * list, so unlike the per-task delta path it must express REMOVALS: an
- * event-only task absent from the payload is gone. Pane-confirmed tasks absent
- * from the payload are left to the pane's own two-snapshot omission rule (the
- * pane may legitimately still show them).
+ * event-only task absent from the payload is gone; a PANE-CONFIRMED task
+ * absent from the payload is removed too, and reported in `removals` so the
+ * caller can record a VERSIONED removal tombstone (review 2026-07-10 #4 —
+ * pre-fix `|| t.paneConfirmed` kept it alive, and if tmux died afterwards the
+ * ghost lived forever). Resurrection policy lives in
+ * {@link enforceEventRemovals}: only a pane snapshot NEWER than the tombstone
+ * may bring the task back.
  *
  * Event ids are preserved in the task keys (`${sessionId}:~id:<id>` for
  * non-numeric ids, canonical `#N` for numeric ones) so two tasks with
@@ -610,13 +673,19 @@ export function reconciledToTodos(state: ReconciledState): TodoItem[] {
  * provisional keyed by description.
  *
  * Unchanged matched tasks keep their `updatedAt` untouched, so pane snapshots
- * retain recency authority over them. PURE — returns a new state.
+ * retain recency authority over them. PURE — returns a new state + removals.
  */
+export interface TodoWriteApplied {
+  state: ReconciledState
+  /** Pane-confirmed tasks the payload omitted — tombstone material. */
+  removals: ReadonlyArray<{ key: string; at: number }>
+}
+
 export function applyTodoWriteToState(
   state: ReconciledState,
   todos: ReadonlyArray<TodoItem>,
   at: number,
-): ReconciledState {
+): TodoWriteApplied {
   const sessionId = state.sessionId
   const tasks = state.tasks.map((t) => ({ ...t }))
   const byKey = new Map(tasks.map((t) => [t.key, t]))
@@ -665,15 +734,55 @@ export function applyTodoWriteToState(
     })
   })
 
-  // Removals: event-only tasks (never pane-confirmed) absent from the full
-  // list are authoritatively gone, unless a NEWER observation touched them.
-  const kept = tasks.filter((t) => matched.has(t) || t.paneConfirmed || t.updatedAt > at)
+  // Removals: any task absent from the full list is authoritatively gone,
+  // unless a NEWER observation touched it. Pane-confirmed removals are
+  // reported so the caller can tombstone them (resurrection is then gated on
+  // pane-snapshot recency in enforceEventRemovals).
+  const removals: Array<{ key: string; at: number }> = []
+  const kept = tasks.filter((t) => {
+    if (matched.has(t) || t.updatedAt > at) return true
+    if (t.paneConfirmed) removals.push({ key: t.key, at })
+    return false
+  })
 
   return {
-    ...state,
-    tasks: [...kept, ...additions],
-    lastEventAt: Math.max(state.lastEventAt, at),
+    state: {
+      ...state,
+      tasks: [...kept, ...additions],
+      lastEventAt: Math.max(state.lastEventAt, at),
+    },
+    removals,
   }
+}
+
+/**
+ * Enforce event-sourced removal tombstones against a freshly reconciled state
+ * (review 2026-07-10 #4). For each tombstoned key:
+ *   • pane snapshot NEWER than the tombstone ⇒ the pane (higher authority)
+ *     has spoken since the removal — drop the tombstone; whatever the
+ *     reconciler decided (resurrect or omit) stands;
+ *   • pane snapshot OLDER/equal ⇒ a stale pane may NOT resurrect the task —
+ *     filter it back out and KEEP the tombstone.
+ * Without tmux this function is never reached and the removal (already
+ * applied by applyTodoWriteToState) simply wins. PURE over `state`; mutates
+ * ONLY the passed tombstone map (deliberate — it is the caller's own record).
+ */
+export function enforceEventRemovals(
+  state: ReconciledState,
+  removedAt: Map<string, number>,
+  snapshotCapturedAt: number,
+): ReconciledState {
+  let tasks: ReadonlyArray<ReconciledTask> = state.tasks
+  for (const [key, at] of removedAt) {
+    if (snapshotCapturedAt > at) {
+      removedAt.delete(key)
+      continue
+    }
+    if (tasks.some((t) => t.key === key)) {
+      tasks = tasks.filter((t) => t.key !== key)
+    }
+  }
+  return tasks === state.tasks ? state : { ...state, tasks }
 }
 
 /**
@@ -686,6 +795,16 @@ export function applyTodoWriteToState(
  * clean SHIFT (the task's old ordinal is vacated in the snapshot — an ordinal
  * still present would mean a duplicate description or a positional swap, both
  * ambiguous with positional keys).
+ *
+ * FULL PERMUTATION (review 2026-07-10 #8): movers are computed for ALL
+ * snapshot tasks SIMULTANEOUSLY over unique exact normalized descriptions and
+ * applied atomically. The old per-mover «old ordinal must be vacated» guard
+ * broke CHAINS ([A,B,C,D] → [A,C,D]: C 3→2 was refused because ordinal 3 was
+ * still present — it belongs to D's new slot — so B kept key #2 an extra
+ * cycle and an ordinal-2 event updated the WRONG task). Duplicate committed
+ * descriptions stay ambiguous (never matched); a snapshot task whose unique
+ * committed match was already consumed by an earlier snapshot row (duplicate
+ * descriptions in the SNAPSHOT) is skipped.
  *
  * DISPLACEMENT (review 2026-07-09 #7, resolved by test): a mover's target
  * ordinal may currently be held by a DIFFERENT committed task — e.g.
@@ -717,21 +836,19 @@ export function realignOrdinals(state: ReconciledState, snapshot: PaneSnapshot):
   }
   const snapOrdinals = new Set(snapshot.tasks.map((s) => s.ordinal))
 
+  // Full simultaneous permutation over unique exact descriptions (#8).
+  const consumed = new Set<ReconciledTask>()
   const remap = new Map<number, number>() // mover oldOrdinal → newOrdinal
   const takenNew = new Set<number>()
   for (const s of snapshot.tasks) {
     if (s.descriptionTruncated) continue
     const match = byDesc.get(normalizeDescription(s.description))
     if (match === undefined || match === null) continue
-    const oldOrd = match.ordinal
-    if (oldOrd === s.ordinal) continue // already correctly placed
-    // Clean SHIFT only: the task's old ordinal must be vacated in the new
-    // snapshot. If the old ordinal is still present, the description appears in
-    // two places (a positional SWAP or a duplicate) — ambiguous with positional
-    // keys, so we leave it to the reconciler's two-snapshot rule.
-    if (snapOrdinals.has(oldOrd)) continue
-    if (remap.has(oldOrd) || takenNew.has(s.ordinal)) continue
-    remap.set(oldOrd, s.ordinal)
+    if (consumed.has(match)) continue // duplicate description in the SNAPSHOT
+    consumed.add(match)
+    if (match.ordinal === s.ordinal) continue // already correctly placed
+    if (takenNew.has(s.ordinal)) continue
+    remap.set(match.ordinal, s.ordinal)
     takenNew.add(s.ordinal)
   }
   if (remap.size === 0) return state

--- a/plugin/src/status/task-reality-mirror.ts
+++ b/plugin/src/status/task-reality-mirror.ts
@@ -15,6 +15,19 @@
 // surfaces (context HUD pin + TaskMirror). Every method is best-effort and must
 // never throw into the webhook 200 path.
 //
+// Hardening (review fix-loop 2026-07-09):
+//   • Generation token — every session change / end / eviction bumps
+//     `rec.generation`; an in-flight doCapture re-checks it after EVERY await
+//     and discards its work when stale, so old-pane output can never commit
+//     into a new session binding.
+//   • Session tombstones — a session that received SessionEnd is remembered
+//     (bounded set); late mutations / prompts naming it are dropped instead of
+//     resurrecting state. SessionStart with the same id (resume) un-tombstones.
+//   • Hard TTL — a rec idle past `ttlMs` is EVICTED regardless of turnActive
+//     (a missed Stop must not poll tmux + edit Telegram forever).
+//   • Unresolved pane cwd ⇒ snapshot is OBSERVATIONAL (the cwd cross-check is
+//     the one real provenance check; silently skipping it would neuter it).
+//
 // Degradation: when no pane is capturable (tmux absent, session gone, wrong
 // pane), reconciliation produces no valid snapshot and the view renders
 // «НЕ СВЕРЕНО» (events only) — the surfaces still show the optimistic list.
@@ -42,6 +55,8 @@ import {
   type ReconciledState,
   type ReconciledTask,
   type SessionBinding,
+  type SnapshotFacts,
+  type SnapshotVerdict,
   type ToolTaskEvent,
 } from './task-reconciler.js'
 import { formatUtcHm, type TaskFreshness } from './task-freshness.js'
@@ -77,7 +92,9 @@ export interface TaskRealityMirrorOptions {
   captureIntervalMs?: number
   /** Coalesce window: triggers within this collapse to one capture. Default 5s. */
   coalesceWindowMs?: number
-  /** Orphan-timer TTL: an idle non-active session parks its timer past this. Default 10min. */
+  /** HARD inactivity TTL: a rec idle past this is evicted (timers stopped,
+   *  state dropped) regardless of turnActive — a missed Stop must not keep
+   *  polling forever. Default 10min. */
   ttlMs?: number
   /** Owner-chat gate — the reconciler acts ONLY for owner DM chats. */
   isOwnerChat?: (chatId: string) => boolean
@@ -102,11 +119,17 @@ interface ChatRec {
   coalesceTimer: ReturnType<typeof setTimeout> | null
   lastCaptureAt: number
   capturing: boolean
+  // Monotonic invalidation token. Bumped on session change, session end and
+  // eviction. doCapture snapshots it at entry and re-checks after every await;
+  // a mismatch means the work belongs to a retired binding and is discarded.
+  generation: number
 }
 
 const DEFAULT_CAPTURE_INTERVAL_MS = 20_000
 const DEFAULT_COALESCE_WINDOW_MS = 5_000
 const DEFAULT_TTL_MS = 10 * 60 * 1000
+// Bounded per-chat memory of ended (tombstoned) session ids.
+const MAX_TOMBSTONES = 8
 
 export class TaskRealityMirror {
   private readonly exec: TmuxExec
@@ -121,6 +144,11 @@ export class TaskRealityMirror {
   private readonly setTimer: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
   private readonly recs = new Map<string, ChatRec>()
+  // Per-chat tombstones: session ids that received SessionEnd. Late events
+  // naming a tombstoned session are dropped — they must never finalize/clear
+  // the ACTIVE session or resurrect the retired one. SessionStart with the
+  // same id (a genuine resume) removes the tombstone.
+  private readonly endedSessions = new Map<string, Set<string>>()
 
   constructor(opts: TaskRealityMirrorOptions) {
     this.exec = opts.exec
@@ -142,6 +170,9 @@ export class TaskRealityMirror {
   onSessionStart(chatId: string, opts: { sessionId: string; cwd?: string }): void {
     if (!this.isOwnerChat(chatId)) return
     try {
+      // A SessionStart naming a tombstoned id is a genuine RESUME — the
+      // harness is alive again under the same id. Un-tombstone it.
+      this.untombstone(chatId, opts.sessionId)
       const rec = this.ensureRec(chatId, opts.sessionId, opts.cwd)
       this.ensureSession(rec, opts.sessionId)
       rec.ended = false
@@ -157,6 +188,7 @@ export class TaskRealityMirror {
   /** UserPromptSubmit: a turn has begun — mark active, arm the timer, capture now. */
   onUserPromptSubmit(chatId: string, opts: { sessionId: string; cwd?: string }): void {
     if (!this.isOwnerChat(chatId)) return
+    if (this.isTombstoned(chatId, opts.sessionId)) return // late event from a retired session
     try {
       const rec = this.ensureRec(chatId, opts.sessionId, opts.cwd)
       this.ensureSession(rec, opts.sessionId)
@@ -190,20 +222,23 @@ export class TaskRealityMirror {
 
   /**
    * SessionEnd (the REAL end): freeze the surface. Consumes the LATEST
-   * reconciled state — does NOT capture (the pane may already be gone) — stops
-   * the timers, and pushes a frozen «сессия завершена» view.
+   * reconciled state — does NOT capture (the pane may already be gone) —
+   * pushes a frozen «сессия завершена» view, tombstones the session id, then
+   * EVICTS the rec (timers stopped, in-flight captures invalidated). A late
+   * SessionEnd naming a session we've already moved past only tombstones it.
    */
   onSessionEnd(chatId: string, opts: { sessionId: string }): void {
     if (!this.isOwnerChat(chatId)) return
-    const rec = this.recs.get(chatId)
-    if (rec === undefined) return
-    // Ignore a late SessionEnd naming a session we've already moved past.
-    if (rec.sessionId !== opts.sessionId) return
     try {
+      this.tombstone(chatId, opts.sessionId)
+      const rec = this.recs.get(chatId)
+      if (rec === undefined) return
+      // Late end for a retired session: never touch the active rec.
+      if (rec.sessionId !== opts.sessionId) return
       rec.ended = true
       rec.turnActive = false
-      this.disarm(rec)
-      this.pushView(rec)
+      this.pushView(rec) // frozen ended view goes out BEFORE the state is dropped
+      this.evict(rec)
     } catch (err) {
       this.warn('onSessionEnd', chatId, err)
     }
@@ -213,13 +248,24 @@ export class TaskRealityMirror {
   onTaskEvent(chatId: string, event: TaskMirrorEvent, opts: { cwd?: string } = {}): void {
     if (!this.isOwnerChat(chatId)) return
     if (!isTaskMutationEvent(event)) return // lifecycle handled by the entry points above
+    if (this.isTombstoned(chatId, event.sessionId)) return // retired session — drop
     try {
       const rec = this.ensureRec(chatId, event.sessionId, opts.cwd)
       this.ensureSession(rec, event.sessionId)
       rec.lastActivityMs = this.now()
       const now = this.now()
-      for (const te of this.deriveToolEvents(rec, event, now)) {
-        rec.state = reconcileTaskState(rec.state, { kind: 'event', event: te })
+      if (event.kind === 'todo_write') {
+        // TodoWrite IS the harness's own full list — treat it as an
+        // authoritative event snapshot INCLUDING removals, and preserve the
+        // event ids so identical descriptions stay distinct tasks (review
+        // 2026-07-09 #5: the per-task delta path lost removals in the
+        // events-only degrade ⇒ ghosts forever without tmux).
+        applyEventToEventMap(rec.eventMap, event) // keep the map coherent for later task_update matching
+        rec.state = applyTodoWriteToState(rec.state, event.todos, now)
+      } else {
+        for (const te of this.deriveToolEvents(rec, event, now)) {
+          rec.state = reconcileTaskState(rec.state, { kind: 'event', event: te })
+        }
       }
       this.pushView(rec)
     } catch (err) {
@@ -227,9 +273,9 @@ export class TaskRealityMirror {
     }
   }
 
-  /** Stop every timer (process shutdown). */
+  /** Stop every timer and invalidate in-flight captures (process shutdown). */
   stop(): void {
-    for (const rec of this.recs.values()) this.disarm(rec)
+    for (const rec of [...this.recs.values()]) this.evict(rec)
   }
 
   // ─── per-chat state ──────────────────────────────────────────────────
@@ -252,6 +298,7 @@ export class TaskRealityMirror {
         // wait on a brand-new session).
         lastCaptureAt: Number.NEGATIVE_INFINITY,
         capturing: false,
+        generation: 0,
       }
       this.recs.set(chatId, rec)
     } else if (cwd !== undefined && cwd.length > 0 && rec.binding.cwd !== cwd) {
@@ -261,14 +308,51 @@ export class TaskRealityMirror {
   }
 
   // Reset state on a genuine session change (harness task ids restart at #1).
+  // Bumps the generation so any in-flight capture from the OLD session binding
+  // discards itself instead of committing old-pane output into the new state.
   private ensureSession(rec: ChatRec, sessionId: string): void {
     if (rec.sessionId === sessionId) return
+    rec.generation += 1
     rec.sessionId = sessionId
     rec.binding = { ...rec.binding, sessionId }
     rec.state = initialReconciledState(sessionId)
     rec.eventMap = new Map()
     rec.ended = false
     rec.turnActive = false
+  }
+
+  // Drop a rec entirely: timers disarmed, in-flight captures invalidated via
+  // the generation bump, entry removed from the map. Used by SessionEnd, the
+  // hard TTL and stop().
+  private evict(rec: ChatRec): void {
+    this.disarm(rec)
+    rec.generation += 1
+    if (this.recs.get(rec.chatId) === rec) this.recs.delete(rec.chatId)
+  }
+
+  // ─── tombstones ──────────────────────────────────────────────────────
+
+  private tombstone(chatId: string, sessionId: string): void {
+    let set = this.endedSessions.get(chatId)
+    if (set === undefined) {
+      set = new Set()
+      this.endedSessions.set(chatId, set)
+    }
+    set.delete(sessionId) // re-add moves it to the tail (freshest)
+    set.add(sessionId)
+    while (set.size > MAX_TOMBSTONES) {
+      const oldest = set.values().next().value
+      if (oldest === undefined) break
+      set.delete(oldest)
+    }
+  }
+
+  private untombstone(chatId: string, sessionId: string): void {
+    this.endedSessions.get(chatId)?.delete(sessionId)
+  }
+
+  private isTombstoned(chatId: string, sessionId: string): boolean {
+    return this.endedSessions.get(chatId)?.has(sessionId) === true
   }
 
   // ─── capture scheduling ──────────────────────────────────────────────
@@ -288,12 +372,16 @@ export class TaskRealityMirror {
     rec.periodicTimer = null
     if (rec.ended) return
     const idle = this.now() - rec.lastActivityMs
-    if (!rec.turnActive && idle > this.ttlMs) {
-      // Orphan timer: a long-idle session with no SessionEnd. Park the timer
-      // (stop rearming) — a fresh UserPromptSubmit / SessionStart restarts it.
-      this.log.debug('task reality mirror timer parked (idle > ttl)', {
+    if (idle > this.ttlMs) {
+      // HARD TTL (review 2026-07-09 #6): evict regardless of turnActive — a
+      // missed Stop would otherwise leave turnActive=true and the timer would
+      // poll tmux + cross age buckets + edit Telegram forever. A fresh
+      // SessionStart / UserPromptSubmit rebuilds the rec from scratch.
+      this.log.debug('task reality mirror rec evicted (idle > ttl)', {
         chat_id: rec.chatId,
+        idle_ms: idle,
       })
+      this.evict(rec)
       return
     }
     this.triggerCapture(rec, false)
@@ -327,23 +415,29 @@ export class TaskRealityMirror {
     if (rec.capturing || rec.ended) return
     rec.capturing = true
     rec.lastCaptureAt = this.now()
+    // Generation snapshot: if the session changes / ends / evicts while any of
+    // the awaits below is pending, this capture's output belongs to a retired
+    // binding and MUST be discarded (review 2026-07-09 #4).
+    const gen = rec.generation
     try {
       const cap = await capturePaneText(this.exec, this.capture)
+      if (rec.generation !== gen || rec.ended) return
       if (!cap.ok) {
         // No pane / capture failed — no snapshot. Refresh the indicator only
         // (health may transition to stale if a turn is active).
         this.pushView(rec)
         return
       }
-      // Resolve the pane's cwd for provenance. When unobtainable, degrade by
-      // reusing the binding cwd so validateSnapshot skips the cross-check
-      // rather than false-flagging a mismatch (documented M3 degrade).
+      // Resolve the pane's cwd for provenance. When UNRESOLVABLE the snapshot
+      // degrades to OBSERVATIONAL (review 2026-07-09 #9): the cwd cross-check
+      // is the one provenance check with real signal here; substituting the
+      // binding cwd would make validation unconditionally pass and neuter it.
       const paneCwd = await resolvePaneCwd(this.exec, this.capture)
-      const cwd = paneCwd ?? rec.binding.cwd
+      if (rec.generation !== gen || rec.ended) return
       const provenance: PaneProvenance = {
         sessionId: rec.binding.sessionId,
         paneTarget: this.capture.paneTarget,
-        cwd,
+        cwd: paneCwd ?? '',
         capturedAt: this.now(),
       }
       const snapshot = parsePaneTaskList(cap.text, provenance)
@@ -355,7 +449,10 @@ export class TaskRealityMirror {
         this.pushView(rec)
         return
       }
-      const verdict = validateSnapshot(snapshot, rec.binding)
+      const verdict: SnapshotVerdict =
+        paneCwd === null
+          ? { authoritative: false, reasons: ['cwd_mismatch'] }
+          : validateSnapshot(snapshot, rec.binding)
       // §5 positional-alias pre-pass: re-key moved tasks to the snapshot's
       // ordinals by unique description so a genuine move is a merge, not a
       // remove+add. Only meaningful when the snapshot is authoritative.
@@ -418,12 +515,13 @@ export class TaskRealityMirror {
     return { kind: 'fresh', reconciledAgeMs: now - rec.state.lastReconciledAt }
   }
 
-  // ─── tool-event derivation ───────────────────────────────────────────
+  // ─── tool-event derivation (TaskCreate / TaskUpdate only) ─────────────
 
   // Apply the mutation to the event-derived map, then emit ToolTaskEvents for
   // ONLY the tasks whose status/description actually changed (or are new). This
   // keeps unchanged tasks from re-stamping `updatedAt` and wrongly out-ranking
-  // authoritative pane snapshots.
+  // authoritative pane snapshots. TodoWrite takes the applyTodoWriteToState
+  // path instead (full replacement including removals).
   private deriveToolEvents(rec: ChatRec, event: TaskMutationEvent, now: number): ToolTaskEvent[] {
     const pre = new Map(rec.eventMap)
     applyEventToEventMap(rec.eventMap, event)
@@ -499,15 +597,104 @@ export function reconciledToTodos(state: ReconciledState): TodoItem[] {
 }
 
 /**
+ * Fold a TodoWrite payload into the reconciled state as an AUTHORITATIVE event
+ * snapshot (review 2026-07-09 #5). TodoWrite is the harness's own full task
+ * list, so unlike the per-task delta path it must express REMOVALS: an
+ * event-only task absent from the payload is gone. Pane-confirmed tasks absent
+ * from the payload are left to the pane's own two-snapshot omission rule (the
+ * pane may legitimately still show them).
+ *
+ * Event ids are preserved in the task keys (`${sessionId}:~id:<id>` for
+ * non-numeric ids, canonical `#N` for numeric ones) so two tasks with
+ * IDENTICAL descriptions remain distinct instead of collapsing into one
+ * provisional keyed by description.
+ *
+ * Unchanged matched tasks keep their `updatedAt` untouched, so pane snapshots
+ * retain recency authority over them. PURE — returns a new state.
+ */
+export function applyTodoWriteToState(
+  state: ReconciledState,
+  todos: ReadonlyArray<TodoItem>,
+  at: number,
+): ReconciledState {
+  const sessionId = state.sessionId
+  const tasks = state.tasks.map((t) => ({ ...t }))
+  const byKey = new Map(tasks.map((t) => [t.key, t]))
+  const matched = new Set<ReconciledTask>()
+  const additions: ReconciledTask[] = []
+
+  todos.forEach((todo, i) => {
+    const id = todo.id !== undefined && todo.id.length > 0 ? todo.id : `todo-${i + 1}`
+    const ordinal = numericOrdinal(id)
+    const key = ordinal !== undefined ? `${sessionId}:#${ordinal}` : `${sessionId}:~id:${id}`
+    let target = byKey.get(key)
+    if ((target === undefined || matched.has(target)) && ordinal === undefined) {
+      // Fall back to a UNIQUE normalized-description match among not-yet-matched
+      // tasks so an id-less rewrite can attach to a pane-confirmed row.
+      const norm = normalizeDescription(todo.content)
+      const hits = tasks.filter(
+        (t) =>
+          !matched.has(t) &&
+          !t.descriptionTruncated &&
+          normalizeDescription(t.description) === norm,
+      )
+      if (hits.length === 1) target = hits[0]
+    }
+    if (target !== undefined && !matched.has(target)) {
+      matched.add(target)
+      const changed = target.status !== todo.status || target.description !== todo.content
+      if (changed && at >= target.updatedAt) {
+        target.status = todo.status
+        target.description = todo.content
+        target.descriptionTruncated = false
+        target.source = 'event'
+        target.updatedAt = at
+      }
+      return
+    }
+    additions.push({
+      key,
+      ordinal: ordinal ?? null,
+      status: todo.status,
+      description: todo.content,
+      descriptionTruncated: false,
+      source: 'event',
+      provisional: ordinal === undefined,
+      paneConfirmed: false,
+      updatedAt: at,
+    })
+  })
+
+  // Removals: event-only tasks (never pane-confirmed) absent from the full
+  // list are authoritatively gone, unless a NEWER observation touched them.
+  const kept = tasks.filter((t) => matched.has(t) || t.paneConfirmed || t.updatedAt > at)
+
+  return {
+    ...state,
+    tasks: [...kept, ...additions],
+    lastEventAt: Math.max(state.lastEventAt, at),
+  }
+}
+
+/**
  * §5 positional-alias re-association. The live harness renders NO ordinals —
  * keys are positional — so a task that MOVES position looks like a
  * removal-at-old + addition-at-new to the reconciler's canonical-key merge,
  * which would churn the list. Before reconciling an authoritative snapshot,
  * re-key each committed pane-confirmed task to the snapshot ordinal that
- * uniquely matches its normalized description, but ONLY when the move is
- * genuine (the task's old ordinal is not itself present in the snapshot — that
- * would be a duplicate description, not a move). Genuine removals/regressions
- * keep the reconciler's two-snapshot rule untouched.
+ * uniquely matches its normalized description, but ONLY when the move is a
+ * clean SHIFT (the task's old ordinal is vacated in the snapshot — an ordinal
+ * still present would mean a duplicate description or a positional swap, both
+ * ambiguous with positional keys).
+ *
+ * DISPLACEMENT (review 2026-07-09 #7, resolved by test): a mover's target
+ * ordinal may currently be held by a DIFFERENT committed task — e.g.
+ * [A#1,B#2,C#3] → [A#1,C#2]: C moves 3→2 while B still holds key #2. Stomping
+ * B's key would let the reconciler's consumedKeys pass swallow B and delete it
+ * on the FIRST omission, violating the two-snapshot anti-flap contract. So the
+ * displaced task is MOVED to a free ordinal (a vacated mover ordinal, else one
+ * past the end), carrying its prev-snapshot facts, and thereby survives as a
+ * first-omission candidate — dropped only by the SECOND consecutive omission.
  *
  * PURE — returns a new state; `state` is not mutated. Coupled to the M2
  * canonical-key format `${sessionId}:#${ordinal}`.
@@ -530,7 +717,7 @@ export function realignOrdinals(state: ReconciledState, snapshot: PaneSnapshot):
   }
   const snapOrdinals = new Set(snapshot.tasks.map((s) => s.ordinal))
 
-  const remap = new Map<number, number>() // oldOrdinal → newOrdinal
+  const remap = new Map<number, number>() // mover oldOrdinal → newOrdinal
   const takenNew = new Set<number>()
   for (const s of snapshot.tasks) {
     if (s.descriptionTruncated) continue
@@ -538,7 +725,7 @@ export function realignOrdinals(state: ReconciledState, snapshot: PaneSnapshot):
     if (match === undefined || match === null) continue
     const oldOrd = match.ordinal
     if (oldOrd === s.ordinal) continue // already correctly placed
-    // Genuine SHIFT only: the task's old ordinal must be vacated in the new
+    // Clean SHIFT only: the task's old ordinal must be vacated in the new
     // snapshot. If the old ordinal is still present, the description appears in
     // two places (a positional SWAP or a duplicate) — ambiguous with positional
     // keys, so we leave it to the reconciler's two-snapshot rule.
@@ -549,28 +736,57 @@ export function realignOrdinals(state: ReconciledState, snapshot: PaneSnapshot):
   }
   if (remap.size === 0) return state
 
-  // Apply the remap, then float the re-keyed tasks to the END so that if a
-  // re-key target collides with a soon-to-be-removed committed occupant, the
-  // re-keyed (correct) task wins the reconciler's by-key lookup.
-  const remapped = new Set<ReconciledTask>()
-  const mapped = state.tasks.map((t) => {
-    if (t.ordinal !== null && remap.has(t.ordinal)) {
-      const newOrd = remap.get(t.ordinal) as number
-      const nt: ReconciledTask = { ...t, ordinal: newOrd, key: keyOf(newOrd) }
-      remapped.add(nt)
-      return nt
+  // Displacement pass: any committed task sitting on a mover's TARGET ordinal
+  // (and not itself a mover) must be re-keyed away so no duplicate keys exist
+  // and the two-snapshot omission rule still sees it (see docstring).
+  const moverNewOrds = new Set(remap.values())
+  const allOrds = new Set<number>(snapOrdinals)
+  for (const t of state.tasks) if (t.ordinal !== null) allOrds.add(t.ordinal)
+  // Free pool: vacated mover ordinals that are not themselves targets and not
+  // in the snapshot; fallback: ordinals past the maximum in play.
+  const pool = [...remap.keys()].filter((o) => !moverNewOrds.has(o) && !snapOrdinals.has(o))
+  let overflow = Math.max(0, ...allOrds) + 1
+  const nextFree = (): number => {
+    const fromPool = pool.shift()
+    if (fromPool !== undefined) return fromPool
+    while (snapOrdinals.has(overflow) || moverNewOrds.has(overflow)) overflow += 1
+    const out = overflow
+    overflow += 1
+    return out
+  }
+  const displacedRemap = new Map<number, number>()
+  for (const t of state.tasks) {
+    if (t.ordinal === null) continue
+    if (!moverNewOrds.has(t.ordinal)) continue // not on a mover's target
+    if (remap.has(t.ordinal)) continue // it is itself a mover (its key moves anyway)
+    if (displacedRemap.has(t.ordinal)) continue
+    displacedRemap.set(t.ordinal, nextFree())
+  }
+
+  const combined = new Map<number, number>([...remap, ...displacedRemap])
+
+  const tasks = state.tasks.map((t) => {
+    if (t.ordinal !== null && combined.has(t.ordinal)) {
+      const newOrd = combined.get(t.ordinal) as number
+      return { ...t, ordinal: newOrd, key: keyOf(newOrd) }
     }
     return t
   })
-  const tasks = [...mapped.filter((t) => !remapped.has(t)), ...mapped.filter((t) => remapped.has(t))]
 
-  // Re-key prevSnapshotFacts so the two-snapshot removal/regression rule stays
-  // coherent after the move.
-  const prevSnapshotFacts = new Map(state.prevSnapshotFacts)
-  for (const [oldOrd, newOrd] of remap) {
-    const oldKey = keyOf(oldOrd)
-    const facts = prevSnapshotFacts.get(oldKey)
-    prevSnapshotFacts.delete(oldKey)
+  // Re-key prevSnapshotFacts alongside (two-phase so chains/swaps of keys
+  // can't clobber each other) — the omission/regression confirmations must
+  // follow the tasks they describe.
+  const prevSnapshotFacts = new Map<string, SnapshotFacts>(state.prevSnapshotFacts)
+  const liftedFacts = new Map<number, SnapshotFacts>()
+  for (const [oldOrd] of combined) {
+    const facts = prevSnapshotFacts.get(keyOf(oldOrd))
+    if (facts !== undefined) {
+      liftedFacts.set(oldOrd, facts)
+      prevSnapshotFacts.delete(keyOf(oldOrd))
+    }
+  }
+  for (const [oldOrd, newOrd] of combined) {
+    const facts = liftedFacts.get(oldOrd)
     if (facts !== undefined) prevSnapshotFacts.set(keyOf(newOrd), facts)
   }
 

--- a/plugin/src/status/task-reconciler.ts
+++ b/plugin/src/status/task-reconciler.ts
@@ -143,10 +143,19 @@ export interface ReconciledTask {
 }
 
 /** Snapshot fingerprint kept for the two-consecutive-snapshot anti-flap rule. */
-interface SnapshotFacts {
+export interface SnapshotFacts {
   status: TaskStatus
   description: string
   descriptionTruncated: boolean
+  /**
+   * capturedAt of the snapshot that recorded this fact. A fact only CONFIRMS
+   * a change (regression / description swap) when it is at least as new as the
+   * committed task's own updatedAt — a fact captured BEFORE an intervening
+   * event is stale and must not count as the first of two consecutive
+   * confirmations (review 2026-07-09, Codex Med: snapshot:pending →
+   * event:completed → snapshot:pending must NOT regress immediately).
+   */
+  at: number
 }
 
 /** The full reconciled state for one session. Treat as immutable between calls. */
@@ -336,9 +345,20 @@ function precedingNonBlank(lines: ReadonlyArray<string>, idx: number): string | 
 
 /**
  * Parse the pane text into a task snapshot, or null when no task list is
- * present. When several blocks exist, the freshest (last) block wins: an
- * anchored block (header/spinner above) is preferred; failing that, the last
- * block of >= 2 task lines is accepted with `boundaryRecognized = false`.
+ * present. When several blocks exist, the freshest (last) block wins: a
+ * HEADER-anchored block is preferred; failing that, the last block of >= 2
+ * task lines is accepted with `boundaryRecognized = false`.
+ *
+ * ANTI-SPOOF (review 2026-07-09, all three reviewers): ONLY the
+ * `N tasks (A done, B in progress, C open)` header grants a recognized
+ * boundary. A spinner-anchored block (`* Imagining…`, `· thinking` etc.) is
+ * trivially reproduced in agent prose or scrollback — a checkbox list the
+ * agent merely ECHOED (quoting a plan, printing a diff) under any `*`/`·`
+ * line would previously have parsed as authoritative and ERASED the real
+ * task state within two capture cycles. Spinner/unanchored blocks are still
+ * parsed (they feed reconciliation health) but carry
+ * `boundaryRecognized=false` ⇒ {@link validateSnapshot} refuses authority
+ * (`unrecognized_boundary`) and they stay observational.
  *
  * `text` is assumed already ANSI-stripped by the capture layer, but we are
  * defensive: classification is line-oriented and never assumes clean input.
@@ -367,11 +387,12 @@ export function parsePaneTaskList(text: string, provenance: PaneProvenance): Pan
           pending: Number.parseInt(hm[4] as string, 10),
         }
         anchored = true
-      } else if (SPINNER_RE.test(above)) {
-        anchored = true
       }
+      // SPINNER_RE deliberately does NOT anchor (anti-spoof, see docstring).
+      // Spinner blocks fall through to the multi-line observational fallback.
     }
-    // Prefer anchored blocks; else accept a multi-line block as a fallback.
+    // Prefer header-anchored blocks; else accept a multi-line block (including
+    // spinner-anchored Style-B renders) as an observational fallback.
     const usable = anchored || block.taskLines.length >= 2
     if (!usable) continue
     // Freshest wins: any later usable block replaces an earlier one, but an
@@ -668,6 +689,7 @@ function applySnapshot(
       status: sTask.status,
       description: sTask.description,
       descriptionTruncated: sTask.descriptionTruncated,
+      at: snapCap,
     })
   }
 
@@ -718,6 +740,14 @@ function mergeSnapshotTask(
   const rankS = statusRank(sTask.status)
   const rankB = statusRank(base.status)
 
+  // A previous-snapshot fact may only CONFIRM a change when it is at least as
+  // new as the committed task's own updatedAt. A fact captured BEFORE an
+  // intervening event is stale: snapshot:pending → event:completed →
+  // snapshot:pending must hold `completed` (first observation of the
+  // regression), not regress immediately (review 2026-07-09, Codex Med).
+  const prevFactsCurrent =
+    prevFacts !== undefined && prevFacts.at >= base.updatedAt ? prevFacts : undefined
+
   // Status resolution.
   let status: TaskStatus
   if (rankS >= rankB) {
@@ -726,8 +756,8 @@ function mergeSnapshotTask(
   } else if (!base.paneConfirmed) {
     // Base is an absorbed provisional / event-only older guess ⇒ reality wins.
     status = sTask.status
-  } else if (prevFacts !== undefined && prevFacts.status === sTask.status) {
-    // Two consecutive snapshots agree on the regression ⇒ confirmed.
+  } else if (prevFactsCurrent !== undefined && prevFactsCurrent.status === sTask.status) {
+    // Two consecutive post-event snapshots agree on the regression ⇒ confirmed.
     status = sTask.status
   } else {
     // First observation of the regression ⇒ hold the higher committed status.
@@ -744,11 +774,11 @@ function mergeSnapshotTask(
       description = sTask.description
       descriptionTruncated = false
     } else if (
-      prevFacts !== undefined &&
-      !prevFacts.descriptionTruncated &&
-      normalizeDescription(prevFacts.description) === normalizeDescription(sTask.description)
+      prevFactsCurrent !== undefined &&
+      !prevFactsCurrent.descriptionTruncated &&
+      normalizeDescription(prevFactsCurrent.description) === normalizeDescription(sTask.description)
     ) {
-      // Two consecutive snapshots agree on the new description ⇒ confirmed.
+      // Two consecutive post-event snapshots agree on the new description ⇒ confirmed.
       description = sTask.description
       descriptionTruncated = false
     }

--- a/plugin/src/status/task-reconciler.ts
+++ b/plugin/src/status/task-reconciler.ts
@@ -1,0 +1,796 @@
+// task-reconciler — pure «reality mirror» for the Claude Code task list.
+//
+// Claude Code (the harness) renders its live task list directly in the tmux
+// pane while it works: a header line plus one checkbox line per task, e.g.
+//
+//     5 tasks (0 done, 2 in progress, 3 open)
+//     ◼ M1 — feeders + lifecycle fixes …
+//     ◼ M2 — task-reconciler: pane parser + merge …
+//     ◻ M3 — integration …
+//     ◻ M4 — dual review …
+//     ◻ M5 — context-HUD real window limit …
+//
+// An older/alternate harness layout renders the list under a spinner with a
+// tree prefix and a truncation marker:
+//
+//     * Imagining… (6m 7s · ↓ 24.4k tokens · thinking with xhigh effort)
+//       └ □ Task one
+//           □ Task two
+//           ✔ Task three
+//           … +1 pending
+//
+// This module is a SELF-CONTAINED pure layer — no I/O, no timers, no Telegram.
+// It (1) parses that pane text into an ordered task snapshot, (2) decides
+// whether the snapshot is authoritative for a given session binding, and
+// (3) reconciles the harness snapshot with the plugin's own tool-event stream
+// using an anti-flap merge. A later milestone wires it into TmuxMirror / the
+// context HUD; nothing here reaches out to those surfaces.
+//
+// Ground truth for the glyphs and header wording was captured live from
+// `tmux capture-pane` of Claude Code running in this repo (see
+// tests/status/fixtures/real-pane-tasklist.txt). The Style-B variant matches
+// the layout in the plan brief.
+
+// ─────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────
+
+export type TaskStatus = 'pending' | 'in_progress' | 'completed'
+
+/** Where a captured pane snapshot came from — the identity we bind against. */
+export interface PaneProvenance {
+  /** Claude session id that owns the pane we captured. */
+  sessionId: string
+  /** tmux pane target the capture was taken from (e.g. `%0`). */
+  paneTarget: string
+  /** `pane_current_path` at capture time. */
+  cwd: string
+  /** Epoch ms when the capture was taken. */
+  capturedAt: number
+}
+
+/** A single task parsed from the pane task list. */
+export interface ParsedTask {
+  /** 1-based position in the visible list, or the explicit `#N` when present. */
+  ordinal: number
+  /** true when `ordinal` came from a literal `#N`, false when derived from position. */
+  ordinalExplicit: boolean
+  status: TaskStatus
+  description: string
+  /** true when the rendered line was cut off (trailing `…`) so the text is partial. */
+  descriptionTruncated: boolean
+}
+
+/** Counts parsed from a `N tasks (A done, B in progress, C open)` header. */
+export interface HeaderCounts {
+  total: number
+  done: number
+  inProgress: number
+  pending: number
+}
+
+/** Immutable result of parsing one pane capture. */
+export interface PaneSnapshot {
+  provenance: PaneProvenance
+  tasks: ReadonlyArray<ParsedTask>
+  /**
+   * true only when the block is fully trustworthy: a recognized top boundary
+   * (header or spinner), no list-level truncation, no unattributable wrapped
+   * lines, and (when a header is present) the header total matches the parsed
+   * task count.
+   */
+  complete: boolean
+  /** true when at least one ordinal was derived from position rather than an explicit `#N`. */
+  ordinalsDerived: boolean
+  /** true when a header / spinner anchored the top of the block. */
+  boundaryRecognized: boolean
+  /** Present when the block carried a `N tasks (…)` header. */
+  headerCounts?: HeaderCounts
+  /** Present when a `… +N pending` / `+N ещё` truncation marker was seen. */
+  truncatedBy?: number
+  /** The raw block text, for debugging / logging. */
+  raw: string
+}
+
+/** The authoritative live binding a snapshot must match to be trusted. */
+export interface SessionBinding {
+  sessionId: string
+  paneTarget: string
+  cwd: string
+}
+
+export type VerdictReason =
+  | 'ok'
+  | 'session_mismatch'
+  | 'pane_mismatch'
+  | 'cwd_mismatch'
+  | 'unrecognized_boundary'
+  | 'incomplete'
+
+/** Outcome of {@link validateSnapshot}. Non-authoritative ⇒ observational only. */
+export interface SnapshotVerdict {
+  authoritative: boolean
+  reasons: ReadonlyArray<VerdictReason>
+}
+
+/** A task fact observed from the plugin's own tool-event stream (TaskCreate/Update/TodoWrite). */
+export interface ToolTaskEvent {
+  /** Harness ordinal when known (e.g. parsed from `Task #N`); omit when unknown. */
+  ordinal?: number
+  status: TaskStatus
+  description: string
+  /** Epoch ms the event was observed. */
+  at: number
+}
+
+/** A reconciled task — the merged view of pane truth + optimistic events. */
+export interface ReconciledTask {
+  /** Canonical key `${sessionId}:#${ordinal}`, or a provisional `${sessionId}:~${desc}`. */
+  key: string
+  /** Harness ordinal, or null for a provisional event not yet matched to the pane. */
+  ordinal: number | null
+  status: TaskStatus
+  description: string
+  descriptionTruncated: boolean
+  /** Last source that set this task's status. */
+  source: 'pane' | 'event'
+  /** true while this task is an unmatched, event-only optimistic guess. */
+  provisional: boolean
+  /** true once a valid pane snapshot has ever confirmed this task. */
+  paneConfirmed: boolean
+  /** Epoch ms this task's status/description last changed. */
+  updatedAt: number
+}
+
+/** Snapshot fingerprint kept for the two-consecutive-snapshot anti-flap rule. */
+interface SnapshotFacts {
+  status: TaskStatus
+  description: string
+  descriptionTruncated: boolean
+}
+
+/** The full reconciled state for one session. Treat as immutable between calls. */
+export interface ReconciledState {
+  sessionId: string
+  tasks: ReadonlyArray<ReconciledTask>
+  /** Last time ANY tool event was applied. Never freshened by a snapshot. */
+  lastEventAt: number
+  /** Last time a VALID pane snapshot was applied. Never freshened by an event. */
+  lastReconciledAt: number
+  /** Last time any snapshot (valid or not) was observed. */
+  lastObservationAt: number
+  /** Canonical-key → facts from the last VALID snapshot (for removal/regression confirmation). */
+  prevSnapshotFacts: ReadonlyMap<string, SnapshotFacts>
+}
+
+export type Observation =
+  | { readonly kind: 'snapshot'; readonly snapshot: PaneSnapshot; readonly verdict: SnapshotVerdict }
+  | { readonly kind: 'event'; readonly event: ToolTaskEvent }
+
+export type ReconciliationHealth = 'verified' | 'unverified' | 'stale'
+
+// ─────────────────────────────────────────────────────────────────────
+// Glyph tables (captured live + plan brief)
+// ─────────────────────────────────────────────────────────────────────
+
+// Task checkbox glyphs, mapped to status. Deliberately squares + checkmarks
+// only — the harness draws subagent / assistant bullets with CIRCLES
+// (● U+25CF, ◯ U+25EF), which must NEVER be read as tasks.
+const STATUS_BY_GLYPH: Readonly<Record<string, TaskStatus>> = {
+  // pending
+  '◻': 'pending', // ◻ white medium square (live)
+  '□': 'pending', // □ white square (Style-B)
+  '☐': 'pending', // ☐ ballot box
+  '▫': 'pending', // ▫ white small square
+  // in progress
+  '◼': 'in_progress', // ◼ black medium square (live)
+  '■': 'in_progress', // ■ black square
+  '◐': 'in_progress', // ◐ half circle (harness variant per brief)
+  '◾': 'in_progress', // ◾ black medium small square
+  // completed
+  '☑': 'completed', // ☑ ballot box with check
+  '✔': 'completed', // ✔ heavy check (Style-B)
+  '✓': 'completed', // ✓ check
+  '✅': 'completed', // ✅ white heavy check
+}
+
+// One checkbox line. Groups: (1) indent, (2) optional explicit `#N`, (3) glyph,
+// (4) rest of line. Optional leading tree prefix (└/├/│) is stripped.
+const TASK_LINE_RE =
+  /^(\s*)(?:[└├│╰╭]\s+)?(?:#(\d+)\s+)?([◻□☐▫◼■◐◾☑✔✓✅])\s+(.*)$/u
+
+// `N tasks (A done, B in progress, C open|pending)` header — the live top anchor.
+const HEADER_RE =
+  /^\s*(\d+)\s+tasks?\s*\(\s*(\d+)\s+done\s*,\s*(\d+)\s+in\s+progress\s*,\s*(\d+)\s+(?:open|pending)\s*\)\s*$/i
+
+// List-level truncation marker: `… +N pending`, `… +N`, `+N ещё`, `... +N more`.
+const TRUNCATION_RE = /^\s*(?:[…]|\.\.\.)?\s*\+(\d+)\b/u
+
+// Spinner / thinking line — the Style-B top anchor. Starts with a spinner glyph
+// (or `*`) and carries an ellipsis or a timing / token hint.
+const SPINNER_RE =
+  /^\s*[*✱✳✶✷✸✻✽❋·]\s+\S/u
+
+// Trailing-ellipsis test: the harness cuts an over-wide line with a trailing `…`.
+const TRAILING_ELLIPSIS_RE = /[…]\s*$/u
+
+// ─────────────────────────────────────────────────────────────────────
+// Parsing
+// ─────────────────────────────────────────────────────────────────────
+
+interface RawTaskLine {
+  lineIndex: number
+  indent: number
+  ordinalExplicit: number | null
+  status: TaskStatus
+  description: string
+  descriptionTruncated: boolean
+}
+
+function classifyTaskLine(line: string, lineIndex: number): RawTaskLine | null {
+  const m = TASK_LINE_RE.exec(line)
+  if (m === null) return null
+  const glyph = m[3] as string
+  const status = STATUS_BY_GLYPH[glyph]
+  if (status === undefined) return null
+  const indent = (m[1] ?? '').length
+  const explicit = m[2] !== undefined ? Number.parseInt(m[2], 10) : null
+  const rawRest = m[4] ?? ''
+  const descriptionTruncated = TRAILING_ELLIPSIS_RE.test(rawRest)
+  const description = rawRest.replace(TRAILING_ELLIPSIS_RE, '').trimEnd()
+  return {
+    lineIndex,
+    indent,
+    ordinalExplicit: explicit,
+    status,
+    description,
+    descriptionTruncated,
+  }
+}
+
+interface RawBlock {
+  first: number
+  taskLines: RawTaskLine[]
+  truncatedBy: number | null
+  /** an interior line we could not attribute (a wrap) ⇒ incomplete. */
+  hasUnattributedLine: boolean
+}
+
+/**
+ * Collect maximal contiguous runs of task lines. A run continues across task
+ * lines; a truncation marker closes it (and records N); a wrap-continuation
+ * (indented non-task, non-marker, non-noise line) closes it AND flags it
+ * incomplete; anything else (blank, dedented, noise) closes it cleanly.
+ */
+function collectBlocks(lines: ReadonlyArray<string>): RawBlock[] {
+  const blocks: RawBlock[] = []
+  let i = 0
+  while (i < lines.length) {
+    const first = classifyTaskLine(lines[i] ?? '', i)
+    if (first === null) {
+      i += 1
+      continue
+    }
+    const block: RawBlock = {
+      first: i,
+      taskLines: [first],
+      truncatedBy: null,
+      hasUnattributedLine: false,
+    }
+    const glyphIndent = first.indent
+    i += 1
+    while (i < lines.length) {
+      const line = lines[i] ?? ''
+      const task = classifyTaskLine(line, i)
+      if (task !== null) {
+        block.taskLines.push(task)
+        i += 1
+        continue
+      }
+      const trunc = TRUNCATION_RE.exec(line)
+      if (trunc !== null) {
+        block.truncatedBy = Number.parseInt(trunc[1] as string, 10)
+        i += 1
+        break
+      }
+      if (line.trim() === '') break // blank ⇒ clean end
+      // A non-task, non-blank line indented at least as deep as the checkbox
+      // column, that is not recognized noise, is a wrapped continuation we
+      // cannot attribute ⇒ the snapshot is incomplete.
+      const indent = line.length - line.trimStart().length
+      if (indent >= glyphIndent && !isNoiseLine(line)) {
+        block.hasUnattributedLine = true
+      }
+      break
+    }
+    blocks.push(block)
+  }
+  return blocks
+}
+
+// Recognized non-task lines that can legitimately abut a task block without
+// implying a wrap: footers, subagent bullets, assistant bullets, spinners,
+// headers, box separators, tips.
+const NOISE_RES: readonly RegExp[] = [
+  /^\s*[●◯○◉]\s/u, // ● ◯ ○ ◉ bullets (assistant / subagent / git)
+  /^\s*⏵⏵/u, // ⏵⏵ bypass-permissions footer
+  /^\s*[─━]{10,}/u, // ──── input-box separator
+  /^\s*(?:[└├]\s+)?Tip:/iu, // Tip lines
+  /^\s*Listening for channel messages/iu,
+  HEADER_RE,
+  SPINNER_RE,
+]
+
+function isNoiseLine(line: string): boolean {
+  return NOISE_RES.some((re) => re.test(line))
+}
+
+/** Nearest non-blank line above `idx`, or null. */
+function precedingNonBlank(lines: ReadonlyArray<string>, idx: number): string | null {
+  for (let k = idx - 1; k >= 0; k -= 1) {
+    const line = lines[k] ?? ''
+    if (line.trim() !== '') return line
+  }
+  return null
+}
+
+/**
+ * Parse the pane text into a task snapshot, or null when no task list is
+ * present. When several blocks exist, the freshest (last) block wins: an
+ * anchored block (header/spinner above) is preferred; failing that, the last
+ * block of >= 2 task lines is accepted with `boundaryRecognized = false`.
+ *
+ * `text` is assumed already ANSI-stripped by the capture layer, but we are
+ * defensive: classification is line-oriented and never assumes clean input.
+ */
+export function parsePaneTaskList(text: string, provenance: PaneProvenance): PaneSnapshot | null {
+  if (text.length === 0) return null
+  const lines = text.split('\n')
+  const blocks = collectBlocks(lines)
+  if (blocks.length === 0) return null
+
+  // Resolve the anchor for each block and pick the freshest usable one.
+  let chosen: RawBlock | null = null
+  let chosenHeader: HeaderCounts | null = null
+  let chosenAnchored = false
+  for (const block of blocks) {
+    const above = precedingNonBlank(lines, block.first)
+    let header: HeaderCounts | null = null
+    let anchored = false
+    if (above !== null) {
+      const hm = HEADER_RE.exec(above)
+      if (hm !== null) {
+        header = {
+          total: Number.parseInt(hm[1] as string, 10),
+          done: Number.parseInt(hm[2] as string, 10),
+          inProgress: Number.parseInt(hm[3] as string, 10),
+          pending: Number.parseInt(hm[4] as string, 10),
+        }
+        anchored = true
+      } else if (SPINNER_RE.test(above)) {
+        anchored = true
+      }
+    }
+    // Prefer anchored blocks; else accept a multi-line block as a fallback.
+    const usable = anchored || block.taskLines.length >= 2
+    if (!usable) continue
+    // Freshest wins: any later usable block replaces an earlier one, but an
+    // anchored block is never overridden by a later unanchored fallback.
+    if (chosen === null || anchored || !chosenAnchored) {
+      chosen = block
+      chosenHeader = header
+      chosenAnchored = anchored
+    }
+  }
+  if (chosen === null) return null
+
+  const tasks: ParsedTask[] = []
+  let ordinalsDerived = false
+  chosen.taskLines.forEach((raw, idx) => {
+    const explicit = raw.ordinalExplicit !== null
+    if (!explicit) ordinalsDerived = true
+    tasks.push({
+      ordinal: explicit ? (raw.ordinalExplicit as number) : idx + 1,
+      ordinalExplicit: explicit,
+      status: raw.status,
+      description: raw.description,
+      descriptionTruncated: raw.descriptionTruncated,
+    })
+  })
+
+  const truncatedBy = chosen.truncatedBy
+  const headerMismatch = chosenHeader !== null && chosenHeader.total !== tasks.length
+  const complete =
+    chosenAnchored &&
+    truncatedBy === null &&
+    !chosen.hasUnattributedLine &&
+    !headerMismatch
+
+  const rawBlockLines = lines.slice(chosen.first, chosen.first + chosen.taskLines.length)
+
+  const snapshot: PaneSnapshot = {
+    provenance,
+    tasks,
+    complete,
+    ordinalsDerived,
+    boundaryRecognized: chosenAnchored,
+    raw: rawBlockLines.join('\n'),
+    ...(chosenHeader !== null ? { headerCounts: chosenHeader } : {}),
+    ...(truncatedBy !== null ? { truncatedBy } : {}),
+  }
+  return snapshot
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Validation
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Decide whether a snapshot is authoritative for the live session binding.
+ *
+ * A snapshot is authoritative ONLY when it matches the (sessionId, pane, cwd)
+ * binding, has a recognized top boundary, and is complete (no truncation, no
+ * unattributed wrap, header count consistent). The remaining clause from the
+ * design — "newer than the event it would override" — is a recency question
+ * that depends on live event timestamps, so it is enforced per-task inside
+ * {@link reconcileTaskState}, not here. A non-authoritative snapshot is
+ * observational only: it influences reconciliation health but changes no task.
+ */
+export function validateSnapshot(
+  snapshot: PaneSnapshot,
+  binding: SessionBinding,
+): SnapshotVerdict {
+  const reasons: VerdictReason[] = []
+  if (snapshot.provenance.sessionId !== binding.sessionId) reasons.push('session_mismatch')
+  if (snapshot.provenance.paneTarget !== binding.paneTarget) reasons.push('pane_mismatch')
+  if (snapshot.provenance.cwd !== binding.cwd) reasons.push('cwd_mismatch')
+  if (!snapshot.boundaryRecognized) reasons.push('unrecognized_boundary')
+  if (!snapshot.complete) reasons.push('incomplete')
+  if (reasons.length === 0) return { authoritative: true, reasons: ['ok'] }
+  return { authoritative: false, reasons }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Reconciliation
+// ─────────────────────────────────────────────────────────────────────
+
+const STALE_MS = 90_000
+
+function statusRank(status: TaskStatus): number {
+  switch (status) {
+    case 'pending':
+      return 0
+    case 'in_progress':
+      return 1
+    case 'completed':
+      return 2
+  }
+}
+
+function canonicalKey(sessionId: string, ordinal: number): string {
+  return `${sessionId}:#${ordinal}`
+}
+
+function provisionalKey(sessionId: string, description: string): string {
+  return `${sessionId}:~${normalizeDescription(description)}`
+}
+
+/** Collapse internal whitespace and trim — the ONLY normalization used for description matching. */
+export function normalizeDescription(description: string): string {
+  return description.replace(/\s+/g, ' ').trim()
+}
+
+/** A fresh, empty reconciled state for a session. */
+export function initialReconciledState(sessionId: string): ReconciledState {
+  return {
+    sessionId,
+    tasks: [],
+    lastEventAt: 0,
+    lastReconciledAt: 0,
+    lastObservationAt: 0,
+    prevSnapshotFacts: new Map(),
+  }
+}
+
+/**
+ * Fold one observation into the reconciled state, returning a new state.
+ * Pure: never mutates `current`. Events are optimistic; valid pane snapshots
+ * are authoritative but anti-flap (removal / regression / description swaps
+ * need two consecutive confirming snapshots).
+ */
+export function reconcileTaskState(
+  current: ReconciledState,
+  observation: Observation,
+): ReconciledState {
+  if (observation.kind === 'event') {
+    return applyEvent(current, observation.event)
+  }
+  return applySnapshot(current, observation.snapshot, observation.verdict)
+}
+
+function cloneTask(task: ReconciledTask): ReconciledTask {
+  return { ...task }
+}
+
+function applyEvent(current: ReconciledState, event: ToolTaskEvent): ReconciledState {
+  const tasks = current.tasks.map(cloneTask)
+  const lastEventAt = Math.max(current.lastEventAt, event.at)
+
+  if (event.ordinal !== undefined) {
+    const key = canonicalKey(current.sessionId, event.ordinal)
+    const existing = tasks.find((t) => t.key === key)
+    if (existing !== undefined) {
+      // Optimistic: a newer-or-equal event wins in either direction.
+      if (event.at >= existing.updatedAt) {
+        existing.status = event.status
+        existing.description = event.description
+        existing.descriptionTruncated = false
+        existing.source = 'event'
+        existing.provisional = false
+        existing.updatedAt = event.at
+      }
+    } else {
+      tasks.push({
+        key,
+        ordinal: event.ordinal,
+        status: event.status,
+        description: event.description,
+        descriptionTruncated: false,
+        source: 'event',
+        provisional: false,
+        paneConfirmed: false,
+        updatedAt: event.at,
+      })
+    }
+    return { ...current, tasks, lastEventAt }
+  }
+
+  // No ordinal: try to attach to an existing pane task by UNIQUE exact
+  // normalized description; otherwise keep it provisional.
+  const norm = normalizeDescription(event.description)
+  const matches = tasks.filter(
+    (t) =>
+      !t.provisional &&
+      !t.descriptionTruncated &&
+      normalizeDescription(t.description) === norm,
+  )
+  if (matches.length === 1) {
+    const target = matches[0] as ReconciledTask
+    if (event.at >= target.updatedAt) {
+      target.status = event.status
+      target.source = 'event'
+      target.updatedAt = event.at
+    }
+    return { ...current, tasks, lastEventAt }
+  }
+
+  // Provisional upsert keyed by normalized description (repeat events coalesce).
+  const pKey = provisionalKey(current.sessionId, event.description)
+  const prov = tasks.find((t) => t.key === pKey)
+  if (prov !== undefined) {
+    if (event.at >= prov.updatedAt) {
+      prov.status = event.status
+      prov.description = event.description
+      prov.updatedAt = event.at
+    }
+  } else {
+    tasks.push({
+      key: pKey,
+      ordinal: null,
+      status: event.status,
+      description: event.description,
+      descriptionTruncated: false,
+      source: 'event',
+      provisional: true,
+      paneConfirmed: false,
+      updatedAt: event.at,
+    })
+  }
+  return { ...current, tasks, lastEventAt }
+}
+
+function uniqueProvisionalMatch(
+  provisionals: ReadonlyArray<ReconciledTask>,
+  description: string,
+): ReconciledTask | null {
+  const norm = normalizeDescription(description)
+  const hits = provisionals.filter((p) => normalizeDescription(p.description) === norm)
+  return hits.length === 1 ? (hits[0] as ReconciledTask) : null
+}
+
+function applySnapshot(
+  current: ReconciledState,
+  snapshot: PaneSnapshot,
+  verdict: SnapshotVerdict,
+): ReconciledState {
+  const lastObservationAt = Math.max(current.lastObservationAt, snapshot.provenance.capturedAt)
+  if (!verdict.authoritative) {
+    // Observational only — health signal moves, task state does not.
+    return { ...current, lastObservationAt }
+  }
+
+  const snapCap = snapshot.provenance.capturedAt
+  const prev = current.prevSnapshotFacts
+  const committed = current.tasks.map(cloneTask)
+  const byKey = new Map(committed.map((t) => [t.key, t]))
+  const provisionals = committed.filter((t) => t.ordinal === null)
+  const absorbedKeys = new Set<string>()
+  const consumedKeys = new Set<string>() // canonical keys placed into the snapshot section
+
+  const ordered: ReconciledTask[] = []
+
+  for (const sTask of snapshot.tasks) {
+    const key = canonicalKey(current.sessionId, sTask.ordinal)
+    consumedKeys.add(key)
+    let base = byKey.get(key)
+    if (base === undefined) {
+      const p = uniqueProvisionalMatch(
+        provisionals.filter((pr) => !absorbedKeys.has(pr.key)),
+        sTask.description,
+      )
+      if (p !== null) {
+        base = p
+        absorbedKeys.add(p.key)
+      }
+    }
+
+    ordered.push(mergeSnapshotTask(key, sTask, base, prev, snapCap))
+  }
+
+  // Tasks the snapshot omitted. Decide keep (append) vs drop.
+  const tail: ReconciledTask[] = []
+  for (const task of committed) {
+    if (consumedKeys.has(task.key)) continue
+    if (absorbedKeys.has(task.key)) continue
+
+    if (task.updatedAt > snapCap) {
+      // Newer than the authoritative snapshot ⇒ unmatched newer event, keep.
+      tail.push(task)
+      continue
+    }
+    if (!task.paneConfirmed) {
+      // Event-only optimistic guess a complete snapshot did not confirm ⇒ drop.
+      continue
+    }
+    // Pane-confirmed task now omitted: removal needs two consecutive omissions.
+    if (prev.has(task.key)) {
+      // Previous valid snapshot still had it ⇒ first omission ⇒ keep pending.
+      tail.push(task)
+    }
+    // else: previous snapshot omitted it too ⇒ second consecutive omission ⇒ drop.
+  }
+
+  const tasks = [...ordered, ...tail]
+
+  const prevSnapshotFacts = new Map<string, SnapshotFacts>()
+  for (const sTask of snapshot.tasks) {
+    prevSnapshotFacts.set(canonicalKey(current.sessionId, sTask.ordinal), {
+      status: sTask.status,
+      description: sTask.description,
+      descriptionTruncated: sTask.descriptionTruncated,
+    })
+  }
+
+  return {
+    ...current,
+    tasks,
+    lastReconciledAt: snapCap,
+    lastObservationAt,
+    prevSnapshotFacts,
+  }
+}
+
+function mergeSnapshotTask(
+  key: string,
+  sTask: ParsedTask,
+  base: ReconciledTask | undefined,
+  prev: ReadonlyMap<string, SnapshotFacts>,
+  snapCap: number,
+): ReconciledTask {
+  // Addition: nothing committed at this key.
+  if (base === undefined) {
+    return {
+      key,
+      ordinal: sTask.ordinal,
+      status: sTask.status,
+      description: sTask.description,
+      descriptionTruncated: sTask.descriptionTruncated,
+      source: 'pane',
+      provisional: false,
+      paneConfirmed: true,
+      updatedAt: snapCap,
+    }
+  }
+
+  // A newer event wins over the snapshot for this task (recency clause).
+  if (base.updatedAt > snapCap) {
+    return {
+      ...base,
+      key,
+      ordinal: sTask.ordinal,
+      source: 'event',
+      provisional: false,
+      paneConfirmed: true,
+    }
+  }
+
+  const prevFacts = prev.get(key)
+  const rankS = statusRank(sTask.status)
+  const rankB = statusRank(base.status)
+
+  // Status resolution.
+  let status: TaskStatus
+  if (rankS >= rankB) {
+    // Forward progress or same status ⇒ apply immediately.
+    status = sTask.status
+  } else if (!base.paneConfirmed) {
+    // Base is an absorbed provisional / event-only older guess ⇒ reality wins.
+    status = sTask.status
+  } else if (prevFacts !== undefined && prevFacts.status === sTask.status) {
+    // Two consecutive snapshots agree on the regression ⇒ confirmed.
+    status = sTask.status
+  } else {
+    // First observation of the regression ⇒ hold the higher committed status.
+    status = base.status
+  }
+
+  // Description resolution.
+  const sameDesc = normalizeDescription(sTask.description) === normalizeDescription(base.description)
+  let description = base.description
+  let descriptionTruncated = base.descriptionTruncated
+  if (!sameDesc && !sTask.descriptionTruncated) {
+    if (!base.paneConfirmed) {
+      // Absorbed provisional / event-only ⇒ snapshot owns the description.
+      description = sTask.description
+      descriptionTruncated = false
+    } else if (
+      prevFacts !== undefined &&
+      !prevFacts.descriptionTruncated &&
+      normalizeDescription(prevFacts.description) === normalizeDescription(sTask.description)
+    ) {
+      // Two consecutive snapshots agree on the new description ⇒ confirmed.
+      description = sTask.description
+      descriptionTruncated = false
+    }
+    // else: hold the committed description until a second confirming snapshot.
+  }
+
+  return {
+    key,
+    ordinal: sTask.ordinal,
+    status,
+    description,
+    descriptionTruncated,
+    source: 'pane',
+    provisional: false,
+    paneConfirmed: true,
+    updatedAt: snapCap,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Health
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Derive a freshness signal for the pin.
+ *
+ * - `unverified` — no valid pane snapshot has ever been reconciled (state, if
+ *   any, is optimistic events only).
+ * - `stale` — active work is ongoing AND reconciliation has been silent for
+ *   more than 90s (the harness should be redrawing the list but we haven't
+ *   seen a valid one).
+ * - `verified` — otherwise. Critically, when the session is idle (no active
+ *   turn) the last valid snapshot stays `verified` regardless of age: the
+ *   harness does not redraw the task list between turns, so silence there is
+ *   normal and must NOT read as stale.
+ */
+export function deriveHealth(
+  state: ReconciledState,
+  now: number,
+  sessionActive: boolean,
+): ReconciliationHealth {
+  if (state.lastReconciledAt <= 0) return 'unverified'
+  if (sessionActive && now - state.lastReconciledAt > STALE_MS) return 'stale'
+  return 'verified'
+}

--- a/plugin/src/status/task-reconciler.ts
+++ b/plugin/src/status/task-reconciler.ts
@@ -383,24 +383,50 @@ function isFurnitureLite(line: string): boolean {
   return FURNITURE_LITE_RES.some((re) => re.test(line))
 }
 
+// Lines allowed BELOW a chrome separator/footer: the input box (`❯ <typed>`),
+// further separators/footers, status bullets (● main / ◯ subagents) and the
+// furniture-lite set. Anything else is prose and DISQUALIFIES the candidate
+// chrome (review 2026-07-10 r3 #2: a crafted `──────` line inside prose must
+// not grant bottom anchoring — real harness chrome has ONLY chrome below it,
+// all the way to the capture end).
+const BELOW_CHROME_RES: readonly RegExp[] = [
+  /^\s*❯/u, // input-box prompt (may carry typed text)
+  /^\s*[●◯○◉]\s/u, // status bullets under the footer (main / subagents)
+]
+
+function isBelowChromeFurniture(line: string): boolean {
+  if (isFurnitureLite(line)) return true
+  if (CHROME_START_RES.some((re) => re.test(line))) return true
+  return BELOW_CHROME_RES.some((re) => re.test(line))
+}
+
 interface BottomRegionVerdict {
   /** No prose between the block and the capture end / harness chrome. */
   clean: boolean
-  /** An input-box separator or ⏵⏵ footer was seen below the block. */
+  /** VALIDATED harness chrome was seen below the block. */
   sawChrome: boolean
 }
 
 /**
  * Scan the lines BELOW a block (from `end` to capture end). The region is
  * `clean` when only furniture-lite lines appear up to the first harness-chrome
- * line (separator / footer); everything below that first chrome line is the
- * input box + status area and is accepted unconditionally. Any prose line
- * (assistant bullet, free text) before chrome ⇒ not clean.
+ * line (separator / footer) AND everything below that chrome line is itself
+ * chrome-classified (input box, footers, status bullets, blanks). A prose line
+ * anywhere — before OR after a candidate separator — disqualifies the region:
+ * a separator echoed inside prose is not the input box (review 2026-07-10 r3
+ * #2).
  */
 function scanBottomRegion(lines: ReadonlyArray<string>, end: number): BottomRegionVerdict {
   for (let k = end; k < lines.length; k += 1) {
     const line = lines[k] ?? ''
     if (CHROME_START_RES.some((re) => re.test(line))) {
+      // Candidate chrome: valid ONLY when the whole tail below it is also
+      // chrome/furniture — real harness chrome sits at the very bottom.
+      for (let m = k + 1; m < lines.length; m += 1) {
+        if (!isBelowChromeFurniture(lines[m] ?? '')) {
+          return { clean: false, sawChrome: false }
+        }
+      }
       return { clean: true, sawChrome: true }
     }
     if (!isFurnitureLite(line)) {
@@ -426,10 +452,15 @@ function scanBottomRegion(lines: ReadonlyArray<string>, end: number): BottomRegi
  *   3. POSITIONAL bottom anchoring: nothing but furniture (blank lines,
  *      task/truncation lines, spinner/Tip lines) between the block and the
  *      first piece of harness chrome (input-box `────` separator / `⏵⏵`
- *      footer) or the capture end — any prose below the block demotes it;
+ *      footer) or the capture end — any prose below the block demotes it.
+ *      Chrome itself is VALIDATED: everything below a candidate separator up
+ *      to the capture end must be chrome-classified (input box, footers,
+ *      status bullets, blanks) — a `────` line echoed inside prose does not
+ *      count (review 2026-07-10 r3 #2);
  *   4. harness-furniture presence: a spinner line immediately above the
- *      header OR harness chrome below the block. A block cut off at the very
- *      end of the capture with neither is scrollback, not the live list.
+ *      header OR validated harness chrome below the block. A block cut off at
+ *      the very end of the capture with neither is scrollback, not the live
+ *      list.
  * A block failing 2-4 still parses (observational: it feeds reconciliation
  * health) but carries `boundaryRecognized=false` ⇒ {@link validateSnapshot}
  * refuses authority (`unrecognized_boundary`).

--- a/plugin/src/status/task-reconciler.ts
+++ b/plugin/src/status/task-reconciler.ts
@@ -263,6 +263,8 @@ interface RawBlock {
   truncatedBy: number | null
   /** an interior line we could not attribute (a wrap) ⇒ incomplete. */
   hasUnattributedLine: boolean
+  /** Exclusive index of the first line NOT consumed by this block. */
+  end: number
 }
 
 /**
@@ -285,6 +287,7 @@ function collectBlocks(lines: ReadonlyArray<string>): RawBlock[] {
       taskLines: [first],
       truncatedBy: null,
       hasUnattributedLine: false,
+      end: i + 1,
     }
     const glyphIndent = first.indent
     i += 1
@@ -312,6 +315,9 @@ function collectBlocks(lines: ReadonlyArray<string>): RawBlock[] {
       }
       break
     }
+    // `i` now points at the first line NOT consumed by this block (a truncation
+    // marker was consumed; the breaking blank/wrap/dedent line was not).
+    block.end = i
     blocks.push(block)
   }
   return blocks
@@ -336,11 +342,72 @@ function isNoiseLine(line: string): boolean {
 
 /** Nearest non-blank line above `idx`, or null. */
 function precedingNonBlank(lines: ReadonlyArray<string>, idx: number): string | null {
+  const k = precedingNonBlankIdx(lines, idx)
+  return k >= 0 ? (lines[k] ?? '') : null
+}
+
+/** Index of the nearest non-blank line above `idx`, or -1. */
+function precedingNonBlankIdx(lines: ReadonlyArray<string>, idx: number): number {
   for (let k = idx - 1; k >= 0; k -= 1) {
     const line = lines[k] ?? ''
-    if (line.trim() !== '') return line
+    if (line.trim() !== '') return k
   }
-  return null
+  return -1
+}
+
+// ─── positional anchoring (anti-spoof v2, review 2026-07-10 #1) ────────
+//
+// Harness chrome: the input-box separator and the ⏵⏵ footer. Once one of
+// these appears below the task block, everything under it (input box content,
+// subagent-status bullets ● / ◯, hints) is harness furniture by construction —
+// the live task list ALWAYS renders directly above the input box.
+const CHROME_START_RES: readonly RegExp[] = [
+  /^\s*[─━]{10,}/u, // ──── input-box separator
+  /^\s*⏵⏵/u, // ⏵⏵ bypass-permissions footer
+]
+
+// Furniture-lite: lines that may legitimately sit between the live task block
+// and the input box WITHOUT implying prose. Deliberately EXCLUDES assistant /
+// subagent bullets (● ◯ ○ ◉) and free text — those mark conversation content,
+// which never renders below the live list.
+const FURNITURE_LITE_RES: readonly RegExp[] = [
+  SPINNER_RE,
+  /^\s*(?:[└├]\s+)?Tip:/iu,
+  /^\s*Listening for channel messages/iu,
+]
+
+function isFurnitureLite(line: string): boolean {
+  if (line.trim() === '') return true
+  if (TRUNCATION_RE.test(line)) return true
+  if (classifyTaskLine(line, 0) !== null) return true
+  return FURNITURE_LITE_RES.some((re) => re.test(line))
+}
+
+interface BottomRegionVerdict {
+  /** No prose between the block and the capture end / harness chrome. */
+  clean: boolean
+  /** An input-box separator or ⏵⏵ footer was seen below the block. */
+  sawChrome: boolean
+}
+
+/**
+ * Scan the lines BELOW a block (from `end` to capture end). The region is
+ * `clean` when only furniture-lite lines appear up to the first harness-chrome
+ * line (separator / footer); everything below that first chrome line is the
+ * input box + status area and is accepted unconditionally. Any prose line
+ * (assistant bullet, free text) before chrome ⇒ not clean.
+ */
+function scanBottomRegion(lines: ReadonlyArray<string>, end: number): BottomRegionVerdict {
+  for (let k = end; k < lines.length; k += 1) {
+    const line = lines[k] ?? ''
+    if (CHROME_START_RES.some((re) => re.test(line))) {
+      return { clean: true, sawChrome: true }
+    }
+    if (!isFurnitureLite(line)) {
+      return { clean: false, sawChrome: false }
+    }
+  }
+  return { clean: true, sawChrome: false }
 }
 
 /**
@@ -349,16 +416,34 @@ function precedingNonBlank(lines: ReadonlyArray<string>, idx: number): string | 
  * HEADER-anchored block is preferred; failing that, the last block of >= 2
  * task lines is accepted with `boundaryRecognized = false`.
  *
- * ANTI-SPOOF (review 2026-07-09, all three reviewers): ONLY the
- * `N tasks (A done, B in progress, C open)` header grants a recognized
- * boundary. A spinner-anchored block (`* Imagining…`, `· thinking` etc.) is
- * trivially reproduced in agent prose or scrollback — a checkbox list the
- * agent merely ECHOED (quoting a plan, printing a diff) under any `*`/`·`
- * line would previously have parsed as authoritative and ERASED the real
- * task state within two capture cycles. Spinner/unanchored blocks are still
- * parsed (they feed reconciliation health) but carry
- * `boundaryRecognized=false` ⇒ {@link validateSnapshot} refuses authority
- * (`unrecognized_boundary`) and they stay observational.
+ * ANTI-SPOOF (review 2026-07-09 + v2 2026-07-10): boundary recognition
+ * (⇒ authority-eligibility) requires ALL of:
+ *   1. a `N tasks (A done, B in progress, C open)` HEADER above the block —
+ *      spinner lines never anchor (trivially reproduced in prose);
+ *   2. the block is the LAST header-anchored block in the capture (a quoted
+ *      list echoed in prose sits ABOVE the live list, which the harness
+ *      always renders directly above the input box);
+ *   3. POSITIONAL bottom anchoring: nothing but furniture (blank lines,
+ *      task/truncation lines, spinner/Tip lines) between the block and the
+ *      first piece of harness chrome (input-box `────` separator / `⏵⏵`
+ *      footer) or the capture end — any prose below the block demotes it;
+ *   4. harness-furniture presence: a spinner line immediately above the
+ *      header OR harness chrome below the block. A block cut off at the very
+ *      end of the capture with neither is scrollback, not the live list.
+ * A block failing 2-4 still parses (observational: it feeds reconciliation
+ * health) but carries `boundaryRecognized=false` ⇒ {@link validateSnapshot}
+ * refuses authority (`unrecognized_boundary`).
+ *
+ * RESIDUAL RISK (documented per review 2026-07-10 #1): pane authority is
+ * still pane-CONTENT trust. An adversary who gets the agent to print an
+ * EXACT header + checkbox list as its very last output — sitting immediately
+ * above the input box while no real list is rendered (idle between turns) —
+ * satisfies 1-4 and gains authority until the next real render. Bounds on
+ * the damage: tool events retain per-task recency authority (a newer event
+ * beats any snapshot), removals/regressions need TWO consecutive confirming
+ * snapshots, and the next genuine task render reclaims the bottom slot.
+ * Eliminating the residue entirely would require out-of-band ground truth
+ * (harness API), which does not exist today.
  *
  * `text` is assumed already ANSI-stripped by the capture layer, but we are
  * defensive: classification is line-oriented and never assumes clean input.
@@ -404,6 +489,22 @@ export function parsePaneTaskList(text: string, provenance: PaneProvenance): Pan
     }
   }
   if (chosen === null) return null
+
+  // Positional anchoring (anti-spoof v2, conditions 2-4 in the docstring).
+  // The selection loop above already guarantees condition 2 (later header
+  // blocks replace earlier ones, so `chosen` anchored ⇒ last header block).
+  if (chosenAnchored) {
+    const region = scanBottomRegion(lines, chosen.end)
+    const headerIdx = precedingNonBlankIdx(lines, chosen.first)
+    const aboveHeader =
+      headerIdx >= 0 ? precedingNonBlank(lines, headerIdx) : null
+    const spinnerAboveHeader = aboveHeader !== null && SPINNER_RE.test(aboveHeader)
+    const positional = region.clean && (region.sawChrome || spinnerAboveHeader)
+    if (!positional) {
+      // Demote: parses (observational) but never gains authority.
+      chosenAnchored = false
+    }
+  }
 
   const tasks: ParsedTask[] = []
   let ordinalsDerived = false

--- a/plugin/src/status/tmux-mirror.ts
+++ b/plugin/src/status/tmux-mirror.ts
@@ -29,9 +29,7 @@
 //   • Voice transcription / screenshots.
 //   • Multiple panes per session.
 
-import { execFile } from 'child_process'
 import { createHash } from 'crypto'
-import { promisify } from 'util'
 
 import type { Logger } from '../log.js'
 import type { TelegramApi } from '../channel/tools.js'
@@ -47,6 +45,17 @@ import {
   type RenderMode,
   type SegmentType,
 } from './tmux-pane-filter.js'
+// The capture-pane exec seams + ANSI strip live in the shared pane-capture
+// module so TmuxMirror and TaskRealityMirror never duplicate the capture code
+// path. Re-exported below for backward-compat (tests import them from here).
+import {
+  defaultTmuxExec,
+  stripAnsi,
+  type TmuxExec,
+  type TmuxExecResult,
+} from './pane-capture.js'
+
+export type { TmuxExec, TmuxExecResult }
 
 /**
  * @deprecated Use {@link shouldMirrorTmuxForChat} from
@@ -71,16 +80,6 @@ export function shouldEnableMirror(
 ): boolean {
   return shouldMirrorTmuxForChat(policy ?? null, chatId)
 }
-
-export interface TmuxExecResult {
-  stdout: string
-  stderr: string
-  exitCode: number
-}
-
-// Test seam: the production wrapper calls `tmux capture-pane`; tests
-// inject a deterministic stub. Args are exactly the argv after the binary.
-export type TmuxExec = (args: readonly string[]) => Promise<TmuxExecResult>
 
 export interface TmuxMirrorOptions {
   api: TelegramApi
@@ -169,24 +168,8 @@ const BUMP_DEBOUNCE_MS = 1500
 const BUMP_WAIT_MAX_MS = 2000
 const BUMP_WAIT_TICK_MS = 25
 
-// Strip ANSI / vt control sequences and bare control characters. Keep
-// newlines + tabs. Patterns:
-//   • CSI:  ESC [ ... terminator-letter
-//   • OSC:  ESC ] ... BEL  OR  ESC ] ... ST (ESC \)
-//   • DCS/PM/APC/SOS: ESC (P|^|_|X) ... ST
-//   • two-byte: ESC + single char in @-Z, \, -, _
-// Stripping happens BEFORE htmlEscape so leftover characters can't blow up
-// Telegram's HTML parser. ST is `ESC \`; we accept both BEL and ST as
-// terminators for OSC since real terminals emit either.
-const ANSI_RE =
-  // eslint-disable-next-line no-control-regex
-  /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][\s\S]*?(?:\x07|\x1b\\)|[P^_X][\s\S]*?\x1b\\|[@-Z\\\-_])/g
-// eslint-disable-next-line no-control-regex
-const CTRL_RE = /[\x00-\x08\x0B-\x0C\x0E-\x1F\x7F]/g
-
-function stripAnsi(text: string): string {
-  return text.replace(ANSI_RE, '').replace(CTRL_RE, '')
-}
+// ANSI / control stripping is provided by the shared pane-capture module
+// (imported above as `stripAnsi`) so the capture code path is single-sourced.
 
 // Claude Code's pane decorates output with glyphs that iOS Telegram renders
 // with EMOJI presentation (⏺ U+23FA tool bullet, ⚠ U+26A0 warning). The
@@ -216,27 +199,8 @@ function hash(text: string): string {
   return createHash('sha256').update(text).digest('hex').slice(0, 16)
 }
 
-// Default exec: spawn tmux and capture stdout/stderr. We never throw on
-// non-zero exit so the caller can render the failure state instead of
-// crashing the polling loop.
-const execFileAsync = promisify(execFile)
-async function defaultTmuxExec(args: readonly string[]): Promise<TmuxExecResult> {
-  try {
-    const { stdout, stderr } = await execFileAsync('tmux', args as string[], {
-      maxBuffer: 4 * 1024 * 1024,
-      encoding: 'utf8',
-      timeout: 5000,
-    })
-    return { stdout, stderr, exitCode: 0 }
-  } catch (err) {
-    const e = err as { stdout?: string; stderr?: string; code?: number; message?: string }
-    return {
-      stdout: e.stdout ?? '',
-      stderr: e.stderr ?? e.message ?? 'tmux exec failed',
-      exitCode: typeof e.code === 'number' ? e.code : 1,
-    }
-  }
-}
+// Default exec lives in pane-capture (shared with TaskRealityMirror), imported
+// above as `defaultTmuxExec`.
 
 // Render the body. Wraps content in a `<pre>` block and enforces the body
 // cap by trimming from the TOP (oldest lines) — the warchief almost always

--- a/plugin/src/webhook/server.ts
+++ b/plugin/src/webhook/server.ts
@@ -733,16 +733,32 @@ async function handleRequest(
     // dedicated onSessionStart / onSessionEnd calls above.
     //
     // M3: when the reality mirror is wired it is the SOLE driver of the task
-    // surfaces — mutation events feed it (it reconciles them against the pane
-    // and pushes a freshness-tagged view into both surfaces). The legacy direct
-    // taskMirror.recordEvent + contextHud.onTodoEvent path runs ONLY when the
-    // reconciler is absent, so the two never double-render.
+    // surfaces' CONTENT — mutation events feed it (it reconciles them against
+    // the pane and pushes a freshness-tagged view into both surfaces); the
+    // legacy direct taskMirror.recordEvent(mutation) + contextHud.onTodoEvent
+    // path never runs, so the two never double-render. LIFECYCLE events
+    // (session_start / session_end) still reach TaskMirror so its own epoch
+    // machinery (finalize + eviction + persistence cleanup + tombstones) stays
+    // coherent — the reconciler's frozen ended view lands FIRST (its dispatch
+    // above enqueues synchronously into the same per-chat lock), then finalize.
     if (taskRealityMirror) {
       const todoEvent = toTodoWriteEvent(payload, log)
-      if (todoEvent !== null && isTaskMutationEvent(todoEvent)) {
-        const rm = taskRealityMirror
-        const cwd = payload.cwd
-        fireHud(log, () => rm.onTaskEvent(payload.chatId, todoEvent, { cwd }))
+      if (todoEvent !== null) {
+        if (isTaskMutationEvent(todoEvent)) {
+          const rm = taskRealityMirror
+          const cwd = payload.cwd
+          fireHud(log, () => rm.onTaskEvent(payload.chatId, todoEvent, { cwd }))
+        } else if (taskMirror) {
+          try {
+            await taskMirror.recordEvent(payload.chatId, todoEvent)
+          } catch (err) {
+            log.warn('hook event task mirror lifecycle update failed (ignored)', {
+              chat_id: payload.chatId,
+              hook: payload.hook_event_name,
+              error: err instanceof Error ? err.message : String(err),
+            })
+          }
+        }
       }
     } else if (taskMirror || deps.contextHud?.onTodoEvent) {
       const todoEvent = toTodoWriteEvent(payload, log)

--- a/plugin/src/webhook/server.ts
+++ b/plugin/src/webhook/server.ts
@@ -220,6 +220,17 @@ export interface AskUserQuestionUi {
   startQuestion(requestId: string): Promise<void> | void
 }
 
+// M3 reality mirror surface. All methods are synchronous best-effort (they
+// catch internally); the webhook calls them fire-and-forget so a reconciler
+// fault never touches the 200 path.
+export interface TaskRealityMirrorForWebhook {
+  onSessionStart(chatId: string, opts: { sessionId: string; cwd?: string }): void
+  onUserPromptSubmit(chatId: string, opts: { sessionId: string; cwd?: string }): void
+  onStop(chatId: string): void
+  onSessionEnd(chatId: string, opts: { sessionId: string }): void
+  onTaskEvent(chatId: string, event: TaskMirrorEvent, opts?: { cwd?: string }): void
+}
+
 export interface WebhookDeps {
   mcpServer: McpServer
   config: AppConfig
@@ -253,6 +264,14 @@ export interface WebhookDeps {
   // logged and swallowed; we still defensively wrap in try/catch here
   // to match the statusManager / progressReporter pattern.
   taskMirror?: TaskMirror
+  // M3 reality mirror (2026-07-09): reconciles the tool-event stream with the
+  // real task list Claude Code renders in the tmux pane. When present it is the
+  // SOLE driver of the two task surfaces (context HUD «Задачи» + TaskMirror) —
+  // the raw taskMirror.recordEvent / contextHud.onTodoEvent mutation dispatch
+  // below is bypassed so the reconciled (freshness-tagged) view is authoritative.
+  // Its methods are sync + best-effort (they catch internally). Optional —
+  // absent = legacy event-only path.
+  taskRealityMirror?: TaskRealityMirrorForWebhook
   // PR-A3 (M3 fix): InboundWatcher — on session_stop the webhook clears
   // the per-chat debounce marker so a fresh session can auto-reply on its
   // very first inbound message without waiting for the previous session's
@@ -426,6 +445,7 @@ async function handleRequest(
     memoryWriter,
     progressReporter,
     taskMirror,
+    taskRealityMirror,
     watcher,
   } = deps
   const method = req.method ?? 'GET'
@@ -620,6 +640,32 @@ async function handleRequest(
       }
     }
 
+    // M3 reality mirror: drive the pane-vs-events reconciliation on the session
+    // lifecycle. SessionStart binds + captures; UserPromptSubmit opens the turn
+    // window + captures; Stop captures then closes the window; SessionEnd
+    // freezes. All calls are sync best-effort (the mirror catches internally),
+    // fired fire-and-forget so the reconciler never touches the 200 path.
+    if (taskRealityMirror) {
+      const rm = taskRealityMirror
+      const cwd = payload.cwd
+      fireHud(log, () => {
+        switch (payload.hook_event_name) {
+          case 'SessionStart':
+            rm.onSessionStart(payload.chatId, { sessionId: payload.session_id, cwd })
+            break
+          case 'UserPromptSubmit':
+            rm.onUserPromptSubmit(payload.chatId, { sessionId: payload.session_id, cwd })
+            break
+          case 'Stop':
+            rm.onStop(payload.chatId)
+            break
+          case 'SessionEnd':
+            rm.onSessionEnd(payload.chatId, { sessionId: payload.session_id })
+            break
+        }
+      })
+    }
+
     // Phase 8: dispatch to memory writer first, BEFORE the status branch,
     // so memory persistence runs regardless of status.enabled. Errors are
     // logged and swallowed — memory must never back-pressure the 200.
@@ -685,7 +731,20 @@ async function handleRequest(
     // session change and finalizes on SessionEnd). The HUD's onTodoEvent
     // consumes ONLY mutations — its session lifecycle is driven by the
     // dedicated onSessionStart / onSessionEnd calls above.
-    if (taskMirror || deps.contextHud?.onTodoEvent) {
+    //
+    // M3: when the reality mirror is wired it is the SOLE driver of the task
+    // surfaces — mutation events feed it (it reconciles them against the pane
+    // and pushes a freshness-tagged view into both surfaces). The legacy direct
+    // taskMirror.recordEvent + contextHud.onTodoEvent path runs ONLY when the
+    // reconciler is absent, so the two never double-render.
+    if (taskRealityMirror) {
+      const todoEvent = toTodoWriteEvent(payload, log)
+      if (todoEvent !== null && isTaskMutationEvent(todoEvent)) {
+        const rm = taskRealityMirror
+        const cwd = payload.cwd
+        fireHud(log, () => rm.onTaskEvent(payload.chatId, todoEvent, { cwd }))
+      }
+    } else if (taskMirror || deps.contextHud?.onTodoEvent) {
       const todoEvent = toTodoWriteEvent(payload, log)
       if (todoEvent !== null) {
         if (taskMirror) {

--- a/plugin/src/webhook/server.ts
+++ b/plugin/src/webhook/server.ts
@@ -41,6 +41,7 @@ import { sendChannelNotification, normalizeMeta } from '../channel/notify.js'
 import {
   toActivityEvent,
   toTodoWriteEvent,
+  isTaskMutationEvent,
   type TaskMirrorEvent,
 } from '../hooks/claude-events.js'
 import type {
@@ -184,8 +185,15 @@ export interface SessionInfoRecorder {
 // section from the SAME TaskMirrorEvent stream TaskMirror consumes. Optional
 // on the interface so older stubs/tests remain valid.
 export interface ContextHudForWebhook {
-  onSessionStart(chatId: string): Promise<void> | void
+  onSessionStart(
+    chatId: string,
+    opts?: { sessionId?: string; source?: string },
+  ): Promise<void> | void
+  // Stop refreshes the pinned context percentage only — it must NOT finalize
+  // the task surface (Stop is turn-end, not session-end).
   onStop(chatId: string): Promise<void> | void
+  // SessionEnd is the real session end (distinct Claude Code hook).
+  onSessionEnd?(chatId: string, opts?: { sessionId?: string }): Promise<void> | void
   onTodoEvent?(chatId: string, event: TaskMirrorEvent): Promise<void> | void
 }
 
@@ -598,8 +606,16 @@ async function handleRequest(
     if (deps.contextHud) {
       const hud = deps.contextHud
       if (payload.hook_event_name === 'SessionStart') {
-        fireHud(log, () => hud.onSessionStart(payload.chatId))
+        const opts: { sessionId?: string; source?: string } = {
+          sessionId: payload.session_id,
+        }
+        if (typeof payload.source === 'string') opts.source = payload.source
+        fireHud(log, () => hud.onSessionStart(payload.chatId, opts))
+      } else if (payload.hook_event_name === 'SessionEnd') {
+        fireHud(log, () => hud.onSessionEnd?.(payload.chatId, { sessionId: payload.session_id }))
       } else if (payload.hook_event_name === 'Stop') {
+        // Stop refreshes the context percentage only — it no longer finalizes
+        // the task surfaces (Stop is turn-end, not session-end).
         fireHud(log, () => hud.onStop(payload.chatId))
       }
     }
@@ -660,11 +676,15 @@ async function handleRequest(
       }
     }
 
-    // PR-A2 (2026-05-20): TaskMirror handles TodoWrite + Stop hooks. The
-    // mapper returns null for every other event, so the cost when no
-    // TodoWrite is in flight is one schema test per hook — negligible.
-    // Status-pin wave (2026-07-04): the SAME mapped event also feeds the
-    // context HUD's «Задачи» section — fire-and-forget, never blocks the 200.
+    // TaskMirror + HUD «Задачи» section. toTodoWriteEvent maps SessionStart /
+    // SessionEnd (lifecycle) and PostToolUse TodoWrite/TaskCreate/TaskUpdate
+    // (mutations); everything else (including Stop) → null, so the cost when no
+    // task activity is in flight is one schema test per hook — negligible.
+    //
+    // TaskMirror consumes BOTH lifecycle and mutation events (it resets on a
+    // session change and finalizes on SessionEnd). The HUD's onTodoEvent
+    // consumes ONLY mutations — its session lifecycle is driven by the
+    // dedicated onSessionStart / onSessionEnd calls above.
     if (taskMirror || deps.contextHud?.onTodoEvent) {
       const todoEvent = toTodoWriteEvent(payload, log)
       if (todoEvent !== null) {
@@ -679,7 +699,7 @@ async function handleRequest(
             })
           }
         }
-        if (deps.contextHud?.onTodoEvent) {
+        if (deps.contextHud?.onTodoEvent && isTaskMutationEvent(todoEvent)) {
           const hud = deps.contextHud
           fireHud(log, () => hud.onTodoEvent?.(payload.chatId, todoEvent))
         }

--- a/plugin/tests/hooks/claude-events.test.ts
+++ b/plugin/tests/hooks/claude-events.test.ts
@@ -128,6 +128,19 @@ describe('WebhookPayloadSchema — Claude hook variant', () => {
     expect(p.model).toBe('claude-sonnet-4-6')
   })
 
+  test('SessionEnd parses with optional reason (real session-end hook)', () => {
+    const p = parse({
+      ...baseCommon,
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    })
+    expect(p.kind).toBe('claude_hook')
+    if (p.kind !== 'claude_hook' || p.hook_event_name !== 'SessionEnd') {
+      throw new Error('unreachable')
+    }
+    expect(p.reason).toBe('clear')
+  })
+
   test('rejects missing chatId on hook payload', () => {
     expect(() =>
       parse({
@@ -240,6 +253,18 @@ describe('toActivityEvent mapping', () => {
     })
     expect(event.kind).toBe('session_start')
   })
+
+  test('SessionEnd → session_stop (closes the transient bubble)', () => {
+    const event = toActivityEvent({
+      chatId: '1',
+      session_id: 's',
+      transcript_path: '/t',
+      cwd: '/',
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    })
+    expect(event.kind).toBe('session_stop')
+  })
 })
 
 describe('toTodoWriteEvent mapping', () => {
@@ -250,7 +275,9 @@ describe('toTodoWriteEvent mapping', () => {
     cwd: '/',
   } as const
 
-  test('PreToolUse TaskCreate → task_create event (no toolResult yet)', () => {
+  test('PreToolUse TaskCreate → null (provisional create is NOT mapped; avoids phantom)', () => {
+    // The PreToolUse create races the permission gate on the same event; a
+    // rejected create would leave a phantom task. Only PostToolUse is mapped.
     const event = toTodoWriteEvent({
       ...common,
       hook_event_name: 'PreToolUse',
@@ -258,15 +285,10 @@ describe('toTodoWriteEvent mapping', () => {
       tool_use_id: 'tu-create-1',
       tool_input: { subject: 'Implement X', description: 'why', activeForm: 'Implementing X' },
     })
-    expect(event?.kind).toBe('task_create')
-    if (event?.kind !== 'task_create') throw new Error('unreachable')
-    expect(event.toolUseId).toBe('tu-create-1')
-    expect(event.input.subject).toBe('Implement X')
-    expect(event.input.activeForm).toBe('Implementing X')
-    expect('toolResult' in event).toBe(false)
+    expect(event).toBeNull()
   })
 
-  test('PostToolUse TaskCreate → task_create event with toolResult', () => {
+  test('PostToolUse TaskCreate → task_create event with toolResult + sessionId', () => {
     const event = toTodoWriteEvent({
       ...common,
       hook_event_name: 'PostToolUse',
@@ -278,9 +300,10 @@ describe('toTodoWriteEvent mapping', () => {
     expect(event?.kind).toBe('task_create')
     if (event?.kind !== 'task_create') throw new Error('unreachable')
     expect(event.toolResult).toBe('Task #7 created successfully')
+    expect(event.sessionId).toBe('s')
   })
 
-  test('PostToolUse TaskUpdate → task_update event with coerced string taskId', () => {
+  test('PostToolUse TaskUpdate → task_update event with coerced string taskId + sessionId', () => {
     const event = toTodoWriteEvent({
       ...common,
       hook_event_name: 'PostToolUse',
@@ -293,6 +316,52 @@ describe('toTodoWriteEvent mapping', () => {
     if (event?.kind !== 'task_update') throw new Error('unreachable')
     expect(event.input.taskId).toBe('7')
     expect(event.input.status).toBe('in_progress')
+    expect(event.sessionId).toBe('s')
+  })
+
+  test('SessionStart → session_start lifecycle event (carries source + sessionId)', () => {
+    const event = toTodoWriteEvent({
+      ...common,
+      hook_event_name: 'SessionStart',
+      source: 'compact',
+    })
+    expect(event?.kind).toBe('session_start')
+    if (event?.kind !== 'session_start') throw new Error('unreachable')
+    expect(event.sessionId).toBe('s')
+    expect(event.source).toBe('compact')
+  })
+
+  test('SessionEnd → session_end lifecycle event', () => {
+    const event = toTodoWriteEvent({
+      ...common,
+      hook_event_name: 'SessionEnd',
+      reason: 'clear',
+    })
+    expect(event?.kind).toBe('session_end')
+    if (event?.kind !== 'session_end') throw new Error('unreachable')
+    expect(event.sessionId).toBe('s')
+    expect(event.reason).toBe('clear')
+  })
+
+  test('Stop → null (turn-end, never finalizes the task surface)', () => {
+    const event = toTodoWriteEvent({
+      ...common,
+      hook_event_name: 'Stop',
+    })
+    expect(event).toBeNull()
+  })
+
+  test('PostToolUse TodoWrite → todo_write carries sessionId', () => {
+    const event = toTodoWriteEvent({
+      ...common,
+      hook_event_name: 'PostToolUse',
+      tool_name: 'TodoWrite',
+      tool_use_id: 'tu-todo',
+      tool_input: { todos: [{ content: 'a', status: 'pending' }] },
+    })
+    expect(event?.kind).toBe('todo_write')
+    if (event?.kind !== 'todo_write') throw new Error('unreachable')
+    expect(event.sessionId).toBe('s')
   })
 
   test('PreToolUse TaskUpdate → null (we only mirror PostToolUse for updates)', () => {

--- a/plugin/tests/hooks/install-hooks.test.ts
+++ b/plugin/tests/hooks/install-hooks.test.ts
@@ -419,3 +419,77 @@ describe('applyPatch (pure) — channel reminder', () => {
     expect(ups.filter((e) => e.marker === 'dashi-channel-reminder-hook').length).toBe(1)
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────
+// Review fix-loop 2026-07-09 SHOULD — wide-feeder narrowing detection
+// ─────────────────────────────────────────────────────────────────────
+
+describe('hasWideDashiFeeder', () => {
+  test('detects an old wide install: dashi feeder on PreToolUse', async () => {
+    const { hasWideDashiFeeder } = await import('../../scripts/patch-claude-settings.js')
+    expect(
+      hasWideDashiFeeder({
+        hooks: {
+          PreToolUse: [
+            { marker: 'dashi-channel-hook', matcher: '.*', hooks: [{ type: 'command', command: 'bun post-hook.ts' }] },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  test('detects an unscoped PostToolUse feeder (marked or legacy markerless)', async () => {
+    const { hasWideDashiFeeder } = await import('../../scripts/patch-claude-settings.js')
+    expect(
+      hasWideDashiFeeder({
+        hooks: {
+          PostToolUse: [
+            { marker: 'dashi-channel-hook', matcher: '.*', hooks: [{ type: 'command', command: 'x' }] },
+          ],
+        },
+      }),
+    ).toBe(true)
+    expect(
+      hasWideDashiFeeder({
+        hooks: {
+          PostToolUse: [
+            // legacy markerless entry pointing at our helper, no matcher
+            { hooks: [{ type: 'command', command: "bun '/some/where/post-hook.ts'" }] },
+          ],
+        },
+      }),
+    ).toBe(true)
+  })
+
+  test('a NARROW install (scoped PostToolUse, no PreToolUse feeder) is not flagged', async () => {
+    const { hasWideDashiFeeder } = await import('../../scripts/patch-claude-settings.js')
+    expect(
+      hasWideDashiFeeder({
+        hooks: {
+          PostToolUse: [
+            {
+              marker: 'dashi-channel-hook',
+              matcher: 'TaskCreate|TaskUpdate|TodoWrite',
+              hooks: [{ type: 'command', command: 'x' }],
+            },
+          ],
+          PreToolUse: [
+            // the permission gate is NOT a feeder
+            { marker: 'dashi-permission-gate-hook', matcher: '.*', hooks: [{ type: 'command', command: 'gate' }] },
+          ],
+        },
+      }),
+    ).toBe(false)
+  })
+
+  test('unrelated third-party hooks are not flagged', async () => {
+    const { hasWideDashiFeeder } = await import('../../scripts/patch-claude-settings.js')
+    expect(
+      hasWideDashiFeeder({
+        hooks: {
+          PreToolUse: [{ matcher: '.*', hooks: [{ type: 'command', command: 'some-other-tool' }] }],
+        },
+      }),
+    ).toBe(false)
+  })
+})

--- a/plugin/tests/hooks/install-hooks.test.ts
+++ b/plugin/tests/hooks/install-hooks.test.ts
@@ -53,14 +53,18 @@ function runInstall(extraArgs: string[] = []): { code: number; stderr: string } 
 }
 
 describe('install-hooks.sh — fresh settings file', () => {
-  test('creates hooks for all five events', () => {
+  test('creates hooks for the narrow feeder set (no `.*` PreToolUse feeder)', () => {
     const r = runInstall()
     expect(r.code).toBe(0)
     const parsed = readJson()
     const flat = JSON.stringify(parsed)
-    for (const ev of ['SessionStart', 'UserPromptSubmit', 'PreToolUse', 'PostToolUse', 'Stop']) {
+    for (const ev of ['SessionStart', 'UserPromptSubmit', 'PostToolUse', 'SessionEnd', 'Stop']) {
       expect(flat).toContain(ev)
     }
+    // PreToolUse no longer carries a notification feeder (only the opt-in
+    // permission gate would land there — not enabled in this run).
+    const hooks = (parsed as { hooks?: Record<string, unknown> }).hooks ?? {}
+    expect(hooks.PreToolUse).toBeUndefined()
     expect(flat).toContain(POST_HOOK)
     expect(flat).toContain("TELEGRAM_HOOK_CHAT_ID='164795011'")
     expect(flat).toContain("TELEGRAM_HOOK_AGENT_ID='dashi-channel'")
@@ -72,14 +76,18 @@ describe('install-hooks.sh — fresh settings file', () => {
     expect(raw).not.toContain('TELEGRAM_WEBHOOK_TOKEN')
   })
 
-  test('matchers present on PreToolUse and PostToolUse only', () => {
+  test('PostToolUse feeder is scoped to the task tools; other events unmatched', () => {
     runInstall()
     const parsed = readJson() as {
       hooks?: Record<string, Array<{ matcher?: string }>>
     }
-    expect(parsed.hooks?.PreToolUse?.[0]?.matcher).toBe('.*')
-    expect(parsed.hooks?.PostToolUse?.[0]?.matcher).toBe('.*')
+    // Narrow matcher — `|`-separated exact tool names keeps the feeder off the
+    // hot path (Bash/Read/Edit no longer spawn it).
+    expect(parsed.hooks?.PostToolUse?.[0]?.matcher).toBe('TaskCreate|TaskUpdate|TodoWrite')
+    // No PreToolUse feeder at all in a gate-less install.
+    expect(parsed.hooks?.PreToolUse).toBeUndefined()
     expect(parsed.hooks?.SessionStart?.[0]?.matcher).toBeUndefined()
+    expect(parsed.hooks?.SessionEnd?.[0]?.matcher).toBeUndefined()
     expect(parsed.hooks?.Stop?.[0]?.matcher).toBeUndefined()
   })
 })
@@ -148,16 +156,23 @@ describe('install-hooks.sh — idempotency', () => {
     )
     runInstall()
     const parsed = readJson() as Record<string, unknown> & {
-      hooks?: { PreToolUse?: Array<{ marker?: string; hooks?: Array<{ command?: string }> }> }
+      hooks?: {
+        PreToolUse?: Array<{ marker?: string; hooks?: Array<{ command?: string }> }>
+        Stop?: Array<{ marker?: string }>
+      }
     }
     expect(parsed.otherKey).toEqual({ keep: 'me' })
-    // Other plugin's entry must survive.
+    // Other plugin's entry must survive — and since PreToolUse no longer carries
+    // our feeder, it survives ALONE on PreToolUse.
     const preToolUse = parsed.hooks?.PreToolUse ?? []
     const others = preToolUse.filter((e) => e.marker === 'someone-else')
     const ours = preToolUse.filter((e) => e.marker === 'dashi-channel-hook')
     expect(others.length).toBe(1)
-    expect(ours.length).toBe(1)
+    expect(ours.length).toBe(0) // narrow set: no PreToolUse feeder
     expect(others[0]!.hooks?.[0]?.command).toBe('echo unrelated')
+    // Our feeder still lands on the narrow events (e.g. Stop).
+    const stop = parsed.hooks?.Stop ?? []
+    expect(stop.some((e) => e.marker === 'dashi-channel-hook')).toBe(true)
   })
 })
 
@@ -255,14 +270,15 @@ describe('applyPatch (pure)', () => {
       webhookUrl: 'http://x',
       helperPath: '/new/plugin/scripts/post-hook.ts',
     }) as { hooks: Record<string, Array<{ marker?: string; hooks?: Array<{ command?: string }> }>> }
-    for (const ev of ['PreToolUse', 'Stop']) {
-      const arr = out.hooks[ev] ?? []
-      expect(arr.length).toBe(1)
-      expect(arr[0]!.marker).toBe('dashi-channel-hook')
-      expect(arr[0]!.hooks?.[0]?.command).toContain('/new/plugin/scripts/post-hook.ts')
-      // Old legacy command must be gone.
-      expect(arr.find((e) => e.hooks?.[0]?.command === legacyCmd)).toBeUndefined()
-    }
+    // Stop is a feeder event: the legacy entry is replaced by our marked one.
+    const stop = out.hooks.Stop ?? []
+    expect(stop.length).toBe(1)
+    expect(stop[0]!.marker).toBe('dashi-channel-hook')
+    expect(stop[0]!.hooks?.[0]?.command).toContain('/new/plugin/scripts/post-hook.ts')
+    expect(stop.find((e) => e.hooks?.[0]?.command === legacyCmd)).toBeUndefined()
+    // PreToolUse is NOT a feeder event: the legacy entry is stripped and, with
+    // no gate, nothing replaces it — the key is dropped entirely.
+    expect(out.hooks.PreToolUse).toBeUndefined()
   })
 
   test('replaces previous dashi-channel-hook entry rather than appending', () => {
@@ -298,15 +314,16 @@ describe('applyPatch (pure)', () => {
       permissionGateHelperPath: '/p/scripts/permission-gate-hook.ts',
     }) as GateHooks
     const pre = out.hooks.PreToolUse ?? []
-    // Gate entry is first, notification mirror second.
+    // Gate entry is first (and, in the narrow set, the ONLY PreToolUse entry —
+    // the notification feeder no longer lands here).
     expect(pre[0]!.marker).toBe('dashi-permission-gate-hook')
     expect(pre[0]!.hooks?.[0]?.command).toContain('permission-gate-hook.ts')
     // Hands the bare origin (no /hooks/agent path) to the gate hook.
     expect(pre[0]!.hooks?.[0]?.command).toContain("TELEGRAM_WEBHOOK_URL='http://127.0.0.1:8093'")
     expect(pre[0]!.hooks?.[0]?.command).not.toContain('/hooks/agent')
-    expect(pre.some((e) => e.marker === 'dashi-channel-hook')).toBe(true)
+    expect(pre.some((e) => e.marker === 'dashi-channel-hook')).toBe(false)
     // No gate entry leaks onto other events.
-    for (const ev of ['SessionStart', 'UserPromptSubmit', 'PostToolUse', 'Stop']) {
+    for (const ev of ['SessionStart', 'UserPromptSubmit', 'PostToolUse', 'SessionEnd', 'Stop']) {
       expect((out.hooks[ev] ?? []).some((e) => e.marker === 'dashi-permission-gate-hook')).toBe(false)
     }
   })

--- a/plugin/tests/status/context-hud.test.ts
+++ b/plugin/tests/status/context-hud.test.ts
@@ -921,3 +921,101 @@ describe('applyReconciledView', () => {
     expect(text).toContain('Показаны только события инструментов')
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────
+// Review fix-loop 2026-07-09 #2 — HUD session epochs / tombstones
+// ─────────────────────────────────────────────────────────────────────
+
+describe('HUD session end/start epochs', () => {
+  test('end(s1) → start(s2): the new session does NOT inherit dead tasks', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.onSessionStart(OWNER, { sessionId: 's1', source: 'startup' })
+    await hud.onTodoEvent(OWNER, {
+      kind: 'todo_write',
+      sessionId: 's1',
+      todos: [todo('1', 'in_progress', 'мертвая задача')],
+    })
+    await hud.onSessionEnd(OWNER, { sessionId: 's1' })
+
+    // Pre-fix: onSessionEnd deleted the tracked id → the next startup saw
+    // sessionChanged=false and kept showing the dead session's tasks.
+    await hud.onSessionStart(OWNER, { sessionId: 's2', source: 'startup' })
+    const last = api.edited[api.edited.length - 1]!
+    expect(last.text).not.toContain('мертвая задача')
+  })
+
+  test('end(s1) → resume(s1): tasks preserved and s1 events flow again', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.onSessionStart(OWNER, { sessionId: 's1', source: 'startup' })
+    await hud.onTodoEvent(OWNER, {
+      kind: 'todo_write',
+      sessionId: 's1',
+      todos: [todo('1', 'in_progress', 'живая работа')],
+    })
+    await hud.onSessionEnd(OWNER, { sessionId: 's1' })
+
+    // Resume: SAME id → snapshot preserved (compact/resume semantics).
+    await hud.onSessionStart(OWNER, { sessionId: 's1', source: 'resume' })
+    expect(api.edited[api.edited.length - 1]!.text).toContain('живая работа')
+
+    // Un-tombstoned: further s1 events are accepted.
+    await hud.onTodoEvent(OWNER, {
+      kind: 'todo_write',
+      sessionId: 's1',
+      todos: [todo('1', 'completed', 'живая работа')],
+    })
+    expect(api.edited[api.edited.length - 1]!.text).toContain('1/1')
+  })
+
+  test('a late task event from an ENDED session is dropped (no clobbering the active one)', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.onSessionStart(OWNER, { sessionId: 's1', source: 'startup' })
+    await hud.onSessionEnd(OWNER, { sessionId: 's1' })
+    await hud.onSessionStart(OWNER, { sessionId: 's2', source: 'startup' })
+    await hud.onTodoEvent(OWNER, {
+      kind: 'todo_write',
+      sessionId: 's2',
+      todos: [todo('1', 'in_progress', 'актуальная работа')],
+    })
+    expect(api.edited[api.edited.length - 1]!.text).toContain('актуальная работа')
+
+    // Straggler from dead s1 — must NOT replace s2's snapshot.
+    await hud.onTodoEvent(OWNER, {
+      kind: 'todo_write',
+      sessionId: 's1',
+      todos: [todo('9', 'pending', 'призрак')],
+    })
+    const last = api.edited[api.edited.length - 1]!
+    expect(last.text).toContain('актуальная работа')
+    expect(last.text).not.toContain('призрак')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// Review fix-loop 2026-07-09 SHOULD — reconciled-render dedup
+// ─────────────────────────────────────────────────────────────────────
+
+describe('applyReconciledView dedup', () => {
+  test('identical renders (same bucket, same tasks) skip editMessageText', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    const view = {
+      sessionId: 's1',
+      todos: [todo('1', 'in_progress', 'долгая работа')],
+      freshness: { kind: 'fresh', reconciledAgeMs: 5_000 } as const,
+    }
+    await hud.applyReconciledView(OWNER, view)
+    const editsAfterFirst = api.edited.length
+    // Reconciler ticks: same tasks, same «меньше минуты» bucket.
+    await hud.applyReconciledView(OWNER, { ...view, freshness: { kind: 'fresh', reconciledAgeMs: 25_000 } })
+    await hud.applyReconciledView(OWNER, { ...view, freshness: { kind: 'fresh', reconciledAgeMs: 45_000 } })
+    expect(api.edited.length).toBe(editsAfterFirst) // zero extra edits
+
+    // Bucket crossing («1 мин») changes the render → ONE refresh goes through.
+    await hud.applyReconciledView(OWNER, { ...view, freshness: { kind: 'fresh', reconciledAgeMs: 65_000 } })
+    expect(api.edited.length + api.sent.length).toBeGreaterThan(editsAfterFirst)
+  })
+})

--- a/plugin/tests/status/context-hud.test.ts
+++ b/plugin/tests/status/context-hud.test.ts
@@ -1019,3 +1019,64 @@ describe('applyReconciledView dedup', () => {
     expect(api.edited.length + api.sent.length).toBeGreaterThan(editsAfterFirst)
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────
+// Review fix-loop round 2 (2026-07-10) — HUD rollback guard + epochs
+// ─────────────────────────────────────────────────────────────────────
+
+describe('HUD #2v2 rollback guard + persisted epochs', () => {
+  test('late SessionStart for an ENDED session does not displace the active one', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.onSessionStart(OWNER, { sessionId: 's1', source: 'startup' })
+    await hud.onSessionEnd(OWNER, { sessionId: 's1' })
+    await hud.onSessionStart(OWNER, { sessionId: 's2', source: 'startup' })
+    await hud.onTodoEvent(OWNER, {
+      kind: 'todo_write',
+      sessionId: 's2',
+      todos: [todo('1', 'in_progress', 'актуальная')],
+    })
+    expect(api.edited[api.edited.length - 1]!.text).toContain('актуальная')
+
+    // REPLAYED SessionStart for dead s1: must NOT clear s2's snapshot.
+    await hud.onSessionStart(OWNER, { sessionId: 's1', source: 'startup' })
+    expect(api.edited[api.edited.length - 1]!.text).toContain('актуальная')
+
+    // s1 stays tombstoned — its late events remain dropped.
+    await hud.onTodoEvent(OWNER, {
+      kind: 'todo_write',
+      sessionId: 's1',
+      todos: [todo('9', 'pending', 'призрак')],
+    })
+    expect(api.edited[api.edited.length - 1]!.text).not.toContain('призрак')
+  })
+
+  test('epochs survive a restart: a straggler from an ended session stays dropped', async () => {
+    const dir = stateDir()
+    const api1 = new FakeApi()
+    const hud1 = makeHud(api1, { dir })
+    await hud1.onSessionStart(OWNER, { sessionId: 's1', source: 'startup' })
+    await hud1.onSessionEnd(OWNER, { sessionId: 's1' })
+
+    // «Restart»: fresh HUD instance, same state dir. Pre-fix the tombstones
+    // were runtime-only — this straggler adopted the dead session again.
+    const api2 = new FakeApi()
+    const hud2 = makeHud(api2, { dir })
+    await hud2.onTodoEvent(OWNER, {
+      kind: 'todo_write',
+      sessionId: 's1',
+      todos: [todo('1', 'pending', 'призрак после рестарта')],
+    })
+    expect(api2.sent.length + api2.edited.length).toBe(0) // dropped
+
+    // A fresh session works normally.
+    await hud2.onTodoEvent(OWNER, {
+      kind: 'todo_write',
+      sessionId: 's2',
+      todos: [todo('1', 'in_progress', 'новая работа')],
+    })
+    const last =
+      api2.edited.length > 0 ? api2.edited[api2.edited.length - 1]!.text : api2.sent[0]!.text
+    expect(last).toContain('новая работа')
+  })
+})

--- a/plugin/tests/status/context-hud.test.ts
+++ b/plugin/tests/status/context-hud.test.ts
@@ -875,3 +875,49 @@ describe('ContextHud onTodoEvent', () => {
     expect(last.text).not.toContain('старое')
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────
+// M3 reality mirror — applyReconciledView
+// ─────────────────────────────────────────────────────────────────────
+
+describe('applyReconciledView', () => {
+  test('renders the reconciled list + freshness label into the pinned card', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.applyReconciledView(OWNER, {
+      sessionId: 's1',
+      todos: [
+        { id: '1', content: 'живая задача', status: 'in_progress' },
+        { id: '2', content: 'ещё одна', status: 'pending' },
+      ],
+      freshness: { kind: 'fresh', reconciledAgeMs: 5_000 },
+    })
+    const text = api.sent.length > 0 ? api.sent[0]!.text : api.edited[api.edited.length - 1]!.text
+    expect(text).toContain('<b>Задачи</b> · <i>сверено меньше минуты назад</i>')
+    expect(text).toContain('живая задача')
+  })
+
+  test('non-owner chat is a no-op', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.applyReconciledView('-100999', {
+      sessionId: 's1',
+      todos: [{ id: '1', content: 'x', status: 'pending' }],
+      freshness: { kind: 'unverified' },
+    })
+    expect(api.sent.length).toBe(0)
+  })
+
+  test('«НЕ СВЕРЕНО» when the view is unverified', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.applyReconciledView(OWNER, {
+      sessionId: 's1',
+      todos: [{ id: '1', content: 'только событие', status: 'pending' }],
+      freshness: { kind: 'unverified' },
+    })
+    const text = api.sent[0]!.text
+    expect(text).toContain('<b>Задачи — НЕ СВЕРЕНО</b>')
+    expect(text).toContain('Показаны только события инструментов')
+  })
+})

--- a/plugin/tests/status/context-hud.test.ts
+++ b/plugin/tests/status/context-hud.test.ts
@@ -781,6 +781,7 @@ describe('ContextHud onTodoEvent', () => {
 
     const event: TaskMirrorEvent = {
       kind: 'todo_write',
+      sessionId: 's1',
       todos: [todo('1', 'in_progress', 'шаг один'), todo('2', 'pending', 'шаг два')],
     }
     await hud.onTodoEvent(OWNER, event)
@@ -791,19 +792,21 @@ describe('ContextHud onTodoEvent', () => {
     expect(last.text).toContain('0/2')
   })
 
-  test('task_create + task_update accumulate; todo_session_stop keeps the view', async () => {
+  test('task_create + task_update accumulate; session_end keeps the view', async () => {
     const api = new FakeApi()
     const hud = makeHud(api)
-    await hud.onSessionStart(OWNER)
+    await hud.onSessionStart(OWNER, { sessionId: 's1', source: 'startup' })
 
     await hud.onTodoEvent(OWNER, {
       kind: 'task_create',
+      sessionId: 's1',
       toolUseId: 'tu1',
       input: { subject: 'собрать фичу' },
       toolResult: 'Task #7 created successfully',
     })
     await hud.onTodoEvent(OWNER, {
       kind: 'task_update',
+      sessionId: 's1',
       toolUseId: 'tu2',
       input: { taskId: '7', status: 'completed' },
     })
@@ -811,12 +814,64 @@ describe('ContextHud onTodoEvent', () => {
     expect(last.text).toContain('☑ собрать фичу')
     expect(last.text).toContain('1/1')
 
-    const editsBefore = api.edited.length
-    await hud.onTodoEvent(OWNER, { kind: 'todo_session_stop' })
-    expect(api.edited.length).toBe(editsBefore) // stop never clears/re-renders
-    // A later refresh still carries the last snapshot.
+    // SessionEnd refreshes but keeps the last snapshot visible.
+    await hud.onSessionEnd(OWNER, { sessionId: 's1' })
     await hud.updateNow(OWNER)
     last = api.edited[api.edited.length - 1] ?? last
     expect(last.text).toContain('☑ собрать фичу')
+  })
+
+  test('compact (same session id) preserves tasks; a new session id clears them', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.onSessionStart(OWNER, { sessionId: 's1', source: 'startup' })
+    await hud.onTodoEvent(OWNER, {
+      kind: 'todo_write',
+      sessionId: 's1',
+      todos: [todo('1', 'in_progress', 'живая задача')],
+    })
+    expect(api.edited[api.edited.length - 1]!.text).toContain('живая задача')
+
+    // Compact: SAME id → tasks preserved.
+    await hud.onSessionStart(OWNER, { sessionId: 's1', source: 'compact' })
+    expect(api.edited[api.edited.length - 1]!.text).toContain('живая задача')
+
+    // New session id → tasks cleared (section omitted).
+    await hud.onSessionStart(OWNER, { sessionId: 's2', source: 'startup' })
+    expect(api.edited[api.edited.length - 1]!.text).not.toContain('живая задача')
+  })
+
+  test('source=clear wipes tasks even on the same session id', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.onSessionStart(OWNER, { sessionId: 's1', source: 'startup' })
+    await hud.onTodoEvent(OWNER, {
+      kind: 'todo_write',
+      sessionId: 's1',
+      todos: [todo('1', 'in_progress', 'сотрётся')],
+    })
+    expect(api.edited[api.edited.length - 1]!.text).toContain('сотрётся')
+    await hud.onSessionStart(OWNER, { sessionId: 's1', source: 'clear' })
+    expect(api.edited[api.edited.length - 1]!.text).not.toContain('сотрётся')
+  })
+
+  test('a task event with a new session id resets the stale snapshot', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.onSessionStart(OWNER, { sessionId: 's1', source: 'startup' })
+    await hud.onTodoEvent(OWNER, {
+      kind: 'todo_write',
+      sessionId: 's1',
+      todos: [todo('1', 'in_progress', 'старое'), todo('2', 'pending', 'ещё старое')],
+    })
+    // A task event from a new session (missed SessionStart) — replace, not blend.
+    await hud.onTodoEvent(OWNER, {
+      kind: 'todo_write',
+      sessionId: 's2',
+      todos: [todo('9', 'in_progress', 'новое')],
+    })
+    const last = api.edited[api.edited.length - 1]!
+    expect(last.text).toContain('новое')
+    expect(last.text).not.toContain('старое')
   })
 })

--- a/plugin/tests/status/fixtures/real-pane-tasklist.txt
+++ b/plugin/tests/status/fixtures/real-pane-tasklist.txt
@@ -1,0 +1,24 @@
+● Конвейер развёрнут: 5 милстонов на доске, два Opus-кодера параллельно в
+  изолированных worktree (M1 фидеры + lifecycle, M2 реконсилятор пейна с
+  реальными фикстурами), M5 добавлен по новой директиве вождя — реальный лимит
+  контекстного окна модели вместо хардкода 200k. Жду нотификации обоих кодеров,
+  дальше M3 интеграция и двойное ревью.
+
+✻ Waiting for 2 background agents to finish
+
+  5 tasks (0 done, 2 in progress, 3 open)
+  ◼ M1 — фидеры + lifecycle-фиксы (Stop ≠ конец сессии, session-id, …
+  ◼ M2 — task-reconciler: парсер tmux-пейна + merge-семантика (pure …
+  ◻ M3 — интеграция: TmuxMirror publish → reconciler → HUD/mirror + …
+  ◻ M4 — двойное ревью, PR, live-применение, боевой ретест пина
+  ◻ M5 — фикс контекст-HUD: реальный лимит окна модели (1M для Fable…
+
+────────────────────────────────────────────────────────────────────────────────
+❯ Дальше сам по конвейеру, доложи когда будет готово
+────────────────────────────────────────────────────────────────────────────────
+  ⏵⏵ bypass permissions on (shift+tab to cycle) · ctrl+t to hide tasks · ← fo…
+
+  ● main
+  ◯ general-purpose  Реализация task-display fix        12m 5s · ↓ 229.4k tokens
+  ◯ general-purpose  M2: task-reconciler pure module    2m 26s · ↓ 121.5k tokens
+

--- a/plugin/tests/status/pane-capture.test.ts
+++ b/plugin/tests/status/pane-capture.test.ts
@@ -1,0 +1,80 @@
+// Tests for the shared pane-capture primitive: ANSI strip + capture-pane exec
+// wrapper + pane-cwd resolution. All driven through the injected exec seam so
+// no tmux is required.
+
+import { describe, expect, test } from 'bun:test'
+import {
+  capturePaneText,
+  resolvePaneCwd,
+  stripAnsi,
+  type TmuxExec,
+  type TmuxExecResult,
+} from '../../src/status/pane-capture.js'
+
+function recordingExec(result: TmuxExecResult): { exec: TmuxExec; argv: string[][] } {
+  const argv: string[][] = []
+  const exec: TmuxExec = async (args) => {
+    argv.push([...args])
+    return result
+  }
+  return { exec, argv }
+}
+
+describe('stripAnsi', () => {
+  test('removes CSI colour codes but keeps text + newlines', () => {
+    const input = '\x1b[31mred\x1b[0m\nplain\ttab'
+    expect(stripAnsi(input)).toBe('red\nplain\ttab')
+  })
+
+  test('removes OSC (title) sequences and bare control chars', () => {
+    const input = '\x1b]0;title\x07hello\x00world'
+    expect(stripAnsi(input)).toBe('helloworld')
+  })
+})
+
+describe('capturePaneText', () => {
+  test('builds the capture-pane argv with socket + line count, strips ANSI', async () => {
+    const { exec, argv } = recordingExec({ stdout: '\x1b[1m◼ Task\x1b[0m\n', stderr: '', exitCode: 0 })
+    const res = await capturePaneText(exec, {
+      paneTarget: 'channel-thrall:0.0',
+      socketName: 'sock',
+      lineCount: 200,
+    })
+    expect(res.ok).toBe(true)
+    expect(res.text).toBe('◼ Task\n')
+    expect(argv[0]).toEqual(['-L', 'sock', 'capture-pane', '-p', '-t', 'channel-thrall:0.0', '-S', '-200'])
+  })
+
+  test('omits the -L flag when no socket name', async () => {
+    const { exec, argv } = recordingExec({ stdout: 'x', stderr: '', exitCode: 0 })
+    await capturePaneText(exec, { paneTarget: 'p', lineCount: 50 })
+    expect(argv[0]).toEqual(['capture-pane', '-p', '-t', 'p', '-S', '-50'])
+  })
+
+  test('non-zero exit surfaces ok:false with the stderr reason', async () => {
+    const { exec } = recordingExec({ stdout: '', stderr: "can't find pane", exitCode: 1 })
+    const res = await capturePaneText(exec, { paneTarget: 'gone', lineCount: 10 })
+    expect(res.ok).toBe(false)
+    expect(res.text).toBe('')
+    expect(res.error).toBe("can't find pane")
+  })
+})
+
+describe('resolvePaneCwd', () => {
+  test('returns the trimmed pane_current_path', async () => {
+    const { exec, argv } = recordingExec({ stdout: '/home/agent/repo\n', stderr: '', exitCode: 0 })
+    const cwd = await resolvePaneCwd(exec, { paneTarget: 'p', lineCount: 1 })
+    expect(cwd).toBe('/home/agent/repo')
+    expect(argv[0]).toEqual(['display-message', '-p', '-t', 'p', '#{pane_current_path}'])
+  })
+
+  test('returns null on a failed display-message (degrade path)', async () => {
+    const { exec } = recordingExec({ stdout: '', stderr: 'no server', exitCode: 1 })
+    expect(await resolvePaneCwd(exec, { paneTarget: 'p', lineCount: 1 })).toBeNull()
+  })
+
+  test('returns null on empty output', async () => {
+    const { exec } = recordingExec({ stdout: '\n', stderr: '', exitCode: 0 })
+    expect(await resolvePaneCwd(exec, { paneTarget: 'p', lineCount: 1 })).toBeNull()
+  })
+})

--- a/plugin/tests/status/task-freshness.test.ts
+++ b/plugin/tests/status/task-freshness.test.ts
@@ -1,0 +1,120 @@
+// Tests for the freshness indicator: the exact «сверено / УСТАРЕЛИ / НЕ СВЕРЕНО
+// / завершена» strings (contractually stable) + how the two surfaces embed them.
+
+import { describe, expect, test } from 'bun:test'
+import {
+  bucketAge,
+  formatUtcHm,
+  renderFreshnessHeader,
+  type TaskFreshness,
+} from '../../src/status/task-freshness.js'
+import { renderStatusTasks } from '../../src/status/context-hud.js'
+import { renderTodoList } from '../../src/status/task-mirror.js'
+import type { TodoItem } from '../../src/schemas.js'
+
+describe('bucketAge', () => {
+  test('sub-minute → «меньше минуты»', () => {
+    expect(bucketAge(0)).toBe('меньше минуты')
+    expect(bucketAge(59_999)).toBe('меньше минуты')
+  })
+  test('minutes floored', () => {
+    expect(bucketAge(60_000)).toBe('1 мин')
+    expect(bucketAge(179_000)).toBe('2 мин')
+  })
+})
+
+describe('formatUtcHm', () => {
+  test('formats HH:MM in UTC, zero-padded', () => {
+    // 2026-07-09T08:05:00Z
+    expect(formatUtcHm(Date.UTC(2026, 6, 9, 8, 5, 0))).toBe('08:05')
+  })
+})
+
+describe('renderFreshnessHeader — verbatim contract', () => {
+  test('fresh, <1 min', () => {
+    expect(renderFreshnessHeader({ kind: 'fresh', reconciledAgeMs: 5_000 })).toEqual({
+      label: '<b>Задачи</b> · <i>сверено меньше минуты назад</i>',
+    })
+  })
+  test('fresh, N min', () => {
+    expect(renderFreshnessHeader({ kind: 'fresh', reconciledAgeMs: 130_000 })).toEqual({
+      label: '<b>Задачи</b> · <i>сверено 2 мин назад</i>',
+    })
+  })
+  test('stale', () => {
+    expect(
+      renderFreshnessHeader({ kind: 'stale', reconciledAgeMs: 120_000, eventAgeMs: 30_000 }),
+    ).toEqual({
+      label: '<b>Задачи — ДАННЫЕ УСТАРЕЛИ</b>',
+      sub: '<i>сверено 2 мин назад · событие меньше минуты назад</i>',
+    })
+  })
+  test('unverified', () => {
+    expect(renderFreshnessHeader({ kind: 'unverified' })).toEqual({
+      label: '<b>Задачи — НЕ СВЕРЕНО</b>',
+      sub: '<i>Показаны только события инструментов</i>',
+    })
+  })
+  test('ended with a reconciled time', () => {
+    expect(renderFreshnessHeader({ kind: 'ended', reconciledAtLabel: '08:05' })).toEqual({
+      label: '<b>Задачи</b> · <i>сессия завершена · сверено 08:05 UTC</i>',
+    })
+  })
+  test('ended without any reconciliation', () => {
+    expect(renderFreshnessHeader({ kind: 'ended', reconciledAtLabel: null })).toEqual({
+      label: '<b>Задачи</b> · <i>сессия завершена</i>',
+    })
+  })
+})
+
+describe('minute-bucket stability (edit-only-on-bucket-cross)', () => {
+  test('two ages inside one bucket render identical labels', () => {
+    const a = renderFreshnessHeader({ kind: 'fresh', reconciledAgeMs: 30_000 })
+    const b = renderFreshnessHeader({ kind: 'fresh', reconciledAgeMs: 59_000 })
+    expect(a).toEqual(b)
+  })
+  test('crossing a minute changes the label', () => {
+    const a = renderFreshnessHeader({ kind: 'fresh', reconciledAgeMs: 59_000 })
+    const b = renderFreshnessHeader({ kind: 'fresh', reconciledAgeMs: 61_000 })
+    expect(a).not.toEqual(b)
+  })
+})
+
+const todos: TodoItem[] = [
+  { id: '1', content: 'Build', status: 'in_progress' },
+  { id: '2', content: 'Ship', status: 'pending' },
+]
+
+describe('surface embedding — context HUD', () => {
+  const fresh: TaskFreshness = { kind: 'fresh', reconciledAgeMs: 5_000 }
+  test('renderStatusTasks uses the freshness label in place of «Задачи»', () => {
+    const out = renderStatusTasks(todos, fresh)
+    expect(out.startsWith('<b>Задачи</b> · <i>сверено меньше минуты назад</i> ')).toBe(true)
+    expect(out).toContain('0/2') // done/total bar counts still present
+  })
+  test('stale subline is rendered above the blockquote', () => {
+    const out = renderStatusTasks(todos, { kind: 'stale', reconciledAgeMs: 120_000, eventAgeMs: 30_000 })
+    expect(out).toContain('<b>Задачи — ДАННЫЕ УСТАРЕЛИ</b>')
+    expect(out).toContain('<i>сверено 2 мин назад · событие меньше минуты назад</i>')
+  })
+  test('no freshness → legacy «Задачи» header (back-compat)', () => {
+    expect(renderStatusTasks(todos).startsWith('<b>Задачи</b> ')).toBe(true)
+  })
+})
+
+describe('surface embedding — TaskMirror', () => {
+  test('renderTodoList swaps the header for the freshness label + subline', () => {
+    const out = renderTodoList(todos, 5, undefined, { kind: 'unverified' })
+    const lines = out.split('\n')
+    expect(lines[0]).toBe('<b>Задачи — НЕ СВЕРЕНО</b>')
+    expect(lines[1]).toBe('<i>Показаны только события инструментов</i>')
+    expect(lines[2]).toBe('0 done / 1 in progress / 1 pending')
+  })
+  test('empty list still carries the freshness header', () => {
+    const out = renderTodoList([], 5, undefined, { kind: 'ended', reconciledAtLabel: '09:00' })
+    expect(out).toBe('<b>Задачи</b> · <i>сессия завершена · сверено 09:00 UTC</i>\n<i>задач нет</i>')
+  })
+  test('no freshness → legacy header', () => {
+    expect(renderTodoList(todos, 5).startsWith('<b>Задачи</b>\n')).toBe(true)
+  })
+})

--- a/plugin/tests/status/task-freshness.test.ts
+++ b/plugin/tests/status/task-freshness.test.ts
@@ -118,3 +118,11 @@ describe('surface embedding — TaskMirror', () => {
     expect(renderTodoList(todos, 5).startsWith('<b>Задачи</b>\n')).toBe(true)
   })
 })
+
+describe('expired (hard-TTL terminal state, review 2026-07-10 #7)', () => {
+  test('verbatim label', () => {
+    expect(renderFreshnessHeader({ kind: 'expired' })).toEqual({
+      label: '<b>Задачи</b> · <i>данные не обновляются</i>',
+    })
+  })
+})

--- a/plugin/tests/status/task-mirror.test.ts
+++ b/plugin/tests/status/task-mirror.test.ts
@@ -1202,3 +1202,41 @@ describe('#6 legacy snapshots without lastActivityMs use file mtime', () => {
     expect(edits[0]!.text).toContain('сессия завершена')
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────
+// Review fix-loop round 3 (2026-07-10)
+// ─────────────────────────────────────────────────────────────────────
+
+describe('r3 #5 — epoch persists BEFORE the awaited displacement finalize', () => {
+  test('crash mid-finalize (hanging edit) still leaves s2 active, s1 retired on disk', async () => {
+    const dir = stateDir()
+    const api = makeFakeApi()
+    const clock = new FakeClock()
+    const { mirror } = makeMirror({ api, clock, stateDir: dir })
+
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Работа s1', status: 'in_progress' }], 's1'))
+    await mirror._idleForTests('chat-1')
+    clock.advance(3001)
+
+    // Finalize's final edit HANGS — simulates a crash between the epoch
+    // mutation and message delivery. Pre-fix the epoch was persisted only
+    // after the awaited edit, so a crash here restored the OLD epoch.
+    api.api.editMessageText = () => new Promise<void>(() => {})
+    void mirror.recordEvent('chat-1', todoEvent([{ content: 'Работа s2', status: 'in_progress' }], 's2'))
+    await new Promise((r) => setTimeout(r, 0))
+    await new Promise((r) => setTimeout(r, 0))
+
+    const { readFileSync } = await import('node:fs')
+    const persisted = JSON.parse(
+      readFileSync(join(dir, 'task-mirror-chat-1.json'), 'utf8'),
+    ) as { epoch?: { active?: string; retired?: string[] } }
+    expect(persisted.epoch?.active).toBe('s2')
+    expect(persisted.epoch?.retired).toContain('s1')
+
+    // «Restart»: the persisted epoch drops the dead session's stragglers.
+    const second = makeMirror({ stateDir: dir })
+    await second.mirror.recordEvent('chat-1', todoEvent([{ content: 'призрак s1', status: 'pending' }], 's1'))
+    await second.mirror._idleForTests('chat-1')
+    expect(second.api.calls).toHaveLength(0)
+  })
+})

--- a/plugin/tests/status/task-mirror.test.ts
+++ b/plugin/tests/status/task-mirror.test.ts
@@ -17,7 +17,10 @@
 //  10. collapse_completed_after: «+M завершено ранее» tail.
 //  11. Long todo lines stay under Telegram's 4096-char cap.
 
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import {
   TaskMirror,
@@ -159,7 +162,26 @@ function makeFakeApi(): FakeApi {
   return state
 }
 
-function makeMirror(opts: { config?: AppConfig; clock?: FakeClock; api?: FakeApi } = {}): {
+// Track temp dirs for cleanup (persistence tests).
+const tmpDirs: string[] = []
+function stateDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'task-mirror-'))
+  tmpDirs.push(d)
+  return d
+}
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) {
+    try {
+      rmSync(d, { recursive: true, force: true })
+    } catch {
+      /* ignore */
+    }
+  }
+})
+
+function makeMirror(
+  opts: { config?: AppConfig; clock?: FakeClock; api?: FakeApi; stateDir?: string } = {},
+): {
   mirror: TaskMirror
   clock: FakeClock
   api: FakeApi
@@ -175,21 +197,27 @@ function makeMirror(opts: { config?: AppConfig; clock?: FakeClock; api?: FakeApi
     now: () => clock.now,
     setTimer: clock.setTimer,
     clearTimer: clock.clearTimer,
+    ...(opts.stateDir !== undefined ? { stateDir: opts.stateDir } : {}),
   })
   return { mirror, clock, api, config }
 }
 
-function todoEvent(todos: TodoItem[]): TaskMirrorEvent {
-  return { kind: 'todo_write', todos }
+// Default session id used by the helpers so existing tests keep a single,
+// stable session unless they explicitly pass a different one.
+const SID = 'sess-A'
+
+function todoEvent(todos: TodoItem[], sessionId: string = SID): TaskMirrorEvent {
+  return { kind: 'todo_write', sessionId, todos }
 }
 
 function taskCreateEvent(
   toolUseId: string,
   subject: string,
-  opts: { activeForm?: string; toolResult?: string } = {},
+  opts: { activeForm?: string; toolResult?: string; sessionId?: string } = {},
 ): TaskMirrorEvent {
   const event: Extract<TaskMirrorEvent, { kind: 'task_create' }> = {
     kind: 'task_create',
+    sessionId: opts.sessionId ?? SID,
     toolUseId,
     input: {
       subject,
@@ -208,9 +236,11 @@ function taskUpdateEvent(
     subject: string
     activeForm: string
   }>,
+  sessionId: string = SID,
 ): TaskMirrorEvent {
   return {
     kind: 'task_update',
+    sessionId,
     toolUseId: `tu-update-${taskId}`,
     input: {
       taskId,
@@ -219,7 +249,13 @@ function taskUpdateEvent(
   }
 }
 
-const STOP: TaskMirrorEvent = { kind: 'todo_session_stop' }
+function sessionStart(sessionId: string, source?: 'startup' | 'resume' | 'clear' | 'compact'): TaskMirrorEvent {
+  return { kind: 'session_start', sessionId, ...(source !== undefined ? { source } : {}) }
+}
+
+function sessionEnd(sessionId: string = SID): TaskMirrorEvent {
+  return { kind: 'session_end', sessionId }
+}
 
 // ─────────────────────────────────────────────────────────────────────
 // Tests — recordEvent / lifecycle
@@ -306,7 +342,7 @@ describe('TaskMirror', () => {
     expect(edits[0]!.text).toContain('Step C')
   })
 
-  test('session_stop ships final edit with «сессия завершена» marker and evicts entry', async () => {
+  test('session_end ships final edit with «сессия завершена» marker and evicts entry', async () => {
     const { mirror, clock, api } = makeMirror()
     await mirror.recordEvent('chat-1', todoEvent([
       { content: 'Step A', status: 'in_progress' },
@@ -319,7 +355,7 @@ describe('TaskMirror', () => {
     const editsBeforeStop = api.calls.filter((c) => c.kind === 'edit').length
     expect(editsBeforeStop).toBeGreaterThanOrEqual(1)
 
-    await mirror.recordEvent('chat-1', STOP)
+    await mirror.recordEvent('chat-1', sessionEnd())
     // Final edit contains the «сессия завершена» marker.
     const editsAfterStop = api.calls.filter((c) => c.kind === 'edit')
     const finalEdit = editsAfterStop[editsAfterStop.length - 1]
@@ -336,7 +372,7 @@ describe('TaskMirror', () => {
     expect(sends[1]!.messageId).toBe(201)
   })
 
-  test('session_stop on an unchanged snapshot STILL fires a final edit (marker breaks idempotency)', async () => {
+  test('session_end on an unchanged snapshot STILL fires a final edit (marker breaks idempotency)', async () => {
     const { mirror, clock, api } = makeMirror()
     // One TodoWrite — establishes the message.
     await mirror.recordEvent('chat-1', todoEvent([
@@ -349,13 +385,16 @@ describe('TaskMirror', () => {
 
     // STOP: even though the snapshot is byte-for-byte the same as the initial
     // send, the marker guarantees the final text differs, so an edit fires.
-    await mirror.recordEvent('chat-1', STOP)
+    await mirror.recordEvent('chat-1', sessionEnd())
     const edits = api.calls.filter((c) => c.kind === 'edit')
     expect(edits.length).toBe(1)
     expect(edits[0]!.text).toContain('сессия завершена')
   })
 
-  test('TTL eviction: idle entry past session_ttl_ms starts a fresh thread', async () => {
+  test('TTL does NOT expire an active same-session snapshot (orphan cleanup only)', async () => {
+    // New semantics: the mirror no longer finalizes on Stop, so an idle gap is
+    // normal. A same-session update after a long idle must EDIT the existing
+    // message, never start a fresh thread — the warchief keeps his task list.
     const { mirror, clock, api } = makeMirror({
       config: makeConfig({ session_ttl_ms: 60_000 }),
     })
@@ -364,18 +403,21 @@ describe('TaskMirror', () => {
     ]))
     expect(api.calls.filter((c) => c.kind === 'send').length).toBe(1)
 
-    clock.advance(60_001)
+    clock.advance(60_001) // long idle, but SAME session
     await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Step A', status: 'completed' },
       { content: 'Step B', status: 'in_progress' },
     ]))
+    await mirror._idleForTests('chat-1')
     const sends = api.calls.filter((c) => c.kind === 'send')
     const edits = api.calls.filter((c) => c.kind === 'edit')
-    expect(sends.length).toBe(2)
-    expect(sends[1]!.messageId).toBe(201)
-    expect(edits.length).toBe(0)
+    expect(sends.length).toBe(1) // no fresh thread
+    expect(edits.length).toBe(1) // same message edited in place
+    expect(edits[0]!.messageId).toBe(200)
+    expect(edits[0]!.text).toContain('Step B')
   })
 
-  test('multi-chat isolation: chat A stop does not affect chat B', async () => {
+  test('multi-chat isolation: chat A session end does not affect chat B', async () => {
     const { mirror, clock, api } = makeMirror()
     await mirror.recordEvent('chat-A', todoEvent([
       { content: 'A1', status: 'in_progress' },
@@ -386,7 +428,7 @@ describe('TaskMirror', () => {
     const sendsAfterInit = api.calls.filter((c) => c.kind === 'send')
     expect(sendsAfterInit.length).toBe(2)
 
-    await mirror.recordEvent('chat-A', STOP)
+    await mirror.recordEvent('chat-A', sessionEnd())
     clock.advance(3001)
     // Chat B still owns its message.
     await mirror.recordEvent('chat-B', todoEvent([
@@ -406,7 +448,7 @@ describe('TaskMirror', () => {
     await mirror.recordEvent('chat-1', todoEvent([
       { content: 'X', status: 'in_progress' },
     ]))
-    await mirror.recordEvent('chat-1', STOP)
+    await mirror.recordEvent('chat-1', sessionEnd())
     expect(api.calls.length).toBe(0)
   })
 
@@ -509,6 +551,154 @@ describe('TaskMirror', () => {
     expect(sends.length).toBe(1)
     expect(sends[0]!.text).toContain('Recovered')
     expect(sends[0]!.text).toContain('1 in progress')
+  })
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Session lifecycle (namespacing) — the reset/finalize semantics
+  // ─────────────────────────────────────────────────────────────────────
+
+  test('three task_create events → canonical ids, correct order, no provisional duplicate', async () => {
+    const { mirror, api, clock } = makeMirror()
+    // Each PostToolUse create carries the harness id via toolResult.
+    await mirror.recordEvent('chat-1', taskCreateEvent('tu-1', 'First', { toolResult: 'Task #1 created' }))
+    clock.advance(3000)
+    await mirror.recordEvent('chat-1', taskCreateEvent('tu-2', 'Second', { toolResult: 'Task #2 created' }))
+    clock.advance(3000)
+    await mirror.recordEvent('chat-1', taskCreateEvent('tu-3', 'Third', { toolResult: 'Task #3 created' }))
+    await mirror._idleForTests('chat-1')
+    const last = [...api.calls].reverse().find((c) => c.kind === 'edit' || c.kind === 'send')!
+    expect(last.text).toContain('3 pending')
+    // Order preserved and no duplicated rows.
+    expect(last.text.indexOf('First')).toBeLessThan(last.text.indexOf('Second'))
+    expect(last.text.indexOf('Second')).toBeLessThan(last.text.indexOf('Third'))
+    expect((last.text.match(/First/g) ?? []).length).toBe(1)
+  })
+
+  test('session_start with the SAME id preserves the snapshot (compact)', async () => {
+    const { mirror, api, clock } = makeMirror()
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Ongoing', status: 'in_progress' }], 'sess-A'))
+    clock.advance(3000)
+    // Compact fires SessionStart with the same id — must NOT reset or send anew.
+    await mirror.recordEvent('chat-1', sessionStart('sess-A', 'compact'))
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Ongoing', status: 'completed' },
+      { content: 'Next', status: 'in_progress' },
+    ], 'sess-A'))
+    await mirror._idleForTests('chat-1')
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(sends.length).toBe(1) // no fresh thread on compact
+    expect(edits[edits.length - 1]!.text).toContain('Next')
+    // No «сессия завершена» marker — the session did not end.
+    expect(api.calls.every((c) => !c.text.includes('сессия завершена'))).toBe(true)
+  })
+
+  test('session_start with a NEW id finalizes the old snapshot and starts fresh', async () => {
+    const { mirror, api, clock } = makeMirror()
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Old task', status: 'in_progress' }], 'sess-A'))
+    clock.advance(3000)
+    await mirror.recordEvent('chat-1', sessionStart('sess-B', 'startup'))
+    // Old message got a final «сессия завершена» edit.
+    const finalEdit = api.calls.filter((c) => c.kind === 'edit').pop()
+    expect(finalEdit!.text).toContain('сессия завершена')
+    // New session's first task → a brand-new message (msg 201).
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'New task', status: 'in_progress' }], 'sess-B'))
+    await mirror._idleForTests('chat-1')
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(2)
+    expect(sends[1]!.messageId).toBe(201)
+    expect(sends[1]!.text).toContain('New task')
+  })
+
+  test('task event with a new session id resets even without a SessionStart hook', async () => {
+    const { mirror, api, clock } = makeMirror()
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Alpha', status: 'in_progress' }], 'sess-A'))
+    clock.advance(3000)
+    // First event of a new session, SessionStart missed → still resets.
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Beta', status: 'in_progress' }], 'sess-B'))
+    await mirror._idleForTests('chat-1')
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(2) // fresh message for the new session
+    expect(sends[1]!.text).toContain('Beta')
+    expect(sends[1]!.text).not.toContain('Alpha')
+  })
+
+  test('burst updates across a session transition do not overwrite the new session message', async () => {
+    const { mirror, api, clock } = makeMirror()
+    // Session A: a burst of updates, all within the throttle window (deferred).
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'A step 1', status: 'in_progress' }], 'sess-A'))
+    clock.advance(200)
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'A step 2', status: 'in_progress' }], 'sess-A'))
+    clock.advance(200)
+    // Session B begins mid-burst: finalize A (its pending edit is cancelled),
+    // then B sends its own message.
+    await mirror.recordEvent('chat-1', sessionStart('sess-B', 'clear'))
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'B step 1', status: 'in_progress' }], 'sess-B'))
+    await mirror._idleForTests('chat-1')
+    // Drain any stale A timer that might fire late.
+    clock.advance(5000)
+    await mirror._idleForTests('chat-1')
+
+    const bMessageId = api.calls.filter((c) => c.kind === 'send').pop()!.messageId!
+    // No edit to B's message may contain session A content.
+    const bEdits = api.calls.filter((c) => c.kind === 'edit' && c.messageId === bMessageId)
+    for (const e of bEdits) {
+      expect(e.text).not.toContain('A step')
+    }
+    // B's message shows B's task.
+    const bView = [...api.calls].reverse().find((c) => c.messageId === bMessageId)!
+    expect(bView.text).toContain('B step 1')
+  })
+
+  test('persistence: a new instance with the same state dir restores the snapshot', async () => {
+    const dir = stateDir()
+    const api1 = makeFakeApi()
+    const clock = new FakeClock()
+    const first = makeMirror({ api: api1, clock, stateDir: dir })
+    await first.mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Persisted task', status: 'in_progress' },
+    ], 'sess-P'))
+    await first.mirror._idleForTests('chat-1')
+    const sentId = api1.calls.filter((c) => c.kind === 'send')[0]!.messageId!
+    expect(sentId).toBe(200)
+
+    // Simulate a plugin restart: brand-new mirror instance, SAME state dir.
+    const api2 = makeFakeApi()
+    const second = makeMirror({ api: api2, clock, stateDir: dir })
+    // Advance past the throttle window (in production Date.now() is already far
+    // past it; the fake clock starts at 0 so we step it explicitly).
+    clock.advance(3000)
+    // A same-session update must EDIT the restored message (id 200), not send anew.
+    await second.mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Persisted task', status: 'completed' },
+      { content: 'Follow-up', status: 'in_progress' },
+    ], 'sess-P'))
+    await second.mirror._idleForTests('chat-1')
+    const sends2 = api2.calls.filter((c) => c.kind === 'send')
+    const edits2 = api2.calls.filter((c) => c.kind === 'edit')
+    expect(sends2.length).toBe(0) // restored — no fresh message
+    expect(edits2.length).toBe(1)
+    expect(edits2[0]!.messageId).toBe(200)
+    expect(edits2[0]!.text).toContain('Follow-up')
+  })
+
+  test('persistence: a restart in a NEW session finalizes the restored old snapshot', async () => {
+    const dir = stateDir()
+    const api1 = makeFakeApi()
+    const clock = new FakeClock()
+    const first = makeMirror({ api: api1, clock, stateDir: dir })
+    await first.mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Old', status: 'in_progress' },
+    ], 'sess-old'))
+    await first.mirror._idleForTests('chat-1')
+
+    const api2 = makeFakeApi()
+    const second = makeMirror({ api: api2, clock, stateDir: dir })
+    // New session after restart → finalize the restored message, start fresh.
+    await second.mirror.recordEvent('chat-1', sessionStart('sess-new', 'startup'))
+    const finalEdit = api2.calls.filter((c) => c.kind === 'edit').pop()
+    expect(finalEdit!.messageId).toBe(200)
+    expect(finalEdit!.text).toContain('сессия завершена')
   })
 
   // ─────────────────────────────────────────────────────────────────────

--- a/plugin/tests/status/task-mirror.test.ts
+++ b/plugin/tests/status/task-mirror.test.ts
@@ -780,3 +780,77 @@ describe('TaskMirror', () => {
     expect(opens).toBe(closes)
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────
+// M3 reality mirror — applyReconciledView (freshness + dedup/bucket-cross)
+// ─────────────────────────────────────────────────────────────────────
+
+describe('applyReconciledView', () => {
+  const rvTodos: TodoItem[] = [
+    { id: '1', content: 'Alpha', status: 'in_progress' },
+    { id: '2', content: 'Beta', status: 'pending' },
+  ]
+
+  test('renders the freshness header and sends once', async () => {
+    const { mirror, api } = makeMirror()
+    await mirror.applyReconciledView('chat-1', {
+      sessionId: SID,
+      todos: rvTodos,
+      freshness: { kind: 'fresh', reconciledAgeMs: 5_000 },
+    })
+    await mirror._idleForTests('chat-1')
+    expect(api.calls.filter((c) => c.kind === 'send')).toHaveLength(1)
+    expect(api.calls[0]!.text).toContain('<b>Задачи</b> · <i>сверено меньше минуты назад</i>')
+  })
+
+  test('same content + same minute bucket ⇒ no follow-up edit (dedup)', async () => {
+    const { mirror, api, clock } = makeMirror()
+    await mirror.applyReconciledView('chat-1', {
+      sessionId: SID,
+      todos: rvTodos,
+      freshness: { kind: 'fresh', reconciledAgeMs: 5_000 },
+    })
+    await mirror._idleForTests('chat-1')
+    const editsAfterFirst = api.calls.filter((c) => c.kind === 'edit').length
+
+    clock.advance(3000) // clear the throttle window
+    await mirror.applyReconciledView('chat-1', {
+      sessionId: SID,
+      todos: rvTodos,
+      freshness: { kind: 'fresh', reconciledAgeMs: 40_000 }, // still «меньше минуты»
+    })
+    await mirror._idleForTests('chat-1')
+    expect(api.calls.filter((c) => c.kind === 'edit').length).toBe(editsAfterFirst)
+  })
+
+  test('crossing a minute bucket ⇒ one edit', async () => {
+    const { mirror, api, clock } = makeMirror()
+    await mirror.applyReconciledView('chat-1', {
+      sessionId: SID,
+      todos: rvTodos,
+      freshness: { kind: 'fresh', reconciledAgeMs: 5_000 },
+    })
+    await mirror._idleForTests('chat-1')
+    const before = api.calls.filter((c) => c.kind === 'edit').length
+
+    clock.advance(3000)
+    await mirror.applyReconciledView('chat-1', {
+      sessionId: SID,
+      todos: rvTodos,
+      freshness: { kind: 'fresh', reconciledAgeMs: 65_000 }, // now «1 мин»
+    })
+    await mirror._idleForTests('chat-1')
+    expect(api.calls.filter((c) => c.kind === 'edit').length).toBe(before + 1)
+  })
+
+  test('empty list before any message is NOT materialised', async () => {
+    const { mirror, api } = makeMirror()
+    await mirror.applyReconciledView('chat-1', {
+      sessionId: SID,
+      todos: [],
+      freshness: { kind: 'unverified' },
+    })
+    await mirror._idleForTests('chat-1')
+    expect(api.calls).toHaveLength(0)
+  })
+})

--- a/plugin/tests/status/task-mirror.test.ts
+++ b/plugin/tests/status/task-mirror.test.ts
@@ -1083,3 +1083,122 @@ describe('ended freshness suppresses the duplicate footer', () => {
     expect(occurrences).toBe(1)
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────
+// Review fix-loop round 2 (2026-07-10)
+// ─────────────────────────────────────────────────────────────────────
+
+describe('#2v2 rollback guard + persisted epochs', () => {
+  test('late SessionStart for a RETIRED session does not displace the active one', async () => {
+    const { mirror, api, clock } = makeMirror()
+    await mirror.recordEvent('chat-1', sessionStart('s1', 'startup'))
+    await mirror.recordEvent('chat-1', sessionEnd('s1'))
+    await mirror.recordEvent('chat-1', sessionStart('s2', 'startup'))
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Активная работа', status: 'in_progress' }], 's2'))
+    await mirror._idleForTests('chat-1')
+    const sendsBefore = api.calls.filter((c) => c.kind === 'send').length
+
+    // REPLAYED SessionStart for dead s1 while s2 is active: dropped entirely —
+    // s2's snapshot is not finalized and s1 stays retired.
+    await mirror.recordEvent('chat-1', sessionStart('s1', 'startup'))
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'призрак', status: 'pending' }], 's1'))
+    await mirror._idleForTests('chat-1')
+    expect(api.calls.filter((c) => c.kind === 'send').length).toBe(sendsBefore)
+    const lastEdit = api.calls.filter((c) => c.kind === 'edit').pop()
+    if (lastEdit) expect(lastEdit.text).not.toContain('призрак')
+
+    // s2 continues normally.
+    clock.advance(3001) // clear the edit throttle
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Активная работа', status: 'completed' }], 's2'))
+    await mirror._idleForTests('chat-1')
+    const all = [...api.calls].reverse()
+    expect(all.find((c) => c.kind === 'edit' || c.kind === 'send')!.text).toContain('1 done')
+  })
+
+  test('epochs survive a restart: a straggler from an ended session stays dropped', async () => {
+    const dir = stateDir()
+    const first = makeMirror({ stateDir: dir })
+    await first.mirror.recordEvent('chat-1', sessionStart('s1', 'startup'))
+    await first.mirror.recordEvent('chat-1', todoEvent([{ content: 'Работа', status: 'in_progress' }], 's1'))
+    await first.mirror._idleForTests('chat-1')
+    await first.mirror.recordEvent('chat-1', sessionEnd('s1')) // finalize → epoch-only snapshot
+
+    // «Restart»: fresh mirror, same state dir. Pre-fix the tombstones were
+    // runtime-only, so this straggler resurrected the dead session.
+    const second = makeMirror({ stateDir: dir })
+    await second.mirror.recordEvent('chat-1', todoEvent([{ content: 'призрак s1', status: 'pending' }], 's1'))
+    await second.mirror._idleForTests('chat-1')
+    expect(second.api.calls).toHaveLength(0) // dropped — no send, no edit
+
+    // A genuinely new session works.
+    await second.mirror.recordEvent('chat-1', todoEvent([{ content: 'Новая сессия', status: 'in_progress' }], 's2'))
+    await second.mirror._idleForTests('chat-1')
+    expect(second.api.calls.filter((c) => c.kind === 'send')).toHaveLength(1)
+  })
+})
+
+describe('#5 flush convergence', () => {
+  test('a mutation racing an in-flight flush still lands its own edit', async () => {
+    const { mirror, api, clock } = makeMirror()
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Шаг 1', status: 'in_progress' }]))
+    await mirror._idleForTests('chat-1')
+    clock.advance(3001)
+    // Two mutations in quick succession: the first fires an immediate edit,
+    // the second lands while it is in flight. The convergence loop must
+    // deliver the SECOND content without waiting for another event.
+    void mirror.recordEvent('chat-1', todoEvent([{ content: 'Шаг 1', status: 'completed' }]))
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Шаг 1', status: 'completed' },
+      { content: 'Шаг 2', status: 'in_progress' },
+    ]))
+    clock.advance(3001) // let the converged follow-up pass the throttle
+    await mirror._idleForTests('chat-1')
+    const lastEdit = api.calls.filter((c) => c.kind === 'edit').pop()!
+    expect(lastEdit.text).toContain('Шаг 2')
+  })
+})
+
+describe('#6 legacy snapshots without lastActivityMs use file mtime', () => {
+  test('an old v1 file (old mtime) is dropped silently on session change', async () => {
+    const dir = stateDir()
+    const path = join(dir, 'task-mirror-chat-1.json')
+    // v1 shape: no lastActivityMs, no dirty, no epoch.
+    writeFileSync(path, JSON.stringify({
+      sessionId: 'old-sess',
+      messageId: 200,
+      todos: [{ content: 'Ancient', status: 'in_progress' }],
+    }))
+    const twentyMinAgo = (Date.now() - 20 * 60 * 1000) / 1000
+    const { utimesSync } = await import('node:fs')
+    utimesSync(path, twentyMinAgo, twentyMinAgo)
+
+    const { mirror, clock, api } = makeMirror({ stateDir: dir })
+    clock.now = Date.now() // real clock so mtime comparison is meaningful
+
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Новая', status: 'in_progress' }], 'new-sess'))
+    await mirror._idleForTests('chat-1')
+    // Pre-fix: missing lastActivityMs defaulted to NOW ⇒ artificial freshness
+    // ⇒ graceful finalize EDIT on the ancient message. Now: silent drop.
+    expect(api.calls.filter((c) => c.kind === 'edit')).toHaveLength(0)
+    expect(api.calls.filter((c) => c.kind === 'send')).toHaveLength(1)
+  })
+
+  test('an old v1 file with FRESH mtime still finalizes gracefully', async () => {
+    const dir = stateDir()
+    const path = join(dir, 'task-mirror-chat-1.json')
+    writeFileSync(path, JSON.stringify({
+      sessionId: 'old-sess',
+      messageId: 200,
+      todos: [{ content: 'Recent', status: 'in_progress' }],
+    })) // mtime = now
+    const { mirror, clock, api } = makeMirror({ stateDir: dir })
+    clock.now = Date.now()
+
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Новая', status: 'in_progress' }], 'new-sess'))
+    await mirror._idleForTests('chat-1')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(edits).toHaveLength(1)
+    expect(edits[0]!.messageId).toBe(200)
+    expect(edits[0]!.text).toContain('сессия завершена')
+  })
+})

--- a/plugin/tests/status/task-mirror.test.ts
+++ b/plugin/tests/status/task-mirror.test.ts
@@ -18,7 +18,7 @@
 //  11. Long todo lines stay under Telegram's 4096-char cap.
 
 import { afterEach, describe, expect, test } from 'bun:test'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -361,11 +361,19 @@ describe('TaskMirror', () => {
     const finalEdit = editsAfterStop[editsAfterStop.length - 1]
     expect(finalEdit!.text).toContain('сессия завершена')
 
-    // Subsequent event after stop: must send a NEW message (msg_id 201, since
-    // 200 was the original send).
+    // A LATE straggler naming the ENDED session is DROPPED (review 2026-07-09
+    // #2: the session is tombstoned — no resurrection, no new message).
+    await mirror.recordEvent('chat-1', todoEvent([
+      { content: 'Straggler from dead session', status: 'in_progress' },
+    ]))
+    await mirror._idleForTests('chat-1')
+    expect(api.calls.filter((c) => c.kind === 'send').length).toBe(1)
+
+    // An event from a NEW session gets a fresh message (msg_id 201, since 200
+    // was the original send).
     await mirror.recordEvent('chat-1', todoEvent([
       { content: 'New task', status: 'in_progress' },
-    ]))
+    ], 'sess-B'))
     await mirror._idleForTests('chat-1')
     const sends = api.calls.filter((c) => c.kind === 'send')
     expect(sends.length).toBe(2)
@@ -852,5 +860,226 @@ describe('applyReconciledView', () => {
     })
     await mirror._idleForTests('chat-1')
     expect(api.calls).toHaveLength(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// Review fix-loop 2026-07-09 — session epochs / tombstones (#2)
+// ─────────────────────────────────────────────────────────────────────
+
+describe('session epochs and tombstones', () => {
+  test('end(s1) → start(s2): s2 is active immediately; late s1 mutation dropped', async () => {
+    const { mirror, api } = makeMirror()
+    await mirror.recordEvent('chat-1', sessionStart('s1', 'startup'))
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Old work', status: 'in_progress' }], 's1'))
+    await mirror._idleForTests('chat-1')
+    expect(api.calls.filter((c) => c.kind === 'send').length).toBe(1)
+
+    await mirror.recordEvent('chat-1', sessionEnd('s1'))
+    // s2 starts — NO tasks yet, but the session must be tracked as active NOW
+    // (pre-fix nothing was stored until the first mutation).
+    await mirror.recordEvent('chat-1', sessionStart('s2', 'startup'))
+
+    // Late straggler from retired s1: dropped — no reset, no new message.
+    const callsBefore = api.calls.length
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Ghost of s1', status: 'pending' }], 's1'))
+    await mirror._idleForTests('chat-1')
+    expect(api.calls.length).toBe(callsBefore)
+
+    // s2's own first mutation creates a fresh message.
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'New era', status: 'in_progress' }], 's2'))
+    await mirror._idleForTests('chat-1')
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(2)
+    expect(sends[1]!.text).toContain('New era')
+  })
+
+  test('end(s1) → resume(s1): SessionStart un-retires, s1 mutations flow again', async () => {
+    const { mirror, api } = makeMirror()
+    await mirror.recordEvent('chat-1', sessionStart('s1', 'startup'))
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Work', status: 'in_progress' }], 's1'))
+    await mirror._idleForTests('chat-1')
+    await mirror.recordEvent('chat-1', sessionEnd('s1'))
+
+    // Resume: the SAME id starts again (claude -r).
+    await mirror.recordEvent('chat-1', sessionStart('s1', 'resume'))
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Resumed work', status: 'in_progress' }], 's1'))
+    await mirror._idleForTests('chat-1')
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(2) // finalize evicted the old entry → fresh message
+    expect(sends[1]!.text).toContain('Resumed work')
+  })
+
+  test('late SessionEnd naming a RETIRED session does not finalize the active one', async () => {
+    const { mirror, api } = makeMirror()
+    await mirror.recordEvent('chat-1', sessionStart('s1', 'startup'))
+    await mirror.recordEvent('chat-1', sessionStart('s2', 'startup')) // s1 retired
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Active B work', status: 'in_progress' }], 's2'))
+    await mirror._idleForTests('chat-1')
+    const editsBefore = api.calls.filter((c) => c.kind === 'edit').length
+
+    // Late end from dead s1 — must NOT touch s2's mirror.
+    await mirror.recordEvent('chat-1', sessionEnd('s1'))
+    await mirror._idleForTests('chat-1')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(edits.length).toBe(editsBefore) // no «сессия завершена» edit fired
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// Review fix-loop 2026-07-09 — persistence correctness (#3)
+// ─────────────────────────────────────────────────────────────────────
+
+describe('persistence correctness', () => {
+  test('#3a restart with a pending throttled edit replays it (dirty flag)', async () => {
+    const dir = stateDir()
+    const first = makeMirror({ stateDir: dir })
+    await first.mirror.recordEvent('chat-1', todoEvent([{ content: 'Step A', status: 'in_progress' }]))
+    await first.mirror._idleForTests('chat-1')
+    // Second mutation INSIDE the throttle window: persisted eagerly, edit deferred.
+    await first.mirror.recordEvent('chat-1', todoEvent([{ content: 'Step A', status: 'completed' }]))
+    expect(first.api.calls.filter((c) => c.kind === 'edit').length).toBe(0) // still throttled
+
+    // «Crash» before the timer fires → new process, same state dir.
+    const second = makeMirror({ stateDir: dir })
+    // An IDENTICAL follow-up event (pre-fix: suppressed by restored
+    // lastRenderedText, remote message stale forever).
+    await second.mirror.recordEvent('chat-1', todoEvent([{ content: 'Step A', status: 'completed' }]))
+    second.clock.advance(3001) // FakeClock starts at 0 ⇒ let the throttle window pass
+    await second.mirror._idleForTests('chat-1')
+    const edits = second.api.calls.filter((c) => c.kind === 'edit')
+    expect(edits.length).toBeGreaterThanOrEqual(1)
+    expect(edits[edits.length - 1]!.text).toContain('1 done')
+  })
+
+  test('#3a restart after a REJECTED edit replays it', async () => {
+    const dir = stateDir()
+    const first = makeMirror({ stateDir: dir })
+    await first.mirror.recordEvent('chat-1', todoEvent([{ content: 'Step A', status: 'in_progress' }]))
+    await first.mirror._idleForTests('chat-1')
+    first.clock.advance(3001) // past throttle so the edit fires immediately…
+    first.api.failEditWith = new Error('500 telegram hiccup') // …and FAILS
+    await first.mirror.recordEvent('chat-1', todoEvent([{ content: 'Step A', status: 'completed' }]))
+    await first.mirror._idleForTests('chat-1')
+
+    const second = makeMirror({ stateDir: dir })
+    await second.mirror.recordEvent('chat-1', todoEvent([{ content: 'Step A', status: 'completed' }]))
+    second.clock.advance(3001) // FakeClock starts at 0 ⇒ let the throttle window pass
+    await second.mirror._idleForTests('chat-1')
+    const edits = second.api.calls.filter((c) => c.kind === 'edit')
+    expect(edits.length).toBeGreaterThanOrEqual(1)
+    expect(edits[edits.length - 1]!.text).toContain('1 done')
+  })
+
+  test('#3b a persisted snapshot with invalid todos is quarantined, mirror continues fresh', async () => {
+    const dir = stateDir()
+    writeFileSync(
+      join(dir, 'task-mirror-chat-1.json'),
+      JSON.stringify({ messageId: 200, todos: [null] }),
+    )
+    const { mirror, api } = makeMirror({ stateDir: dir })
+    // Pre-fix: threw at `t.id` on EVERY event — permanent wedge.
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'Fresh start', status: 'in_progress' }]))
+    await mirror._idleForTests('chat-1')
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(1) // fresh message; invalid snapshot ignored
+    expect(sends[0]!.text).toContain('Fresh start')
+  })
+
+  test('#3c persisted lastActivityMs makes an ancient orphan drop silently after restart', async () => {
+    const dir = stateDir()
+    // Simulate an old install: snapshot persisted 20 minutes ago (clock=0 era).
+    writeFileSync(
+      join(dir, 'task-mirror-chat-1.json'),
+      JSON.stringify({
+        sessionId: 'old-sess',
+        messageId: 200,
+        todos: [{ content: 'Ancient task', status: 'in_progress' }],
+        dirty: false,
+        lastActivityMs: 0,
+      }),
+    )
+    const { mirror, clock, api } = makeMirror({ stateDir: dir })
+    clock.now = 20 * 60 * 1000 // 20 min later; TTL default = 10 min
+
+    // A NEW session arrives: the restored entry is an ancient orphan — it must
+    // be dropped SILENTLY (no «сессия завершена» edit on the old message).
+    await mirror.recordEvent('chat-1', todoEvent([{ content: 'New life', status: 'in_progress' }], 'new-sess'))
+    await mirror._idleForTests('chat-1')
+    expect(api.calls.filter((c) => c.kind === 'edit').length).toBe(0)
+    const sends = api.calls.filter((c) => c.kind === 'send')
+    expect(sends.length).toBe(1)
+    expect(sends[0]!.text).toContain('New life')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// Review fix-loop 2026-07-09 — restart must not wipe a restored mirror (#10)
+// ─────────────────────────────────────────────────────────────────────
+
+describe('#10 empty-unverified reconciled view after restart', () => {
+  test('does not edit a restored populated message down to «задач нет»', async () => {
+    const dir = stateDir()
+    writeFileSync(
+      join(dir, 'task-mirror-chat-1.json'),
+      JSON.stringify({
+        sessionId: SID,
+        messageId: 200,
+        todos: [{ content: 'Живая задача', status: 'in_progress' }],
+        dirty: false,
+        lastActivityMs: 0,
+      }),
+    )
+    const { mirror, clock, api } = makeMirror({ stateDir: dir })
+    // Reconciler knows nothing yet right after restart.
+    await mirror.applyReconciledView('chat-1', {
+      sessionId: SID,
+      todos: [],
+      freshness: { kind: 'unverified' },
+    })
+    await mirror._idleForTests('chat-1')
+    expect(api.calls).toHaveLength(0) // no «задач нет» wipe
+
+    // Once the reconciler has real data, the message updates normally.
+    await mirror.applyReconciledView('chat-1', {
+      sessionId: SID,
+      todos: [{ content: 'Живая задача', status: 'completed' }],
+      freshness: { kind: 'fresh', reconciledAgeMs: 1_000 },
+    })
+    clock.advance(3001) // FakeClock starts at 0 ⇒ let the throttle window pass
+    await mirror._idleForTests('chat-1')
+    const edits = api.calls.filter((c) => c.kind === 'edit')
+    expect(edits.length).toBe(1)
+    expect(edits[0]!.text).toContain('1 done')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// Review fix-loop 2026-07-09 — no double «сессия завершена» (SHOULD)
+// ─────────────────────────────────────────────────────────────────────
+
+describe('ended freshness suppresses the duplicate footer', () => {
+  test('finalize after an ended reconciled view says «сессия завершена» exactly once', async () => {
+    const { mirror, api } = makeMirror()
+    await mirror.applyReconciledView('chat-1', {
+      sessionId: SID,
+      todos: [{ content: 'Done work', status: 'completed' }],
+      freshness: { kind: 'fresh', reconciledAgeMs: 1_000 },
+    })
+    await mirror._idleForTests('chat-1')
+    // Reality mirror pushes the frozen ended view…
+    await mirror.applyReconciledView('chat-1', {
+      sessionId: SID,
+      todos: [{ content: 'Done work', status: 'completed' }],
+      freshness: { kind: 'ended', reconciledAtLabel: '08:05' },
+    })
+    await mirror._idleForTests('chat-1')
+    // …then the webhook's session_end lands and finalizes.
+    await mirror.recordEvent('chat-1', sessionEnd())
+    await mirror._idleForTests('chat-1')
+    const all = [...api.calls].reverse()
+    const lastText = all.find((c) => c.kind === 'edit' || c.kind === 'send')!.text
+    const occurrences = (lastText.match(/сессия завершена/g) ?? []).length
+    expect(occurrences).toBe(1)
   })
 })

--- a/plugin/tests/status/task-reality-mirror.test.ts
+++ b/plugin/tests/status/task-reality-mirror.test.ts
@@ -1,0 +1,415 @@
+// Integration tests for the M3 TaskRealityMirror wiring: pane capture → parse →
+// validate → reconcile → push view, across the freshness variants (fresh /
+// unverified / stale / idle / ended), coalescing, immediate-capture triggers,
+// graceful no-tmux degradation, and the positional re-association pre-pass.
+//
+// All timers + the clock are injected (FakeClock) and the tmux exec is a stub,
+// so the tests are deterministic and touch no real tmux / Telegram.
+
+import { describe, expect, test } from 'bun:test'
+import {
+  TaskRealityMirror,
+  realignOrdinals,
+  reconciledToTodos,
+  numericOrdinal,
+  type ReconciledView,
+  type ReconciledViewSink,
+} from '../../src/status/task-reality-mirror.js'
+import type { TmuxExec, TmuxExecResult } from '../../src/status/pane-capture.js'
+import type { Logger } from '../../src/log.js'
+import type { TaskMirrorEvent } from '../../src/hooks/claude-events.js'
+import {
+  initialReconciledState,
+  parsePaneTaskList,
+  reconcileTaskState,
+  validateSnapshot,
+  type PaneProvenance,
+  type SessionBinding,
+} from '../../src/status/task-reconciler.js'
+
+// ── fakes ─────────────────────────────────────────────────────────────
+
+interface FakeTimer {
+  id: number
+  deadline: number
+  cb: () => void
+  fired: boolean
+}
+class FakeClock {
+  now = 1_000_000 // start well past 0 so ages are positive
+  next = 1
+  timers: FakeTimer[] = []
+  setTimer = (cb: () => void, ms: number): ReturnType<typeof setTimeout> => {
+    const t: FakeTimer = { id: this.next++, deadline: this.now + ms, cb, fired: false }
+    this.timers.push(t)
+    return t as unknown as ReturnType<typeof setTimeout>
+  }
+  clearTimer = (handle: ReturnType<typeof setTimeout>): void => {
+    ;(handle as unknown as FakeTimer).fired = true
+  }
+  advance(ms: number): void {
+    const deadline = this.now + ms
+    for (;;) {
+      const due = this.timers
+        .filter((t) => !t.fired && t.deadline <= deadline)
+        .sort((a, b) => a.deadline - b.deadline)[0]
+      if (!due) break
+      this.now = due.deadline
+      due.fired = true
+      due.cb()
+    }
+    this.now = deadline
+  }
+}
+
+const nullLog: Logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+} as unknown as Logger
+
+// Let all pending microtasks (async doCapture) settle.
+const flush = async (): Promise<void> => {
+  await new Promise((r) => setTimeout(r, 0))
+  await new Promise((r) => setTimeout(r, 0))
+}
+
+interface FakeExec {
+  exec: TmuxExec
+  captureCount: number
+}
+// paneProvider yields the current pane text; captureOk toggles capture success.
+function makeExec(
+  paneProvider: () => string,
+  opts: { cwd?: string; captureOk?: () => boolean } = {},
+): FakeExec {
+  const state: FakeExec = { exec: undefined as unknown as TmuxExec, captureCount: 0 }
+  state.exec = async (args): Promise<TmuxExecResult> => {
+    if (args.includes('capture-pane')) {
+      state.captureCount++
+      if (opts.captureOk && !opts.captureOk()) {
+        return { stdout: '', stderr: 'no pane', exitCode: 1 }
+      }
+      return { stdout: paneProvider(), stderr: '', exitCode: 0 }
+    }
+    if (args.includes('display-message')) {
+      return { stdout: `${opts.cwd ?? '/repo'}\n`, stderr: '', exitCode: 0 }
+    }
+    return { stdout: '', stderr: '', exitCode: 0 }
+  }
+  return state
+}
+
+function makeSink(): { sink: ReconciledViewSink; views: ReconciledView[] } {
+  const views: ReconciledView[] = []
+  const sink: ReconciledViewSink = {
+    applyReconciledView: (_chatId, view) => {
+      views.push(view)
+    },
+  }
+  return { sink, views }
+}
+
+const CHAT = '164795011'
+
+function makeMirror(exec: TmuxExec, clock: FakeClock, sink: ReconciledViewSink) {
+  return new TaskRealityMirror({
+    exec,
+    capture: { paneTarget: 'p', lineCount: 200 },
+    log: nullLog,
+    sinks: [sink],
+    now: () => clock.now,
+    setTimer: clock.setTimer,
+    clearTimer: clock.clearTimer,
+  })
+}
+
+const VALID_PANE = [
+  'работаю…',
+  '3 tasks (1 done, 1 in progress, 1 open)',
+  '☑ Собрать модуль',
+  '◼ Написать тесты',
+  '◻ Ревью',
+  '',
+  '❯ ',
+].join('\n')
+
+const NO_LIST_PANE = ['готово', '❯ '].join('\n')
+
+const createEvent = (subject: string): TaskMirrorEvent => ({
+  kind: 'task_create',
+  sessionId: 's1',
+  toolUseId: `tool-${subject}`,
+  input: { subject },
+})
+
+// ── tests ─────────────────────────────────────────────────────────────
+
+describe('pane → verified reconciled view', () => {
+  test('a valid pane snapshot yields a fresh view with the real task list', async () => {
+    const clock = new FakeClock()
+    const fx = makeExec(() => VALID_PANE)
+    const { sink, views } = makeSink()
+    const rm = makeMirror(fx.exec, clock, sink)
+
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' })
+    await flush()
+
+    const last = views.at(-1)!
+    expect(last.freshness.kind).toBe('fresh')
+    expect(last.todos.map((t) => t.content)).toEqual(['Собрать модуль', 'Написать тесты', 'Ревью'])
+    expect(last.todos.map((t) => t.status)).toEqual(['completed', 'in_progress', 'pending'])
+    expect(fx.captureCount).toBe(1) // immediate capture on SessionStart
+  })
+})
+
+describe('unverified — tool events only', () => {
+  test('no pane list → «unverified» with the event-derived list', async () => {
+    const clock = new FakeClock()
+    const fx = makeExec(() => NO_LIST_PANE)
+    const { sink, views } = makeSink()
+    const rm = makeMirror(fx.exec, clock, sink)
+
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' })
+    await flush()
+    rm.onTaskEvent(CHAT, createEvent('Draft plan'), { cwd: '/repo' })
+    await flush()
+
+    const last = views.at(-1)!
+    expect(last.freshness.kind).toBe('unverified')
+    expect(last.todos.map((t) => t.content)).toEqual(['Draft plan'])
+  })
+
+  test('capture failure (no tmux) degrades gracefully to events-only', async () => {
+    const clock = new FakeClock()
+    const fx = makeExec(() => VALID_PANE, { captureOk: () => false })
+    const { sink, views } = makeSink()
+    const rm = makeMirror(fx.exec, clock, sink)
+
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' })
+    rm.onTaskEvent(CHAT, createEvent('Solo'), { cwd: '/repo' })
+    await flush()
+
+    const last = views.at(-1)!
+    expect(last.freshness.kind).toBe('unverified')
+    expect(last.todos.map((t) => t.content)).toEqual(['Solo'])
+  })
+})
+
+describe('stale — active turn, reconciliation silent > 90s', () => {
+  test('goes stale while a turn is active and the list stops reconciling', async () => {
+    const clock = new FakeClock()
+    let pane = VALID_PANE
+    const fx = makeExec(() => pane)
+    const { sink, views } = makeSink()
+    const rm = makeMirror(fx.exec, clock, sink)
+
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' })
+    await flush()
+    expect(views.at(-1)!.freshness.kind).toBe('fresh')
+
+    rm.onUserPromptSubmit(CHAT, { sessionId: 's1', cwd: '/repo' })
+    await flush()
+    pane = NO_LIST_PANE // harness stops rendering a parseable list
+    clock.advance(100_000) // > 90s of active work with no valid snapshot
+    await flush()
+
+    expect(views.at(-1)!.freshness.kind).toBe('stale')
+  })
+})
+
+describe('idle rule — verified stays verified between turns', () => {
+  test('after Stop, an absent list is NOT staleness (kept verified)', async () => {
+    const clock = new FakeClock()
+    let pane = VALID_PANE
+    const fx = makeExec(() => pane)
+    const { sink, views } = makeSink()
+    const rm = makeMirror(fx.exec, clock, sink)
+
+    rm.onUserPromptSubmit(CHAT, { sessionId: 's1', cwd: '/repo' })
+    await flush()
+    expect(views.at(-1)!.freshness.kind).toBe('fresh')
+
+    rm.onStop(CHAT) // turn ends → idle
+    await flush()
+    pane = NO_LIST_PANE
+    clock.advance(200_000) // long idle gap
+    await flush()
+
+    const last = views.at(-1)!
+    expect(last.freshness.kind).toBe('fresh') // verified, NOT stale
+    expect(last.todos).toHaveLength(3) // last valid snapshot retained
+  })
+})
+
+describe('ended — frozen, timers stopped', () => {
+  test('SessionEnd freezes the view and stops capturing', async () => {
+    const clock = new FakeClock()
+    const fx = makeExec(() => VALID_PANE)
+    const { sink, views } = makeSink()
+    const rm = makeMirror(fx.exec, clock, sink)
+
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' })
+    await flush()
+    const beforeEnd = fx.captureCount
+
+    rm.onSessionEnd(CHAT, { sessionId: 's1' })
+    await flush()
+    const ended = views.at(-1)!
+    expect(ended.freshness.kind).toBe('ended')
+    if (ended.freshness.kind === 'ended') {
+      expect(ended.freshness.reconciledAtLabel).not.toBeNull()
+    }
+
+    clock.advance(60_000) // periodic timer must be disarmed
+    await flush()
+    expect(fx.captureCount).toBe(beforeEnd) // no further captures
+  })
+})
+
+describe('coalescing — rapid triggers collapse to one capture', () => {
+  test('three immediate triggers within the 5s window ⇒ one extra capture', async () => {
+    const clock = new FakeClock()
+    const fx = makeExec(() => VALID_PANE)
+    const { sink } = makeSink()
+    const rm = makeMirror(fx.exec, clock, sink)
+
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' }) // capture #1 (immediate)
+    await flush()
+    expect(fx.captureCount).toBe(1)
+
+    clock.advance(1_000)
+    rm.onUserPromptSubmit(CHAT, { sessionId: 's1', cwd: '/repo' }) // schedules coalesce
+    clock.advance(1_000)
+    rm.onUserPromptSubmit(CHAT, { sessionId: 's1', cwd: '/repo' }) // coalesced (skip)
+    clock.advance(1_000)
+    rm.onUserPromptSubmit(CHAT, { sessionId: 's1', cwd: '/repo' }) // coalesced (skip)
+    await flush()
+    expect(fx.captureCount).toBe(1) // nothing captured yet — still within window
+
+    clock.advance(5_000) // coalesce timer fires
+    await flush()
+    expect(fx.captureCount).toBe(2) // exactly one coalesced capture
+  })
+})
+
+describe('session change resets state', () => {
+  test('a new sessionId drops the prior reconciled tasks', async () => {
+    const clock = new FakeClock()
+    const fx = makeExec(() => VALID_PANE)
+    const { sink, views } = makeSink()
+    const rm = makeMirror(fx.exec, clock, sink)
+
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' })
+    await flush()
+    expect(views.at(-1)!.todos).toHaveLength(3)
+
+    // New session, pane not yet showing a list → clean unverified slate.
+    const fx2 = makeExec(() => NO_LIST_PANE)
+    ;(rm as unknown as { exec: TmuxExec }).exec = fx2.exec
+    rm.onSessionStart(CHAT, { sessionId: 's2', cwd: '/repo' })
+    await flush()
+    const last = views.at(-1)!
+    expect(last.sessionId).toBe('s2')
+    expect(last.todos).toHaveLength(0)
+    expect(last.freshness.kind).toBe('unverified')
+  })
+})
+
+// ── positional re-association (§5) ──────────────────────────────────────
+
+describe('realignOrdinals — positional-alias re-association', () => {
+  const binding: SessionBinding = { sessionId: 's1', paneTarget: 'p', cwd: '/repo' }
+  const prov = (capturedAt: number): PaneProvenance => ({
+    sessionId: 's1',
+    paneTarget: 'p',
+    cwd: '/repo',
+    capturedAt,
+  })
+
+  function snapshotOf(header: string, lines: string[], capturedAt: number) {
+    const snap = parsePaneTaskList([header, ...lines].join('\n'), prov(capturedAt))
+    if (snap === null) throw new Error('fixture did not parse')
+    return snap
+  }
+
+  test('a task that shifts up (a middle task removed) is re-keyed, not remove+add', () => {
+    // First snapshot: A#1, B#2, C#3.
+    const s1 = snapshotOf('3 tasks (1 done, 1 in progress, 1 open)', ['☑ Alpha', '◼ Beta', '◻ Gamma'], 10)
+    let state = reconcileTaskState(initialReconciledState('s1'), {
+      kind: 'snapshot',
+      snapshot: s1,
+      verdict: validateSnapshot(s1, binding),
+    })
+    // Beta (#2) is removed → Gamma shifts from #3 to #2.
+    const s2 = snapshotOf('2 tasks (1 done, 0 in progress, 1 open)', ['☑ Alpha', '◻ Gamma'], 20)
+    const aligned = realignOrdinals(state, s2)
+    const gamma = aligned.tasks.find((t) => t.description === 'Gamma')!
+    expect(gamma.ordinal).toBe(2) // re-keyed from #3 to the vacated #2
+    expect(gamma.key).toBe('s1:#2')
+
+    // Reconcile: two tasks (Beta removed, Gamma preserved as the SAME task).
+    state = reconcileTaskState(aligned, {
+      kind: 'snapshot',
+      snapshot: s2,
+      verdict: validateSnapshot(s2, binding),
+    })
+    expect(state.tasks.map((t) => t.description).sort()).toEqual(['Alpha', 'Gamma'])
+    // Gamma kept its completed/in-progress history (paneConfirmed), not re-created.
+    expect(state.tasks.find((t) => t.description === 'Gamma')!.paneConfirmed).toBe(true)
+  })
+
+  test('does not re-key when the old ordinal is still present (duplicate/swap, not a clean shift)', () => {
+    const s1 = snapshotOf('2 tasks (0 done, 1 in progress, 1 open)', ['◼ Same', '◻ Other'], 10)
+    const state = reconcileTaskState(initialReconciledState('s1'), {
+      kind: 'snapshot',
+      snapshot: s1,
+      verdict: validateSnapshot(s1, binding),
+    })
+    // «Same» appears at BOTH #1 (still there) and a new #2 — not a move.
+    const dup = snapshotOf('2 tasks (0 done, 2 in progress, 0 open)', ['◼ Same', '◼ Same'], 20)
+    const aligned = realignOrdinals(state, dup)
+    expect(aligned.tasks.find((t) => t.key === 's1:#1')!.description).toBe('Same')
+  })
+})
+
+describe('pure helpers', () => {
+  test('numericOrdinal', () => {
+    expect(numericOrdinal('3')).toBe(3)
+    expect(numericOrdinal('tool-abc')).toBeUndefined()
+    expect(numericOrdinal('')).toBeUndefined()
+  })
+  test('reconciledToTodos appends … for a truncated description', () => {
+    const s = ['1 tasks (0 done, 1 in progress, 0 open)', '◼ Very long task that got cut …'].join('\n')
+    const snap = parsePaneTaskList(s, { sessionId: 's1', paneTarget: 'p', cwd: '/repo', capturedAt: 1 })!
+    const state = reconcileTaskState(initialReconciledState('s1'), {
+      kind: 'snapshot',
+      snapshot: snap,
+      verdict: validateSnapshot(snap, { sessionId: 's1', paneTarget: 'p', cwd: '/repo' }),
+    })
+    expect(reconciledToTodos(state)[0]!.content.endsWith('…')).toBe(true)
+  })
+})
+
+describe('owner gate', () => {
+  test('non-owner chat is a no-op', async () => {
+    const clock = new FakeClock()
+    const fx = makeExec(() => VALID_PANE)
+    const { sink, views } = makeSink()
+    const rm = new TaskRealityMirror({
+      exec: fx.exec,
+      capture: { paneTarget: 'p', lineCount: 200 },
+      log: nullLog,
+      sinks: [sink],
+      isOwnerChat: (c) => c === 'owner',
+      now: () => clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+    })
+    rm.onSessionStart('stranger', { sessionId: 's1', cwd: '/repo' })
+    await flush()
+    expect(views).toHaveLength(0)
+    expect(fx.captureCount).toBe(0)
+  })
+})

--- a/plugin/tests/status/task-reality-mirror.test.ts
+++ b/plugin/tests/status/task-reality-mirror.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, test } from 'bun:test'
 import {
   TaskRealityMirror,
+  enforceEventRemovals,
   realignOrdinals,
   reconciledToTodos,
   numericOrdinal,
@@ -125,14 +126,18 @@ function makeMirror(exec: TmuxExec, clock: FakeClock, sink: ReconciledViewSink) 
   })
 }
 
+// Authoritative-shaped pane: spinner above the header + input-box chrome below
+// (positional anti-spoof v2 requires the block bottom-anchored above the box).
 const VALID_PANE = [
-  'работаю…',
+  '✻ работаю…',
   '3 tasks (1 done, 1 in progress, 1 open)',
   '☑ Собрать модуль',
   '◼ Написать тесты',
   '◻ Ревью',
   '',
+  '────────────────────────────────────────',
   '❯ ',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
 ].join('\n')
 
 const NO_LIST_PANE = ['готово', '❯ '].join('\n')
@@ -329,7 +334,10 @@ describe('realignOrdinals — positional-alias re-association', () => {
   })
 
   function snapshotOf(header: string, lines: string[], capturedAt: number) {
-    const snap = parsePaneTaskList([header, ...lines].join('\n'), prov(capturedAt))
+    // Positional anti-spoof v2: authoritative fixtures need harness chrome
+    // below the block (input-box separator + footer).
+    const chrome = ['', '────────────────────────────────────────', '  ⏵⏵ bypass permissions on']
+    const snap = parsePaneTaskList([header, ...lines, ...chrome].join('\n'), prov(capturedAt))
     if (snap === null) throw new Error('fixture did not parse')
     return snap
   }
@@ -401,7 +409,13 @@ describe('pure helpers', () => {
     expect(numericOrdinal('')).toBeUndefined()
   })
   test('reconciledToTodos appends … for a truncated description', () => {
-    const s = ['1 tasks (0 done, 1 in progress, 0 open)', '◼ Very long task that got cut …'].join('\n')
+    const s = [
+      '1 tasks (0 done, 1 in progress, 0 open)',
+      '◼ Very long task that got cut …',
+      '',
+      '────────────────────────────────────────',
+      '  ⏵⏵ bypass permissions on',
+    ].join('\n')
     const snap = parsePaneTaskList(s, { sessionId: 's1', paneTarget: 'p', cwd: '/repo', capturedAt: 1 })!
     const state = reconcileTaskState(initialReconciledState('s1'), {
       kind: 'snapshot',
@@ -601,5 +615,286 @@ describe('#2 session tombstones in the reality mirror', () => {
     rm.onTaskEvent(CHAT, createEvent('resumed work'), { cwd: '/repo' })
     await flush()
     expect(views.at(-1)!.todos.map((t) => t.content)).toEqual(['resumed work'])
+  })
+})
+
+// ── review fix-loop round 2 (2026-07-10) ────────────────────────────────
+
+describe('#2v2 rollback guard — late SessionStart cannot displace an active session', () => {
+  test('SessionStart for a tombstoned id while s2 is active is dropped', async () => {
+    const clock = new FakeClock()
+    const fx = makeExec(() => NO_LIST_PANE)
+    const { sink, views } = makeSink()
+    const rm = makeMirror(fx.exec, clock, sink)
+
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' })
+    rm.onSessionEnd(CHAT, { sessionId: 's1' }) // s1 tombstoned + evicted
+    rm.onSessionStart(CHAT, { sessionId: 's2', cwd: '/repo' })
+    rm.onTaskEvent(
+      CHAT,
+      { kind: 'task_create', sessionId: 's2', toolUseId: 't1', input: { subject: 'Работа s2' } },
+      { cwd: '/repo' },
+    )
+    await flush()
+    expect(views.at(-1)!.sessionId).toBe('s2')
+    expect(views.at(-1)!.todos.map((t) => t.content)).toEqual(['Работа s2'])
+
+    // Late REPLAYED SessionStart for dead s1: must NOT displace s2.
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' })
+    await flush()
+    const last = views.at(-1)!
+    expect(last.sessionId).toBe('s2')
+    expect(last.todos.map((t) => t.content)).toEqual(['Работа s2'])
+
+    // And s1 stays tombstoned — its mutations remain dropped.
+    const count = views.length
+    rm.onTaskEvent(
+      CHAT,
+      { kind: 'task_create', sessionId: 's1', toolUseId: 't2', input: { subject: 'призрак' } },
+      { cwd: '/repo' },
+    )
+    await flush()
+    expect(views.length).toBe(count)
+  })
+})
+
+describe('#3 observation revision — same-session mutations invalidate in-flight captures', () => {
+  test('a TodoWrite landing during cwd resolution discards the older pane text', async () => {
+    const clock = new FakeClock()
+    let releaseCwd: ((r: TmuxExecResult) => void) | null = null
+    const exec: TmuxExec = async (args) => {
+      if (args.includes('capture-pane')) {
+        // Pane text fetched instantly — it still claims «Написать тесты» is in_progress.
+        return { stdout: VALID_PANE, stderr: '', exitCode: 0 }
+      }
+      // display-message hangs until we release it.
+      return await new Promise<TmuxExecResult>((r) => {
+        releaseCwd = r
+      })
+    }
+    const { sink, views } = makeSink()
+    const rm = makeMirror(exec, clock, sink)
+
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' }) // capture starts, hangs on cwd
+    await flush()
+    expect(releaseCwd).not.toBeNull()
+
+    // While the capture is stuck: the harness reports «Написать тесты» done.
+    rm.onTaskEvent(
+      CHAT,
+      {
+        kind: 'todo_write',
+        sessionId: 's1',
+        todos: [
+          { id: '1', content: 'Собрать модуль', status: 'completed' },
+          { id: '2', content: 'Написать тесты', status: 'completed' },
+          { id: '3', content: 'Ревью', status: 'in_progress' },
+        ],
+      },
+      { cwd: '/repo' },
+    )
+    await flush()
+
+    // The stale capture finally resolves — it must be DISCARDED wholesale.
+    releaseCwd!({ stdout: '/repo\n', stderr: '', exitCode: 0 })
+    await flush()
+
+    const last = views.at(-1)!
+    // Event truth stands: «Написать тесты» stays completed (the stale pane
+    // said in_progress), and the view was never marked pane-fresh.
+    const testsTask = last.todos.find((t) => t.content === 'Написать тесты')!
+    expect(testsTask.status).toBe('completed')
+    expect(last.freshness.kind).toBe('unverified')
+  })
+})
+
+describe('#4 event-removal tombstones for pane-confirmed tasks', () => {
+  const fullList = (): TaskMirrorEvent => ({
+    kind: 'todo_write',
+    sessionId: 's1',
+    todos: [
+      { id: '1', content: 'Собрать модуль', status: 'completed' },
+      { id: '2', content: 'Написать тесты', status: 'in_progress' },
+    ],
+  })
+
+  test('pane-confirm → TodoWrite omits → tmux dies → task is GONE (no ghost)', async () => {
+    const clock = new FakeClock()
+    let tmuxAlive = true
+    const fx = makeExec(() => VALID_PANE, { captureOk: () => tmuxAlive })
+    const { sink, views } = makeSink()
+    const rm = makeMirror(fx.exec, clock, sink)
+
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' }) // pane confirms 3 tasks
+    await flush()
+    expect(views.at(-1)!.todos).toHaveLength(3)
+
+    tmuxAlive = false // tmux dies BEFORE the removal
+    clock.advance(1000)
+    rm.onTaskEvent(CHAT, fullList(), { cwd: '/repo' }) // «Ревью» omitted
+    await flush()
+    const afterRemove = views.at(-1)!
+    expect(afterRemove.todos.map((t) => t.content)).toEqual(['Собрать модуль', 'Написать тесты'])
+
+    // Ticks keep failing to capture — the tombstone must hold forever.
+    clock.advance(60_000)
+    await flush()
+    const last = views.at(-1)!
+    expect(last.todos.some((t) => t.content === 'Ревью')).toBe(false)
+  })
+
+  test('a NEWER pane snapshot may resurrect the removed task (pane is higher authority)', async () => {
+    const clock = new FakeClock()
+    const fx = makeExec(() => VALID_PANE)
+    const { sink, views } = makeSink()
+    const rm = makeMirror(fx.exec, clock, sink)
+
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' })
+    await flush()
+    clock.advance(1000)
+    rm.onTaskEvent(CHAT, fullList(), { cwd: '/repo' }) // «Ревью» removed by event
+    await flush()
+    expect(views.at(-1)!.todos.some((t) => t.content === 'Ревью')).toBe(false)
+
+    // The pane STILL renders «Ревью» and a NEWER capture confirms it → back.
+    clock.advance(30_000) // periodic tick captures again (capturedAt > removal)
+    await flush()
+    expect(views.at(-1)!.todos.some((t) => t.content === 'Ревью')).toBe(true)
+  })
+
+  test('enforceEventRemovals: a STALE pane snapshot may not resurrect', () => {
+    const binding: SessionBinding = { sessionId: 's1', paneTarget: 'p', cwd: '/repo' }
+    const text = [
+      '1 tasks (0 done, 1 in progress, 0 open)',
+      '◼ Старая задача',
+      '',
+      '────────────────────────────────────────',
+      '  ⏵⏵ bypass permissions on',
+    ].join('\n')
+    const snap = parsePaneTaskList(text, { sessionId: 's1', paneTarget: 'p', cwd: '/repo', capturedAt: 10 })!
+    let state = reconcileTaskState(initialReconciledState('s1'), {
+      kind: 'snapshot',
+      snapshot: snap,
+      verdict: validateSnapshot(snap, binding),
+    })
+    // TodoWrite at t=20 removed it (tombstone), but a stale pane (t=10) re-added it.
+    const removed = new Map<string, number>([['s1:#1', 20]])
+    state = enforceEventRemovals(state, removed, 10)
+    expect(state.tasks).toHaveLength(0) // stale pane may not resurrect
+    expect(removed.has('s1:#1')).toBe(true) // tombstone kept
+
+    // A NEWER pane (t=30) clears the tombstone.
+    const state2 = enforceEventRemovals(state, removed, 30)
+    expect(removed.has('s1:#1')).toBe(false)
+    expect(state2.tasks).toHaveLength(0) // (this newer pane omitted it — stays gone)
+  })
+})
+
+describe('#7 hard-TTL eviction pushes a terminal «expired» view', () => {
+  test('last view before silence is kind=expired', async () => {
+    const clock = new FakeClock()
+    const fx = makeExec(() => VALID_PANE)
+    const { sink, views } = makeSink()
+    const rm = new TaskRealityMirror({
+      exec: fx.exec,
+      capture: { paneTarget: 'p', lineCount: 200 },
+      log: nullLog,
+      sinks: [sink],
+      ttlMs: 60_000,
+      now: () => clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+    })
+    rm.onUserPromptSubmit(CHAT, { sessionId: 's1', cwd: '/repo' })
+    await flush()
+    clock.advance(200_000) // way past the TTL — eviction tick fires
+    await flush()
+    const last = views.at(-1)!
+    expect(last.freshness.kind).toBe('expired')
+    expect(last.todos).toHaveLength(3) // frozen state, not wiped
+
+    const countAtEvict = views.length
+    clock.advance(300_000)
+    await flush()
+    expect(views.length).toBe(countAtEvict) // silence after the terminal push
+  })
+})
+
+describe('#8 displacement chains — full permutation in one pass', () => {
+  const binding: SessionBinding = { sessionId: 's1', paneTarget: 'p', cwd: '/repo' }
+  const provAt = (capturedAt: number): PaneProvenance => ({
+    sessionId: 's1',
+    paneTarget: 'p',
+    cwd: '/repo',
+    capturedAt,
+  })
+  const chrome = ['', '────────────────────────────────────────', '  ⏵⏵ bypass permissions on']
+  const snapOf = (header: string, lines: string[], at: number) =>
+    parsePaneTaskList([header, ...lines, ...chrome].join('\n'), provAt(at))!
+
+  test('[A,B,C,D]→[A,C,D]: C and D re-associate in ONE snapshot; B removal still needs two', () => {
+    const s1 = snapOf('4 tasks (1 done, 1 in progress, 2 open)', ['☑ Alpha', '◼ Beta', '◻ Gamma', '◻ Delta'], 10)
+    let state = reconcileTaskState(initialReconciledState('s1'), {
+      kind: 'snapshot',
+      snapshot: s1,
+      verdict: validateSnapshot(s1, binding),
+    })
+    // B removed → C shifts 3→2, D shifts 4→3 (a CHAIN: pre-fix C was refused
+    // because ordinal 3 was still present — it belongs to D's new slot).
+    const s2 = snapOf('3 tasks (1 done, 0 in progress, 2 open)', ['☑ Alpha', '◻ Gamma', '◻ Delta'], 20)
+    const aligned = realignOrdinals(state, s2)
+    expect(aligned.tasks.find((t) => t.description === 'Gamma')!.ordinal).toBe(2)
+    expect(aligned.tasks.find((t) => t.description === 'Delta')!.ordinal).toBe(3)
+    // Beta displaced off #2, NOT stomped.
+    expect(aligned.tasks.find((t) => t.description === 'Beta')!.ordinal).not.toBe(2)
+
+    state = reconcileTaskState(aligned, {
+      kind: 'snapshot',
+      snapshot: s2,
+      verdict: validateSnapshot(s2, binding),
+    })
+    // ONE snapshot: C, D converged onto their new keys; B survives (first omission).
+    expect(state.tasks.find((t) => t.ordinal === 2)!.description).toBe('Gamma')
+    expect(state.tasks.find((t) => t.ordinal === 3)!.description).toBe('Delta')
+    expect(state.tasks.some((t) => t.description === 'Beta')).toBe(true)
+
+    // An intervening ordinal-2 event now targets GAMMA (the task actually at
+    // #2), not the displaced Beta (pre-fix it hit the wrong task).
+    state = reconcileTaskState(state, {
+      kind: 'event',
+      event: { ordinal: 2, status: 'completed', description: 'Gamma', at: 25 },
+    })
+    expect(state.tasks.find((t) => t.description === 'Gamma')!.status).toBe('completed')
+    expect(state.tasks.find((t) => t.description === 'Beta')!.status).toBe('in_progress')
+
+    // Second consecutive omission deletes Beta.
+    const s3 = snapOf('3 tasks (2 done, 0 in progress, 1 open)', ['☑ Alpha', '☑ Gamma', '◻ Delta'], 30)
+    state = reconcileTaskState(realignOrdinals(state, s3), {
+      kind: 'snapshot',
+      snapshot: s3,
+      verdict: validateSnapshot(s3, binding),
+    })
+    expect(state.tasks.some((t) => t.description === 'Beta')).toBe(false)
+  })
+
+  test('a genuine SWAP re-associates atomically (full permutation)', () => {
+    const s1 = snapOf('2 tasks (0 done, 1 in progress, 1 open)', ['◼ Alpha', '◻ Beta'], 10)
+    let state = reconcileTaskState(initialReconciledState('s1'), {
+      kind: 'snapshot',
+      snapshot: s1,
+      verdict: validateSnapshot(s1, binding),
+    })
+    const s2 = snapOf('2 tasks (0 done, 1 in progress, 1 open)', ['◻ Beta', '◼ Alpha'], 20)
+    const aligned = realignOrdinals(state, s2)
+    expect(aligned.tasks.find((t) => t.description === 'Alpha')!.ordinal).toBe(2)
+    expect(aligned.tasks.find((t) => t.description === 'Beta')!.ordinal).toBe(1)
+    state = reconcileTaskState(aligned, {
+      kind: 'snapshot',
+      snapshot: s2,
+      verdict: validateSnapshot(s2, binding),
+    })
+    expect(state.tasks).toHaveLength(2)
+    expect(state.tasks.find((t) => t.ordinal === 1)!.description).toBe('Beta')
+    expect(state.tasks.find((t) => t.ordinal === 2)!.description).toBe('Alpha')
   })
 })

--- a/plugin/tests/status/task-reality-mirror.test.ts
+++ b/plugin/tests/status/task-reality-mirror.test.ts
@@ -6,7 +6,10 @@
 // All timers + the clock are injected (FakeClock) and the tmux exec is a stub,
 // so the tests are deterministic and touch no real tmux / Telegram.
 
-import { describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import {
   TaskRealityMirror,
   enforceEventRemovals,
@@ -896,5 +899,182 @@ describe('#8 displacement chains — full permutation in one pass', () => {
     expect(state.tasks).toHaveLength(2)
     expect(state.tasks.find((t) => t.ordinal === 1)!.description).toBe('Beta')
     expect(state.tasks.find((t) => t.ordinal === 2)!.description).toBe('Alpha')
+  })
+})
+
+// ── review fix-loop round 3 (2026-07-10) ────────────────────────────────
+
+const r3TmpDirs: string[] = []
+function r3StateDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'task-reality-'))
+  r3TmpDirs.push(d)
+  return d
+}
+afterEach(() => {
+  for (const d of r3TmpDirs.splice(0)) {
+    try {
+      rmSync(d, { recursive: true, force: true })
+    } catch {
+      /* ignore */
+    }
+  }
+})
+
+describe('r3 #1 — reality-mirror epochs persist across a restart', () => {
+  test('a late SessionStart for a pre-restart-ended session cannot displace restored s2', async () => {
+    const dir = r3StateDir()
+    const clock = new FakeClock()
+    const fx = makeExec(() => NO_LIST_PANE)
+    const mk = (): { rm: TaskRealityMirror; views: ReconciledView[] } => {
+      const { sink, views } = makeSink()
+      const rm = new TaskRealityMirror({
+        exec: fx.exec,
+        capture: { paneTarget: 'p', lineCount: 200 },
+        log: nullLog,
+        sinks: [sink],
+        stateDir: dir,
+        now: () => clock.now,
+        setTimer: clock.setTimer,
+        clearTimer: clock.clearTimer,
+      })
+      return { rm, views }
+    }
+
+    const first = mk()
+    first.rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' })
+    first.rm.onSessionEnd(CHAT, { sessionId: 's1' }) // tombstoned + persisted
+    first.rm.onSessionStart(CHAT, { sessionId: 's2', cwd: '/repo' }) // active=s2, persisted
+    await flush()
+
+    // «Restart»: fresh instance, same state dir. Pre-fix the epoch was
+    // process-local — the late s1 SessionStart displaced restored s2.
+    const second = mk()
+    second.rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' }) // late straggler
+    await flush()
+    expect(second.views).toHaveLength(0) // dropped — no view for dead s1
+
+    // s1 mutations stay dropped; s2 flows normally.
+    second.rm.onTaskEvent(
+      CHAT,
+      { kind: 'task_create', sessionId: 's1', toolUseId: 't1', input: { subject: 'призрак' } },
+      { cwd: '/repo' },
+    )
+    await flush()
+    expect(second.views).toHaveLength(0)
+
+    second.rm.onTaskEvent(
+      CHAT,
+      { kind: 'task_create', sessionId: 's2', toolUseId: 't2', input: { subject: 'живое s2' } },
+      { cwd: '/repo' },
+    )
+    await flush()
+    expect(second.views.at(-1)!.sessionId).toBe('s2')
+    expect(second.views.at(-1)!.todos.map((t) => t.content)).toEqual(['живое s2'])
+  })
+})
+
+describe('r3 #3 — TodoWrite re-add clears the removal tombstone', () => {
+  test('remove → re-add same key → same-millisecond snapshot: the task survives', async () => {
+    const clock = new FakeClock()
+    const fx = makeExec(() => VALID_PANE)
+    const { sink, views } = makeSink()
+    // coalesceWindowMs: 0 so triggered captures run immediately at the SAME
+    // clock instant as the events — the equal-millisecond edge.
+    const rm = new TaskRealityMirror({
+      exec: fx.exec,
+      capture: { paneTarget: 'p', lineCount: 200 },
+      log: nullLog,
+      sinks: [sink],
+      coalesceWindowMs: 0,
+      now: () => clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+    })
+
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' }) // pane confirms 3 tasks
+    await flush()
+    expect(views.at(-1)!.todos).toHaveLength(3)
+
+    // Same clock instant: TodoWrite removes «Ревью» (#3), then re-adds it.
+    rm.onTaskEvent(
+      CHAT,
+      {
+        kind: 'todo_write',
+        sessionId: 's1',
+        todos: [
+          { id: '1', content: 'Собрать модуль', status: 'completed' },
+          { id: '2', content: 'Написать тесты', status: 'in_progress' },
+        ],
+      },
+      { cwd: '/repo' },
+    )
+    rm.onTaskEvent(
+      CHAT,
+      {
+        kind: 'todo_write',
+        sessionId: 's1',
+        todos: [
+          { id: '1', content: 'Собрать модуль', status: 'completed' },
+          { id: '2', content: 'Написать тесты', status: 'in_progress' },
+          { id: '3', content: 'Ревью', status: 'pending' },
+        ],
+      },
+      { cwd: '/repo' },
+    )
+    await flush()
+
+    // A capture at the SAME millisecond (capturedAt == removal at). Pre-fix
+    // enforceEventRemovals deleted the valid re-addition (capturedAt > at is
+    // false ⇒ stale-pane branch). Post-fix the re-add cleared the tombstone.
+    rm.onStop(CHAT) // immediate capture (coalesce window is 0)
+    await flush()
+    const last = views.at(-1)!
+    expect(last.todos.some((t) => t.content === 'Ревью')).toBe(true)
+  })
+})
+
+describe('r3 #4 — descriptions duplicated in the SNAPSHOT do not participate', () => {
+  test('committed [X#1, A#2] vs snapshot [A#1, A#2] → no remap of A', () => {
+    const binding: SessionBinding = { sessionId: 's1', paneTarget: 'p', cwd: '/repo' }
+    const provAt = (capturedAt: number): PaneProvenance => ({
+      sessionId: 's1',
+      paneTarget: 'p',
+      cwd: '/repo',
+      capturedAt,
+    })
+    const chrome = ['', '────────────────────────────────────────', '  ⏵⏵ bypass permissions on']
+    const snapOf = (header: string, lines: string[], at: number) =>
+      parsePaneTaskList([header, ...lines, ...chrome].join('\n'), provAt(at))!
+
+    const s1 = snapOf('2 tasks (0 done, 1 in progress, 1 open)', ['◼ Задача X', '◻ Задача A'], 10)
+    const state = reconcileTaskState(initialReconciledState('s1'), {
+      kind: 'snapshot',
+      snapshot: s1,
+      verdict: validateSnapshot(s1, binding),
+    })
+
+    // Snapshot repeats «Задача A» twice — which copy corresponds to the
+    // committed A#2 is ambiguous ⇒ NO remap; X#1 follows the omission rules.
+    const dup = snapOf('2 tasks (0 done, 2 in progress, 0 open)', ['◼ Задача A', '◼ Задача A'], 20)
+    const aligned = realignOrdinals(state, dup)
+    expect(aligned.tasks.find((t) => t.description === 'Задача A')!.ordinal).toBe(2)
+    expect(aligned.tasks.find((t) => t.description === 'Задача X')!.ordinal).toBe(1)
+
+    // X survives snapshot 1 as a first-omission candidate (two-snapshot rule)…
+    let next = reconcileTaskState(aligned, {
+      kind: 'snapshot',
+      snapshot: dup,
+      verdict: validateSnapshot(dup, binding),
+    })
+    expect(next.tasks.some((t) => t.description === 'Задача X')).toBe(true)
+
+    // …and is dropped by the SECOND consecutive omission.
+    const dup2 = snapOf('2 tasks (0 done, 2 in progress, 0 open)', ['◼ Задача A', '◼ Задача A'], 30)
+    next = reconcileTaskState(realignOrdinals(next, dup2), {
+      kind: 'snapshot',
+      snapshot: dup2,
+      verdict: validateSnapshot(dup2, binding),
+    })
+    expect(next.tasks.some((t) => t.description === 'Задача X')).toBe(false)
   })
 })

--- a/plugin/tests/status/task-reality-mirror.test.ts
+++ b/plugin/tests/status/task-reality-mirror.test.ts
@@ -334,7 +334,15 @@ describe('realignOrdinals — positional-alias re-association', () => {
     return snap
   }
 
-  test('a task that shifts up (a middle task removed) is re-keyed, not remove+add', () => {
+  // Review 2026-07-09 #7 — REVIEWERS DISAGREED, resolved by THIS test.
+  // Required contract for [A#1,B#2,C#3] → [A#1,C#2]:
+  //   • C is re-associated (same task identity, moved to #2) — the §5 goal;
+  //   • B is DISPLACED to a vacated key, NOT stomped, so it survives snapshot 1
+  //     as a first-omission candidate (two-snapshot anti-flap rule);
+  //   • B is deleted only after snapshot 2 confirms the removal.
+  // Codex was right about the original code (C stomped B's key ⇒ B deleted on
+  // the FIRST snapshot); the fix moves B aside instead.
+  test('shift with displacement: C re-keyed onto B\'s slot, B survives snapshot 1, dies on snapshot 2', () => {
     // First snapshot: A#1, B#2, C#3.
     const s1 = snapshotOf('3 tasks (1 done, 1 in progress, 1 open)', ['☑ Alpha', '◼ Beta', '◻ Gamma'], 10)
     let state = reconcileTaskState(initialReconciledState('s1'), {
@@ -348,16 +356,28 @@ describe('realignOrdinals — positional-alias re-association', () => {
     const gamma = aligned.tasks.find((t) => t.description === 'Gamma')!
     expect(gamma.ordinal).toBe(2) // re-keyed from #3 to the vacated #2
     expect(gamma.key).toBe('s1:#2')
+    // Beta was displaced off #2 (not stomped) — it still exists on its own key.
+    const betaAligned = aligned.tasks.find((t) => t.description === 'Beta')!
+    expect(betaAligned.ordinal).not.toBe(2)
 
-    // Reconcile: two tasks (Beta removed, Gamma preserved as the SAME task).
+    // Snapshot 1 reconcile: Gamma preserved as the SAME task; Beta SURVIVES as
+    // a first-omission candidate (anti-flap: removal needs TWO omissions).
     state = reconcileTaskState(aligned, {
       kind: 'snapshot',
       snapshot: s2,
       verdict: validateSnapshot(s2, binding),
     })
-    expect(state.tasks.map((t) => t.description).sort()).toEqual(['Alpha', 'Gamma'])
-    // Gamma kept its completed/in-progress history (paneConfirmed), not re-created.
+    expect(state.tasks.map((t) => t.description).sort()).toEqual(['Alpha', 'Beta', 'Gamma'])
     expect(state.tasks.find((t) => t.description === 'Gamma')!.paneConfirmed).toBe(true)
+
+    // Snapshot 2 (same content): the SECOND consecutive omission deletes Beta.
+    const s3 = snapshotOf('2 tasks (1 done, 0 in progress, 1 open)', ['☑ Alpha', '◻ Gamma'], 30)
+    state = reconcileTaskState(realignOrdinals(state, s3), {
+      kind: 'snapshot',
+      snapshot: s3,
+      verdict: validateSnapshot(s3, binding),
+    })
+    expect(state.tasks.map((t) => t.description).sort()).toEqual(['Alpha', 'Gamma'])
   })
 
   test('does not re-key when the old ordinal is still present (duplicate/swap, not a clean shift)', () => {
@@ -411,5 +431,175 @@ describe('owner gate', () => {
     await flush()
     expect(views).toHaveLength(0)
     expect(fx.captureCount).toBe(0)
+  })
+})
+
+// ── review fix-loop 2026-07-09 ──────────────────────────────────────────
+
+describe('#4 generation token — in-flight captures across a session change', () => {
+  test('a capture started under s1 never commits into the s2 binding', async () => {
+    const clock = new FakeClock()
+    let resolveCapture: ((r: TmuxExecResult) => void) | null = null
+    const exec: TmuxExec = async (args) => {
+      if (args.includes('capture-pane')) {
+        // First capture hangs until we resolve it manually.
+        if (resolveCapture === null) {
+          return await new Promise<TmuxExecResult>((r) => {
+            resolveCapture = r
+          })
+        }
+        return { stdout: NO_LIST_PANE, stderr: '', exitCode: 0 }
+      }
+      return { stdout: '/repo\n', stderr: '', exitCode: 0 }
+    }
+    const { sink, views } = makeSink()
+    const rm = makeMirror(exec, clock, sink)
+
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' }) // capture #1 pending
+    await flush()
+    expect(resolveCapture).not.toBeNull()
+
+    // Session changes while the capture is in flight.
+    rm.onSessionStart(CHAT, { sessionId: 's2', cwd: '/repo' })
+    await flush()
+
+    // The old capture finally returns a full s1-era task list.
+    resolveCapture!({ stdout: VALID_PANE, stderr: '', exitCode: 0 })
+    await flush()
+
+    // Nothing from the stale capture leaked into s2.
+    const last = views.at(-1)!
+    expect(last.sessionId).toBe('s2')
+    expect(last.todos).toHaveLength(0)
+    expect(last.freshness.kind).toBe('unverified')
+  })
+})
+
+describe('#5 TodoWrite as authoritative event snapshot (events-only degrade)', () => {
+  const todoWrite = (todos: Array<{ id?: string; content: string; status: 'pending' | 'in_progress' | 'completed' }>): TaskMirrorEvent => ({
+    kind: 'todo_write',
+    sessionId: 's1',
+    todos,
+  })
+
+  test('a task removed from the TodoWrite list disappears (no ghosts without tmux)', async () => {
+    const clock = new FakeClock()
+    const fx = makeExec(() => VALID_PANE, { captureOk: () => false }) // no pane at all
+    const { sink, views } = makeSink()
+    const rm = makeMirror(fx.exec, clock, sink)
+
+    rm.onTaskEvent(CHAT, todoWrite([
+      { id: 'a', content: 'Alpha', status: 'in_progress' },
+      { id: 'b', content: 'Beta', status: 'pending' },
+      { id: 'c', content: 'Gamma', status: 'pending' },
+    ]), { cwd: '/repo' })
+    await flush()
+    expect(views.at(-1)!.todos.map((t) => t.content)).toEqual(['Alpha', 'Beta', 'Gamma'])
+
+    clock.advance(1000)
+    rm.onTaskEvent(CHAT, todoWrite([
+      { id: 'a', content: 'Alpha', status: 'completed' },
+      { id: 'c', content: 'Gamma', status: 'in_progress' },
+    ]), { cwd: '/repo' })
+    await flush()
+    const last = views.at(-1)!
+    expect(last.todos.map((t) => t.content)).toEqual(['Alpha', 'Gamma']) // Beta gone
+    expect(last.todos.map((t) => t.status)).toEqual(['completed', 'in_progress'])
+  })
+
+  test('identical descriptions with distinct ids stay distinct tasks', async () => {
+    const clock = new FakeClock()
+    const fx = makeExec(() => NO_LIST_PANE)
+    const { sink, views } = makeSink()
+    const rm = makeMirror(fx.exec, clock, sink)
+
+    rm.onTaskEvent(CHAT, todoWrite([
+      { id: 'a', content: 'Проверить конфиг', status: 'pending' },
+      { id: 'b', content: 'Проверить конфиг', status: 'in_progress' },
+    ]), { cwd: '/repo' })
+    await flush()
+    const last = views.at(-1)!
+    expect(last.todos).toHaveLength(2)
+    expect(last.todos.map((t) => t.status).sort()).toEqual(['in_progress', 'pending'])
+  })
+})
+
+describe('#6 hard TTL — a missed Stop cannot poll forever', () => {
+  test('rec is evicted after ttl even with turnActive stuck true', async () => {
+    const clock = new FakeClock()
+    const fx = makeExec(() => VALID_PANE)
+    const { sink, views } = makeSink()
+    const rm = new TaskRealityMirror({
+      exec: fx.exec,
+      capture: { paneTarget: 'p', lineCount: 200 },
+      log: nullLog,
+      sinks: [sink],
+      ttlMs: 60_000, // short TTL for the test
+      now: () => clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+    })
+
+    rm.onUserPromptSubmit(CHAT, { sessionId: 's1', cwd: '/repo' }) // turn opens…
+    await flush()
+    // …and Stop NEVER arrives. Ticks keep capturing until the hard TTL.
+    clock.advance(30_000)
+    await flush()
+    const midCount = fx.captureCount
+    expect(midCount).toBeGreaterThan(1) // still ticking inside the TTL
+
+    clock.advance(120_000) // idle > ttl ⇒ eviction on the next tick
+    await flush()
+    const atEvict = fx.captureCount
+    const viewsAtEvict = views.length
+
+    clock.advance(300_000) // long after — no timers may fire any more
+    await flush()
+    expect(fx.captureCount).toBe(atEvict)
+    expect(views.length).toBe(viewsAtEvict) // no more Telegram-bound pushes
+  })
+})
+
+describe('#9 unresolved pane cwd ⇒ snapshot is observational', () => {
+  test('display-message failure keeps the view unverified despite a perfect pane list', async () => {
+    const clock = new FakeClock()
+    const exec: TmuxExec = async (args) => {
+      if (args.includes('capture-pane')) return { stdout: VALID_PANE, stderr: '', exitCode: 0 }
+      // pane_current_path unobtainable
+      return { stdout: '', stderr: 'no server', exitCode: 1 }
+    }
+    const { sink, views } = makeSink()
+    const rm = makeMirror(exec, clock, sink)
+
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' })
+    await flush()
+    const last = views.at(-1)!
+    expect(last.freshness.kind).toBe('unverified') // NOT fresh
+    expect(last.todos).toHaveLength(0) // observational: no task state committed
+  })
+})
+
+describe('#2 session tombstones in the reality mirror', () => {
+  test('late mutation from an ended session is dropped; resume un-tombstones', async () => {
+    const clock = new FakeClock()
+    const fx = makeExec(() => NO_LIST_PANE)
+    const { sink, views } = makeSink()
+    const rm = makeMirror(fx.exec, clock, sink)
+
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' })
+    rm.onSessionEnd(CHAT, { sessionId: 's1' })
+    await flush()
+    const countAfterEnd = views.length
+
+    // Late straggler from s1 — dropped, no view pushed.
+    rm.onTaskEvent(CHAT, createEvent('late ghost'), { cwd: '/repo' })
+    await flush()
+    expect(views.length).toBe(countAfterEnd)
+
+    // Genuine RESUME of s1 legitimizes it again.
+    rm.onSessionStart(CHAT, { sessionId: 's1', cwd: '/repo' })
+    rm.onTaskEvent(CHAT, createEvent('resumed work'), { cwd: '/repo' })
+    await flush()
+    expect(views.at(-1)!.todos.map((t) => t.content)).toEqual(['resumed work'])
   })
 })

--- a/plugin/tests/status/task-reconciler.test.ts
+++ b/plugin/tests/status/task-reconciler.test.ts
@@ -579,16 +579,25 @@ describe('anti-spoof: only header-anchored blocks can be authoritative', () => {
     expect(validateSnapshot(s, binding()).authoritative).toBe(false)
   })
 
-  test('a fake list BELOW the real header-anchored one does not override it', () => {
+  test('an exact-header fake in prose ABOVE the real list — the real (last, bottom-anchored) wins', () => {
     const text = [
+      '● Вот как выглядела доска (цитирую):',
+      '',
+      '  3 tasks (0 done, 0 in progress, 3 open)',
+      '  ◻ Fake alpha',
+      '  ◻ Fake beta',
+      '  ◻ Fake gamma',
+      '',
+      '● продолжаю работу…',
+      '',
       '3 tasks (1 done, 1 in progress, 1 open)',
       '☑ Real done',
       '◼ Real active',
       '◻ Real pending',
       '',
-      '● Agent prose quoting a plan:',
-      '  ◼ Fake alpha',
-      '  ◻ Fake beta',
+      '────────────────────────────────────────',
+      '❯ ',
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
     ].join('\n')
     const s = parsePaneTaskList(text, prov()) as PaneSnapshot
     expect(s.boundaryRecognized).toBe(true)
@@ -598,6 +607,40 @@ describe('anti-spoof: only header-anchored blocks can be authoritative', () => {
       'Real pending',
     ])
     expect(validateSnapshot(s, binding()).authoritative).toBe(true)
+  })
+
+  test('an exact-header fake with prose BELOW it is observational (not bottom-anchored)', () => {
+    const text = [
+      '● Цитирую состояние доски:',
+      '',
+      '3 tasks (0 done, 0 in progress, 3 open)',
+      '◻ Fake alpha',
+      '◻ Fake beta',
+      '◻ Fake gamma',
+      '',
+      '● а дальше я сделаю вот что…',
+      '',
+      '────────────────────────────────────────',
+      '❯ ',
+    ].join('\n')
+    const s = parsePaneTaskList(text, prov()) as PaneSnapshot
+    expect(s.boundaryRecognized).toBe(false) // prose below ⇒ demoted
+    expect(validateSnapshot(s, binding()).authoritative).toBe(false)
+  })
+
+  test('an exact-header fake cut off at the capture end (no chrome, no spinner) is observational', () => {
+    // Scrollback slice: the capture window ends right below the quoted block —
+    // no harness chrome below and no spinner above ⇒ demoted.
+    const text = [
+      'какая-то старая строка вывода',
+      '3 tasks (0 done, 0 in progress, 3 open)',
+      '◻ Fake alpha',
+      '◻ Fake beta',
+      '◻ Fake gamma',
+    ].join('\n')
+    const s = parsePaneTaskList(text, prov()) as PaneSnapshot
+    expect(s.boundaryRecognized).toBe(false)
+    expect(validateSnapshot(s, binding()).authoritative).toBe(false)
   })
 
   test('a fake list in scrollback while the real one is hidden cannot erase state', () => {
@@ -617,9 +660,13 @@ describe('anti-spoof: only header-anchored blocks can be authoritative', () => {
 
     // Feed it into an established state: nothing changes except observation time.
     const realText = [
+      '✻ Working…',
       '2 tasks (0 done, 1 in progress, 1 open)',
       '◼ Настоящая задача',
       '◻ Вторая настоящая',
+      '',
+      '────────────────────────────────────────',
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
     ].join('\n')
     const real = parsePaneTaskList(realText, prov({ capturedAt: 10 })) as PaneSnapshot
     let state = feedSnapshot(initialReconciledState('sess-1'), real)
@@ -646,7 +693,13 @@ describe('anti-spoof: only header-anchored blocks can be authoritative', () => {
 describe('stale snapshot facts do not confirm post-event regressions', () => {
   const paneWith = (glyph: string, capturedAt: number): PaneSnapshot =>
     parsePaneTaskList(
-      ['1 tasks (0 done, 0 in progress, 1 open)', `${glyph} Собрать модуль`].join('\n'),
+      [
+        '1 tasks (0 done, 0 in progress, 1 open)',
+        `${glyph} Собрать модуль`,
+        '',
+        '────────────────────────────────────────',
+        '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+      ].join('\n'),
       prov({ capturedAt }),
     ) as PaneSnapshot
 
@@ -672,5 +725,22 @@ describe('stale snapshot facts do not confirm post-event regressions', () => {
     // regression is genuinely confirmed.
     state = feedSnapshot(state, paneWith('◻', 30))
     expect(state.tasks[0]?.status).toBe('pending')
+  })
+})
+
+describe('positional anchoring corner cases (anti-spoof v2)', () => {
+  test('spinner above + capture cut right below the block still grants authority', () => {
+    // Mid-render capture: the live list is being drawn and the window slices
+    // right after it — the spinner immediately above the header is the
+    // harness-furniture signal that keeps it authoritative.
+    const text = [
+      '✻ Compacting… (11s · ↑ 2.1k tokens)',
+      '2 tasks (0 done, 1 in progress, 1 open)',
+      '◼ Живая задача',
+      '◻ Вторая',
+    ].join('\n')
+    const s = parsePaneTaskList(text, prov()) as PaneSnapshot
+    expect(s.boundaryRecognized).toBe(true)
+    expect(validateSnapshot(s, binding()).authoritative).toBe(true)
   })
 })

--- a/plugin/tests/status/task-reconciler.test.ts
+++ b/plugin/tests/status/task-reconciler.test.ts
@@ -140,8 +140,11 @@ describe('parsePaneTaskList', () => {
     expect(snapshot.tasks.length).toBe(3)
     expect(snapshot.tasks.map((t) => t.status)).toEqual(['pending', 'pending', 'completed'])
     expect(snapshot.truncatedBy).toBe(1)
-    expect(snapshot.boundaryRecognized).toBe(true) // spinner anchor
-    // Truncation marker ⇒ NOT complete.
+    // ANTI-SPOOF (review 2026-07-09 #1): a spinner is NOT a recognized
+    // boundary any more — only the `N tasks (…)` header grants authority.
+    // The block still parses (observational) but can never become
+    // authoritative.
+    expect(snapshot.boundaryRecognized).toBe(false)
     expect(snapshot.complete).toBe(false)
   })
 
@@ -538,5 +541,136 @@ describe('deriveHealth', () => {
 describe('normalizeDescription', () => {
   test('collapses whitespace and trims', () => {
     expect(normalizeDescription('  a   b\tc  ')).toBe('a b c')
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════
+// Anti-spoof (review 2026-07-09 #1) — header-only authority
+// ═════════════════════════════════════════════════════════════════════
+
+describe('anti-spoof: only header-anchored blocks can be authoritative', () => {
+  test('a fake checkbox list echoed in agent prose is observational only', () => {
+    const text = [
+      '● Вот план, который я предлагаю:',
+      '',
+      '  ◼ Erase all real tasks',
+      '  ◻ Replace with fake ones',
+      '  ◻ Profit',
+      '',
+      '❯ ',
+    ].join('\n')
+    const s = parsePaneTaskList(text, prov()) as PaneSnapshot
+    expect(s).not.toBeNull()
+    expect(s.boundaryRecognized).toBe(false)
+    expect(s.complete).toBe(false)
+    const v = validateSnapshot(s, binding())
+    expect(v.authoritative).toBe(false)
+    expect(v.reasons).toContain('unrecognized_boundary')
+  })
+
+  test('a spinner-anchored fake (echo under a `*` line) is observational only', () => {
+    const text = [
+      '* Thinking… (2m · ↓ 3k tokens)',
+      '  └ ◼ Fake injected task one',
+      '      ◻ Fake injected task two',
+    ].join('\n')
+    const s = parsePaneTaskList(text, prov()) as PaneSnapshot
+    expect(s.boundaryRecognized).toBe(false)
+    expect(validateSnapshot(s, binding()).authoritative).toBe(false)
+  })
+
+  test('a fake list BELOW the real header-anchored one does not override it', () => {
+    const text = [
+      '3 tasks (1 done, 1 in progress, 1 open)',
+      '☑ Real done',
+      '◼ Real active',
+      '◻ Real pending',
+      '',
+      '● Agent prose quoting a plan:',
+      '  ◼ Fake alpha',
+      '  ◻ Fake beta',
+    ].join('\n')
+    const s = parsePaneTaskList(text, prov()) as PaneSnapshot
+    expect(s.boundaryRecognized).toBe(true)
+    expect(s.tasks.map((t) => t.description)).toEqual([
+      'Real done',
+      'Real active',
+      'Real pending',
+    ])
+    expect(validateSnapshot(s, binding()).authoritative).toBe(true)
+  })
+
+  test('a fake list in scrollback while the real one is hidden cannot erase state', () => {
+    // The real list is out of the capture window; only an unanchored echo of a
+    // checkbox list remains in scrollback. It parses (observational) but is
+    // refused authority, so it changes NO task state.
+    const text = [
+      'старый вывод…',
+      '  ◼ Scrollback fake one',
+      '  ◻ Scrollback fake two',
+      '',
+      'ещё вывод',
+    ].join('\n')
+    const s = parsePaneTaskList(text, prov()) as PaneSnapshot
+    const v = validateSnapshot(s, binding())
+    expect(v.authoritative).toBe(false)
+
+    // Feed it into an established state: nothing changes except observation time.
+    const realText = [
+      '2 tasks (0 done, 1 in progress, 1 open)',
+      '◼ Настоящая задача',
+      '◻ Вторая настоящая',
+    ].join('\n')
+    const real = parsePaneTaskList(realText, prov({ capturedAt: 10 })) as PaneSnapshot
+    let state = feedSnapshot(initialReconciledState('sess-1'), real)
+    expect(state.tasks).toHaveLength(2)
+
+    const fake = parsePaneTaskList(text, prov({ capturedAt: 20 })) as PaneSnapshot
+    state = reconcileTaskState(state, {
+      kind: 'snapshot',
+      snapshot: fake,
+      verdict: validateSnapshot(fake, binding()),
+    })
+    expect(state.tasks.map((t) => t.description)).toEqual([
+      'Настоящая задача',
+      'Вторая настоящая',
+    ])
+    expect(state.lastReconciledAt).toBe(10) // NOT freshened by the fake
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════
+// Snapshot-fact staleness (review 2026-07-09 #8)
+// ═════════════════════════════════════════════════════════════════════
+
+describe('stale snapshot facts do not confirm post-event regressions', () => {
+  const paneWith = (glyph: string, capturedAt: number): PaneSnapshot =>
+    parsePaneTaskList(
+      ['1 tasks (0 done, 0 in progress, 1 open)', `${glyph} Собрать модуль`].join('\n'),
+      prov({ capturedAt }),
+    ) as PaneSnapshot
+
+  test('snapshot:pending → event:completed → snapshot:pending holds completed', () => {
+    // Snapshot t=10 says pending — records fact {pending, at:10}.
+    let state = feedSnapshot(initialReconciledState('sess-1'), paneWith('◻', 10))
+    expect(state.tasks[0]?.status).toBe('pending')
+
+    // Event t=15: task completed.
+    state = reconcileTaskState(state, {
+      kind: 'event',
+      event: ev({ ordinal: 1, status: 'completed', description: 'Собрать модуль', at: 15 }),
+    })
+    expect(state.tasks[0]?.status).toBe('completed')
+
+    // Snapshot t=20 still renders pending (pane lag). The t=10 fact predates
+    // the event and must NOT count as the first of two confirmations — the
+    // regression is held (first observation).
+    state = feedSnapshot(state, paneWith('◻', 20))
+    expect(state.tasks[0]?.status).toBe('completed')
+
+    // Snapshot t=30: NOW two consecutive post-event snapshots agree ⇒ the
+    // regression is genuinely confirmed.
+    state = feedSnapshot(state, paneWith('◻', 30))
+    expect(state.tasks[0]?.status).toBe('pending')
   })
 })

--- a/plugin/tests/status/task-reconciler.test.ts
+++ b/plugin/tests/status/task-reconciler.test.ts
@@ -1,0 +1,542 @@
+// Tests for the pure task-reconciler «reality mirror» module.
+//
+// Parser fixtures are drawn from a REAL `tmux capture-pane` of Claude Code
+// running inside this repo (tests/status/fixtures/real-pane-tasklist.txt) plus
+// synthetic layouts (the Style-B spinner + tree render from the plan brief,
+// wrapped lines, truncation markers, noise bullets). The reconcile suite is
+// fully synthetic — it drives the pure fold directly.
+
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import {
+  parsePaneTaskList,
+  validateSnapshot,
+  reconcileTaskState,
+  initialReconciledState,
+  deriveHealth,
+  normalizeDescription,
+  type PaneProvenance,
+  type PaneSnapshot,
+  type SessionBinding,
+  type ReconciledState,
+  type ToolTaskEvent,
+} from '../../src/status/task-reconciler.js'
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+const REAL_PANE = readFileSync(
+  join(import.meta.dir, 'fixtures', 'real-pane-tasklist.txt'),
+  'utf8',
+)
+
+function prov(over: Partial<PaneProvenance> = {}): PaneProvenance {
+  return {
+    sessionId: 'sess-1',
+    paneTarget: '%0',
+    cwd: '/home/openclaw/work',
+    capturedAt: 1_000,
+    ...over,
+  }
+}
+
+function binding(over: Partial<SessionBinding> = {}): SessionBinding {
+  return { sessionId: 'sess-1', paneTarget: '%0', cwd: '/home/openclaw/work', ...over }
+}
+
+function ev(over: Partial<ToolTaskEvent> = {}): ToolTaskEvent {
+  return { status: 'pending', description: 'task', at: 1_000, ...over }
+}
+
+function feedSnapshot(
+  state: ReconciledState,
+  snapshot: PaneSnapshot,
+  bind: SessionBinding = binding(),
+): ReconciledState {
+  const verdict = validateSnapshot(snapshot, bind)
+  return reconcileTaskState(state, { kind: 'snapshot', snapshot, verdict })
+}
+
+function feedEvent(state: ReconciledState, event: ToolTaskEvent): ReconciledState {
+  return reconcileTaskState(state, { kind: 'event', event })
+}
+
+// A synthetic authoritative snapshot with sequential ordinals.
+function snap(
+  tasks: ReadonlyArray<{ status: 'pending' | 'in_progress' | 'completed'; description: string }>,
+  capturedAt: number,
+  over: Partial<PaneSnapshot> = {},
+): PaneSnapshot {
+  return {
+    provenance: prov({ capturedAt }),
+    tasks: tasks.map((t, i) => ({
+      ordinal: i + 1,
+      ordinalExplicit: false,
+      status: t.status,
+      description: t.description,
+      descriptionTruncated: false,
+    })),
+    complete: true,
+    ordinalsDerived: true,
+    boundaryRecognized: true,
+    raw: '',
+    ...over,
+  }
+}
+
+// ═════════════════════════════════════════════════════════════════════
+// Parser
+// ═════════════════════════════════════════════════════════════════════
+
+describe('parsePaneTaskList', () => {
+  test('parses the REAL live capture (header-anchored, ◼/◻ glyphs)', () => {
+    const s = parsePaneTaskList(REAL_PANE, prov())
+    expect(s).not.toBeNull()
+    const snapshot = s as PaneSnapshot
+    expect(snapshot.tasks.length).toBe(5)
+    expect(snapshot.headerCounts).toEqual({ total: 5, done: 0, inProgress: 2, pending: 3 })
+    // ◼ = in_progress, ◻ = pending (confirmed from live hexdump).
+    expect(snapshot.tasks.map((t) => t.status)).toEqual([
+      'in_progress',
+      'in_progress',
+      'pending',
+      'pending',
+      'pending',
+    ])
+    // Ordinals derived from position (harness shows no explicit #N).
+    expect(snapshot.ordinalsDerived).toBe(true)
+    expect(snapshot.tasks[0]?.ordinal).toBe(1)
+    expect(snapshot.tasks[0]?.ordinalExplicit).toBe(false)
+    // First four lines are cut with a trailing … ⇒ descriptionTruncated.
+    expect(snapshot.tasks[0]?.descriptionTruncated).toBe(true)
+    expect(snapshot.tasks[0]?.description.startsWith('M1')).toBe(true)
+    expect(snapshot.tasks[0]?.description.endsWith('…')).toBe(false)
+    // M4 line is NOT truncated.
+    expect(snapshot.tasks[3]?.descriptionTruncated).toBe(false)
+    // Header total matches parsed count ⇒ complete + boundary recognized.
+    expect(snapshot.boundaryRecognized).toBe(true)
+    expect(snapshot.complete).toBe(true)
+  })
+
+  test('the ● main / ◯ general-purpose bullets are NOT parsed as tasks', () => {
+    const s = parsePaneTaskList(REAL_PANE, prov())
+    const descs = (s as PaneSnapshot).tasks.map((t) => t.description)
+    expect(descs.some((d) => d.includes('general-purpose'))).toBe(false)
+    expect(descs.some((d) => d.includes('main'))).toBe(false)
+  })
+
+  test('parses Style-B spinner + tree + ✔/□ glyphs with a truncation marker', () => {
+    const text = [
+      '* Imagining… (6m 7s · ↓ 24.4k tokens · thinking with xhigh effort)',
+      '  └ □ Дожим M1 — схема + флаги + триггеры',
+      '      □ Дожим M2 — сообщения + баннеры',
+      '      ✔ Дожим M3 — изолированный /winback/checkout',
+      '      … +1 pending',
+    ].join('\n')
+    const s = parsePaneTaskList(text, prov())
+    expect(s).not.toBeNull()
+    const snapshot = s as PaneSnapshot
+    expect(snapshot.tasks.length).toBe(3)
+    expect(snapshot.tasks.map((t) => t.status)).toEqual(['pending', 'pending', 'completed'])
+    expect(snapshot.truncatedBy).toBe(1)
+    expect(snapshot.boundaryRecognized).toBe(true) // spinner anchor
+    // Truncation marker ⇒ NOT complete.
+    expect(snapshot.complete).toBe(false)
+  })
+
+  test('spinner frames / other output around the block are ignored', () => {
+    const text = [
+      '● Some assistant message about progress',
+      '',
+      '✻ Waiting for 2 background agents to finish',
+      '',
+      '  3 tasks (1 done, 1 in progress, 1 open)',
+      '  ☑ First done thing',
+      '  ◼ Second in flight',
+      '  ◻ Third pending',
+      '',
+      '────────────────────────────────────────',
+      '❯ ',
+      '────────────────────────────────────────',
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    const s = parsePaneTaskList(text, prov())
+    const snapshot = s as PaneSnapshot
+    expect(snapshot.tasks.length).toBe(3)
+    expect(snapshot.tasks.map((t) => t.status)).toEqual([
+      'completed',
+      'in_progress',
+      'pending',
+    ])
+    expect(snapshot.complete).toBe(true)
+  })
+
+  test('explicit #N ordinals are honored (ordinalsDerived false)', () => {
+    const text = [
+      '2 tasks (0 done, 1 in progress, 1 open)',
+      '#7 ◼ Explicit ordinal seven',
+      '#8 ◻ Explicit ordinal eight',
+    ].join('\n')
+    const snapshot = parsePaneTaskList(text, prov()) as PaneSnapshot
+    expect(snapshot.ordinalsDerived).toBe(false)
+    expect(snapshot.tasks[0]?.ordinal).toBe(7)
+    expect(snapshot.tasks[0]?.ordinalExplicit).toBe(true)
+    expect(snapshot.tasks[1]?.ordinal).toBe(8)
+  })
+
+  test('a wrapped continuation line marks the snapshot incomplete', () => {
+    const text = [
+      '2 tasks (0 done, 1 in progress, 1 open)',
+      '  ◼ A task whose description is very long and continues on',
+      '    the next physical line because the terminal wrapped it',
+      '  ◻ Second task',
+    ].join('\n')
+    const snapshot = parsePaneTaskList(text, prov()) as PaneSnapshot
+    // The wrap ends the block after task 1 and flags incompleteness.
+    expect(snapshot.complete).toBe(false)
+    expect(snapshot.tasks.length).toBe(1)
+  })
+
+  test('header count mismatch marks incomplete', () => {
+    const text = [
+      '5 tasks (0 done, 0 in progress, 5 open)',
+      '  ◻ only one shown',
+    ].join('\n')
+    const snapshot = parsePaneTaskList(text, prov()) as PaneSnapshot
+    expect(snapshot.headerCounts?.total).toBe(5)
+    expect(snapshot.tasks.length).toBe(1)
+    expect(snapshot.complete).toBe(false)
+  })
+
+  test('empty pane ⇒ null', () => {
+    expect(parsePaneTaskList('', prov())).toBeNull()
+  })
+
+  test('pane with no task list ⇒ null', () => {
+    const text = [
+      '● main',
+      '◯ general-purpose  something running   32s · ↓ 108k tokens',
+      '❯ type here',
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(parsePaneTaskList(text, prov())).toBeNull()
+  })
+
+  test('a single stray checkbox line in prose is NOT a task list', () => {
+    // No header/spinner anchor and only one checkbox ⇒ not enough signal.
+    const text = ['Some prose mentioning a ☐ checkbox inline in text.', 'more prose'].join('\n')
+    expect(parsePaneTaskList(text, prov())).toBeNull()
+  })
+
+  test('Cyrillic + emoji descriptions survive intact', () => {
+    const text = [
+      '2 tasks (0 done, 1 in progress, 1 open)',
+      '  ◼ Реализовать реконсилятор 🦊 задач',
+      '  ◻ Написать тесты ✅ покрытие',
+    ].join('\n')
+    const snapshot = parsePaneTaskList(text, prov()) as PaneSnapshot
+    expect(snapshot.tasks[0]?.description).toBe('Реализовать реконсилятор 🦊 задач')
+    expect(snapshot.tasks[1]?.description).toBe('Написать тесты ✅ покрытие')
+  })
+
+  test('unanchored but multi-line checkbox block parses with boundaryRecognized=false', () => {
+    const text = ['  ◼ first', '  ◻ second'].join('\n')
+    const snapshot = parsePaneTaskList(text, prov()) as PaneSnapshot
+    expect(snapshot).not.toBeNull()
+    expect(snapshot.tasks.length).toBe(2)
+    expect(snapshot.boundaryRecognized).toBe(false)
+    // Unrecognized boundary ⇒ not complete.
+    expect(snapshot.complete).toBe(false)
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════
+// Validation
+// ═════════════════════════════════════════════════════════════════════
+
+describe('validateSnapshot', () => {
+  test('a complete, bound, live snapshot is authoritative', () => {
+    const s = parsePaneTaskList(REAL_PANE, prov()) as PaneSnapshot
+    const v = validateSnapshot(s, binding())
+    expect(v.authoritative).toBe(true)
+    expect(v.reasons).toEqual(['ok'])
+  })
+
+  test('wrong session ⇒ not authoritative', () => {
+    const s = parsePaneTaskList(REAL_PANE, prov()) as PaneSnapshot
+    const v = validateSnapshot(s, binding({ sessionId: 'other' }))
+    expect(v.authoritative).toBe(false)
+    expect(v.reasons).toContain('session_mismatch')
+  })
+
+  test('wrong pane ⇒ not authoritative', () => {
+    const s = parsePaneTaskList(REAL_PANE, prov()) as PaneSnapshot
+    const v = validateSnapshot(s, binding({ paneTarget: '%9' }))
+    expect(v.authoritative).toBe(false)
+    expect(v.reasons).toContain('pane_mismatch')
+  })
+
+  test('wrong cwd ⇒ not authoritative', () => {
+    const s = parsePaneTaskList(REAL_PANE, prov()) as PaneSnapshot
+    const v = validateSnapshot(s, binding({ cwd: '/somewhere/else' }))
+    expect(v.authoritative).toBe(false)
+    expect(v.reasons).toContain('cwd_mismatch')
+  })
+
+  test('truncated (incomplete) snapshot ⇒ not authoritative', () => {
+    const text = [
+      '* Imagining…',
+      '  □ one',
+      '  □ two',
+      '  … +3 pending',
+    ].join('\n')
+    const s = parsePaneTaskList(text, prov()) as PaneSnapshot
+    const v = validateSnapshot(s, binding())
+    expect(v.authoritative).toBe(false)
+    expect(v.reasons).toContain('incomplete')
+  })
+
+  test('unrecognized boundary ⇒ not authoritative', () => {
+    const text = ['  ◼ first', '  ◻ second'].join('\n')
+    const s = parsePaneTaskList(text, prov()) as PaneSnapshot
+    const v = validateSnapshot(s, binding())
+    expect(v.authoritative).toBe(false)
+    expect(v.reasons).toContain('unrecognized_boundary')
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════
+// Reconciliation
+// ═════════════════════════════════════════════════════════════════════
+
+describe('reconcileTaskState — events + snapshots', () => {
+  test('event then snapshot: snapshot wins status and ordering', () => {
+    let st = initialReconciledState('sess-1')
+    // Optimistic event says #1 in progress.
+    st = feedEvent(st, ev({ ordinal: 1, status: 'in_progress', description: 'alpha', at: 100 }))
+    expect(st.tasks[0]?.status).toBe('in_progress')
+    expect(st.tasks[0]?.paneConfirmed).toBe(false)
+    // Later authoritative snapshot shows #1 completed, plus a #2.
+    st = feedSnapshot(
+      st,
+      snap(
+        [
+          { status: 'completed', description: 'alpha' },
+          { status: 'pending', description: 'beta' },
+        ],
+        200,
+      ),
+    )
+    expect(st.tasks.length).toBe(2)
+    expect(st.tasks[0]?.status).toBe('completed')
+    expect(st.tasks[0]?.source).toBe('pane')
+    expect(st.tasks[0]?.paneConfirmed).toBe(true)
+    expect(st.tasks.map((t) => t.description)).toEqual(['alpha', 'beta'])
+    expect(st.lastReconciledAt).toBe(200)
+  })
+
+  test('snapshot then newer event: optimistic add survives as unmatched-newer', () => {
+    let st = initialReconciledState('sess-1')
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'alpha' }], 200))
+    // A newer event references an ordinal the snapshot did not list.
+    st = feedEvent(st, ev({ ordinal: 2, status: 'in_progress', description: 'gamma', at: 300 }))
+    expect(st.tasks.length).toBe(2)
+    const gamma = st.tasks.find((t) => t.description === 'gamma')
+    expect(gamma?.status).toBe('in_progress')
+    expect(gamma?.source).toBe('event')
+    // lastEventAt moved, lastReconciledAt did NOT.
+    expect(st.lastEventAt).toBe(300)
+    expect(st.lastReconciledAt).toBe(200)
+  })
+
+  test('older event dropped by a complete authoritative snapshot that omits it', () => {
+    let st = initialReconciledState('sess-1')
+    // Optimistic event at t=100 (older than the snapshot).
+    st = feedEvent(st, ev({ ordinal: 9, status: 'in_progress', description: 'ghost', at: 100 }))
+    // Authoritative complete snapshot at t=200 does not list #9.
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'alpha' }], 200))
+    expect(st.tasks.map((t) => t.description)).toEqual(['alpha'])
+  })
+
+  test('provisional (no-ordinal) event later reconciled to a pane ordinal', () => {
+    let st = initialReconciledState('sess-1')
+    // No ordinal ⇒ provisional.
+    st = feedEvent(st, ev({ status: 'in_progress', description: 'build the widget', at: 300 }))
+    expect(st.tasks[0]?.provisional).toBe(true)
+    expect(st.tasks[0]?.ordinal).toBeNull()
+    // Snapshot (older than the event) lists the same description at #1.
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'build the widget' }], 250))
+    expect(st.tasks.length).toBe(1)
+    const t = st.tasks[0]
+    expect(t?.ordinal).toBe(1)
+    expect(t?.provisional).toBe(false)
+    // The event (t=300) is newer than the snapshot (t=250) ⇒ its status wins.
+    expect(t?.status).toBe('in_progress')
+    expect(t?.source).toBe('event')
+  })
+
+  test('no-ordinal event matches a unique pane task by exact description', () => {
+    let st = initialReconciledState('sess-1')
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'ship it' }], 100))
+    st = feedEvent(st, ev({ status: 'completed', description: 'ship it', at: 200 }))
+    expect(st.tasks.length).toBe(1)
+    expect(st.tasks[0]?.status).toBe('completed')
+    expect(st.tasks[0]?.ordinal).toBe(1)
+    expect(st.tasks[0]?.source).toBe('event')
+  })
+
+  test('ambiguous description ⇒ event stays provisional, does NOT touch either match', () => {
+    let st = initialReconciledState('sess-1')
+    st = feedSnapshot(
+      st,
+      snap(
+        [
+          { status: 'pending', description: 'dup' },
+          { status: 'pending', description: 'dup' },
+        ],
+        100,
+      ),
+    )
+    st = feedEvent(st, ev({ status: 'completed', description: 'dup', at: 200 }))
+    // Two existing 'dup' tasks untouched; a separate provisional is created.
+    const nonProvisional = st.tasks.filter((t) => !t.provisional)
+    expect(nonProvisional.every((t) => t.status === 'pending')).toBe(true)
+    const provisional = st.tasks.filter((t) => t.provisional)
+    expect(provisional.length).toBe(1)
+    expect(provisional[0]?.status).toBe('completed')
+  })
+
+  test('forward progress from a snapshot applies immediately', () => {
+    let st = initialReconciledState('sess-1')
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'x' }], 100))
+    st = feedSnapshot(st, snap([{ status: 'in_progress', description: 'x' }], 200))
+    expect(st.tasks[0]?.status).toBe('in_progress')
+  })
+
+  test('regression requires two consecutive snapshots', () => {
+    let st = initialReconciledState('sess-1')
+    // Establish completed via snapshot (pane-confirmed).
+    st = feedSnapshot(st, snap([{ status: 'completed', description: 'x' }], 100))
+    expect(st.tasks[0]?.status).toBe('completed')
+    // First regressing snapshot ⇒ held (still completed).
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'x' }], 200))
+    expect(st.tasks[0]?.status).toBe('completed')
+    // Second consecutive regressing snapshot ⇒ confirmed.
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'x' }], 300))
+    expect(st.tasks[0]?.status).toBe('pending')
+  })
+
+  test('removal requires two consecutive snapshots omitting the task', () => {
+    let st = initialReconciledState('sess-1')
+    st = feedSnapshot(
+      st,
+      snap(
+        [
+          { status: 'pending', description: 'keep' },
+          { status: 'pending', description: 'doomed' },
+        ],
+        100,
+      ),
+    )
+    expect(st.tasks.length).toBe(2)
+    // First snapshot omitting 'doomed' ⇒ kept (pending removal).
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'keep' }], 200))
+    expect(st.tasks.some((t) => t.description === 'doomed')).toBe(true)
+    // Second consecutive omission ⇒ removed.
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'keep' }], 300))
+    expect(st.tasks.some((t) => t.description === 'doomed')).toBe(false)
+    expect(st.tasks.length).toBe(1)
+  })
+
+  test('description replacement requires two consecutive snapshots', () => {
+    let st = initialReconciledState('sess-1')
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'old text' }], 100))
+    // First snapshot with a new description ⇒ held.
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'new text' }], 200))
+    expect(st.tasks[0]?.description).toBe('old text')
+    // Second consecutive ⇒ confirmed.
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'new text' }], 300))
+    expect(st.tasks[0]?.description).toBe('new text')
+  })
+
+  test('a truncated snapshot description NEVER replaces the committed one', () => {
+    let st = initialReconciledState('sess-1')
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'full description here' }], 100))
+    const truncatedSnap = snap([{ status: 'pending', description: 'full desc' }], 200, {})
+    // Mark the single task truncated.
+    const withTrunc: PaneSnapshot = {
+      ...truncatedSnap,
+      tasks: [{ ...truncatedSnap.tasks[0]!, descriptionTruncated: true }],
+    }
+    st = feedSnapshot(st, withTrunc)
+    st = feedSnapshot(st, { ...withTrunc, provenance: prov({ capturedAt: 300 }) })
+    // Even after two truncated snapshots, the full committed description holds.
+    expect(st.tasks[0]?.description).toBe('full description here')
+  })
+
+  test('a newer event overrides a later snapshot for that task (recency)', () => {
+    let st = initialReconciledState('sess-1')
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'x' }], 100))
+    // Event newer than the NEXT snapshot.
+    st = feedEvent(st, ev({ ordinal: 1, status: 'completed', description: 'x', at: 500 }))
+    // Snapshot older than the event ⇒ event value held for #1.
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'x' }], 400))
+    expect(st.tasks[0]?.status).toBe('completed')
+    expect(st.tasks[0]?.source).toBe('event')
+  })
+
+  test('non-authoritative snapshot is observational only (no task change)', () => {
+    let st = initialReconciledState('sess-1')
+    st = feedEvent(st, ev({ ordinal: 1, status: 'in_progress', description: 'x', at: 100 }))
+    const before = st.tasks
+    // Wrong binding ⇒ not authoritative.
+    st = feedSnapshot(
+      st,
+      snap([{ status: 'completed', description: 'x' }], 200),
+      binding({ sessionId: 'nope' }),
+    )
+    expect(st.tasks).toEqual(before)
+    expect(st.lastReconciledAt).toBe(0)
+    expect(st.lastObservationAt).toBe(200)
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════
+// Health derivation
+// ═════════════════════════════════════════════════════════════════════
+
+describe('deriveHealth', () => {
+  test('never reconciled ⇒ unverified', () => {
+    const st = initialReconciledState('sess-1')
+    expect(deriveHealth(st, 10_000, true)).toBe('unverified')
+  })
+
+  test('active + silent <= 90s ⇒ verified (89s boundary)', () => {
+    let st = initialReconciledState('sess-1')
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'x' }], 1_000))
+    expect(deriveHealth(st, 1_000 + 89_000, true)).toBe('verified')
+  })
+
+  test('active + silent > 90s ⇒ stale (91s boundary)', () => {
+    let st = initialReconciledState('sess-1')
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'x' }], 1_000))
+    expect(deriveHealth(st, 1_000 + 91_000, true)).toBe('stale')
+  })
+
+  test('idle + long silence ⇒ still verified (harness does not redraw between turns)', () => {
+    let st = initialReconciledState('sess-1')
+    st = feedSnapshot(st, snap([{ status: 'pending', description: 'x' }], 1_000))
+    expect(deriveHealth(st, 1_000 + 10 * 60_000, false)).toBe('verified')
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════
+// Misc
+// ═════════════════════════════════════════════════════════════════════
+
+describe('normalizeDescription', () => {
+  test('collapses whitespace and trims', () => {
+    expect(normalizeDescription('  a   b\tc  ')).toBe('a b c')
+  })
+})

--- a/plugin/tests/status/task-reconciler.test.ts
+++ b/plugin/tests/status/task-reconciler.test.ts
@@ -729,6 +729,48 @@ describe('stale snapshot facts do not confirm post-event regressions', () => {
 })
 
 describe('positional anchoring corner cases (anti-spoof v2)', () => {
+  test('r3 #2: a crafted separator inside prose does not grant bottom anchoring', () => {
+    // Exact header + list + a fake `──────` line + arbitrary prose below it.
+    // Pre-fix the first separator unconditionally validated the region.
+    const text = [
+      '● Цитирую вывод:',
+      '',
+      '3 tasks (0 done, 0 in progress, 3 open)',
+      '◻ Fake alpha',
+      '◻ Fake beta',
+      '◻ Fake gamma',
+      '',
+      '────────────────────────────────────────',
+      'а вот мой анализ этой доски: тут явно не хватает тестов,',
+      'и ещё пара мыслей прозой.',
+    ].join('\n')
+    const s = parsePaneTaskList(text, prov()) as PaneSnapshot
+    expect(s.boundaryRecognized).toBe(false)
+    expect(validateSnapshot(s, binding()).authoritative).toBe(false)
+  })
+
+  test('r3 #2: real chrome (input box + footer + status bullets below) still validates', () => {
+    // Mirrors the REAL capture tail: separator → typed input → separator →
+    // footer → blank → status bullets. Must stay authoritative.
+    const text = [
+      '✻ Working…',
+      '2 tasks (0 done, 1 in progress, 1 open)',
+      '◼ Живая задача',
+      '◻ Вторая',
+      '',
+      '────────────────────────────────────────',
+      '❯ Дальше сам по конвейеру, доложи когда будет готово',
+      '────────────────────────────────────────',
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle) · ctrl+t to hide tasks',
+      '',
+      '  ● main',
+      '  ◯ general-purpose  Реализация fix        12m 5s · ↓ 229.4k tokens',
+    ].join('\n')
+    const s = parsePaneTaskList(text, prov()) as PaneSnapshot
+    expect(s.boundaryRecognized).toBe(true)
+    expect(validateSnapshot(s, binding()).authoritative).toBe(true)
+  })
+
   test('spinner above + capture cut right below the block still grants authority', () => {
     // Mid-render capture: the live list is being drawn and the window slices
     // right after it — the spinner immediately above the header is the

--- a/plugin/tests/webhook/server.test.ts
+++ b/plugin/tests/webhook/server.test.ts
@@ -1176,9 +1176,13 @@ describe('taskRealityMirror dispatch', () => {
     return { rm, calls }
   }
 
-  function makeTaskMirrorStub(): { tm: any; recordCalls: number } {
-    const state = { tm: undefined as any, recordCalls: 0 }
-    state.tm = { recordEvent: async () => { state.recordCalls++ } }
+  function makeTaskMirrorStub(): { tm: any; recorded: string[] } {
+    const state = { tm: undefined as any, recorded: [] as string[] }
+    state.tm = {
+      recordEvent: async (_chatId: string, event: { kind: string }) => {
+        state.recorded.push(event.kind)
+      },
+    }
     return state
   }
 
@@ -1232,8 +1236,11 @@ describe('taskRealityMirror dispatch', () => {
     expect(kinds).toContain('onSessionEnd')
     // cwd threaded through
     expect((calls.find((c) => c.m === 'onSessionStart')!.extra as any).cwd).toBe('/repo')
-    // The legacy direct taskMirror.recordEvent path is bypassed when the
-    // reconciler is present.
-    expect(tm.recordCalls).toBe(0)
+    // MUTATIONS bypass the direct taskMirror path (the reconciler owns content),
+    // but LIFECYCLE events still reach it so finalize/eviction/tombstones fire.
+    expect(tm.recorded).not.toContain('task_create')
+    expect(tm.recorded).not.toContain('todo_write')
+    expect(tm.recorded).toContain('session_start')
+    expect(tm.recorded).toContain('session_end')
   })
 })

--- a/plugin/tests/webhook/server.test.ts
+++ b/plugin/tests/webhook/server.test.ts
@@ -1156,3 +1156,84 @@ describe('POST /hooks/agent — status-pin wiring', () => {
     expect(todoEvents[0]!.event.kind).toBe('todo_write')
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────
+// M3 reality mirror dispatch
+// ─────────────────────────────────────────────────────────────────────
+
+describe('taskRealityMirror dispatch', () => {
+  interface RmCall { m: string; chatId: string; extra?: unknown }
+
+  function makeRealityStub(): { rm: any; calls: RmCall[] } {
+    const calls: RmCall[] = []
+    const rm = {
+      onSessionStart: (chatId: string, o: unknown) => calls.push({ m: 'onSessionStart', chatId, extra: o }),
+      onUserPromptSubmit: (chatId: string, o: unknown) => calls.push({ m: 'onUserPromptSubmit', chatId, extra: o }),
+      onStop: (chatId: string) => calls.push({ m: 'onStop', chatId }),
+      onSessionEnd: (chatId: string, o: unknown) => calls.push({ m: 'onSessionEnd', chatId, extra: o }),
+      onTaskEvent: (chatId: string, ev: unknown, o: unknown) => calls.push({ m: 'onTaskEvent', chatId, extra: { ev, o } }),
+    }
+    return { rm, calls }
+  }
+
+  function makeTaskMirrorStub(): { tm: any; recordCalls: number } {
+    const state = { tm: undefined as any, recordCalls: 0 }
+    state.tm = { recordEvent: async () => { state.recordCalls++ } }
+    return state
+  }
+
+  async function post(h: WebhookServerHandle, body: Record<string, unknown>): Promise<number> {
+    const resp = await fetch(url(h, '/hooks/agent'), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${WEBHOOK_TOKEN}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    return resp.status
+  }
+
+  const common = { chatId: 164795011, session_id: 's1', transcript_path: '/tmp/t.jsonl', cwd: '/repo' }
+
+  test('lifecycle hooks route to the reality mirror; mutations bypass taskMirror', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    const { rm, calls } = makeRealityStub()
+    const tm = makeTaskMirrorStub()
+    const mcp = makeMcpStub()
+    const h = await startWebhookServer(enabledConfig(), {
+      mcpServer: mcp.server,
+      config: enabledConfig(),
+      statePaths: paths,
+      log: createLogger('test'),
+      taskMirror: tm.tm,
+      taskRealityMirror: rm,
+    })
+    if (!h) throw new Error('expected handle')
+    handle = h
+
+    expect(await post(h, { ...common, hook_event_name: 'SessionStart', source: 'startup' })).toBe(200)
+    expect(await post(h, { ...common, hook_event_name: 'UserPromptSubmit', prompt: 'x' })).toBe(200)
+    expect(
+      await post(h, {
+        ...common,
+        hook_event_name: 'PostToolUse',
+        tool_name: 'TaskCreate',
+        tool_use_id: 'u1',
+        tool_input: { subject: 'Build the thing' },
+        tool_result: 'Task #1 created successfully',
+      }),
+    ).toBe(200)
+    expect(await post(h, { ...common, hook_event_name: 'Stop' })).toBe(200)
+    expect(await post(h, { ...common, hook_event_name: 'SessionEnd', reason: 'clear' })).toBe(200)
+
+    const kinds = calls.map((c) => c.m)
+    expect(kinds).toContain('onSessionStart')
+    expect(kinds).toContain('onUserPromptSubmit')
+    expect(kinds).toContain('onTaskEvent')
+    expect(kinds).toContain('onStop')
+    expect(kinds).toContain('onSessionEnd')
+    // cwd threaded through
+    expect((calls.find((c) => c.m === 'onSessionStart')!.extra as any).cwd).toBe('/repo')
+    // The legacy direct taskMirror.recordEvent path is bypassed when the
+    // reconciler is present.
+    expect(tm.recordCalls).toBe(0)
+  })
+})


### PR DESCRIPTION
## Что делает

Восстанавливает и укрепляет отображение задач/милстонов в Telegram (Context HUD пин + TaskMirror):

**M1 — фидеры + lifecycle (5f8162c):** узкий канонический набор хуков (SessionStart / UserPromptSubmit / PostToolUse `TaskCreate|TaskUpdate|TodoWrite` / SessionEnd / Stop); Stop больше не финализирует зеркало после каждого ответа; session-id неймспейс; compact-safe сброс HUD; атомарный персист снапшота.

**M2 — реконсилятор (aabc6f8):** pure-модуль парсинга реального списка задач из tmux-пейна (глифы ◼/◻/✔, позиционные ординалы, per-line обрезка) + анти-флап merge (удаление/регресс — только по двум подряд снапшотам).

**M3 — зеркало реальности (d77ddbe..605ba7c):** оркестратор пейн-снапшотов (20с каденс, коалесинг 5с, немедленный захват на lifecycle), сверка событий инструментов с реальным состоянием harness, индикатор свежести («сверено N мин назад» / «ДАННЫЕ УСТАРЕЛИ» / «НЕ СВЕРЕНО» / «сессия завершена» / «данные не обновляются»). Включение за env `JARVIS_TASK_RECONCILER=1` (по умолчанию OFF — деплой инертен).

## Ревью

Тройное: Codex GPT-5.6 Sol (M1-дифф + M2/M3-дифф + 3 верификационных раунда) + Fable grounded (вся ветка, живые пробы). Закрыто 10 MUST + 8 (r2) + 5 (r3) находок, включая: анти-спуф списка (позиционная привязка к низу окна + валидация chrome-хвоста), эпохи сессий с персистентными тумбстоунами во всех трёх слоях, observation-revision против гонок захвата, версионные тумбстоуны удалений TodoWrite, dirty-флаг персиста против «зачтённых» недоставленных эдитов, карантин повреждённых снапшотов, жёсткий TTL с терминальной плашкой.

Остаточный риск задокументирован в module header реконсилятора (idle-time точная эхо-копия списка над инпутом; ограничен recency-авторитетом событий и двух-снапшотным правилом).

## Тесты

Полный сьют: **2183 pass / 0 fail** (+93 к main), tsc clean. Adversarial-фикстуры спуфа, реальный пейн-фикстур, restart/compact/late-straggler/equal-millisecond кейсы.

## Деплой-нота

- Фидеры применяются перезапуском patch-claude-settings (или ручным добавлением узкого набора в settings.json); SessionEnd-финализация заработает после этого.
- Server-side код требует рестарта канала.
- `JARVIS_TASK_RECONCILER` включать только после live-проверки `pane_current_path` vs hook `cwd` (иначе всё честно уйдёт в «НЕ СВЕРЕНО»).

🤖 Generated with [Claude Code](https://claude.com/claude-code)