### PR TITLE
Автономия M1: реестр мандатов и вопросов (lease store + MCP-тул + инъекция + HUD)

### DIFF
--- a/plugin/scripts/channel-reminder.ts
+++ b/plugin/scripts/channel-reminder.ts
@@ -27,20 +27,29 @@
 //     missing reminder must never gate the turn.
 //   * stdout carries ONLY the JSON envelope (no logs, no secrets) — anything
 //     else on stdout becomes additional model context.
-//   * The only file read is the OPTIONAL, best-effort TOV reminder file; a
-//     read failure silently falls back to the embedded constant and never
-//     gates the turn. Everything else is env-only.
+//   * File reads are OPTIONAL and best-effort: the TOV reminder file (falls
+//     back to the embedded constant) and the per-chat autonomy registry
+//     (autonomy-<chat>.json; unreadable/corrupt → the block is omitted).
+//     Neither can ever gate the turn. Everything else is env-only.
+//   * The autonomy store module is loaded LAZILY inside a try (fix-loop #6):
+//     a module-load failure (partial deploy, syntax error in src/) degrades
+//     to «no autonomy block» — it can never kill the hook and lose the
+//     channel-discipline reminder itself.
 //
 // Env:
 //   CHAT_ID              the Telegram chat id this session serves. Negative
 //                        ids are groups/supergroups (multichat); anything
 //                        else is a direct chat. Absent → DM-safe generic. Also
 //                        keys the autonomy-registry lookup below.
-//   TELEGRAM_STATE_DIR   (or MULTICHAT_STATE_DIR) the plugin state root. When
-//                        set, the per-turn autonomy block (active mandates +
-//                        open owner questions) is read from
-//                        <state-dir>/autonomy-<chat>.json and appended. Absent
-//                        or unreadable → the block is silently omitted
+//   TELEGRAM_STATE_DIR   the plugin state root, BAKED into the hook command by
+//                        patch-claude-settings (fix-loop #5) so the hook reads
+//                        the same registry the server writes. The per-turn
+//                        autonomy block (active mandates + open owner
+//                        questions) is read from
+//                        <state-dir>/autonomy-<chat>.json and appended.
+//                        MULTICHAT_STATE_DIR is a documented last-resort
+//                        fallback for legacy per-chat sessions. Absent or
+//                        unreadable → the block is silently omitted
 //                        (fail-open; a broken registry never gates the turn).
 //   TOV_REMINDER_ENABLED falsy (0/false/no/off, case-insensitive) disables
 //                        the TOV block. Default: enabled.
@@ -54,8 +63,6 @@
 import { readFileSync, realpathSync } from 'node:fs'
 import { dirname, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
-
-import { buildAutonomyReminderBlock, loadAutonomyState } from '../src/autonomy/store.js'
 
 const DM_REMINDER =
   'Telegram bridge: the sender reads Telegram, not this terminal — terminal/transcript text never reaches them. ' +
@@ -156,32 +163,43 @@ export function tovReminder(env: NodeJS.ProcessEnv = process.env): string | unde
  * error returns undefined so the reminder still ships without the block — a
  * broken registry must never gate the turn.
  *
- * State dir resolution mirrors the other dashi hooks
- * (read-receipt/fallback-reply): TELEGRAM_STATE_DIR ?? MULTICHAT_STATE_DIR. The
- * chat id comes from CHAT_ID (the same var reminderForChat reads). When neither
- * a state dir nor a chat id is available (e.g. a per-chat session whose env was
- * wiped), the block is simply omitted.
+ * State dir resolution: the CANONICAL source is the inline TELEGRAM_STATE_DIR
+ * that patch-claude-settings bakes into the hook command (fix-loop #5) — that
+ * is the SAME resolved root the running server writes its registry into.
+ * MULTICHAT_STATE_DIR is honored only as a documented last-resort fallback
+ * for legacy per-chat sessions whose command predates the baked var. When
+ * neither a state dir nor a chat id is available, the block is simply omitted.
+ *
+ * The store module is imported LAZILY inside the try (fix-loop #6): a static
+ * top-level import from ../src/ would make a module-load failure (partial
+ * deploy, syntax error) kill the WHOLE hook — losing the channel-discipline
+ * reminder too. A failed dynamic import degrades to «no autonomy block».
  */
-export function autonomyReminder(env: NodeJS.ProcessEnv = process.env): string | undefined {
+export async function autonomyReminder(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string | undefined> {
   try {
     const chatId = (env.CHAT_ID ?? '').trim()
     if (chatId === '') return undefined
     const stateDir = env.TELEGRAM_STATE_DIR ?? env.MULTICHAT_STATE_DIR
     if (!stateDir || stateDir.trim() === '') return undefined
+    const { buildAutonomyReminderBlock, loadAutonomyState } = await import(
+      '../src/autonomy/store.js'
+    )
     const state = loadAutonomyState({ root: stateDir }, chatId)
     return buildAutonomyReminderBlock(state, Date.now())
   } catch {
-    // Never gate the turn on an autonomy-state failure.
+    // Never gate the turn on an autonomy-state / module-load failure.
     return undefined
   }
 }
 
 /** Compose the full additionalContext string: channel discipline first, then
  *  the optional autonomy block, then the optional TOV block — each separated by
- *  a blank line. */
-export function composeReminder(env: NodeJS.ProcessEnv = process.env): string {
+ *  a blank line. Async because the autonomy block loads its module lazily. */
+export async function composeReminder(env: NodeJS.ProcessEnv = process.env): Promise<string> {
   const channel = reminderForChat(env.CHAT_ID)
-  const autonomy = autonomyReminder(env)
+  const autonomy = await autonomyReminder(env)
   const tov = tovReminder(env)
   return [channel, autonomy, tov].filter((s): s is string => s !== undefined && s.length > 0).join('\n\n')
 }
@@ -205,9 +223,16 @@ if (import.meta.main) {
   // payload before the stream flushes (Codex review). The payload is one
   // short line, but natural termination is the safe pattern.
   try {
-    process.stdout.write(renderContext(composeReminder(process.env)))
+    const text = await composeReminder(process.env)
+    process.stdout.write(renderContext(text))
   } catch {
-    // Never gate the turn on a reminder failure.
+    // Never gate the turn on a reminder failure. Emit the bare channel
+    // reminder as the floor so the discipline text still reaches the turn.
+    try {
+      process.stdout.write(renderContext(reminderForChat(process.env.CHAT_ID)))
+    } catch {
+      // truly nothing to do
+    }
   }
   process.exitCode = 0
 }

--- a/plugin/scripts/channel-reminder.ts
+++ b/plugin/scripts/channel-reminder.ts
@@ -34,7 +34,14 @@
 // Env:
 //   CHAT_ID              the Telegram chat id this session serves. Negative
 //                        ids are groups/supergroups (multichat); anything
-//                        else is a direct chat. Absent → DM-safe generic.
+//                        else is a direct chat. Absent → DM-safe generic. Also
+//                        keys the autonomy-registry lookup below.
+//   TELEGRAM_STATE_DIR   (or MULTICHAT_STATE_DIR) the plugin state root. When
+//                        set, the per-turn autonomy block (active mandates +
+//                        open owner questions) is read from
+//                        <state-dir>/autonomy-<chat>.json and appended. Absent
+//                        or unreadable → the block is silently omitted
+//                        (fail-open; a broken registry never gates the turn).
 //   TOV_REMINDER_ENABLED falsy (0/false/no/off, case-insensitive) disables
 //                        the TOV block. Default: enabled.
 //   TOV_REMINDER_PATH    per-agent override file for the TOV block. MUST live
@@ -47,6 +54,8 @@
 import { readFileSync, realpathSync } from 'node:fs'
 import { dirname, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
+
+import { buildAutonomyReminderBlock, loadAutonomyState } from '../src/autonomy/store.js'
 
 const DM_REMINDER =
   'Telegram bridge: the sender reads Telegram, not this terminal — terminal/transcript text never reaches them. ' +
@@ -141,12 +150,40 @@ export function tovReminder(env: NodeJS.ProcessEnv = process.env): string | unde
   return EMBEDDED_TOV_REMINDER
 }
 
+/**
+ * Resolve the per-turn AUTONOMY block from the durable registry, or undefined
+ * when there is nothing active / the state can't be located. FAIL-OPEN: any
+ * error returns undefined so the reminder still ships without the block — a
+ * broken registry must never gate the turn.
+ *
+ * State dir resolution mirrors the other dashi hooks
+ * (read-receipt/fallback-reply): TELEGRAM_STATE_DIR ?? MULTICHAT_STATE_DIR. The
+ * chat id comes from CHAT_ID (the same var reminderForChat reads). When neither
+ * a state dir nor a chat id is available (e.g. a per-chat session whose env was
+ * wiped), the block is simply omitted.
+ */
+export function autonomyReminder(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  try {
+    const chatId = (env.CHAT_ID ?? '').trim()
+    if (chatId === '') return undefined
+    const stateDir = env.TELEGRAM_STATE_DIR ?? env.MULTICHAT_STATE_DIR
+    if (!stateDir || stateDir.trim() === '') return undefined
+    const state = loadAutonomyState({ root: stateDir }, chatId)
+    return buildAutonomyReminderBlock(state, Date.now())
+  } catch {
+    // Never gate the turn on an autonomy-state failure.
+    return undefined
+  }
+}
+
 /** Compose the full additionalContext string: channel discipline first, then
- *  the optional TOV block separated by a blank line. */
+ *  the optional autonomy block, then the optional TOV block — each separated by
+ *  a blank line. */
 export function composeReminder(env: NodeJS.ProcessEnv = process.env): string {
   const channel = reminderForChat(env.CHAT_ID)
+  const autonomy = autonomyReminder(env)
   const tov = tovReminder(env)
-  return tov ? `${channel}\n\n${tov}` : channel
+  return [channel, autonomy, tov].filter((s): s is string => s !== undefined && s.length > 0).join('\n\n')
 }
 
 /** The exact stdout envelope Claude Code reads for UserPromptSubmit context. */

--- a/plugin/scripts/patch-claude-settings.ts
+++ b/plugin/scripts/patch-claude-settings.ts
@@ -94,6 +94,13 @@ export interface PatchOptions {
   /** When set, register the channel-reminder UserPromptSubmit hook pointing at
    *  this helper (scripts/channel-reminder.ts). Defaulted by the CLI. */
   readonly reminderHelperPath?: string
+  /** The RESOLVED plugin state root, baked into the reminder hook command as
+   *  inline TELEGRAM_STATE_DIR (review 2026-07-10 fix-loop #5). Without it the
+   *  hook process often has no TELEGRAM_* env at all (default installs don't
+   *  export it; multichat sessions strip it) and would silently never find
+   *  the autonomy registry the MCP tool writes. Defaulted by the CLI from
+   *  env.TELEGRAM_STATE_DIR ?? ~/.claude/channels/dashi-telegram-canary. */
+  readonly reminderStateDir?: string
 }
 
 interface HookEntry {
@@ -172,10 +179,19 @@ function buildGateEntry(opts: PatchOptions): HookEntry {
 }
 
 // UserPromptSubmit command for the channel-reminder hook. The hook reads
-// CHAT_ID from env to pick the DM vs group reminder. No token, no webhook —
-// it emits additionalContext to stdout and never makes a network call.
+// CHAT_ID from env to pick the DM vs group reminder, and TELEGRAM_STATE_DIR
+// to locate the autonomy registry (autonomy-<chat>.json) for the per-turn
+// mandate/question block. The state dir is BAKED into the command (fix-loop
+// #5): the hook's process env carries no TELEGRAM_* on default installs, and
+// multichat sessions strip it — an inline shell assignment survives both.
+// No token, no webhook — the hook emits additionalContext to stdout and
+// never makes a network call.
 function buildReminderCommand(opts: PatchOptions): string {
-  return `CHAT_ID=${sq(opts.chatId)} bun ${sq(opts.reminderHelperPath!)}`
+  const envParts: string[] = [`CHAT_ID=${sq(opts.chatId)}`]
+  if (opts.reminderStateDir !== undefined && opts.reminderStateDir.length > 0) {
+    envParts.push(`TELEGRAM_STATE_DIR=${sq(opts.reminderStateDir)}`)
+  }
+  return `${envParts.join(' ')} bun ${sq(opts.reminderHelperPath!)}`
 }
 
 function buildReminderEntry(opts: PatchOptions): HookEntry {
@@ -289,6 +305,11 @@ function parseArgs(argv: ReadonlyArray<string>): PatchOptions {
   if (!noReminder && !reminderHelperPath) {
     reminderHelperPath = pathResolve(scriptDir, 'channel-reminder.ts')
   }
+  // Resolve the state root the same way loadConfig does (fix-loop #5) so the
+  // reminder hook reads the SAME registry files the running server writes.
+  const reminderStateDir =
+    process.env.TELEGRAM_STATE_DIR ??
+    join(homedir(), '.claude', 'channels', 'dashi-telegram-canary')
   const opts: PatchOptions = {
     settingsPath,
     chatId,
@@ -297,7 +318,7 @@ function parseArgs(argv: ReadonlyArray<string>): PatchOptions {
     ...(agentId ? { agentId } : {}),
     ...(permissionGateHelperPath ? { permissionGateHelperPath } : {}),
     ...(policyPath ? { policyPath } : {}),
-    ...(reminderHelperPath ? { reminderHelperPath } : {}),
+    ...(reminderHelperPath ? { reminderHelperPath, reminderStateDir } : {}),
   }
   return opts
 }

--- a/plugin/src/autonomy/store.ts
+++ b/plugin/src/autonomy/store.ts
@@ -1,0 +1,536 @@
+// src/autonomy/store.ts
+//
+// Per-chat AUTONOMY state: the durable registry of owner-granted autonomy
+// mandates (leases) and open questions to the owner.
+//
+// Why this exists (2026-07-10 communication audit): owner-granted autonomy
+// mandates get forgotten after context compaction, and questions to the owner
+// die silently. This module is the durable state layer that survives a
+// compact/restart; PR-1 wires it into three read surfaces (an `autonomy` MCP
+// tool, the per-turn channel-reminder injection, and the pinned context HUD).
+// Enforcement hooks and lease-GRANTING arrive in later PRs — this module never
+// grants a lease on its own; leases are added only through the store API.
+//
+// Persistence: one JSON file per chat, `autonomy-<chatId>.json`, in the same
+// state root the other per-chat persisters use (StatePaths.root — see
+// context-hud.ts `context-hud-<chatId>.json` and task-reality-mirror.ts
+// `task-reality-epoch-<chatId>.json`). Atomic tmp+fsync+rename, 0o600, exactly
+// like state/store.ts writeUpdateOffset. A corrupt/missing file loads as empty
+// state and NEVER throws — a broken registry must never break message delivery.
+
+import {
+  closeSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from 'node:fs'
+import { join } from 'node:path'
+
+import type { StatePaths } from '../config.js'
+import type { Logger } from '../log.js'
+
+// ─────────────────────────────────────────────────────────────────────
+// Types.
+// ─────────────────────────────────────────────────────────────────────
+
+export const AUTONOMY_STATE_VERSION = 1 as const
+
+// Where a lease came from. `ask_card` = an authenticated AskUserQuestion
+// button grant (PR-2). `owner_cmd` = an owner command. `manual` = operator /
+// test insertion. The tool surface can NEVER mint any of these.
+export type LeaseSource = 'ask_card' | 'owner_cmd' | 'manual'
+
+export interface AutonomyLease {
+  // e.g. `L-20260710-a1b2`. Stable across the lease's lifetime.
+  id: string
+  // Verbatim owner-granted scope text (never paraphrased).
+  scope: string
+  grantedAtMs: number
+  expiresAtMs: number
+  source: LeaseSource
+  // The Telegram message id of the grant, when known (PR-2 button relay).
+  grantorMessageId?: number
+  // Set to a timestamp when the lease is consumed; null/undefined while active.
+  consumedAtMs?: number | null
+  notes?: string
+}
+
+export type QuestionStatus = 'open' | 'answered' | 'bypassed'
+
+export interface OpenQuestion {
+  // e.g. `Q-20260710-a1b2`.
+  id: string
+  summary: string
+  askedAtMs: number
+  // Telegram message id the question was posted as, when known.
+  messageId?: number
+  status: QuestionStatus
+  // What the agent should do if the owner never answers (the >2h default).
+  defaultAction?: string
+  // Security questions — NEVER auto-bypassed regardless of age.
+  sticky?: boolean
+  resolvedAtMs?: number
+}
+
+export interface AutonomyState {
+  version: typeof AUTONOMY_STATE_VERSION
+  leases: AutonomyLease[]
+  questions: OpenQuestion[]
+}
+
+// The subset of StatePaths the store needs — just the state root. Full
+// StatePaths is structurally assignable, and the reminder hook (which has no
+// full StatePaths) can pass a bare `{ root }`.
+export type AutonomyPaths = Pick<StatePaths, 'root'>
+
+// ─────────────────────────────────────────────────────────────────────
+// Pure state helpers (no I/O, no clock unless nowMs passed) — unit-tested
+// in isolation.
+// ─────────────────────────────────────────────────────────────────────
+
+export function emptyAutonomyState(): AutonomyState {
+  return { version: AUTONOMY_STATE_VERSION, leases: [], questions: [] }
+}
+
+// A lease is active when it has NOT been consumed and has NOT expired.
+function isLeaseActive(lease: AutonomyLease, nowMs: number): boolean {
+  const consumed = lease.consumedAtMs !== undefined && lease.consumedAtMs !== null
+  return !consumed && lease.expiresAtMs > nowMs
+}
+
+/** Active leases (not consumed, not expired), soonest-expiry first. */
+export function activeLeases(state: AutonomyState, nowMs: number): AutonomyLease[] {
+  return state.leases
+    .filter((l) => isLeaseActive(l, nowMs))
+    .sort((a, b) => a.expiresAtMs - b.expiresAtMs)
+}
+
+/** Open questions (status === 'open'), oldest-first. */
+export function openQuestions(state: AutonomyState): OpenQuestion[] {
+  return state.questions
+    .filter((q) => q.status === 'open')
+    .sort((a, b) => a.askedAtMs - b.askedAtMs)
+}
+
+/** Age of a question in ms (clamped ≥ 0 so a future askedAtMs never underflows). */
+export function questionAgeMs(question: OpenQuestion, nowMs: number): number {
+  return Math.max(0, nowMs - question.askedAtMs)
+}
+
+// Short random suffix for generated ids. Filename-safe (base36).
+function randSuffix(): string {
+  return Math.random().toString(36).slice(2, 6).padEnd(4, '0')
+}
+
+// `YYYYMMDD` from an epoch-ms clock (UTC — stable across the fleet).
+function yyyymmdd(nowMs: number): string {
+  const d = new Date(nowMs)
+  const y = d.getUTCFullYear().toString().padStart(4, '0')
+  const m = (d.getUTCMonth() + 1).toString().padStart(2, '0')
+  const day = d.getUTCDate().toString().padStart(2, '0')
+  return `${y}${m}${day}`
+}
+
+export function newLeaseId(nowMs: number): string {
+  return `L-${yyyymmdd(nowMs)}-${randSuffix()}`
+}
+
+export function newQuestionId(nowMs: number): string {
+  return `Q-${yyyymmdd(nowMs)}-${randSuffix()}`
+}
+
+export interface NewLeaseInput {
+  scope: string
+  expiresAtMs: number
+  source: LeaseSource
+  id?: string
+  grantedAtMs?: number
+  grantorMessageId?: number
+  notes?: string
+}
+
+/**
+ * Add a lease and return the NEW state plus the created lease. Pure: the input
+ * `state` is not mutated (a fresh `leases` array is returned). Granting still
+ * only happens through this API — the MCP tool never reaches it.
+ */
+export function addLease(
+  state: AutonomyState,
+  input: NewLeaseInput,
+  nowMs: number = Date.now(),
+): { state: AutonomyState; lease: AutonomyLease } {
+  const lease: AutonomyLease = {
+    id: input.id ?? newLeaseId(nowMs),
+    scope: input.scope,
+    grantedAtMs: input.grantedAtMs ?? nowMs,
+    expiresAtMs: input.expiresAtMs,
+    source: input.source,
+    consumedAtMs: null,
+    ...(input.grantorMessageId !== undefined ? { grantorMessageId: input.grantorMessageId } : {}),
+    ...(input.notes !== undefined ? { notes: input.notes } : {}),
+  }
+  return { state: { ...state, leases: [...state.leases, lease] }, lease }
+}
+
+export type ConsumeOutcome = 'ok' | 'not_found' | 'already_consumed'
+
+/**
+ * Mark a lease consumed. Returns the new state and an outcome the caller turns
+ * into user-facing text. `already_consumed` is reported for an id that exists
+ * but is already consumed (an expired-but-unconsumed lease still consumes ok —
+ * expiry is a render concern, not a consume concern).
+ */
+export function consumeLease(
+  state: AutonomyState,
+  id: string,
+  nowMs: number = Date.now(),
+): { state: AutonomyState; outcome: ConsumeOutcome } {
+  const idx = state.leases.findIndex((l) => l.id === id)
+  if (idx === -1) return { state, outcome: 'not_found' }
+  const lease = state.leases[idx] as AutonomyLease
+  if (lease.consumedAtMs !== undefined && lease.consumedAtMs !== null) {
+    return { state, outcome: 'already_consumed' }
+  }
+  const leases = state.leases.slice()
+  leases[idx] = { ...lease, consumedAtMs: nowMs }
+  return { state: { ...state, leases }, outcome: 'ok' }
+}
+
+export interface NewQuestionInput {
+  summary: string
+  id?: string
+  askedAtMs?: number
+  messageId?: number
+  defaultAction?: string
+  sticky?: boolean
+  status?: QuestionStatus
+}
+
+/** Add an open question and return the NEW state plus the created question. */
+export function addQuestion(
+  state: AutonomyState,
+  input: NewQuestionInput,
+  nowMs: number = Date.now(),
+): { state: AutonomyState; question: OpenQuestion } {
+  const question: OpenQuestion = {
+    id: input.id ?? newQuestionId(nowMs),
+    summary: input.summary,
+    askedAtMs: input.askedAtMs ?? nowMs,
+    status: input.status ?? 'open',
+    ...(input.messageId !== undefined ? { messageId: input.messageId } : {}),
+    ...(input.defaultAction !== undefined ? { defaultAction: input.defaultAction } : {}),
+    ...(input.sticky !== undefined ? { sticky: input.sticky } : {}),
+  }
+  return { state: { ...state, questions: [...state.questions, question] }, question }
+}
+
+export type ResolveOutcome = 'ok' | 'not_found'
+
+/**
+ * Resolve a question to `answered` or `bypassed`, stamping resolvedAtMs.
+ * `not_found` when the id is unknown. Re-resolving an already-resolved question
+ * is allowed (idempotent-ish) — the status/timestamp are simply overwritten.
+ */
+export function resolveQuestion(
+  state: AutonomyState,
+  id: string,
+  status: Exclude<QuestionStatus, 'open'>,
+  nowMs: number = Date.now(),
+): { state: AutonomyState; outcome: ResolveOutcome } {
+  const idx = state.questions.findIndex((q) => q.id === id)
+  if (idx === -1) return { state, outcome: 'not_found' }
+  const q = state.questions[idx] as OpenQuestion
+  const questions = state.questions.slice()
+  questions[idx] = { ...q, status, resolvedAtMs: nowMs }
+  return { state: { ...state, questions }, outcome: 'ok' }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Rendering helpers (pure) — shared by the MCP tool, the reminder hook and
+// the context HUD so the three surfaces never drift.
+// ─────────────────────────────────────────────────────────────────────
+
+// Compact humanizer for a NON-NEGATIVE duration: "<45>м" under an hour,
+// otherwise "<h>ч" (+ minutes when a partial hour remains and it fits). Used
+// for both "time left" and "age".
+export function humanizeDurationMs(ms: number): string {
+  const clamped = Math.max(0, ms)
+  const totalMin = Math.floor(clamped / 60_000)
+  if (totalMin < 60) return `${totalMin}м`
+  const h = Math.floor(totalMin / 60)
+  const m = totalMin % 60
+  return m > 0 ? `${h}ч ${m}м` : `${h}ч`
+}
+
+// Truncate on code points (not UTF-16 units) so a surrogate pair is never
+// sliced — mirrors context-hud.taskLine.
+function truncate(s: string, maxChars: number): string {
+  const cps = Array.from(s)
+  if (cps.length <= maxChars) return s
+  return `${cps.slice(0, Math.max(0, maxChars - 1)).join('')}…`
+}
+
+const SCOPE_MAX_CHARS = 100
+const SUMMARY_MAX_CHARS = 100
+// Cap how many entries each read surface lists so the injected/pinned text
+// stays short even with a pile of leases/questions.
+const RENDER_MAX_ENTRIES = 3
+
+/**
+ * Compact human-readable status for the `autonomy` tool's `status` action:
+ * active leases (id, scope, time left) + open questions (id, summary, age,
+ * default action, sticky flag). Plain text, no markup. Empty state → a clear
+ * "nothing active" line.
+ */
+export function renderAutonomyStatus(state: AutonomyState, nowMs: number): string {
+  const leases = activeLeases(state, nowMs)
+  const questions = openQuestions(state)
+  const lines: string[] = []
+
+  if (leases.length === 0) {
+    lines.push('Активных мандатов нет.')
+  } else {
+    lines.push(`Активные мандаты (${leases.length}):`)
+    for (const l of leases) {
+      const left = humanizeDurationMs(l.expiresAtMs - nowMs)
+      lines.push(`  ${l.id}: «${truncate(l.scope, SCOPE_MAX_CHARS)}» — ещё ${left} (source: ${l.source})`)
+    }
+  }
+
+  if (questions.length === 0) {
+    lines.push('Открытых вопросов нет.')
+  } else {
+    lines.push(`Открытые вопросы (${questions.length}):`)
+    for (const q of questions) {
+      const age = humanizeDurationMs(questionAgeMs(q, nowMs))
+      const def = q.defaultAction !== undefined ? `; дефолт: ${truncate(q.defaultAction, SUMMARY_MAX_CHARS)}` : ''
+      const sticky = q.sticky === true ? ' [sticky]' : ''
+      lines.push(`  ${q.id}: «${truncate(q.summary, SUMMARY_MAX_CHARS)}» — без ответа ${age}${def}${sticky}`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * The per-turn reminder block appended by channel-reminder.ts (plain text,
+ * Russian). Returns undefined when there is nothing active — the caller then
+ * emits only the bridge/TOV reminder. Lists at most RENDER_MAX_ENTRIES of each.
+ */
+export function buildAutonomyReminderBlock(
+  state: AutonomyState,
+  nowMs: number,
+): string | undefined {
+  const leases = activeLeases(state, nowMs).slice(0, RENDER_MAX_ENTRIES)
+  const questions = openQuestions(state).slice(0, RENDER_MAX_ENTRIES)
+  if (leases.length === 0 && questions.length === 0) return undefined
+
+  const lines: string[] = []
+  for (const l of leases) {
+    const left = humanizeDurationMs(l.expiresAtMs - nowMs)
+    lines.push(
+      `Активный мандат ${l.id}: «${truncate(l.scope, SCOPE_MAX_CHARS)}» — истекает через ${left}. ` +
+        'Act-with-veto: в границах scope не спрашивай разрешения, действуй и докладывай.',
+    )
+  }
+  for (const q of questions) {
+    const age = humanizeDurationMs(questionAgeMs(q, nowMs))
+    const def = q.defaultAction !== undefined ? truncate(q.defaultAction, SUMMARY_MAX_CHARS) : '—'
+    const stickyNote = q.sticky === true
+      ? ' Это sticky-вопрос — НЕ обходить дефолтом, дождись ответа вождя.'
+      : ' >2ч без ответа — бери дефолт и сообщи (sticky-вопросы не обходить).'
+    lines.push(
+      `Открытый вопрос вождю ${q.id}: «${truncate(q.summary, SUMMARY_MAX_CHARS)}» — без ответа ${age}; дефолт: ${def}.${stickyNote}`,
+    )
+  }
+  return lines.join('\n')
+}
+
+/**
+ * The single optional HUD line (context-hud.ts). Returns undefined when there
+ * is nothing active. `escape` is injected by the HUD (its escapeHtml) so the
+ * line is safe under HTML parse mode; defaults to identity for plain contexts.
+ * Shape: `Мандат: L-… (<short scope>, ещё <h>) · Вопросы без ответа: N (старший <age>)`.
+ */
+export function buildAutonomyHudLine(
+  state: AutonomyState,
+  nowMs: number,
+  opts: { escape?: (s: string) => string } = {},
+): string | undefined {
+  const escape = opts.escape ?? ((s: string) => s)
+  const leases = activeLeases(state, nowMs)
+  const questions = openQuestions(state)
+  if (leases.length === 0 && questions.length === 0) return undefined
+
+  const parts: string[] = []
+  const primary = leases[0]
+  if (primary !== undefined) {
+    const left = humanizeDurationMs(primary.expiresAtMs - nowMs)
+    const scope = escape(truncate(primary.scope, 32))
+    const extra = leases.length > 1 ? ` +${leases.length - 1}` : ''
+    parts.push(`Мандат: ${escape(primary.id)} (${scope}, ещё ${left})${extra}`)
+  }
+  if (questions.length > 0) {
+    const oldest = questions[0] as OpenQuestion
+    const age = humanizeDurationMs(questionAgeMs(oldest, nowMs))
+    parts.push(`Вопросы без ответа: ${questions.length} (старший ${age})`)
+  }
+  return parts.join(' · ')
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Persistence (I/O). Never throws on load; atomic write like state/store.ts.
+// ─────────────────────────────────────────────────────────────────────
+
+// Filename-safe per-chat path. chatId is a numeric string (possibly negative
+// for supergroups); sanitize defensively so a surprising value can never
+// escape the state dir — identical convention to context-hud.persistPath.
+export function autonomyStatePath(paths: AutonomyPaths, chatId: string): string {
+  const safe = chatId.replace(/[^0-9A-Za-z_-]/g, '_')
+  return join(paths.root, `autonomy-${safe}.json`)
+}
+
+// Narrow an unknown parsed blob into a valid AutonomyState, dropping anything
+// malformed. A partially-corrupt file yields the well-formed entries it can and
+// empty state otherwise — never throws.
+function coerceState(parsed: unknown): AutonomyState {
+  const out = emptyAutonomyState()
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return out
+  const obj = parsed as Record<string, unknown>
+  if (Array.isArray(obj.leases)) {
+    for (const raw of obj.leases) {
+      const lease = coerceLease(raw)
+      if (lease !== undefined) out.leases.push(lease)
+    }
+  }
+  if (Array.isArray(obj.questions)) {
+    for (const raw of obj.questions) {
+      const q = coerceQuestion(raw)
+      if (q !== undefined) out.questions.push(q)
+    }
+  }
+  return out
+}
+
+const LEASE_SOURCES: ReadonlySet<string> = new Set<LeaseSource>(['ask_card', 'owner_cmd', 'manual'])
+const QUESTION_STATUSES: ReadonlySet<string> = new Set<QuestionStatus>(['open', 'answered', 'bypassed'])
+
+function coerceLease(raw: unknown): AutonomyLease | undefined {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return undefined
+  const o = raw as Record<string, unknown>
+  if (typeof o.id !== 'string' || o.id.length === 0) return undefined
+  if (typeof o.scope !== 'string') return undefined
+  if (typeof o.grantedAtMs !== 'number' || !Number.isFinite(o.grantedAtMs)) return undefined
+  if (typeof o.expiresAtMs !== 'number' || !Number.isFinite(o.expiresAtMs)) return undefined
+  if (typeof o.source !== 'string' || !LEASE_SOURCES.has(o.source)) return undefined
+  const lease: AutonomyLease = {
+    id: o.id,
+    scope: o.scope,
+    grantedAtMs: o.grantedAtMs,
+    expiresAtMs: o.expiresAtMs,
+    source: o.source as LeaseSource,
+  }
+  if (typeof o.grantorMessageId === 'number' && Number.isFinite(o.grantorMessageId)) {
+    lease.grantorMessageId = o.grantorMessageId
+  }
+  if (o.consumedAtMs === null) lease.consumedAtMs = null
+  else if (typeof o.consumedAtMs === 'number' && Number.isFinite(o.consumedAtMs)) {
+    lease.consumedAtMs = o.consumedAtMs
+  }
+  if (typeof o.notes === 'string') lease.notes = o.notes
+  return lease
+}
+
+function coerceQuestion(raw: unknown): OpenQuestion | undefined {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return undefined
+  const o = raw as Record<string, unknown>
+  if (typeof o.id !== 'string' || o.id.length === 0) return undefined
+  if (typeof o.summary !== 'string') return undefined
+  if (typeof o.askedAtMs !== 'number' || !Number.isFinite(o.askedAtMs)) return undefined
+  if (typeof o.status !== 'string' || !QUESTION_STATUSES.has(o.status)) return undefined
+  const q: OpenQuestion = {
+    id: o.id,
+    summary: o.summary,
+    askedAtMs: o.askedAtMs,
+    status: o.status as QuestionStatus,
+  }
+  if (typeof o.messageId === 'number' && Number.isFinite(o.messageId)) q.messageId = o.messageId
+  if (typeof o.defaultAction === 'string') q.defaultAction = o.defaultAction
+  if (o.sticky === true) q.sticky = true
+  if (typeof o.resolvedAtMs === 'number' && Number.isFinite(o.resolvedAtMs)) q.resolvedAtMs = o.resolvedAtMs
+  return q
+}
+
+/**
+ * Load the per-chat autonomy state. A missing file, unreadable file, or corrupt
+ * JSON → empty state (never throws). An optional logger emits a single warning
+ * on a genuine read/parse error (not on the expected missing-file case).
+ */
+export function loadAutonomyState(
+  paths: AutonomyPaths,
+  chatId: string,
+  log?: Logger,
+): AutonomyState {
+  const file = autonomyStatePath(paths, chatId)
+  let raw: string
+  try {
+    raw = readFileSync(file, 'utf8')
+  } catch {
+    // Missing file on first use is expected — empty state, no warning.
+    return emptyAutonomyState()
+  }
+  try {
+    return coerceState(JSON.parse(raw))
+  } catch (err) {
+    // File existed but held invalid JSON — worth a warning, but never fatal.
+    if (log) {
+      log.warn('autonomy state parse failed, using empty state', {
+        chat_id: chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+    return emptyAutonomyState()
+  }
+}
+
+/**
+ * Persist the per-chat autonomy state atomically (tmp + fsync + rename, 0o600).
+ * On rename failure the tmp file is removed so no partial-write stray remains —
+ * same contract as state/store.ts writeUpdateOffset.
+ */
+export function saveAutonomyState(
+  paths: AutonomyPaths,
+  chatId: string,
+  state: AutonomyState,
+): void {
+  mkdirSync(paths.root, { recursive: true, mode: 0o700 })
+  const target = autonomyStatePath(paths, chatId)
+  const tmp = join(paths.root, `autonomy-${chatId.replace(/[^0-9A-Za-z_-]/g, '_')}.tmp.${process.pid}.${Date.now()}`)
+  // Normalize on write: always stamp the current schema version.
+  const body = JSON.stringify(
+    { version: AUTONOMY_STATE_VERSION, leases: state.leases, questions: state.questions },
+    null,
+    2,
+  )
+  const fd = openSync(tmp, 'w', 0o600)
+  try {
+    writeSync(fd, body)
+    fsyncSync(fd)
+  } finally {
+    closeSync(fd)
+  }
+  try {
+    renameSync(tmp, target)
+  } catch (err) {
+    try {
+      unlinkSync(tmp)
+    } catch {
+      // best-effort cleanup
+    }
+    throw err
+  }
+}

--- a/plugin/src/autonomy/store.ts
+++ b/plugin/src/autonomy/store.ts
@@ -11,15 +11,25 @@
 // Enforcement hooks and lease-GRANTING arrive in later PRs — this module never
 // grants a lease on its own; leases are added only through the store API.
 //
-// Persistence: one JSON file per chat, `autonomy-<chatId>.json`, in the same
+// Persistence: one JSON file per chat, `autonomy-<chatKey>.json`, in the same
 // state root the other per-chat persisters use (StatePaths.root — see
 // context-hud.ts `context-hud-<chatId>.json` and task-reality-mirror.ts
-// `task-reality-epoch-<chatId>.json`). Atomic tmp+fsync+rename, 0o600, exactly
-// like state/store.ts writeUpdateOffset. A corrupt/missing file loads as empty
-// state and NEVER throws — a broken registry must never break message delivery.
+// `task-reality-epoch-<chatId>.json`). Atomic tmp('wx')+fchmod+fsync+rename
+// (+ best-effort directory fsync), 0o600. A corrupt/missing file loads as
+// empty state and NEVER throws — a broken registry must never break delivery.
+//
+// SINGLE-WRITER ASSUMPTION (review 2026-07-10 fix-loop #1): the MCP/webhook
+// server process is the ONLY writer of these files. The hooks
+// (channel-reminder, HUD render path) are strictly READ-ONLY consumers.
+// Within the server process, ALL mutations MUST go through
+// `updateAutonomyState`, which serializes load→mutate→save per chat via an
+// in-process promise chain — two concurrent `consume` calls can never both
+// observe the pre-consume state. Cross-PROCESS locking is deliberately out of
+// scope: there is no second writer process by design.
 
 import {
   closeSync,
+  fchmodSync,
   fsyncSync,
   mkdirSync,
   openSync,
@@ -28,6 +38,7 @@ import {
   unlinkSync,
   writeSync,
 } from 'node:fs'
+import { randomBytes } from 'node:crypto'
 import { join } from 'node:path'
 
 import type { StatePaths } from '../config.js'
@@ -121,9 +132,11 @@ export function questionAgeMs(question: OpenQuestion, nowMs: number): number {
   return Math.max(0, nowMs - question.askedAtMs)
 }
 
-// Short random suffix for generated ids. Filename-safe (base36).
+// Short crypto-random suffix for generated ids (8 hex chars, filename-safe).
+// Crypto-sourced so regenerated-on-collision ids can't cycle through the same
+// PRNG sequence (review 2026-07-10 fix-loop #4).
 function randSuffix(): string {
-  return Math.random().toString(36).slice(2, 6).padEnd(4, '0')
+  return randomBytes(4).toString('hex')
 }
 
 // `YYYYMMDD` from an epoch-ms clock (UTC — stable across the fleet).
@@ -153,18 +166,40 @@ export interface NewLeaseInput {
   notes?: string
 }
 
+// Outcome of an add: `duplicate` is returned ONLY for an EXPLICIT id that
+// already exists (the state is returned unchanged so a colliding grant can
+// never create two consumable leases with one id). Auto-generated ids
+// regenerate on collision instead — they never report duplicate.
+export type AddOutcome = 'ok' | 'duplicate'
+
+// Generate an id guaranteed unique within `existing`, regenerating on the
+// (astronomically unlikely) crypto-random collision.
+function uniqueId(gen: () => string, existing: ReadonlySet<string>): string {
+  let id = gen()
+  while (existing.has(id)) id = gen()
+  return id
+}
+
 /**
  * Add a lease and return the NEW state plus the created lease. Pure: the input
  * `state` is not mutated (a fresh `leases` array is returned). Granting still
  * only happens through this API — the MCP tool never reaches it.
+ *
+ * ID uniqueness (fix-loop #4): an explicit `input.id` colliding with an
+ * existing lease → `outcome: 'duplicate'`, state unchanged, no lease. An
+ * omitted id is generated and regenerated until unique.
  */
 export function addLease(
   state: AutonomyState,
   input: NewLeaseInput,
   nowMs: number = Date.now(),
-): { state: AutonomyState; lease: AutonomyLease } {
+): { state: AutonomyState; lease?: AutonomyLease; outcome: AddOutcome } {
+  const existing = new Set(state.leases.map((l) => l.id))
+  if (input.id !== undefined && existing.has(input.id)) {
+    return { state, outcome: 'duplicate' }
+  }
   const lease: AutonomyLease = {
-    id: input.id ?? newLeaseId(nowMs),
+    id: input.id ?? uniqueId(() => newLeaseId(nowMs), existing),
     scope: input.scope,
     grantedAtMs: input.grantedAtMs ?? nowMs,
     expiresAtMs: input.expiresAtMs,
@@ -173,16 +208,19 @@ export function addLease(
     ...(input.grantorMessageId !== undefined ? { grantorMessageId: input.grantorMessageId } : {}),
     ...(input.notes !== undefined ? { notes: input.notes } : {}),
   }
-  return { state: { ...state, leases: [...state.leases, lease] }, lease }
+  return { state: { ...state, leases: [...state.leases, lease] }, lease, outcome: 'ok' }
 }
 
-export type ConsumeOutcome = 'ok' | 'not_found' | 'already_consumed'
+export type ConsumeOutcome = 'ok' | 'not_found' | 'already_consumed' | 'expired'
 
 /**
  * Mark a lease consumed. Returns the new state and an outcome the caller turns
- * into user-facing text. `already_consumed` is reported for an id that exists
- * but is already consumed (an expired-but-unconsumed lease still consumes ok —
- * expiry is a render concern, not a consume concern).
+ * into user-facing text:
+ *   `not_found`         — unknown id.
+ *   `already_consumed`  — the id exists but was consumed earlier.
+ *   `expired`           — the mandate's window has passed (fix-loop #8): the
+ *                         consume is refused honestly instead of reporting a
+ *                         success on a dead mandate.
  */
 export function consumeLease(
   state: AutonomyState,
@@ -194,6 +232,9 @@ export function consumeLease(
   const lease = state.leases[idx] as AutonomyLease
   if (lease.consumedAtMs !== undefined && lease.consumedAtMs !== null) {
     return { state, outcome: 'already_consumed' }
+  }
+  if (lease.expiresAtMs <= nowMs) {
+    return { state, outcome: 'expired' }
   }
   const leases = state.leases.slice()
   leases[idx] = { ...lease, consumedAtMs: nowMs }
@@ -210,14 +251,22 @@ export interface NewQuestionInput {
   status?: QuestionStatus
 }
 
-/** Add an open question and return the NEW state plus the created question. */
+/**
+ * Add an open question and return the NEW state plus the created question.
+ * Same ID-uniqueness contract as addLease: explicit colliding id →
+ * `outcome: 'duplicate'` (state unchanged); omitted id regenerates to unique.
+ */
 export function addQuestion(
   state: AutonomyState,
   input: NewQuestionInput,
   nowMs: number = Date.now(),
-): { state: AutonomyState; question: OpenQuestion } {
+): { state: AutonomyState; question?: OpenQuestion; outcome: AddOutcome } {
+  const existing = new Set(state.questions.map((q) => q.id))
+  if (input.id !== undefined && existing.has(input.id)) {
+    return { state, outcome: 'duplicate' }
+  }
   const question: OpenQuestion = {
-    id: input.id ?? newQuestionId(nowMs),
+    id: input.id ?? uniqueId(() => newQuestionId(nowMs), existing),
     summary: input.summary,
     askedAtMs: input.askedAtMs ?? nowMs,
     status: input.status ?? 'open',
@@ -225,15 +274,19 @@ export function addQuestion(
     ...(input.defaultAction !== undefined ? { defaultAction: input.defaultAction } : {}),
     ...(input.sticky !== undefined ? { sticky: input.sticky } : {}),
   }
-  return { state: { ...state, questions: [...state.questions, question] }, question }
+  return { state: { ...state, questions: [...state.questions, question] }, question, outcome: 'ok' }
 }
 
-export type ResolveOutcome = 'ok' | 'not_found'
+export type ResolveOutcome = 'ok' | 'not_found' | 'sticky_forbidden' | 'already_resolved'
 
 /**
  * Resolve a question to `answered` or `bypassed`, stamping resolvedAtMs.
- * `not_found` when the id is unknown. Re-resolving an already-resolved question
- * is allowed (idempotent-ish) — the status/timestamp are simply overwritten.
+ * Invariants live HERE, in the store, not in prose (fix-loop #2):
+ *   `not_found`        — unknown id.
+ *   `sticky_forbidden` — a sticky (security) question can NEVER be bypassed;
+ *                        only `answered` is accepted for it.
+ *   `already_resolved` — the question is no longer open; resolution is final
+ *                        and cannot be rewritten.
  */
 export function resolveQuestion(
   state: AutonomyState,
@@ -244,6 +297,10 @@ export function resolveQuestion(
   const idx = state.questions.findIndex((q) => q.id === id)
   if (idx === -1) return { state, outcome: 'not_found' }
   const q = state.questions[idx] as OpenQuestion
+  if (q.status !== 'open') return { state, outcome: 'already_resolved' }
+  if (q.sticky === true && status === 'bypassed') {
+    return { state, outcome: 'sticky_forbidden' }
+  }
   const questions = state.questions.slice()
   questions[idx] = { ...q, status, resolvedAtMs: nowMs }
   return { state: { ...state, questions }, outcome: 'ok' }
@@ -386,12 +443,36 @@ export function buildAutonomyHudLine(
 // Persistence (I/O). Never throws on load; atomic write like state/store.ts.
 // ─────────────────────────────────────────────────────────────────────
 
-// Filename-safe per-chat path. chatId is a numeric string (possibly negative
-// for supergroups); sanitize defensively so a surprising value can never
-// escape the state dir — identical convention to context-hud.persistPath.
+// ONE canonicalizer for the per-chat file key, used by path building, the
+// tmp-file naming AND the write-serialization map — so "00123" and "123" can
+// never address two different files/locks (fix-loop #3).
+//   * Numeric strings (the normal Telegram case, incl. negative supergroup
+//     ids) normalize via BigInt: leading zeros / "-0" collapse to the
+//     canonical integer form.
+//   * Non-numeric strings encode INJECTIVELY: [0-9A-Za-z-] pass through,
+//     every other code point (including `_`, the escape char itself) becomes
+//     `_<hex>_` — two distinct inputs can never collide, unlike a lossy
+//     replace-with-`_`.
+export function canonicalChatKey(chatId: string): string {
+  const trimmed = chatId.trim()
+  if (/^-?\d+$/.test(trimmed)) {
+    try {
+      return BigInt(trimmed).toString()
+    } catch {
+      // unreachable for the regex above; fall through defensively
+    }
+  }
+  let out = ''
+  for (const ch of trimmed) {
+    if (/[0-9A-Za-z-]/.test(ch)) out += ch
+    else out += `_${(ch.codePointAt(0) as number).toString(16)}_`
+  }
+  return out
+}
+
+// Filename-safe per-chat path, keyed by the canonical chat key.
 export function autonomyStatePath(paths: AutonomyPaths, chatId: string): string {
-  const safe = chatId.replace(/[^0-9A-Za-z_-]/g, '_')
-  return join(paths.root, `autonomy-${safe}.json`)
+  return join(paths.root, `autonomy-${canonicalChatKey(chatId)}.json`)
 }
 
 // Narrow an unknown parsed blob into a valid AutonomyState, dropping anything
@@ -485,12 +566,14 @@ export function loadAutonomyState(
   }
   try {
     return coerceState(JSON.parse(raw))
-  } catch (err) {
+  } catch {
     // File existed but held invalid JSON — worth a warning, but never fatal.
+    // Log ONLY a stable error code: the JSON.parse message can embed file
+    // content, which must never reach the logs (fix-loop #9).
     if (log) {
       log.warn('autonomy state parse failed, using empty state', {
         chat_id: chatId,
-        error: err instanceof Error ? err.message : String(err),
+        code: 'autonomy_state_parse_error',
       })
     }
     return emptyAutonomyState()
@@ -498,9 +581,14 @@ export function loadAutonomyState(
 }
 
 /**
- * Persist the per-chat autonomy state atomically (tmp + fsync + rename, 0o600).
- * On rename failure the tmp file is removed so no partial-write stray remains —
- * same contract as state/store.ts writeUpdateOffset.
+ * Persist the per-chat autonomy state atomically. Durability hardening
+ * (fix-loop #7, upgrades over state/store.ts writeUpdateOffset):
+ *   * tmp opened with 'wx' (exclusive — a name collision fails loud instead
+ *     of clobbering a concurrent writer's staging file);
+ *   * fchmod 0600 right after open (mode arg is umask-masked; fchmod is not);
+ *   * tmp cleaned up on ANY failure of the write path, not just rename;
+ *   * best-effort directory fsync after rename so the rename itself is
+ *     durable across a crash.
  */
 export function saveAutonomyState(
   paths: AutonomyPaths,
@@ -508,29 +596,99 @@ export function saveAutonomyState(
   state: AutonomyState,
 ): void {
   mkdirSync(paths.root, { recursive: true, mode: 0o700 })
+  const key = canonicalChatKey(chatId)
   const target = autonomyStatePath(paths, chatId)
-  const tmp = join(paths.root, `autonomy-${chatId.replace(/[^0-9A-Za-z_-]/g, '_')}.tmp.${process.pid}.${Date.now()}`)
+  const rand = randomBytes(3).toString('hex')
+  const tmp = join(paths.root, `autonomy-${key}.tmp.${process.pid}.${Date.now()}.${rand}`)
   // Normalize on write: always stamp the current schema version.
   const body = JSON.stringify(
     { version: AUTONOMY_STATE_VERSION, leases: state.leases, questions: state.questions },
     null,
     2,
   )
-  const fd = openSync(tmp, 'w', 0o600)
+  let fd: number | undefined
+  let renamed = false
   try {
+    fd = openSync(tmp, 'wx', 0o600)
+    fchmodSync(fd, 0o600)
     writeSync(fd, body)
     fsyncSync(fd)
-  } finally {
     closeSync(fd)
-  }
-  try {
+    fd = undefined
     renameSync(tmp, target)
-  } catch (err) {
-    try {
-      unlinkSync(tmp)
-    } catch {
-      // best-effort cleanup
+    renamed = true
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd)
+      } catch {
+        // best-effort
+      }
     }
-    throw err
+    if (!renamed) {
+      try {
+        unlinkSync(tmp)
+      } catch {
+        // best-effort cleanup — tmp may never have been created
+      }
+    }
   }
+  // Directory fsync: makes the rename durable. Best-effort — some platforms
+  // refuse O_RDONLY fsync on directories; a failure never breaks the save.
+  try {
+    const dirFd = openSync(paths.root, 'r')
+    try {
+      fsyncSync(dirFd)
+    } finally {
+      closeSync(dirFd)
+    }
+  } catch {
+    // best-effort
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Serialized read-modify-write (fix-loop #1). ALL mutations of the per-chat
+// file MUST route through here — a bare load→mutate→save in a caller races
+// (two concurrent consumes both observing the pre-consume state).
+// ─────────────────────────────────────────────────────────────────────
+
+// Per-(root, chatKey) promise chain. Keyed by root TOO so two test dirs with
+// the same chat id never share a lock. In-process only — see the
+// single-writer assumption in the module header.
+const updateChains = new Map<string, Promise<void>>()
+
+/**
+ * Atomically (within this process) apply `mutator` to the chat's state:
+ * load → mutate → save, serialized per chat via a promise chain. The mutator
+ * is pure/synchronous and returns the next state plus a result; when it
+ * returns the SAME state reference (a failed/no-op mutation), the save is
+ * skipped. Returns the mutator's result.
+ */
+export function updateAutonomyState<T>(
+  paths: AutonomyPaths,
+  chatId: string,
+  mutator: (state: AutonomyState) => { state: AutonomyState; result: T },
+  log?: Logger,
+): Promise<T> {
+  const key = `${paths.root}|${canonicalChatKey(chatId)}`
+  const step = (): T => {
+    const state = loadAutonomyState(paths, chatId, log)
+    const { state: next, result } = mutator(state)
+    if (next !== state) saveAutonomyState(paths, chatId, next)
+    return result
+  }
+  const prior = updateChains.get(key) ?? Promise.resolve()
+  // Run after the prior op regardless of its outcome (the chain must never
+  // poison). Errors from THIS op propagate to the caller.
+  const run = prior.then(step, step)
+  const settled: Promise<void> = run.then(
+    () => undefined,
+    () => undefined,
+  )
+  updateChains.set(key, settled)
+  void settled.then(() => {
+    if (updateChains.get(key) === settled) updateChains.delete(key)
+  })
+  return run
 }

--- a/plugin/src/autonomy/store.ts
+++ b/plugin/src/autonomy/store.ts
@@ -675,15 +675,29 @@ export function loadAutonomyState(
 // Keep at most this many `*.json.corrupt-*` evidence files per chat key.
 const MAX_CORRUPT_FILES = 3
 
-// Rename `autonomy-<key>.json` → `autonomy-<key>.json.corrupt-<ts>-<rand>`
-// and prune older evidence beyond MAX_CORRUPT_FILES. The ms timestamp is
-// fixed-width for the foreseeable future, so a lexicographic sort of the
-// filenames is chronological. Best-effort: every step is allowed to fail.
+// Per-process monotonic sequence for corrupt-evidence suffixes. Several
+// corruptions can land in the SAME millisecond (a tight retry loop); with a
+// random tie-breaker the lexicographic prune order within that ms was decided
+// by the random hex — the «oldest» pruned could actually be the NEWEST file
+// (flaky forensics test caught in review). The seq resolves same-ms ties
+// deterministically. Cross-PROCESS ties are out of scope: the single-writer
+// assumption (module header) means one process produces this evidence.
+let corruptEvidenceSeq = 0
+
+// Rename `autonomy-<key>.json` → `autonomy-<key>.json.corrupt-<ts>-<seq>-<rand>`
+// and prune older evidence beyond MAX_CORRUPT_FILES. The suffix is MONOTONIC
+// within the process so a lexicographic filename sort IS chronological:
+// zero-padded 14-digit ms timestamp (fixes digit-length ordering for good),
+// then the zero-padded base36 seq (same-ms ties), and the crypto-rand LAST —
+// uniqueness across restarts only, never an ordering key. Best-effort: every
+// step is allowed to fail.
 function preserveCorruptFile(paths: AutonomyPaths, chatId: string): void {
   try {
     const key = canonicalChatKey(chatId)
     const file = autonomyStatePath(paths, chatId)
-    const suffix = `${Date.now()}-${randomBytes(3).toString('hex')}`
+    const ts = String(Date.now()).padStart(14, '0')
+    const seq = (corruptEvidenceSeq++).toString(36).padStart(4, '0')
+    const suffix = `${ts}-${seq}-${randomBytes(3).toString('hex')}`
     renameSync(file, join(paths.root, `autonomy-${key}.json.corrupt-${suffix}`))
     const prefix = `autonomy-${key}.json.corrupt-`
     const evidence = readdirSync(paths.root)

--- a/plugin/src/autonomy/store.ts
+++ b/plugin/src/autonomy/store.ts
@@ -18,14 +18,23 @@
 // (+ best-effort directory fsync), 0o600. A corrupt/missing file loads as
 // empty state and NEVER throws — a broken registry must never break delivery.
 //
-// SINGLE-WRITER ASSUMPTION (review 2026-07-10 fix-loop #1): the MCP/webhook
-// server process is the ONLY writer of these files. The hooks
-// (channel-reminder, HUD render path) are strictly READ-ONLY consumers.
-// Within the server process, ALL mutations MUST go through
+// SINGLE-WRITER MODEL (fix-loop #1 + fix-loop-2 #1/#2, Sol architecture
+// review): the MCP/webhook server process is the DESIGNED sole writer of
+// these files; the hooks (channel-reminder, HUD render path) are strictly
+// READ-ONLY consumers. Within the process, ALL mutations MUST go through
 // `updateAutonomyState`, which serializes load→mutate→save per chat via an
-// in-process promise chain — two concurrent `consume` calls can never both
-// observe the pre-consume state. Cross-PROCESS locking is deliberately out of
-// scope: there is no second writer process by design.
+// in-process promise chain. Two additional guarantees make a second-process
+// writer SAFE to detect rather than silently corrupting:
+//   * `revision` counter — every save increments it; updateAutonomyState
+//     re-reads the on-disk revision before writing and, when it moved under
+//     us, reloads + re-applies the mutator on the fresh state (logged as
+//     `autonomy_state_revision_conflict`).
+//   * writer heartbeat lock — `autonomy-writer.lock` (writerId + pid +
+//     refreshedAtMs, refreshed lazily on write). A FRESH lock held by a
+//     DIFFERENT writerId refuses the mutation with `writer_conflict`; a
+//     stale or own lock is taken over / refreshed atomically. Freshness +
+//     writerId is the criterion — pid is diagnostic only, PID-existence is
+//     deliberately NOT used as a lock.
 
 import {
   closeSync,
@@ -33,12 +42,13 @@ import {
   fsyncSync,
   mkdirSync,
   openSync,
+  readdirSync,
   readFileSync,
   renameSync,
   unlinkSync,
   writeSync,
 } from 'node:fs'
-import { randomBytes } from 'node:crypto'
+import { createHash, randomBytes } from 'node:crypto'
 import { join } from 'node:path'
 
 import type { StatePaths } from '../config.js'
@@ -56,10 +66,16 @@ export const AUTONOMY_STATE_VERSION = 1 as const
 export type LeaseSource = 'ask_card' | 'owner_cmd' | 'manual'
 
 export interface AutonomyLease {
-  // e.g. `L-20260710-a1b2`. Stable across the lease's lifetime.
+  // e.g. `L-20260710-a1b2c3d4`. Stable across the lease's lifetime.
   id: string
   // Verbatim owner-granted scope text (never paraphrased).
   scope: string
+  // Integrity anchor for the scope text (fix-loop-2 #3):
+  // `sha256:<hex(sha256(utf8 scope))>`. Lets a later audit prove the scope
+  // was not silently edited. Optional on read (pre-digest files).
+  scopeDigest?: string
+  // Version of the scope-digest scheme (1 = sha256 over raw utf8 bytes).
+  scopeVersion?: number
   grantedAtMs: number
   expiresAtMs: number
   source: LeaseSource
@@ -67,6 +83,11 @@ export interface AutonomyLease {
   grantorMessageId?: number
   // Set to a timestamp when the lease is consumed; null/undefined while active.
   consumedAtMs?: number | null
+  // Revocation is a TERMINAL state distinct from consumption (fix-loop-2 #4):
+  // consumed = the mandate was USED; revoked = authority was WITHDRAWN.
+  revokedAtMs?: number
+  revokedBy?: string
+  revokeReason?: string
   notes?: string
 }
 
@@ -89,6 +110,10 @@ export interface OpenQuestion {
 
 export interface AutonomyState {
   version: typeof AUTONOMY_STATE_VERSION
+  // Monotonic save counter (fix-loop-2 #1): every successful save writes
+  // `revision + 1`. updateAutonomyState compares the loaded revision against
+  // the on-disk one right before writing to DETECT a cross-process writer.
+  revision: number
   leases: AutonomyLease[]
   questions: OpenQuestion[]
 }
@@ -104,13 +129,15 @@ export type AutonomyPaths = Pick<StatePaths, 'root'>
 // ─────────────────────────────────────────────────────────────────────
 
 export function emptyAutonomyState(): AutonomyState {
-  return { version: AUTONOMY_STATE_VERSION, leases: [], questions: [] }
+  return { version: AUTONOMY_STATE_VERSION, revision: 0, leases: [], questions: [] }
 }
 
-// A lease is active when it has NOT been consumed and has NOT expired.
+// A lease is active when it has NOT been consumed, NOT been revoked and has
+// NOT expired.
 function isLeaseActive(lease: AutonomyLease, nowMs: number): boolean {
   const consumed = lease.consumedAtMs !== undefined && lease.consumedAtMs !== null
-  return !consumed && lease.expiresAtMs > nowMs
+  const revoked = lease.revokedAtMs !== undefined
+  return !consumed && !revoked && lease.expiresAtMs > nowMs
 }
 
 /** Active leases (not consumed, not expired), soonest-expiry first. */
@@ -201,6 +228,8 @@ export function addLease(
   const lease: AutonomyLease = {
     id: input.id ?? uniqueId(() => newLeaseId(nowMs), existing),
     scope: input.scope,
+    scopeDigest: computeScopeDigest(input.scope),
+    scopeVersion: SCOPE_DIGEST_VERSION,
     grantedAtMs: input.grantedAtMs ?? nowMs,
     expiresAtMs: input.expiresAtMs,
     source: input.source,
@@ -211,13 +240,23 @@ export function addLease(
   return { state: { ...state, leases: [...state.leases, lease] }, lease, outcome: 'ok' }
 }
 
-export type ConsumeOutcome = 'ok' | 'not_found' | 'already_consumed' | 'expired'
+// Scope-digest scheme v1: sha256 over the RAW utf8 bytes of the verbatim
+// scope text, hex-encoded, prefixed with the algorithm (fix-loop-2 #3).
+export const SCOPE_DIGEST_VERSION = 1 as const
+
+export function computeScopeDigest(scope: string): string {
+  return `sha256:${createHash('sha256').update(scope, 'utf8').digest('hex')}`
+}
+
+export type ConsumeOutcome = 'ok' | 'not_found' | 'already_consumed' | 'revoked' | 'expired'
 
 /**
  * Mark a lease consumed. Returns the new state and an outcome the caller turns
  * into user-facing text:
  *   `not_found`         — unknown id.
  *   `already_consumed`  — the id exists but was consumed earlier.
+ *   `revoked`           — the mandate's authority was withdrawn (fix-loop-2
+ *                         #4): a revoked lease can never be consumed.
  *   `expired`           — the mandate's window has passed (fix-loop #8): the
  *                         consume is refused honestly instead of reporting a
  *                         success on a dead mandate.
@@ -230,6 +269,9 @@ export function consumeLease(
   const idx = state.leases.findIndex((l) => l.id === id)
   if (idx === -1) return { state, outcome: 'not_found' }
   const lease = state.leases[idx] as AutonomyLease
+  if (lease.revokedAtMs !== undefined) {
+    return { state, outcome: 'revoked' }
+  }
   if (lease.consumedAtMs !== undefined && lease.consumedAtMs !== null) {
     return { state, outcome: 'already_consumed' }
   }
@@ -238,6 +280,41 @@ export function consumeLease(
   }
   const leases = state.leases.slice()
   leases[idx] = { ...lease, consumedAtMs: nowMs }
+  return { state: { ...state, leases }, outcome: 'ok' }
+}
+
+export type RevokeOutcome = 'ok' | 'not_found' | 'already_consumed' | 'already_revoked' | 'expired'
+
+/**
+ * Revoke a lease — withdraw its authority (fix-loop-2 #4). TERMINAL and
+ * distinct from consumption. Kept simple by design:
+ *   `already_consumed` — a used mandate cannot be revoked (nothing to withdraw);
+ *   `already_revoked`  — revocation is final;
+ *   `expired`          — an expired mandate has no authority left, revoke is a
+ *                        no-op (reported honestly, state untouched).
+ */
+export function revokeLease(
+  state: AutonomyState,
+  id: string,
+  nowMs: number,
+  revokedBy: string,
+  reason?: string,
+): { state: AutonomyState; outcome: RevokeOutcome } {
+  const idx = state.leases.findIndex((l) => l.id === id)
+  if (idx === -1) return { state, outcome: 'not_found' }
+  const lease = state.leases[idx] as AutonomyLease
+  if (lease.revokedAtMs !== undefined) return { state, outcome: 'already_revoked' }
+  if (lease.consumedAtMs !== undefined && lease.consumedAtMs !== null) {
+    return { state, outcome: 'already_consumed' }
+  }
+  if (lease.expiresAtMs <= nowMs) return { state, outcome: 'expired' }
+  const leases = state.leases.slice()
+  leases[idx] = {
+    ...lease,
+    revokedAtMs: nowMs,
+    revokedBy,
+    ...(reason !== undefined ? { revokeReason: reason } : {}),
+  }
   return { state: { ...state, leases }, outcome: 'ok' }
 }
 
@@ -354,7 +431,10 @@ export function renderAutonomyStatus(state: AutonomyState, nowMs: number): strin
     lines.push(`Активные мандаты (${leases.length}):`)
     for (const l of leases) {
       const left = humanizeDurationMs(l.expiresAtMs - nowMs)
-      lines.push(`  ${l.id}: «${truncate(l.scope, SCOPE_MAX_CHARS)}» — ещё ${left} (source: ${l.source})`)
+      // Short scope-digest anchor (first 12 hex chars) — tool status ONLY,
+      // never in the reminder/HUD surfaces (fix-loop-2 #3).
+      const digest = l.scopeDigest !== undefined ? ` [${l.scopeDigest.slice(7, 19)}]` : ''
+      lines.push(`  ${l.id}: «${truncate(l.scope, SCOPE_MAX_CHARS)}» — ещё ${left} (source: ${l.source})${digest}`)
     }
   }
 
@@ -482,6 +562,9 @@ function coerceState(parsed: unknown): AutonomyState {
   const out = emptyAutonomyState()
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return out
   const obj = parsed as Record<string, unknown>
+  if (typeof obj.revision === 'number' && Number.isFinite(obj.revision) && obj.revision >= 0) {
+    out.revision = Math.floor(obj.revision)
+  }
   if (Array.isArray(obj.leases)) {
     for (const raw of obj.leases) {
       const lease = coerceLease(raw)
@@ -522,6 +605,11 @@ function coerceLease(raw: unknown): AutonomyLease | undefined {
   else if (typeof o.consumedAtMs === 'number' && Number.isFinite(o.consumedAtMs)) {
     lease.consumedAtMs = o.consumedAtMs
   }
+  if (typeof o.scopeDigest === 'string' && o.scopeDigest.length > 0) lease.scopeDigest = o.scopeDigest
+  if (typeof o.scopeVersion === 'number' && Number.isFinite(o.scopeVersion)) lease.scopeVersion = o.scopeVersion
+  if (typeof o.revokedAtMs === 'number' && Number.isFinite(o.revokedAtMs)) lease.revokedAtMs = o.revokedAtMs
+  if (typeof o.revokedBy === 'string') lease.revokedBy = o.revokedBy
+  if (typeof o.revokeReason === 'string') lease.revokeReason = o.revokeReason
   if (typeof o.notes === 'string') lease.notes = o.notes
   return lease
 }
@@ -576,7 +664,42 @@ export function loadAutonomyState(
         code: 'autonomy_state_parse_error',
       })
     }
+    // Forensics (fix-loop-2 #5): move the corrupt file aside so the next
+    // save does not destroy evidence — a rogue-empty-state incident stays
+    // investigable. Best-effort, never throws.
+    preserveCorruptFile(paths, chatId)
     return emptyAutonomyState()
+  }
+}
+
+// Keep at most this many `*.json.corrupt-*` evidence files per chat key.
+const MAX_CORRUPT_FILES = 3
+
+// Rename `autonomy-<key>.json` → `autonomy-<key>.json.corrupt-<ts>-<rand>`
+// and prune older evidence beyond MAX_CORRUPT_FILES. The ms timestamp is
+// fixed-width for the foreseeable future, so a lexicographic sort of the
+// filenames is chronological. Best-effort: every step is allowed to fail.
+function preserveCorruptFile(paths: AutonomyPaths, chatId: string): void {
+  try {
+    const key = canonicalChatKey(chatId)
+    const file = autonomyStatePath(paths, chatId)
+    const suffix = `${Date.now()}-${randomBytes(3).toString('hex')}`
+    renameSync(file, join(paths.root, `autonomy-${key}.json.corrupt-${suffix}`))
+    const prefix = `autonomy-${key}.json.corrupt-`
+    const evidence = readdirSync(paths.root)
+      .filter((f) => f.startsWith(prefix))
+      .sort()
+    while (evidence.length > MAX_CORRUPT_FILES) {
+      const oldest = evidence.shift()
+      if (oldest === undefined) break
+      try {
+        unlinkSync(join(paths.root, oldest))
+      } catch {
+        // best-effort
+      }
+    }
+  } catch {
+    // best-effort — forensics must never break the load path
   }
 }
 
@@ -595,17 +718,30 @@ export function saveAutonomyState(
   chatId: string,
   state: AutonomyState,
 ): void {
-  mkdirSync(paths.root, { recursive: true, mode: 0o700 })
-  const key = canonicalChatKey(chatId)
-  const target = autonomyStatePath(paths, chatId)
-  const rand = randomBytes(3).toString('hex')
-  const tmp = join(paths.root, `autonomy-${key}.tmp.${process.pid}.${Date.now()}.${rand}`)
-  // Normalize on write: always stamp the current schema version.
+  // Normalize on write: stamp the current schema version and INCREMENT the
+  // revision counter (fix-loop-2 #1) — every save is observable on disk.
+  const nextRevision = (Number.isFinite(state.revision) ? state.revision : 0) + 1
   const body = JSON.stringify(
-    { version: AUTONOMY_STATE_VERSION, leases: state.leases, questions: state.questions },
+    {
+      version: AUTONOMY_STATE_VERSION,
+      revision: nextRevision,
+      leases: state.leases,
+      questions: state.questions,
+    },
     null,
     2,
   )
+  atomicWriteInRoot(paths, `autonomy-${canonicalChatKey(chatId)}.json`, body)
+}
+
+// Shared atomic writer for files in the state root (state files + the writer
+// lock). tmp('wx') + fchmod 0600 + fsync + rename + tmp cleanup on ANY
+// failure + best-effort directory fsync.
+function atomicWriteInRoot(paths: AutonomyPaths, filename: string, body: string): void {
+  mkdirSync(paths.root, { recursive: true, mode: 0o700 })
+  const target = join(paths.root, filename)
+  const rand = randomBytes(3).toString('hex')
+  const tmp = join(paths.root, `${filename}.tmp.${process.pid}.${Date.now()}.${rand}`)
   let fd: number | undefined
   let renamed = false
   try {
@@ -648,6 +784,92 @@ export function saveAutonomyState(
 }
 
 // ─────────────────────────────────────────────────────────────────────
+// Writer heartbeat lock (fix-loop-2 #2). One lock per state root, shared by
+// all chats. Sol's criterion: freshness + writerId, NEVER bare PID-existence
+// (pid stored for diagnostics only).
+// ─────────────────────────────────────────────────────────────────────
+
+export const WRITER_LOCK_FILENAME = 'autonomy-writer.lock'
+// Refresh the own lock lazily when it is older than this (no timers).
+export const WRITER_LOCK_REFRESH_MS = 30_000
+// A FOREIGN lock younger than this blocks mutations; older is stale and is
+// taken over.
+export const WRITER_LOCK_STALE_MS = 90_000
+
+// Random per-process writer identity — two processes can never share it even
+// with equal pids across container boundaries.
+export const AUTONOMY_WRITER_ID = randomBytes(8).toString('hex')
+
+interface WriterLock {
+  writerId: string
+  pid: number
+  refreshedAtMs: number
+}
+
+function readWriterLock(paths: AutonomyPaths): WriterLock | undefined {
+  try {
+    const raw = readFileSync(join(paths.root, WRITER_LOCK_FILENAME), 'utf8')
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return undefined
+    const o = parsed as Record<string, unknown>
+    if (typeof o.writerId !== 'string' || o.writerId.length === 0) return undefined
+    if (typeof o.refreshedAtMs !== 'number' || !Number.isFinite(o.refreshedAtMs)) return undefined
+    return {
+      writerId: o.writerId,
+      pid: typeof o.pid === 'number' && Number.isFinite(o.pid) ? o.pid : -1,
+      refreshedAtMs: o.refreshedAtMs,
+    }
+  } catch {
+    // Missing or corrupt lock → treated as absent (take-over path).
+    return undefined
+  }
+}
+
+function writeWriterLock(paths: AutonomyPaths, nowMs: number): void {
+  atomicWriteInRoot(
+    paths,
+    WRITER_LOCK_FILENAME,
+    JSON.stringify({ writerId: AUTONOMY_WRITER_ID, pid: process.pid, refreshedAtMs: nowMs }),
+  )
+}
+
+/**
+ * Ensure THIS process holds the writer lock. Returns false when a FRESH lock
+ * belongs to a different writer (the caller must refuse the mutation).
+ *   * missing/corrupt lock → take it (write own), true;
+ *   * own lock → refresh when older than WRITER_LOCK_REFRESH_MS, true;
+ *   * foreign fresh (<WRITER_LOCK_STALE_MS) → log + false;
+ *   * foreign stale → take over atomically, true.
+ */
+export function acquireWriterLock(
+  paths: AutonomyPaths,
+  nowMs: number = Date.now(),
+  log?: Logger,
+): boolean {
+  const lock = readWriterLock(paths)
+  if (lock === undefined) {
+    writeWriterLock(paths, nowMs)
+    return true
+  }
+  if (lock.writerId === AUTONOMY_WRITER_ID) {
+    if (nowMs - lock.refreshedAtMs > WRITER_LOCK_REFRESH_MS) writeWriterLock(paths, nowMs)
+    return true
+  }
+  if (nowMs - lock.refreshedAtMs < WRITER_LOCK_STALE_MS) {
+    if (log) {
+      log.warn('autonomy writer lock held by another live process — mutation refused', {
+        code: 'autonomy_writer_conflict',
+        holder_pid: lock.pid,
+      })
+    }
+    return false
+  }
+  // Stale foreign lock — the holder stopped heartbeating; take over.
+  writeWriterLock(paths, nowMs)
+  return true
+}
+
+// ─────────────────────────────────────────────────────────────────────
 // Serialized read-modify-write (fix-loop #1). ALL mutations of the per-chat
 // file MUST route through here — a bare load→mutate→save in a caller races
 // (two concurrent consumes both observing the pre-consume state).
@@ -658,25 +880,69 @@ export function saveAutonomyState(
 // single-writer assumption in the module header.
 const updateChains = new Map<string, Promise<void>>()
 
+// Cheap read of the ON-DISK revision, never throws. Missing/corrupt/invalid
+// → 0 (matches what loadAutonomyState would produce for the same file).
+function peekRevision(paths: AutonomyPaths, chatId: string): number {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(autonomyStatePath(paths, chatId), 'utf8'))
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      const r = (parsed as Record<string, unknown>).revision
+      if (typeof r === 'number' && Number.isFinite(r) && r >= 0) return Math.floor(r)
+    }
+    return 0
+  } catch {
+    return 0
+  }
+}
+
+// Result of a serialized update. `writer_conflict` = a FRESH writer lock is
+// held by another process — the mutation was refused entirely (fix-loop-2 #2).
+export type UpdateResult<T> = { kind: 'ok'; result: T } | { kind: 'writer_conflict' }
+
 /**
  * Atomically (within this process) apply `mutator` to the chat's state:
  * load → mutate → save, serialized per chat via a promise chain. The mutator
  * is pure/synchronous and returns the next state plus a result; when it
  * returns the SAME state reference (a failed/no-op mutation), the save is
- * skipped. Returns the mutator's result.
+ * skipped.
+ *
+ * Cross-process guards (fix-loop-2):
+ *   * writer lock — a fresh foreign `autonomy-writer.lock` refuses the whole
+ *     mutation with `{ kind: 'writer_conflict' }`;
+ *   * revision check — right before writing, the on-disk revision is
+ *     re-read; if it moved under us (a second-process writer slipped past
+ *     the lock window), the state is RELOADED and the mutator re-applied on
+ *     the fresh state, so the foreign write is absorbed, not clobbered.
+ *     Within the in-process queue this never triggers.
  */
 export function updateAutonomyState<T>(
   paths: AutonomyPaths,
   chatId: string,
   mutator: (state: AutonomyState) => { state: AutonomyState; result: T },
   log?: Logger,
-): Promise<T> {
+): Promise<UpdateResult<T>> {
   const key = `${paths.root}|${canonicalChatKey(chatId)}`
-  const step = (): T => {
-    const state = loadAutonomyState(paths, chatId, log)
-    const { state: next, result } = mutator(state)
-    if (next !== state) saveAutonomyState(paths, chatId, next)
-    return result
+  const step = (): UpdateResult<T> => {
+    if (!acquireWriterLock(paths, Date.now(), log)) {
+      return { kind: 'writer_conflict' }
+    }
+    let state = loadAutonomyState(paths, chatId, log)
+    let out = mutator(state)
+    if (out.state === state) return { kind: 'ok', result: out.result }
+    // Detect a cross-process write between our load and this write.
+    if (peekRevision(paths, chatId) !== state.revision) {
+      if (log) {
+        log.warn('autonomy state revision moved under writer — re-applying mutator on fresh state', {
+          chat_id: chatId,
+          code: 'autonomy_state_revision_conflict',
+        })
+      }
+      state = loadAutonomyState(paths, chatId, log)
+      out = mutator(state)
+      if (out.state === state) return { kind: 'ok', result: out.result }
+    }
+    saveAutonomyState(paths, chatId, out.state)
+    return { kind: 'ok', result: out.result }
   }
   const prior = updateChains.get(key) ?? Promise.resolve()
   // Run after the prior op regardless of its outcome (the chain must never

--- a/plugin/src/channel/tools.ts
+++ b/plugin/src/channel/tools.ts
@@ -34,7 +34,7 @@ import {
   loadAutonomyState,
   renderAutonomyStatus,
   resolveQuestion,
-  saveAutonomyState,
+  updateAutonomyState,
 } from '../autonomy/store.js'
 import { assertAllowedChat } from '../telegram/gate.js'
 import type { GuestQueryRegistry } from '../telegram/guest-queries.js'
@@ -898,29 +898,66 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
         }
 
         const now = Date.now()
-        const state = loadAutonomyState(statePaths, args.chat_id, log)
 
         if (args.action === 'status') {
+          // Read-only — no serialization needed.
+          const state = loadAutonomyState(statePaths, args.chat_id, log)
           return { content: [{ type: 'text', text: renderAutonomyStatus(state, now) }] }
         }
 
         if (args.action === 'consume') {
-          // lease_id presence is enforced by the schema's superRefine.
+          // lease_id presence is enforced by the schema's superRefine. The
+          // mutation routes through updateAutonomyState — the serialized
+          // read-modify-write — so two concurrent consumes can never both
+          // succeed (fix-loop #1).
           const leaseId = args.lease_id as string
-          const { state: next, outcome } = consumeLease(state, leaseId, now)
-          if (outcome === 'not_found') return toolError(name, `lease not found: ${leaseId}`)
-          if (outcome === 'already_consumed') return toolError(name, `lease already consumed: ${leaseId}`)
-          saveAutonomyState(statePaths, args.chat_id, next)
-          return { content: [{ type: 'text', text: `lease consumed: ${leaseId}` }] }
+          const outcome = await updateAutonomyState(
+            statePaths,
+            args.chat_id,
+            (state) => {
+              const r = consumeLease(state, leaseId, now)
+              return { state: r.state, result: r.outcome }
+            },
+            log,
+          )
+          switch (outcome) {
+            case 'not_found':
+              return toolError(name, `lease not found: ${leaseId}`)
+            case 'already_consumed':
+              return toolError(name, `lease already consumed: ${leaseId}`)
+            case 'expired':
+              // Honest refusal (fix-loop #8): the mandate's window has
+              // passed — do not report success on a dead mandate.
+              return toolError(name, `lease expired: ${leaseId} — the mandate window has passed, it cannot be consumed`)
+            case 'ok':
+              return { content: [{ type: 'text', text: `lease consumed: ${leaseId}` }] }
+          }
         }
 
         // action === 'resolve_question' (question_id + resolution enforced by schema).
         const questionId = args.question_id as string
         const resolution = args.resolution as 'answered' | 'bypassed'
-        const { state: next, outcome } = resolveQuestion(state, questionId, resolution, now)
-        if (outcome === 'not_found') return toolError(name, `question not found: ${questionId}`)
-        saveAutonomyState(statePaths, args.chat_id, next)
-        return { content: [{ type: 'text', text: `question ${questionId} resolved: ${resolution}` }] }
+        const outcome = await updateAutonomyState(
+          statePaths,
+          args.chat_id,
+          (state) => {
+            const r = resolveQuestion(state, questionId, resolution, now)
+            return { state: r.state, result: r.outcome }
+          },
+          log,
+        )
+        switch (outcome) {
+          case 'not_found':
+            return toolError(name, `question not found: ${questionId}`)
+          case 'sticky_forbidden':
+            // Store-enforced invariant (fix-loop #2): security questions can
+            // never be bypassed — only an owner answer resolves them.
+            return toolError(name, `question ${questionId} is sticky (security) — bypass is forbidden, it requires the owner's answer`)
+          case 'already_resolved':
+            return toolError(name, `question already resolved: ${questionId}`)
+          case 'ok':
+            return { content: [{ type: 'text', text: `question ${questionId} resolved: ${resolution}` }] }
+        }
       }
 
       default:

--- a/plugin/src/channel/tools.ts
+++ b/plugin/src/channel/tools.ts
@@ -1,7 +1,8 @@
 // MCP tool surface for the Telegram channel.
 //
-// 5 tools: reply, react, download_attachment, edit_message, status.
-// Status is currently a stub (returns not_implemented) — T11 will wire it.
+// 6 tools: reply, react, download_attachment, edit_message, status, autonomy.
+// `autonomy` (PR-1) is a READ + resolve surface over the durable autonomy
+// registry (leases + open questions); it can never GRANT a lease.
 //
 // All tool args are validated through Zod schemas; we never reach into
 // `req.params.arguments` with `as Record<string, unknown>` casts. If a
@@ -21,12 +22,20 @@ import type { Logger } from '../log.js'
 import type { MultichatPolicy } from '../chats/policy-loader.js'
 import type { StatusManager, StatusState } from '../status/status-manager.js'
 import {
+  AutonomyArgsSchema,
   DownloadAttachmentArgsSchema,
   EditMessageArgsSchema,
   ReactArgsSchema,
   ReplyArgsSchema,
   StatusArgsSchema,
 } from '../schemas.js'
+import {
+  consumeLease,
+  loadAutonomyState,
+  renderAutonomyStatus,
+  resolveQuestion,
+  saveAutonomyState,
+} from '../autonomy/store.js'
 import { assertAllowedChat } from '../telegram/gate.js'
 import type { GuestQueryRegistry } from '../telegram/guest-queries.js'
 import {
@@ -403,6 +412,35 @@ const TOOL_DEFINITIONS: ToolDefinition[] = [
         },
       },
       required: ['chat_id', 'state'],
+    },
+  },
+  {
+    name: 'autonomy',
+    description:
+      'Inspect and resolve the durable autonomy registry for a chat — the owner-granted mandates (leases) that survive context compaction, plus open questions to the owner. Pass chat_id from the inbound <channel> meta. action="status" returns active leases (id, scope, time left) and open questions (id, summary, age, default action, sticky flag). action="consume" marks a lease consumed (pass lease_id). action="resolve_question" sets a question answered/bypassed (pass question_id and resolution). This tool CANNOT grant a lease — grants come from the owner via the authenticated button flow.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        chat_id: { type: 'string' },
+        action: {
+          type: 'string',
+          enum: ['status', 'consume', 'resolve_question'],
+        },
+        lease_id: {
+          type: 'string',
+          description: 'Required when action="consume". The lease id (e.g. L-20260710-a1b2).',
+        },
+        question_id: {
+          type: 'string',
+          description: 'Required when action="resolve_question". The question id (e.g. Q-20260710-a1b2).',
+        },
+        resolution: {
+          type: 'string',
+          enum: ['answered', 'bypassed'],
+          description: 'Required when action="resolve_question". How the question was resolved.',
+        },
+      },
+      required: ['chat_id', 'action'],
     },
   },
 ]
@@ -847,6 +885,42 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
               : { kind: 'thinking' }
         await statusManager.updateByChatId(args.chat_id, state)
         return { content: [{ type: 'text', text: 'status updated' }] }
+      }
+
+      case 'autonomy': {
+        const parsed = AutonomyArgsSchema.safeParse(rawArgs)
+        if (!parsed.success) return toolError(name, zodErrorMessage(parsed.error))
+        const args = parsed.data
+        try {
+          assertAllowedChat(args.chat_id, config, deps.policy)
+        } catch (err) {
+          return toolError(name, err instanceof Error ? err.message : String(err))
+        }
+
+        const now = Date.now()
+        const state = loadAutonomyState(statePaths, args.chat_id, log)
+
+        if (args.action === 'status') {
+          return { content: [{ type: 'text', text: renderAutonomyStatus(state, now) }] }
+        }
+
+        if (args.action === 'consume') {
+          // lease_id presence is enforced by the schema's superRefine.
+          const leaseId = args.lease_id as string
+          const { state: next, outcome } = consumeLease(state, leaseId, now)
+          if (outcome === 'not_found') return toolError(name, `lease not found: ${leaseId}`)
+          if (outcome === 'already_consumed') return toolError(name, `lease already consumed: ${leaseId}`)
+          saveAutonomyState(statePaths, args.chat_id, next)
+          return { content: [{ type: 'text', text: `lease consumed: ${leaseId}` }] }
+        }
+
+        // action === 'resolve_question' (question_id + resolution enforced by schema).
+        const questionId = args.question_id as string
+        const resolution = args.resolution as 'answered' | 'bypassed'
+        const { state: next, outcome } = resolveQuestion(state, questionId, resolution, now)
+        if (outcome === 'not_found') return toolError(name, `question not found: ${questionId}`)
+        saveAutonomyState(statePaths, args.chat_id, next)
+        return { content: [{ type: 'text', text: `question ${questionId} resolved: ${resolution}` }] }
       }
 
       default:

--- a/plugin/src/channel/tools.ts
+++ b/plugin/src/channel/tools.ts
@@ -34,7 +34,9 @@ import {
   loadAutonomyState,
   renderAutonomyStatus,
   resolveQuestion,
+  revokeLease,
   updateAutonomyState,
+  type UpdateResult,
 } from '../autonomy/store.js'
 import { assertAllowedChat } from '../telegram/gate.js'
 import type { GuestQueryRegistry } from '../telegram/guest-queries.js'
@@ -417,18 +419,22 @@ const TOOL_DEFINITIONS: ToolDefinition[] = [
   {
     name: 'autonomy',
     description:
-      'Inspect and resolve the durable autonomy registry for a chat — the owner-granted mandates (leases) that survive context compaction, plus open questions to the owner. Pass chat_id from the inbound <channel> meta. action="status" returns active leases (id, scope, time left) and open questions (id, summary, age, default action, sticky flag). action="consume" marks a lease consumed (pass lease_id). action="resolve_question" sets a question answered/bypassed (pass question_id and resolution). This tool CANNOT grant a lease — grants come from the owner via the authenticated button flow.',
+      'Inspect and resolve the durable autonomy registry for a chat — the owner-granted mandates (leases) that survive context compaction, plus open questions to the owner. Pass chat_id from the inbound <channel> meta. action="status" returns active leases (id, scope, time left) and open questions (id, summary, age, default action, sticky flag). action="consume" marks a lease consumed (pass lease_id). action="revoke" withdraws a lease\'s authority (pass lease_id, optional reason) — self-revoke only shrinks authority. action="resolve_question" sets a question answered/bypassed (pass question_id and resolution). This tool CANNOT grant a lease — grants come from the owner via the authenticated button flow.',
     inputSchema: {
       type: 'object',
       properties: {
         chat_id: { type: 'string' },
         action: {
           type: 'string',
-          enum: ['status', 'consume', 'resolve_question'],
+          enum: ['status', 'consume', 'revoke', 'resolve_question'],
         },
         lease_id: {
           type: 'string',
-          description: 'Required when action="consume". The lease id (e.g. L-20260710-a1b2).',
+          description: 'Required when action="consume" or action="revoke". The lease id (e.g. L-20260710-a1b2c3d4).',
+        },
+        reason: {
+          type: 'string',
+          description: 'Optional short reason for action="revoke" (stored as revokeReason).',
         },
         question_id: {
           type: 'string',
@@ -905,13 +911,21 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
           return { content: [{ type: 'text', text: renderAutonomyStatus(state, now) }] }
         }
 
+        // Honest refusal when a FRESH writer lock is held by another process
+        // (fix-loop-2 #2) — shared by all three mutating actions.
+        const writerConflict = (): CallToolResult =>
+          toolError(
+            name,
+            'autonomy registry is write-locked by another live writer process — mutation refused (writer_conflict), retry later',
+          )
+
         if (args.action === 'consume') {
           // lease_id presence is enforced by the schema's superRefine. The
           // mutation routes through updateAutonomyState — the serialized
           // read-modify-write — so two concurrent consumes can never both
           // succeed (fix-loop #1).
           const leaseId = args.lease_id as string
-          const outcome = await updateAutonomyState(
+          const upd = await updateAutonomyState(
             statePaths,
             args.chat_id,
             (state) => {
@@ -920,11 +934,16 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
             },
             log,
           )
-          switch (outcome) {
+          if (upd.kind === 'writer_conflict') return writerConflict()
+          switch (upd.result) {
             case 'not_found':
               return toolError(name, `lease not found: ${leaseId}`)
             case 'already_consumed':
               return toolError(name, `lease already consumed: ${leaseId}`)
+            case 'revoked':
+              // Terminal revoked state (fix-loop-2 #4): withdrawn authority
+              // can never be consumed.
+              return toolError(name, `lease revoked: ${leaseId} — the mandate's authority was withdrawn, it cannot be consumed`)
             case 'expired':
               // Honest refusal (fix-loop #8): the mandate's window has
               // passed — do not report success on a dead mandate.
@@ -934,10 +953,38 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
           }
         }
 
+        if (args.action === 'revoke') {
+          // Self-revoke (fix-loop-2 #4): the agent may WITHDRAW its own
+          // authority (revokedBy='agent') — shrinking is safe; granting is not.
+          const leaseId = args.lease_id as string
+          const upd = await updateAutonomyState(
+            statePaths,
+            args.chat_id,
+            (state) => {
+              const r = revokeLease(state, leaseId, now, 'agent', args.reason)
+              return { state: r.state, result: r.outcome }
+            },
+            log,
+          )
+          if (upd.kind === 'writer_conflict') return writerConflict()
+          switch (upd.result) {
+            case 'not_found':
+              return toolError(name, `lease not found: ${leaseId}`)
+            case 'already_consumed':
+              return toolError(name, `lease already consumed: ${leaseId} — a used mandate cannot be revoked`)
+            case 'already_revoked':
+              return toolError(name, `lease already revoked: ${leaseId}`)
+            case 'expired':
+              return toolError(name, `lease expired: ${leaseId} — an expired mandate has no authority left, nothing to revoke`)
+            case 'ok':
+              return { content: [{ type: 'text', text: `lease revoked: ${leaseId}` }] }
+          }
+        }
+
         // action === 'resolve_question' (question_id + resolution enforced by schema).
         const questionId = args.question_id as string
         const resolution = args.resolution as 'answered' | 'bypassed'
-        const outcome = await updateAutonomyState(
+        const upd: UpdateResult<ReturnType<typeof resolveQuestion>['outcome']> = await updateAutonomyState(
           statePaths,
           args.chat_id,
           (state) => {
@@ -946,7 +993,8 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
           },
           log,
         )
-        switch (outcome) {
+        if (upd.kind === 'writer_conflict') return writerConflict()
+        switch (upd.result) {
           case 'not_found':
             return toolError(name, `question not found: ${questionId}`)
           case 'sticky_forbidden':

--- a/plugin/src/schemas.ts
+++ b/plugin/src/schemas.ts
@@ -129,19 +129,24 @@ export type StatusArgs = z.infer<typeof StatusArgsSchema>
 // lease — granting arrives in PR-2 via the authenticated button relay.
 //   status            → compact human-readable dump of active leases + open Qs.
 //   consume           → mark a lease consumed (requires lease_id).
+//   revoke            → withdraw a lease's authority (requires lease_id,
+//                       optional reason; revokedBy='agent'). Self-revoke only
+//                       SHRINKS authority, so the tool may do it — it still
+//                       can never GRANT.
 //   resolve_question  → set a question answered/bypassed (requires question_id
 //                       + resolution).
 export const AutonomyArgsSchema = z
   .object({
     chat_id: z.union([z.number(), z.string()]).transform((v) => String(v)),
-    action: z.enum(['status', 'consume', 'resolve_question']),
+    action: z.enum(['status', 'consume', 'revoke', 'resolve_question']),
     lease_id: z.string().min(1).optional(),
     question_id: z.string().min(1).optional(),
     resolution: z.enum(['answered', 'bypassed']).optional(),
+    reason: z.string().min(1).max(1000).optional(),
   })
   .superRefine((a, ctx) => {
-    if (a.action === 'consume' && a.lease_id === undefined) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'action="consume" requires lease_id', path: ['lease_id'] })
+    if ((a.action === 'consume' || a.action === 'revoke') && a.lease_id === undefined) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: `action="${a.action}" requires lease_id`, path: ['lease_id'] })
     }
     if (a.action === 'resolve_question') {
       if (a.question_id === undefined) {

--- a/plugin/src/schemas.ts
+++ b/plugin/src/schemas.ts
@@ -124,6 +124,36 @@ export const StatusArgsSchema = z.object({
 })
 export type StatusArgs = z.infer<typeof StatusArgsSchema>
 
+// Tool args - autonomy (PR-1, 2026-07-10). A READ + resolve surface over the
+// per-chat autonomy registry (leases + open questions). It can NEVER grant a
+// lease — granting arrives in PR-2 via the authenticated button relay.
+//   status            → compact human-readable dump of active leases + open Qs.
+//   consume           → mark a lease consumed (requires lease_id).
+//   resolve_question  → set a question answered/bypassed (requires question_id
+//                       + resolution).
+export const AutonomyArgsSchema = z
+  .object({
+    chat_id: z.union([z.number(), z.string()]).transform((v) => String(v)),
+    action: z.enum(['status', 'consume', 'resolve_question']),
+    lease_id: z.string().min(1).optional(),
+    question_id: z.string().min(1).optional(),
+    resolution: z.enum(['answered', 'bypassed']).optional(),
+  })
+  .superRefine((a, ctx) => {
+    if (a.action === 'consume' && a.lease_id === undefined) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'action="consume" requires lease_id', path: ['lease_id'] })
+    }
+    if (a.action === 'resolve_question') {
+      if (a.question_id === undefined) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'action="resolve_question" requires question_id', path: ['question_id'] })
+      }
+      if (a.resolution === undefined) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'action="resolve_question" requires resolution', path: ['resolution'] })
+      }
+    }
+  })
+export type AutonomyArgs = z.infer<typeof AutonomyArgsSchema>
+
 // Webhook payload for /hooks/agent — message variant.
 // Today's `/hooks/agent` callers post `{ message, chatId, agentId? }` and the
 // server forwards content as a channel notification (gateway.py:3531-3589 path).

--- a/plugin/src/status/context-hud.ts
+++ b/plugin/src/status/context-hud.ts
@@ -25,6 +25,7 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { resolveContextWindowForModel } from '../config.js'
+import { buildAutonomyHudLine, loadAutonomyState } from '../autonomy/store.js'
 import { classifyEditError } from '../safety/telegram-edit-classifier.js'
 import {
   formatWindowTokens,
@@ -203,6 +204,7 @@ export function renderHud(
   windowTokens: number,
   model?: string,
   work?: HudWorkView,
+  autonomyLine?: string,
 ): { text: string; keyboard: InlineKeyboardLike } {
   const keyboard = buildHudKeyboard()
   const modelLine = model !== undefined && model.length > 0 ? `\n<i>${escapeHtml(model)}</i>` : ''
@@ -210,9 +212,14 @@ export function renderHud(
     work?.permissionMode !== undefined && work.permissionMode.length > 0
       ? `\n<i>режим: ${modeLabel(work.permissionMode)}</i>`
       : ''
+  // Autonomy pin line (PR-1): one compact line when active mandates / open
+  // owner questions exist. Already HTML-escaped by buildAutonomyHudLine (the
+  // HUD passes escapeHtml), so it is safe under the card's HTML parse mode.
+  const autonomyBlock =
+    autonomyLine !== undefined && autonomyLine.length > 0 ? `\n${autonomyLine}` : ''
   const tasksBlock = work !== undefined ? renderStatusTasks(work.todos, work.freshness) : ''
   const tasksSection = tasksBlock.length > 0 ? `\n\n${tasksBlock}` : ''
-  const tail = `${modelLine}${modeLine}${tasksSection}`
+  const tail = `${modelLine}${modeLine}${autonomyBlock}${tasksSection}`
 
   if (usage === null) {
     return { text: `🧠 <b>Контекст</b>: —${tail}`, keyboard }
@@ -719,7 +726,21 @@ export class ContextHud {
     const work: HudWorkView = rv !== undefined
       ? { todos: rv.todos, freshness: rv.freshness, ...permissionMode }
       : { todos: this.work.get(chatId)?.todos ?? [], ...permissionMode }
-    return renderHud(usage, windowTokens, model, work)
+    // Autonomy pin line (PR-1). Best-effort: a broken/missing registry must
+    // never break HUD rendering, so load + line-build are guarded and degrade
+    // to no line. Escaped via escapeHtml for the card's HTML parse mode.
+    let autonomyLine: string | undefined
+    try {
+      const state = loadAutonomyState({ root: this.stateDir }, chatId, this.log)
+      autonomyLine = buildAutonomyHudLine(state, Date.now(), { escape: escapeHtml })
+    } catch (err) {
+      this.log.warn('context hud autonomy line failed (ignored)', {
+        chat_id: chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      autonomyLine = undefined
+    }
+    return renderHud(usage, windowTokens, model, work, autonomyLine)
   }
 
   // Resolve the HUD message id for a chat: in-memory cache → persisted file →

--- a/plugin/tests/autonomy/store.test.ts
+++ b/plugin/tests/autonomy/store.test.ts
@@ -22,8 +22,13 @@ import {
   questionAgeMs,
   renderAutonomyStatus,
   resolveQuestion,
+  revokeLease,
   saveAutonomyState,
   updateAutonomyState,
+  AUTONOMY_WRITER_ID,
+  WRITER_LOCK_FILENAME,
+  acquireWriterLock,
+  computeScopeDigest,
   type AutonomyState,
 } from '../../src/autonomy/store.js'
 
@@ -58,16 +63,18 @@ function seedState(): AutonomyState {
 
 describe('emptyAutonomyState', () => {
   test('is a versioned empty registry', () => {
-    expect(emptyAutonomyState()).toEqual({ version: AUTONOMY_STATE_VERSION, leases: [], questions: [] })
+    expect(emptyAutonomyState()).toEqual({ version: AUTONOMY_STATE_VERSION, revision: 0, leases: [], questions: [] })
   })
 })
 
 describe('round-trip persistence', () => {
-  test('save then load returns identical state', () => {
+  test('save then load returns identical content (revision bumped by the save)', () => {
     const state = seedState()
     saveAutonomyState(paths(), '164795011', state)
     const loaded = loadAutonomyState(paths(), '164795011')
-    expect(loaded).toEqual(state)
+    expect(loaded.leases).toEqual(state.leases)
+    expect(loaded.questions).toEqual(state.questions)
+    expect(loaded.revision).toBe(state.revision + 1)
   })
 
   test('file lives at autonomy-<chatId>.json in the state root', () => {
@@ -91,7 +98,7 @@ describe('round-trip persistence', () => {
   })
 
   test('save always stamps the current schema version', () => {
-    const state = { version: 999 as unknown as typeof AUTONOMY_STATE_VERSION, leases: [], questions: [] }
+    const state = { version: 999 as unknown as typeof AUTONOMY_STATE_VERSION, revision: 0, leases: [], questions: [] }
     saveAutonomyState(paths(), '1', state)
     expect(loadAutonomyState(paths(), '1').version).toBe(AUTONOMY_STATE_VERSION)
   })
@@ -324,7 +331,11 @@ describe('updateAutonomyState — serialized read-modify-write', () => {
         const r = consumeLease(state, 'L-race', NOW)
         return { state: r.state, result: r.outcome }
       })
-    const [a, b] = await Promise.all([consume(), consume()])
+    const [ua, ub] = await Promise.all([consume(), consume()])
+    expect(ua.kind).toBe('ok')
+    expect(ub.kind).toBe('ok')
+    const a = ua.kind === 'ok' ? ua.result : 'conflict'
+    const b = ub.kind === 'ok' ? ub.result : 'conflict'
     expect([a, b].sort()).toEqual(['already_consumed', 'ok'])
     // On disk: consumed exactly once.
     const final = loadAutonomyState(paths(), '1')
@@ -345,11 +356,11 @@ describe('updateAutonomyState — serialized read-modify-write', () => {
 
   test('no-op mutation (same state reference) skips the save', async () => {
     // No file exists; a not_found consume returns the same state → no write.
-    const outcome = await updateAutonomyState(paths(), '3', (state) => {
+    const upd = await updateAutonomyState(paths(), '3', (state) => {
       const r = consumeLease(state, 'L-none', NOW)
       return { state: r.state, result: r.outcome }
     })
-    expect(outcome).toBe('not_found')
+    expect(upd).toEqual({ kind: 'ok', result: 'not_found' })
     expect(readdirSync(root)).not.toContain('autonomy-3.json')
   })
 })
@@ -446,5 +457,205 @@ describe('buildAutonomyHudLine', () => {
     state = addLease(state, { id: 'L-1', scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW).state
     state = addLease(state, { id: 'L-2', scope: 's', expiresAtMs: NOW + 2 * HOUR, source: 'manual' }, NOW).state
     expect(buildAutonomyHudLine(state, NOW) as string).toContain('+1')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// Fix-loop-2 (Sol architecture review): revision counter, writer lock,
+// scopeDigest, revoke terminal state, corrupt-file forensics.
+// ─────────────────────────────────────────────────────────────────────
+
+import { existsSync, writeFileSync as wfs, readFileSync as rfs } from 'node:fs'
+
+describe('revision counter (fix-loop-2 #1)', () => {
+  test('every save increments the on-disk revision', () => {
+    saveAutonomyState(paths(), '1', emptyAutonomyState())
+    expect(loadAutonomyState(paths(), '1').revision).toBe(1)
+    saveAutonomyState(paths(), '1', loadAutonomyState(paths(), '1'))
+    expect(loadAutonomyState(paths(), '1').revision).toBe(2)
+    saveAutonomyState(paths(), '1', loadAutonomyState(paths(), '1'))
+    expect(loadAutonomyState(paths(), '1').revision).toBe(3)
+  })
+
+  test('external revision bump between load and save → mutator re-applied on fresh state (no lost update)', async () => {
+    // Seed: lease A, on-disk revision 1.
+    saveAutonomyState(
+      paths(),
+      '9',
+      addLease(emptyAutonomyState(), { id: 'L-A', scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW).state,
+    )
+    let mutatorCalls = 0
+    const upd = await updateAutonomyState(paths(), '9', (state) => {
+      mutatorCalls++
+      if (mutatorCalls === 1) {
+        // Simulate a SECOND-PROCESS writer landing between our load and save:
+        // it adds L-EXT and bumps the on-disk revision under us.
+        saveAutonomyState(paths(), '9', addLease(state, { id: 'L-EXT', scope: 'x', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW).state)
+      }
+      const r = addLease(state, { id: 'L-MINE', scope: 'm', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW)
+      return { state: r.state, result: r.outcome }
+    })
+    expect(upd).toEqual({ kind: 'ok', result: 'ok' })
+    // The mutator ran TWICE: stale apply detected, fresh re-apply persisted.
+    expect(mutatorCalls).toBe(2)
+    const final = loadAutonomyState(paths(), '9')
+    const ids = final.leases.map((l) => l.id).sort()
+    // BOTH the external write and ours survived — nothing was lost.
+    expect(ids).toEqual(['L-A', 'L-EXT', 'L-MINE'])
+  })
+})
+
+describe('writer heartbeat lock (fix-loop-2 #2)', () => {
+  const lockPath = () => join(root, WRITER_LOCK_FILENAME)
+
+  test('fresh FOREIGN lock blocks the mutation with writer_conflict', async () => {
+    wfs(lockPath(), JSON.stringify({ writerId: 'feedfacedeadbeef', pid: 424242, refreshedAtMs: Date.now() }), 'utf8')
+    const upd = await updateAutonomyState(paths(), '1', (state) => {
+      const r = addLease(state, { id: 'L-x', scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW)
+      return { state: r.state, result: r.outcome }
+    })
+    expect(upd).toEqual({ kind: 'writer_conflict' })
+    // Nothing was written; the foreign lock still stands.
+    expect(loadAutonomyState(paths(), '1').leases).toEqual([])
+    expect((JSON.parse(rfs(lockPath(), 'utf8')) as { writerId: string }).writerId).toBe('feedfacedeadbeef')
+  })
+
+  test('STALE foreign lock is taken over and the mutation proceeds', async () => {
+    wfs(lockPath(), JSON.stringify({ writerId: 'feedfacedeadbeef', pid: 424242, refreshedAtMs: Date.now() - 120_000 }), 'utf8')
+    const upd = await updateAutonomyState(paths(), '1', (state) => {
+      const r = addLease(state, { id: 'L-x', scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW)
+      return { state: r.state, result: r.outcome }
+    })
+    expect(upd).toEqual({ kind: 'ok', result: 'ok' })
+    expect((JSON.parse(rfs(lockPath(), 'utf8')) as { writerId: string }).writerId).toBe(AUTONOMY_WRITER_ID)
+    expect(loadAutonomyState(paths(), '1').leases.length).toBe(1)
+  })
+
+  test('own aged lock refreshes lazily on write', () => {
+    const before = Date.now()
+    wfs(lockPath(), JSON.stringify({ writerId: AUTONOMY_WRITER_ID, pid: process.pid, refreshedAtMs: before - 60_000 }), 'utf8')
+    expect(acquireWriterLock(paths(), before)).toBe(true)
+    const after = JSON.parse(rfs(lockPath(), 'utf8')) as { writerId: string; refreshedAtMs: number }
+    expect(after.writerId).toBe(AUTONOMY_WRITER_ID)
+    expect(after.refreshedAtMs).toBe(before) // refreshed, not left at -60s
+  })
+
+  test('own FRESH lock is not rewritten (lazy refresh only)', () => {
+    const stamped = Date.now() - 1000
+    wfs(lockPath(), JSON.stringify({ writerId: AUTONOMY_WRITER_ID, pid: process.pid, refreshedAtMs: stamped }), 'utf8')
+    expect(acquireWriterLock(paths(), Date.now())).toBe(true)
+    const after = JSON.parse(rfs(lockPath(), 'utf8')) as { refreshedAtMs: number }
+    expect(after.refreshedAtMs).toBe(stamped) // untouched — under refresh window
+  })
+
+  test('missing/corrupt lock is acquired', () => {
+    expect(acquireWriterLock(paths(), Date.now())).toBe(true)
+    wfs(lockPath(), '{broken', 'utf8')
+    expect(acquireWriterLock(paths(), Date.now())).toBe(true)
+    expect((JSON.parse(rfs(lockPath(), 'utf8')) as { writerId: string }).writerId).toBe(AUTONOMY_WRITER_ID)
+  })
+})
+
+describe('scopeDigest (fix-loop-2 #3)', () => {
+  test('stable for identical text, differs on any byte change', () => {
+    const a = computeScopeDigest('ship the wave')
+    expect(a).toBe(computeScopeDigest('ship the wave'))
+    expect(a).toMatch(/^sha256:[0-9a-f]{64}$/)
+    expect(computeScopeDigest('ship the wavE')).not.toBe(a)
+    expect(computeScopeDigest('ship the wave ')).not.toBe(a)
+  })
+
+  test('addLease stores digest + scopeVersion; digest matches the scope', () => {
+    const { lease } = addLease(emptyAutonomyState(), { scope: 'катить волну', expiresAtMs: NOW + HOUR, source: 'ask_card' }, NOW)
+    expect(lease?.scopeDigest).toBe(computeScopeDigest('катить волну'))
+    expect(lease?.scopeVersion).toBe(1)
+  })
+
+  test('status render shows the first 12 hex chars of the digest', () => {
+    const { state } = addLease(emptyAutonomyState(), { id: 'L-d', scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW)
+    const short = computeScopeDigest('s').slice(7, 19)
+    expect(renderAutonomyStatus(state, NOW)).toContain(`[${short}]`)
+    // But NOT in the reminder / HUD surfaces.
+    expect(buildAutonomyReminderBlock(state, NOW)).not.toContain(short)
+    expect(buildAutonomyHudLine(state, NOW)).not.toContain(short)
+  })
+})
+
+describe('revokeLease (fix-loop-2 #4)', () => {
+  const withLease = (over: Partial<Parameters<typeof addLease>[1]> = {}) =>
+    addLease(emptyAutonomyState(), { id: 'L-r', scope: 's', expiresAtMs: NOW + HOUR, source: 'manual', ...over }, NOW).state
+
+  test('ok: sets revokedAtMs/revokedBy/revokeReason', () => {
+    const r = revokeLease(withLease(), 'L-r', NOW, 'agent', 'scope drift')
+    expect(r.outcome).toBe('ok')
+    expect(r.state.leases[0]?.revokedAtMs).toBe(NOW)
+    expect(r.state.leases[0]?.revokedBy).toBe('agent')
+    expect(r.state.leases[0]?.revokeReason).toBe('scope drift')
+  })
+
+  test('not_found', () => {
+    expect(revokeLease(emptyAutonomyState(), 'L-x', NOW, 'agent').outcome).toBe('not_found')
+  })
+
+  test('consumed lease cannot be revoked (already_consumed)', () => {
+    const consumed = consumeLease(withLease(), 'L-r', NOW).state
+    expect(revokeLease(consumed, 'L-r', NOW, 'agent').outcome).toBe('already_consumed')
+  })
+
+  test('revocation is final (already_revoked)', () => {
+    const revoked = revokeLease(withLease(), 'L-r', NOW, 'agent').state
+    expect(revokeLease(revoked, 'L-r', NOW, 'agent').outcome).toBe('already_revoked')
+  })
+
+  test('expired lease → expired no-op', () => {
+    const st = withLease({ expiresAtMs: NOW - 1 })
+    const r = revokeLease(st, 'L-r', NOW, 'agent')
+    expect(r.outcome).toBe('expired')
+    expect(r.state.leases[0]?.revokedAtMs).toBeUndefined()
+  })
+
+  test('activeLeases excludes revoked; consume of revoked → revoked outcome', () => {
+    const revoked = revokeLease(withLease(), 'L-r', NOW, 'agent').state
+    expect(activeLeases(revoked, NOW)).toEqual([])
+    expect(consumeLease(revoked, 'L-r', NOW).outcome).toBe('revoked')
+  })
+
+  test('revoked state round-trips through persistence', () => {
+    const revoked = revokeLease(withLease(), 'L-r', NOW, 'owner', 'changed my mind').state
+    saveAutonomyState(paths(), '5', revoked)
+    const loaded = loadAutonomyState(paths(), '5')
+    expect(loaded.leases[0]?.revokedAtMs).toBe(NOW)
+    expect(loaded.leases[0]?.revokedBy).toBe('owner')
+    expect(loaded.leases[0]?.revokeReason).toBe('changed my mind')
+  })
+})
+
+describe('corrupt-file forensics (fix-loop-2 #5)', () => {
+  test('corrupt file is preserved as evidence; load returns empty; subsequent save works', () => {
+    const file = autonomyStatePath(paths(), '7')
+    wfs(file, '{definitely broken', 'utf8')
+    const loaded = loadAutonomyState(paths(), '7')
+    expect(loaded).toEqual(emptyAutonomyState())
+    // Original renamed aside — the slot is free, evidence kept.
+    expect(existsSync(file)).toBe(false)
+    const evidence = readdirSync(root).filter((f) => f.startsWith('autonomy-7.json.corrupt-'))
+    expect(evidence.length).toBe(1)
+    expect(rfs(join(root, evidence[0]!), 'utf8')).toBe('{definitely broken')
+    // A subsequent save lands cleanly on the canonical name.
+    saveAutonomyState(paths(), '7', addLease(emptyAutonomyState(), { id: 'L-n', scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW).state)
+    expect(loadAutonomyState(paths(), '7').leases.length).toBe(1)
+  })
+
+  test('keeps at most 3 evidence files, oldest pruned', () => {
+    for (let i = 0; i < 5; i++) {
+      wfs(autonomyStatePath(paths(), '8'), `{broken-${i}`, 'utf8')
+      loadAutonomyState(paths(), '8')
+    }
+    const evidence = readdirSync(root).filter((f) => f.startsWith('autonomy-8.json.corrupt-')).sort()
+    expect(evidence.length).toBe(3)
+    // The NEWEST corruption is among the kept files.
+    const bodies = evidence.map((f) => rfs(join(root, f), 'utf8'))
+    expect(bodies).toContain('{broken-4')
+    expect(bodies).not.toContain('{broken-0')
   })
 })

--- a/plugin/tests/autonomy/store.test.ts
+++ b/plugin/tests/autonomy/store.test.ts
@@ -11,6 +11,7 @@ import {
   autonomyStatePath,
   buildAutonomyHudLine,
   buildAutonomyReminderBlock,
+  canonicalChatKey,
   consumeLease,
   emptyAutonomyState,
   humanizeDurationMs,
@@ -22,6 +23,7 @@ import {
   renderAutonomyStatus,
   resolveQuestion,
   saveAutonomyState,
+  updateAutonomyState,
   type AutonomyState,
 } from '../../src/autonomy/store.js'
 
@@ -138,23 +140,48 @@ describe('loadAutonomyState — corrupt / missing → empty', () => {
   })
 })
 
-describe('id generation', () => {
-  test('lease id: L-YYYYMMDD-xxxx', () => {
-    expect(newLeaseId(NOW)).toMatch(/^L-\d{8}-[0-9a-z]{4}$/)
+describe('id generation + uniqueness', () => {
+  test('lease id: L-YYYYMMDD-<8 hex crypto chars>', () => {
+    expect(newLeaseId(NOW)).toMatch(/^L-\d{8}-[0-9a-f]{8}$/)
   })
-  test('question id: Q-YYYYMMDD-xxxx', () => {
-    expect(newQuestionId(NOW)).toMatch(/^Q-\d{8}-[0-9a-z]{4}$/)
+  test('question id: Q-YYYYMMDD-<8 hex crypto chars>', () => {
+    expect(newQuestionId(NOW)).toMatch(/^Q-\d{8}-[0-9a-f]{8}$/)
   })
-  test('addLease/addQuestion generate ids when omitted', () => {
+  test('addLease/addQuestion generate ids when omitted (outcome ok)', () => {
     const l = addLease(emptyAutonomyState(), { scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW)
-    expect(l.lease.id).toMatch(/^L-/)
+    expect(l.outcome).toBe('ok')
+    expect(l.lease?.id).toMatch(/^L-/)
     const q = addQuestion(emptyAutonomyState(), { summary: 's' }, NOW)
-    expect(q.question.id).toMatch(/^Q-/)
+    expect(q.outcome).toBe('ok')
+    expect(q.question?.id).toMatch(/^Q-/)
   })
   test('addLease is pure — input state is not mutated', () => {
     const s0 = emptyAutonomyState()
     addLease(s0, { scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW)
     expect(s0.leases).toEqual([])
+  })
+
+  test('colliding EXPLICIT lease id → duplicate, state unchanged, consume stays unambiguous', () => {
+    let state = emptyAutonomyState()
+    state = addLease(state, { id: 'L-dup', scope: 'first', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW).state
+    const second = addLease(state, { id: 'L-dup', scope: 'second', expiresAtMs: NOW + 9 * HOUR, source: 'manual' }, NOW)
+    expect(second.outcome).toBe('duplicate')
+    expect(second.lease).toBeUndefined()
+    expect(second.state).toBe(state) // unchanged reference
+    // Exactly ONE lease with the id exists → consume is unambiguous.
+    expect(second.state.leases.filter((l) => l.id === 'L-dup').length).toBe(1)
+    const consumed = consumeLease(second.state, 'L-dup', NOW)
+    expect(consumed.outcome).toBe('ok')
+    expect(consumed.state.leases.filter((l) => l.id === 'L-dup' && l.consumedAtMs === NOW).length).toBe(1)
+  })
+
+  test('colliding EXPLICIT question id → duplicate, state unchanged', () => {
+    let state = emptyAutonomyState()
+    state = addQuestion(state, { id: 'Q-dup', summary: 'first', askedAtMs: NOW }, NOW).state
+    const second = addQuestion(state, { id: 'Q-dup', summary: 'second', askedAtMs: NOW }, NOW)
+    expect(second.outcome).toBe('duplicate')
+    expect(second.question).toBeUndefined()
+    expect(second.state.questions.length).toBe(1)
   })
 })
 
@@ -207,7 +234,7 @@ describe('questions — age + resolve', () => {
   })
 
   test('questionAgeMs clamps a future askedAtMs to 0', () => {
-    const q = addQuestion(emptyAutonomyState(), { summary: 's', askedAtMs: NOW + HOUR }, NOW).question
+    const q = addQuestion(emptyAutonomyState(), { summary: 's', askedAtMs: NOW + HOUR }, NOW).question!
     expect(questionAgeMs(q, NOW)).toBe(0)
   })
 
@@ -221,6 +248,109 @@ describe('questions — age + resolve', () => {
     expect(r.outcome).toBe('ok')
     expect(r.state.questions[0]?.status).toBe('bypassed')
     expect(r.state.questions[0]?.resolvedAtMs).toBe(NOW + HOUR)
+  })
+
+  test('sticky question can NEVER be bypassed (store-enforced)', () => {
+    let state = emptyAutonomyState()
+    state = addQuestion(state, { id: 'Q-s', summary: 'wipe db?', askedAtMs: NOW, sticky: true }, NOW).state
+    const bypass = resolveQuestion(state, 'Q-s', 'bypassed', NOW)
+    expect(bypass.outcome).toBe('sticky_forbidden')
+    expect(bypass.state.questions[0]?.status).toBe('open') // untouched
+    // `answered` is still allowed for a sticky question.
+    const answered = resolveQuestion(state, 'Q-s', 'answered', NOW)
+    expect(answered.outcome).toBe('ok')
+  })
+
+  test('already-resolved question cannot be re-resolved', () => {
+    let state = emptyAutonomyState()
+    state = addQuestion(state, { id: 'Q-1', summary: 's', askedAtMs: NOW }, NOW).state
+    state = resolveQuestion(state, 'Q-1', 'answered', NOW).state
+    const again = resolveQuestion(state, 'Q-1', 'bypassed', NOW + HOUR)
+    expect(again.outcome).toBe('already_resolved')
+    expect(again.state.questions[0]?.status).toBe('answered') // final
+  })
+})
+
+describe('consumeLease — expired honesty', () => {
+  test('expired unconsumed lease → outcome expired, state untouched', () => {
+    let state = emptyAutonomyState()
+    state = addLease(state, { id: 'L-old', scope: 's', expiresAtMs: NOW - 1, source: 'manual' }, NOW - HOUR).state
+    const r = consumeLease(state, 'L-old', NOW)
+    expect(r.outcome).toBe('expired')
+    expect(r.state.leases[0]?.consumedAtMs).toBe(null)
+  })
+
+  test('consumed beats expired in reporting (already_consumed wins)', () => {
+    let state = emptyAutonomyState()
+    state = addLease(state, { id: 'L-1', scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW).state
+    state = consumeLease(state, 'L-1', NOW).state
+    // Later, after expiry:
+    const r = consumeLease(state, 'L-1', NOW + 2 * HOUR)
+    expect(r.outcome).toBe('already_consumed')
+  })
+})
+
+describe('canonicalChatKey', () => {
+  test('numeric strings normalize via BigInt — "00123" and "123" share one file', () => {
+    expect(canonicalChatKey('00123')).toBe('123')
+    expect(canonicalChatKey('123')).toBe('123')
+    expect(autonomyStatePath(paths(), '00123')).toBe(autonomyStatePath(paths(), '123'))
+  })
+
+  test('negative supergroup ids keep the canonical minus form', () => {
+    expect(canonicalChatKey('-1001234567890')).toBe('-1001234567890')
+    expect(canonicalChatKey('-0')).toBe('0')
+  })
+
+  test('non-numeric strings encode injectively (no lossy collisions)', () => {
+    // Underscore and space must map to DIFFERENT keys (the old lossy `_`
+    // replacement collided them).
+    expect(canonicalChatKey('a b')).not.toBe(canonicalChatKey('a_b'))
+    // Encoded output is filename-safe.
+    expect(canonicalChatKey('a b')).toMatch(/^[0-9A-Za-z_-]+$/)
+    expect(canonicalChatKey('@chan/x')).toMatch(/^[0-9A-Za-z_-]+$/)
+  })
+})
+
+describe('updateAutonomyState — serialized read-modify-write', () => {
+  test('two parallel consumes → exactly one ok, one already_consumed', async () => {
+    saveAutonomyState(
+      paths(),
+      '1',
+      addLease(emptyAutonomyState(), { id: 'L-race', scope: 's', expiresAtMs: NOW + 24 * HOUR, source: 'manual' }, NOW).state,
+    )
+    const consume = () =>
+      updateAutonomyState(paths(), '1', (state) => {
+        const r = consumeLease(state, 'L-race', NOW)
+        return { state: r.state, result: r.outcome }
+      })
+    const [a, b] = await Promise.all([consume(), consume()])
+    expect([a, b].sort()).toEqual(['already_consumed', 'ok'])
+    // On disk: consumed exactly once.
+    const final = loadAutonomyState(paths(), '1')
+    expect(final.leases[0]?.consumedAtMs).toBe(NOW)
+  })
+
+  test('N parallel writers → no lost updates', async () => {
+    await Promise.all(
+      Array.from({ length: 10 }, (_, i) =>
+        updateAutonomyState(paths(), '2', (state) => {
+          const r = addLease(state, { id: `L-${i}`, scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW)
+          return { state: r.state, result: r.outcome }
+        }),
+      ),
+    )
+    expect(loadAutonomyState(paths(), '2').leases.length).toBe(10)
+  })
+
+  test('no-op mutation (same state reference) skips the save', async () => {
+    // No file exists; a not_found consume returns the same state → no write.
+    const outcome = await updateAutonomyState(paths(), '3', (state) => {
+      const r = consumeLease(state, 'L-none', NOW)
+      return { state: r.state, result: r.outcome }
+    })
+    expect(outcome).toBe('not_found')
+    expect(readdirSync(root)).not.toContain('autonomy-3.json')
   })
 })
 

--- a/plugin/tests/autonomy/store.test.ts
+++ b/plugin/tests/autonomy/store.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  AUTONOMY_STATE_VERSION,
+  activeLeases,
+  addLease,
+  addQuestion,
+  autonomyStatePath,
+  buildAutonomyHudLine,
+  buildAutonomyReminderBlock,
+  consumeLease,
+  emptyAutonomyState,
+  humanizeDurationMs,
+  loadAutonomyState,
+  newLeaseId,
+  newQuestionId,
+  openQuestions,
+  questionAgeMs,
+  renderAutonomyStatus,
+  resolveQuestion,
+  saveAutonomyState,
+  type AutonomyState,
+} from '../../src/autonomy/store.js'
+
+const HOUR = 3_600_000
+const NOW = 1_752_000_000_000 // fixed clock for deterministic ids/ages
+
+let root: string
+const paths = () => ({ root })
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'dashi-autonomy-'))
+})
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+// Seed a state with one active lease + one open question.
+function seedState(): AutonomyState {
+  let state = emptyAutonomyState()
+  state = addLease(
+    state,
+    { id: 'L-20260710-aaaa', scope: 'catch up the payments wave', expiresAtMs: NOW + 4 * HOUR, source: 'ask_card' },
+    NOW,
+  ).state
+  state = addQuestion(
+    state,
+    { id: 'Q-20260710-bbbb', summary: 'deploy to prod now?', askedAtMs: NOW - 3 * HOUR, defaultAction: 'wait' },
+    NOW,
+  ).state
+  return state
+}
+
+describe('emptyAutonomyState', () => {
+  test('is a versioned empty registry', () => {
+    expect(emptyAutonomyState()).toEqual({ version: AUTONOMY_STATE_VERSION, leases: [], questions: [] })
+  })
+})
+
+describe('round-trip persistence', () => {
+  test('save then load returns identical state', () => {
+    const state = seedState()
+    saveAutonomyState(paths(), '164795011', state)
+    const loaded = loadAutonomyState(paths(), '164795011')
+    expect(loaded).toEqual(state)
+  })
+
+  test('file lives at autonomy-<chatId>.json in the state root', () => {
+    saveAutonomyState(paths(), '164795011', seedState())
+    expect(autonomyStatePath(paths(), '164795011')).toBe(join(root, 'autonomy-164795011.json'))
+    expect(readdirSync(root)).toContain('autonomy-164795011.json')
+  })
+
+  test('negative (supergroup) chat id is sanitized in the filename', () => {
+    saveAutonomyState(paths(), '-1001234567890', seedState())
+    // The `-` is filename-safe and preserved; no path traversal.
+    expect(autonomyStatePath(paths(), '-1001234567890')).toBe(join(root, 'autonomy--1001234567890.json'))
+    expect(readdirSync(root)).toContain('autonomy--1001234567890.json')
+  })
+
+  test('atomic write leaves no tmp strays', () => {
+    saveAutonomyState(paths(), '164795011', seedState())
+    saveAutonomyState(paths(), '164795011', seedState())
+    const strays = readdirSync(root).filter((f) => f.includes('.tmp.'))
+    expect(strays).toEqual([])
+  })
+
+  test('save always stamps the current schema version', () => {
+    const state = { version: 999 as unknown as typeof AUTONOMY_STATE_VERSION, leases: [], questions: [] }
+    saveAutonomyState(paths(), '1', state)
+    expect(loadAutonomyState(paths(), '1').version).toBe(AUTONOMY_STATE_VERSION)
+  })
+})
+
+describe('loadAutonomyState — corrupt / missing → empty', () => {
+  test('missing file → empty state, no throw', () => {
+    expect(loadAutonomyState(paths(), 'nope')).toEqual(emptyAutonomyState())
+  })
+
+  test('corrupt JSON → empty state, no throw, warns via logger', () => {
+    writeFileSync(autonomyStatePath(paths(), '1'), '{not json', 'utf8')
+    const warnings: string[] = []
+    const log = {
+      debug: () => {},
+      info: () => {},
+      warn: (msg: string) => warnings.push(msg),
+      error: () => {},
+    }
+    expect(loadAutonomyState(paths(), '1', log)).toEqual(emptyAutonomyState())
+    expect(warnings.length).toBe(1)
+  })
+
+  test('non-object JSON → empty state', () => {
+    writeFileSync(autonomyStatePath(paths(), '1'), '[1,2,3]', 'utf8')
+    expect(loadAutonomyState(paths(), '1')).toEqual(emptyAutonomyState())
+  })
+
+  test('drops malformed lease/question entries, keeps the well-formed ones', () => {
+    const blob = {
+      version: 1,
+      leases: [
+        { id: 'L-ok', scope: 's', grantedAtMs: NOW, expiresAtMs: NOW + HOUR, source: 'ask_card' },
+        { id: 'L-bad', scope: 's', grantedAtMs: NOW, expiresAtMs: NOW + HOUR, source: 'not_a_source' },
+        { scope: 'no id', grantedAtMs: NOW, expiresAtMs: NOW + HOUR, source: 'manual' },
+      ],
+      questions: [
+        { id: 'Q-ok', summary: 's', askedAtMs: NOW, status: 'open' },
+        { id: 'Q-bad', summary: 's', askedAtMs: NOW, status: 'weird' },
+      ],
+    }
+    writeFileSync(autonomyStatePath(paths(), '1'), JSON.stringify(blob), 'utf8')
+    const loaded = loadAutonomyState(paths(), '1')
+    expect(loaded.leases.map((l) => l.id)).toEqual(['L-ok'])
+    expect(loaded.questions.map((q) => q.id)).toEqual(['Q-ok'])
+  })
+})
+
+describe('id generation', () => {
+  test('lease id: L-YYYYMMDD-xxxx', () => {
+    expect(newLeaseId(NOW)).toMatch(/^L-\d{8}-[0-9a-z]{4}$/)
+  })
+  test('question id: Q-YYYYMMDD-xxxx', () => {
+    expect(newQuestionId(NOW)).toMatch(/^Q-\d{8}-[0-9a-z]{4}$/)
+  })
+  test('addLease/addQuestion generate ids when omitted', () => {
+    const l = addLease(emptyAutonomyState(), { scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW)
+    expect(l.lease.id).toMatch(/^L-/)
+    const q = addQuestion(emptyAutonomyState(), { summary: 's' }, NOW)
+    expect(q.question.id).toMatch(/^Q-/)
+  })
+  test('addLease is pure — input state is not mutated', () => {
+    const s0 = emptyAutonomyState()
+    addLease(s0, { scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW)
+    expect(s0.leases).toEqual([])
+  })
+})
+
+describe('activeLeases — expiry + consume', () => {
+  test('excludes expired leases', () => {
+    let state = emptyAutonomyState()
+    state = addLease(state, { id: 'L-live', scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW).state
+    state = addLease(state, { id: 'L-dead', scope: 's', expiresAtMs: NOW - HOUR, source: 'manual' }, NOW).state
+    expect(activeLeases(state, NOW).map((l) => l.id)).toEqual(['L-live'])
+  })
+
+  test('excludes consumed leases', () => {
+    let state = emptyAutonomyState()
+    state = addLease(state, { id: 'L-1', scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW).state
+    state = consumeLease(state, 'L-1', NOW).state
+    expect(activeLeases(state, NOW)).toEqual([])
+  })
+
+  test('sorts soonest-expiry first', () => {
+    let state = emptyAutonomyState()
+    state = addLease(state, { id: 'L-late', scope: 's', expiresAtMs: NOW + 5 * HOUR, source: 'manual' }, NOW).state
+    state = addLease(state, { id: 'L-soon', scope: 's', expiresAtMs: NOW + 1 * HOUR, source: 'manual' }, NOW).state
+    expect(activeLeases(state, NOW).map((l) => l.id)).toEqual(['L-soon', 'L-late'])
+  })
+
+  test('consumeLease outcomes: ok / not_found / already_consumed', () => {
+    let state = emptyAutonomyState()
+    state = addLease(state, { id: 'L-1', scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW).state
+
+    const miss = consumeLease(state, 'L-nope', NOW)
+    expect(miss.outcome).toBe('not_found')
+
+    const first = consumeLease(state, 'L-1', NOW)
+    expect(first.outcome).toBe('ok')
+    expect(first.state.leases[0]?.consumedAtMs).toBe(NOW)
+
+    const again = consumeLease(first.state, 'L-1', NOW)
+    expect(again.outcome).toBe('already_consumed')
+  })
+})
+
+describe('questions — age + resolve', () => {
+  test('openQuestions excludes resolved, sorts oldest-first', () => {
+    let state = emptyAutonomyState()
+    state = addQuestion(state, { id: 'Q-new', summary: 's', askedAtMs: NOW - HOUR }, NOW).state
+    state = addQuestion(state, { id: 'Q-old', summary: 's', askedAtMs: NOW - 5 * HOUR }, NOW).state
+    state = addQuestion(state, { id: 'Q-done', summary: 's', askedAtMs: NOW - 2 * HOUR }, NOW).state
+    state = resolveQuestion(state, 'Q-done', 'answered', NOW).state
+    expect(openQuestions(state).map((q) => q.id)).toEqual(['Q-old', 'Q-new'])
+  })
+
+  test('questionAgeMs clamps a future askedAtMs to 0', () => {
+    const q = addQuestion(emptyAutonomyState(), { summary: 's', askedAtMs: NOW + HOUR }, NOW).question
+    expect(questionAgeMs(q, NOW)).toBe(0)
+  })
+
+  test('resolveQuestion outcomes + timestamp', () => {
+    let state = emptyAutonomyState()
+    state = addQuestion(state, { id: 'Q-1', summary: 's', askedAtMs: NOW }, NOW).state
+
+    expect(resolveQuestion(state, 'Q-nope', 'answered', NOW).outcome).toBe('not_found')
+
+    const r = resolveQuestion(state, 'Q-1', 'bypassed', NOW + HOUR)
+    expect(r.outcome).toBe('ok')
+    expect(r.state.questions[0]?.status).toBe('bypassed')
+    expect(r.state.questions[0]?.resolvedAtMs).toBe(NOW + HOUR)
+  })
+})
+
+describe('humanizeDurationMs', () => {
+  test('sub-hour → minutes', () => {
+    expect(humanizeDurationMs(45 * 60_000)).toBe('45м')
+  })
+  test('exact hours → "<h>ч"', () => {
+    expect(humanizeDurationMs(2 * HOUR)).toBe('2ч')
+  })
+  test('partial hour → "<h>ч <m>м"', () => {
+    expect(humanizeDurationMs(2 * HOUR + 15 * 60_000)).toBe('2ч 15м')
+  })
+  test('negative clamps to 0м', () => {
+    expect(humanizeDurationMs(-5)).toBe('0м')
+  })
+})
+
+describe('renderAutonomyStatus', () => {
+  test('lists active leases + open questions with ids, time-left and age', () => {
+    const text = renderAutonomyStatus(seedState(), NOW)
+    expect(text).toContain('L-20260710-aaaa')
+    expect(text).toContain('catch up the payments wave')
+    expect(text).toContain('ещё 4ч')
+    expect(text).toContain('Q-20260710-bbbb')
+    expect(text).toContain('без ответа 3ч')
+    expect(text).toContain('дефолт: wait')
+  })
+
+  test('empty state → clear "nothing active" wording', () => {
+    const text = renderAutonomyStatus(emptyAutonomyState(), NOW)
+    expect(text).toContain('Активных мандатов нет')
+    expect(text).toContain('Открытых вопросов нет')
+  })
+
+  test('sticky question is flagged', () => {
+    let state = emptyAutonomyState()
+    state = addQuestion(state, { id: 'Q-s', summary: 'delete prod db?', askedAtMs: NOW, sticky: true }, NOW).state
+    expect(renderAutonomyStatus(state, NOW)).toContain('[sticky]')
+  })
+})
+
+describe('buildAutonomyReminderBlock', () => {
+  test('empty state → undefined (no block)', () => {
+    expect(buildAutonomyReminderBlock(emptyAutonomyState(), NOW)).toBeUndefined()
+  })
+
+  test('renders mandate + question guidance', () => {
+    const block = buildAutonomyReminderBlock(seedState(), NOW) as string
+    expect(block).toContain('Активный мандат L-20260710-aaaa')
+    expect(block).toContain('истекает через 4ч')
+    expect(block).toContain('Act-with-veto')
+    expect(block).toContain('Открытый вопрос вождю Q-20260710-bbbb')
+    expect(block).toContain('дефолт: wait')
+    expect(block).toContain('бери дефолт')
+  })
+
+  test('sticky question → NEVER auto-bypass guidance', () => {
+    let state = emptyAutonomyState()
+    state = addQuestion(state, { id: 'Q-s', summary: 'wipe db?', askedAtMs: NOW, sticky: true }, NOW).state
+    const block = buildAutonomyReminderBlock(state, NOW) as string
+    expect(block).toContain('sticky-вопрос')
+    expect(block).toContain('НЕ обходить')
+    expect(block).not.toContain('бери дефолт')
+  })
+})
+
+describe('buildAutonomyHudLine', () => {
+  test('empty state → undefined', () => {
+    expect(buildAutonomyHudLine(emptyAutonomyState(), NOW)).toBeUndefined()
+  })
+
+  test('renders mandate + unanswered-questions count', () => {
+    const line = buildAutonomyHudLine(seedState(), NOW) as string
+    expect(line).toContain('Мандат: L-20260710-aaaa')
+    expect(line).toContain('ещё 4ч')
+    expect(line).toContain('Вопросы без ответа: 1')
+    expect(line).toContain('старший 3ч')
+    expect(line).toContain(' · ')
+  })
+
+  test('applies the injected escaper to scope + id', () => {
+    let state = emptyAutonomyState()
+    state = addLease(state, { id: 'L-1', scope: 'a < b & c', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW).state
+    const line = buildAutonomyHudLine(state, NOW, { escape: (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;') }) as string
+    expect(line).toContain('&lt;')
+    expect(line).toContain('&amp;')
+    expect(line).not.toMatch(/[^&]< /)
+  })
+
+  test('multiple active leases → "+N" marker', () => {
+    let state = emptyAutonomyState()
+    state = addLease(state, { id: 'L-1', scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW).state
+    state = addLease(state, { id: 'L-2', scope: 's', expiresAtMs: NOW + 2 * HOUR, source: 'manual' }, NOW).state
+    expect(buildAutonomyHudLine(state, NOW) as string).toContain('+1')
+  })
+})

--- a/plugin/tests/channel/tools.test.ts
+++ b/plugin/tests/channel/tools.test.ts
@@ -779,3 +779,78 @@ describe('autonomy tool — fix-loop invariants', () => {
     rmSync(deps.statePaths.root, { recursive: true, force: true })
   })
 })
+
+// Fix-loop-2 (Sol): revoke action, revoked-consume, writer_conflict surface.
+import { revokeLease, WRITER_LOCK_FILENAME } from '../../src/autonomy/store.js'
+import { writeFileSync as wfsTools } from 'node:fs'
+
+describe('autonomy tool — fix-loop-2', () => {
+  test('revoke: withdraws an active lease (revokedBy=agent, reason stored)', async () => {
+    const deps = makeDeps()
+    saveAutonomyState(
+      deps.statePaths,
+      OWNER_CHAT,
+      addLease(emptyAutonomyState(), { id: 'L-rv', scope: 's', expiresAtMs: Date.now() + HOUR, source: 'manual' }, Date.now()).state,
+    )
+    const res = await callTool(
+      callReq('autonomy', { chat_id: OWNER_CHAT, action: 'revoke', lease_id: 'L-rv', reason: 'scope drift' }),
+      deps,
+    )
+    expect(res.isError).toBeUndefined()
+    expect(res.content[0]?.text).toContain('lease revoked: L-rv')
+    const lease = loadAutonomyState(deps.statePaths, OWNER_CHAT).leases[0]
+    expect(lease?.revokedBy).toBe('agent')
+    expect(lease?.revokeReason).toBe('scope drift')
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('revoke without lease_id → schema error', async () => {
+    const deps = makeDeps()
+    const res = await callTool(callReq('autonomy', { chat_id: OWNER_CHAT, action: 'revoke' }), deps)
+    expect(res.isError).toBe(true)
+    expect(res.content[0]?.text).toContain('lease_id')
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('consume of a revoked lease → honest "revoked" error', async () => {
+    const deps = makeDeps()
+    const seeded = addLease(emptyAutonomyState(), { id: 'L-rv2', scope: 's', expiresAtMs: Date.now() + HOUR, source: 'manual' }, Date.now()).state
+    saveAutonomyState(deps.statePaths, OWNER_CHAT, revokeLease(seeded, 'L-rv2', Date.now(), 'owner').state)
+    const res = await callTool(callReq('autonomy', { chat_id: OWNER_CHAT, action: 'consume', lease_id: 'L-rv2' }), deps)
+    expect(res.isError).toBe(true)
+    expect(res.content[0]?.text).toContain('lease revoked')
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('revoke of an already-revoked lease → error; of a consumed lease → error', async () => {
+    const deps = makeDeps()
+    const base = addLease(emptyAutonomyState(), { id: 'L-a', scope: 's', expiresAtMs: Date.now() + HOUR, source: 'manual' }, Date.now()).state
+    saveAutonomyState(deps.statePaths, OWNER_CHAT, revokeLease(base, 'L-a', Date.now(), 'owner').state)
+    const again = await callTool(callReq('autonomy', { chat_id: OWNER_CHAT, action: 'revoke', lease_id: 'L-a' }), deps)
+    expect(again.isError).toBe(true)
+    expect(again.content[0]?.text).toContain('already revoked')
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('fresh foreign writer lock → mutation refused with writer_conflict text', async () => {
+    const deps = makeDeps()
+    saveAutonomyState(
+      deps.statePaths,
+      OWNER_CHAT,
+      addLease(emptyAutonomyState(), { id: 'L-wl', scope: 's', expiresAtMs: Date.now() + HOUR, source: 'manual' }, Date.now()).state,
+    )
+    wfsTools(
+      join(deps.statePaths.root, WRITER_LOCK_FILENAME),
+      JSON.stringify({ writerId: 'feedfacedeadbeef', pid: 99999, refreshedAtMs: Date.now() }),
+      'utf8',
+    )
+    const res = await callTool(callReq('autonomy', { chat_id: OWNER_CHAT, action: 'consume', lease_id: 'L-wl' }), deps)
+    expect(res.isError).toBe(true)
+    expect(res.content[0]?.text).toContain('writer_conflict')
+    // The lease is untouched — and status (read-only) still works.
+    const status = await callTool(callReq('autonomy', { chat_id: OWNER_CHAT, action: 'status' }), deps)
+    expect(status.isError).toBeUndefined()
+    expect(status.content[0]?.text).toContain('L-wl')
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+})

--- a/plugin/tests/channel/tools.test.ts
+++ b/plugin/tests/channel/tools.test.ts
@@ -701,3 +701,81 @@ describe('autonomy tool', () => {
     rmSync(deps.statePaths.root, { recursive: true, force: true })
   })
 })
+
+// Fix-loop 2026-07-10: serialization, expired honesty, sticky/final invariants.
+describe('autonomy tool — fix-loop invariants', () => {
+  test('two PARALLEL consume calls → exactly one ok, one already_consumed', async () => {
+    const deps = makeDeps()
+    saveAutonomyState(
+      deps.statePaths,
+      OWNER_CHAT,
+      addLease(emptyAutonomyState(), { id: 'L-par', scope: 's', expiresAtMs: Date.now() + HOUR, source: 'manual' }, Date.now()).state,
+    )
+    const call = () =>
+      callTool(callReq('autonomy', { chat_id: OWNER_CHAT, action: 'consume', lease_id: 'L-par' }), deps)
+    const [a, b] = await Promise.all([call(), call()])
+    const oks = [a, b].filter((r) => r.isError === undefined)
+    const errs = [a, b].filter((r) => r.isError === true)
+    expect(oks.length).toBe(1)
+    expect(errs.length).toBe(1)
+    expect(errs[0]?.content[0]?.text).toContain('already consumed')
+    // Disk agrees: consumed exactly once.
+    const final = loadAutonomyState(deps.statePaths, OWNER_CHAT)
+    expect(final.leases.filter((l) => l.consumedAtMs != null).length).toBe(1)
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('consume of an EXPIRED lease → honest error, not success', async () => {
+    const deps = makeDeps()
+    saveAutonomyState(
+      deps.statePaths,
+      OWNER_CHAT,
+      addLease(emptyAutonomyState(), { id: 'L-exp', scope: 's', expiresAtMs: Date.now() - 1, source: 'manual' }, Date.now() - HOUR).state,
+    )
+    const res = await callTool(callReq('autonomy', { chat_id: OWNER_CHAT, action: 'consume', lease_id: 'L-exp' }), deps)
+    expect(res.isError).toBe(true)
+    expect(res.content[0]?.text).toContain('lease expired')
+    // Not marked consumed on disk.
+    expect(loadAutonomyState(deps.statePaths, OWNER_CHAT).leases[0]?.consumedAtMs).toBe(null)
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('bypassing a STICKY question → refused with sticky error', async () => {
+    const deps = makeDeps()
+    saveAutonomyState(
+      deps.statePaths,
+      OWNER_CHAT,
+      addQuestion(emptyAutonomyState(), { id: 'Q-st', summary: 'wipe db?', askedAtMs: Date.now(), sticky: true }, Date.now()).state,
+    )
+    const res = await callTool(
+      callReq('autonomy', { chat_id: OWNER_CHAT, action: 'resolve_question', question_id: 'Q-st', resolution: 'bypassed' }),
+      deps,
+    )
+    expect(res.isError).toBe(true)
+    expect(res.content[0]?.text).toContain('sticky')
+    expect(loadAutonomyState(deps.statePaths, OWNER_CHAT).questions[0]?.status).toBe('open')
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('re-resolving an already-resolved question → error', async () => {
+    const deps = makeDeps()
+    saveAutonomyState(
+      deps.statePaths,
+      OWNER_CHAT,
+      addQuestion(emptyAutonomyState(), { id: 'Q-f', summary: 's', askedAtMs: Date.now() }, Date.now()).state,
+    )
+    const first = await callTool(
+      callReq('autonomy', { chat_id: OWNER_CHAT, action: 'resolve_question', question_id: 'Q-f', resolution: 'answered' }),
+      deps,
+    )
+    expect(first.isError).toBeUndefined()
+    const second = await callTool(
+      callReq('autonomy', { chat_id: OWNER_CHAT, action: 'resolve_question', question_id: 'Q-f', resolution: 'bypassed' }),
+      deps,
+    )
+    expect(second.isError).toBe(true)
+    expect(second.content[0]?.text).toContain('already resolved')
+    expect(loadAutonomyState(deps.statePaths, OWNER_CHAT).questions[0]?.status).toBe('answered')
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+})

--- a/plugin/tests/channel/tools.test.ts
+++ b/plugin/tests/channel/tools.test.ts
@@ -152,7 +152,7 @@ function callReq(name: string, args: Record<string, unknown>): CallToolRequest {
 }
 
 describe('listTools', () => {
-  test('returns 5 tools with stable order: reply, react, download_attachment, edit_message, status', () => {
+  test('returns 6 tools with stable order: reply, react, download_attachment, edit_message, status, autonomy', () => {
     const tools = listTools()
     expect(tools.map(t => t.name)).toEqual([
       'reply',
@@ -160,7 +160,13 @@ describe('listTools', () => {
       'download_attachment',
       'edit_message',
       'status',
+      'autonomy',
     ])
+  })
+
+  test('autonomy tool input schema requires chat_id and action', () => {
+    const autonomy = listTools().find(t => t.name === 'autonomy')
+    expect(autonomy?.inputSchema.required).toEqual(['chat_id', 'action'])
   })
 
   test('reply tool input schema requires chat_id and text', () => {
@@ -553,6 +559,145 @@ describe('callTool', () => {
     expect(result.isError).toBeUndefined()
     expect(captured).not.toBeNull()
     expect(captured!.fileId).toBe('AgAD...')
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// autonomy tool (PR-1). READ + resolve over the durable registry; it can
+// NEVER grant a lease (granting arrives in PR-2 via the button relay).
+// ─────────────────────────────────────────────────────────────────────
+
+import {
+  addLease,
+  addQuestion,
+  emptyAutonomyState,
+  loadAutonomyState,
+  saveAutonomyState,
+} from '../../src/autonomy/store.js'
+
+const OWNER_CHAT = '164795011'
+const HOUR = 3_600_000
+
+describe('autonomy tool', () => {
+  test('status on empty registry → "nothing active" text', async () => {
+    const deps = makeDeps()
+    const res = await callTool(callReq('autonomy', { chat_id: OWNER_CHAT, action: 'status' }), deps)
+    expect(res.isError).toBeUndefined()
+    expect(res.content[0]?.text).toContain('Активных мандатов нет')
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('status reflects a lease seeded through the store API', async () => {
+    const deps = makeDeps()
+    const seeded = addLease(
+      emptyAutonomyState(),
+      { id: 'L-seed', scope: 'ship the wave', expiresAtMs: Date.now() + 4 * HOUR, source: 'ask_card' },
+      Date.now(),
+    ).state
+    saveAutonomyState(deps.statePaths, OWNER_CHAT, seeded)
+    const res = await callTool(callReq('autonomy', { chat_id: OWNER_CHAT, action: 'status' }), deps)
+    expect(res.content[0]?.text).toContain('L-seed')
+    expect(res.content[0]?.text).toContain('ship the wave')
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('consume marks the lease consumed on disk', async () => {
+    const deps = makeDeps()
+    const seeded = addLease(
+      emptyAutonomyState(),
+      { id: 'L-c', scope: 's', expiresAtMs: Date.now() + HOUR, source: 'manual' },
+      Date.now(),
+    ).state
+    saveAutonomyState(deps.statePaths, OWNER_CHAT, seeded)
+
+    const res = await callTool(callReq('autonomy', { chat_id: OWNER_CHAT, action: 'consume', lease_id: 'L-c' }), deps)
+    expect(res.isError).toBeUndefined()
+    expect(res.content[0]?.text).toContain('lease consumed: L-c')
+
+    const after = loadAutonomyState(deps.statePaths, OWNER_CHAT)
+    expect(after.leases[0]?.consumedAtMs).toBeGreaterThan(0)
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('consume unknown lease → error', async () => {
+    const deps = makeDeps()
+    const res = await callTool(callReq('autonomy', { chat_id: OWNER_CHAT, action: 'consume', lease_id: 'L-nope' }), deps)
+    expect(res.isError).toBe(true)
+    expect(res.content[0]?.text).toContain('lease not found')
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('consume already-consumed lease → error', async () => {
+    const deps = makeDeps()
+    saveAutonomyState(
+      deps.statePaths,
+      OWNER_CHAT,
+      addLease(emptyAutonomyState(), { id: 'L-c', scope: 's', expiresAtMs: Date.now() + HOUR, source: 'manual' }, Date.now()).state,
+    )
+    await callTool(callReq('autonomy', { chat_id: OWNER_CHAT, action: 'consume', lease_id: 'L-c' }), deps)
+    const res = await callTool(callReq('autonomy', { chat_id: OWNER_CHAT, action: 'consume', lease_id: 'L-c' }), deps)
+    expect(res.isError).toBe(true)
+    expect(res.content[0]?.text).toContain('already consumed')
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('consume without lease_id → schema error', async () => {
+    const deps = makeDeps()
+    const res = await callTool(callReq('autonomy', { chat_id: OWNER_CHAT, action: 'consume' }), deps)
+    expect(res.isError).toBe(true)
+    expect(res.content[0]?.text).toContain('lease_id')
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('resolve_question sets status on disk', async () => {
+    const deps = makeDeps()
+    saveAutonomyState(
+      deps.statePaths,
+      OWNER_CHAT,
+      addQuestion(emptyAutonomyState(), { id: 'Q-1', summary: 'deploy?', askedAtMs: Date.now() }, Date.now()).state,
+    )
+    const res = await callTool(
+      callReq('autonomy', { chat_id: OWNER_CHAT, action: 'resolve_question', question_id: 'Q-1', resolution: 'answered' }),
+      deps,
+    )
+    expect(res.isError).toBeUndefined()
+    expect(res.content[0]?.text).toContain('Q-1 resolved: answered')
+    expect(loadAutonomyState(deps.statePaths, OWNER_CHAT).questions[0]?.status).toBe('answered')
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('resolve_question unknown id → error', async () => {
+    const deps = makeDeps()
+    const res = await callTool(
+      callReq('autonomy', { chat_id: OWNER_CHAT, action: 'resolve_question', question_id: 'Q-x', resolution: 'answered' }),
+      deps,
+    )
+    expect(res.isError).toBe(true)
+    expect(res.content[0]?.text).toContain('question not found')
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('resolve_question missing question_id/resolution → schema error', async () => {
+    const deps = makeDeps()
+    const res = await callTool(callReq('autonomy', { chat_id: OWNER_CHAT, action: 'resolve_question' }), deps)
+    expect(res.isError).toBe(true)
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('CANNOT grant: there is no grant action (enum rejects it)', async () => {
+    const deps = makeDeps()
+    const res = await callTool(callReq('autonomy', { chat_id: OWNER_CHAT, action: 'grant', scope: 'x' }), deps)
+    expect(res.isError).toBe(true)
+    // No file is created / no lease appears.
+    expect(loadAutonomyState(deps.statePaths, OWNER_CHAT).leases).toEqual([])
+    rmSync(deps.statePaths.root, { recursive: true, force: true })
+  })
+
+  test('rejects a non-allowlisted chat', async () => {
+    const deps = makeDeps()
+    const res = await callTool(callReq('autonomy', { chat_id: '999999', action: 'status' }), deps)
+    expect(res.isError).toBe(true)
     rmSync(deps.statePaths.root, { recursive: true, force: true })
   })
 })

--- a/plugin/tests/hooks/install-hooks.test.ts
+++ b/plugin/tests/hooks/install-hooks.test.ts
@@ -408,6 +408,37 @@ describe('applyPatch (pure) — channel reminder', () => {
     expect((out.hooks.UserPromptSubmit ?? []).find((e) => e.marker === 'dashi-channel-reminder-hook')).toBeUndefined()
   })
 
+  test('bakes the resolved state root into the reminder command (fix-loop #5)', () => {
+    const out = applyPatch({}, {
+      settingsPath: '/tmp/x',
+      chatId: '164795011',
+      webhookUrl: 'http://127.0.0.1:8093/hooks/agent',
+      helperPath: '/p/scripts/post-hook.ts',
+      reminderHelperPath: '/p/scripts/channel-reminder.ts',
+      reminderStateDir: '/home/u/.claude/channels/dashi-telegram-canary',
+    }) as { hooks: Record<string, Array<{ marker?: string; hooks?: Array<{ command?: string }> }>> }
+    const reminder = (out.hooks.UserPromptSubmit ?? []).find((e) => e.marker === 'dashi-channel-reminder-hook')
+    const cmd = reminder!.hooks?.[0]?.command ?? ''
+    // Inline env assignment survives env -i multichat spawns and default
+    // installs where TELEGRAM_STATE_DIR is never exported.
+    expect(cmd).toContain("TELEGRAM_STATE_DIR='/home/u/.claude/channels/dashi-telegram-canary'")
+    // CHAT_ID stays first; the command still points at the helper.
+    expect(cmd.indexOf('CHAT_ID=')).toBeLessThan(cmd.indexOf('TELEGRAM_STATE_DIR='))
+    expect(cmd).toContain('channel-reminder.ts')
+  })
+
+  test('absent reminderStateDir → command has no TELEGRAM_STATE_DIR (back-compat)', () => {
+    const out = applyPatch({}, {
+      settingsPath: '/tmp/x',
+      chatId: '1',
+      webhookUrl: 'http://x',
+      helperPath: '/p/post-hook.ts',
+      reminderHelperPath: '/p/channel-reminder.ts',
+    }) as { hooks: Record<string, Array<{ marker?: string; hooks?: Array<{ command?: string }> }>> }
+    const reminder = (out.hooks.UserPromptSubmit ?? []).find((e) => e.marker === 'dashi-channel-reminder-hook')
+    expect(reminder!.hooks?.[0]?.command).not.toContain('TELEGRAM_STATE_DIR=')
+  })
+
   test('re-run replaces the reminder entry rather than duplicating', () => {
     const opts = {
       settingsPath: '/tmp/x', chatId: '1', webhookUrl: 'http://x',

--- a/plugin/tests/scripts/channel-reminder.test.ts
+++ b/plugin/tests/scripts/channel-reminder.test.ts
@@ -188,3 +188,90 @@ describe('composeReminder', () => {
     expect(added).toBeLessThanOrEqual(10)
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────
+// Autonomy block injection (PR-1). The reminder appends a per-turn block
+// listing active mandates + open owner questions, read from the durable
+// registry. Fail-open: any error → no block, never gate the turn.
+// ─────────────────────────────────────────────────────────────────────
+
+import { mkdtempSync, rmSync as rmSyncNode, writeFileSync as writeFileSyncNode } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join as joinNode } from 'node:path'
+
+import { autonomyReminder } from '../../scripts/channel-reminder.js'
+import {
+  addLease,
+  emptyAutonomyState,
+  saveAutonomyState,
+} from '../../src/autonomy/store.js'
+
+describe('autonomyReminder (registry injection)', () => {
+  test('no state dir → undefined (block omitted)', () => {
+    expect(autonomyReminder({ CHAT_ID: '164795011' })).toBeUndefined()
+  })
+
+  test('no chat id → undefined', () => {
+    const dir = mkdtempSync(joinNode(tmpdir(), 'reminder-autonomy-'))
+    expect(autonomyReminder({ TELEGRAM_STATE_DIR: dir })).toBeUndefined()
+    rmSyncNode(dir, { recursive: true, force: true })
+  })
+
+  test('empty registry → undefined', () => {
+    const dir = mkdtempSync(joinNode(tmpdir(), 'reminder-autonomy-'))
+    saveAutonomyState({ root: dir }, '164795011', emptyAutonomyState())
+    expect(autonomyReminder({ CHAT_ID: '164795011', TELEGRAM_STATE_DIR: dir })).toBeUndefined()
+    rmSyncNode(dir, { recursive: true, force: true })
+  })
+
+  test('active mandate → block with Act-with-veto guidance', () => {
+    const dir = mkdtempSync(joinNode(tmpdir(), 'reminder-autonomy-'))
+    const state = addLease(
+      emptyAutonomyState(),
+      { id: 'L-1', scope: 'ship the wave', expiresAtMs: Date.now() + 3 * 3_600_000, source: 'ask_card' },
+      Date.now(),
+    ).state
+    saveAutonomyState({ root: dir }, '164795011', state)
+    const block = autonomyReminder({ CHAT_ID: '164795011', TELEGRAM_STATE_DIR: dir }) as string
+    expect(block).toContain('Активный мандат L-1')
+    expect(block).toContain('Act-with-veto')
+    rmSyncNode(dir, { recursive: true, force: true })
+  })
+
+  test('MULTICHAT_STATE_DIR is honored as a fallback state root', () => {
+    const dir = mkdtempSync(joinNode(tmpdir(), 'reminder-autonomy-'))
+    const state = addLease(
+      emptyAutonomyState(),
+      { id: 'L-mc', scope: 's', expiresAtMs: Date.now() + 3_600_000, source: 'manual' },
+      Date.now(),
+    ).state
+    saveAutonomyState({ root: dir }, '-100999', state)
+    const block = autonomyReminder({ CHAT_ID: '-100999', MULTICHAT_STATE_DIR: dir }) as string
+    expect(block).toContain('L-mc')
+    rmSyncNode(dir, { recursive: true, force: true })
+  })
+
+  test('corrupt registry file → fail-open (undefined, no throw)', () => {
+    const dir = mkdtempSync(joinNode(tmpdir(), 'reminder-autonomy-'))
+    writeFileSyncNode(joinNode(dir, 'autonomy-164795011.json'), '{broken', 'utf8')
+    expect(autonomyReminder({ CHAT_ID: '164795011', TELEGRAM_STATE_DIR: dir })).toBeUndefined()
+    rmSyncNode(dir, { recursive: true, force: true })
+  })
+
+  test('composeReminder places the autonomy block between channel and TOV', () => {
+    const dir = mkdtempSync(joinNode(tmpdir(), 'reminder-autonomy-'))
+    const state = addLease(
+      emptyAutonomyState(),
+      { id: 'L-z', scope: 's', expiresAtMs: Date.now() + 3_600_000, source: 'manual' },
+      Date.now(),
+    ).state
+    saveAutonomyState({ root: dir }, '164795011', state)
+    const r = composeReminder({ CHAT_ID: '164795011', TELEGRAM_STATE_DIR: dir })
+    const iChannel = r.indexOf('mcp__dashi-channel__reply')
+    const iAutonomy = r.indexOf('Активный мандат L-z')
+    const iTov = r.indexOf('по-русски')
+    expect(iChannel).toBeLessThan(iAutonomy)
+    expect(iAutonomy).toBeLessThan(iTov)
+    rmSyncNode(dir, { recursive: true, force: true })
+  })
+})

--- a/plugin/tests/scripts/channel-reminder.test.ts
+++ b/plugin/tests/scripts/channel-reminder.test.ts
@@ -168,21 +168,21 @@ describe('tovReminder', () => {
 })
 
 describe('composeReminder', () => {
-  test('DM: channel discipline first, then TOV block', () => {
-    const r = composeReminder({ CHAT_ID: '164795011' })
+  test('DM: channel discipline first, then TOV block', async () => {
+    const r = await composeReminder({ CHAT_ID: '164795011' })
     expect(r).toContain('mcp__dashi-channel__reply')
     expect(r).toContain('по-русски')
     // Channel reminder precedes the TOV block.
     expect(r.indexOf('mcp__dashi-channel__reply')).toBeLessThan(r.indexOf('по-русски'))
   })
 
-  test('TOV disabled → only the channel reminder', () => {
-    const r = composeReminder({ CHAT_ID: '164795011', TOV_REMINDER_ENABLED: 'no' })
+  test('TOV disabled → only the channel reminder', async () => {
+    const r = await composeReminder({ CHAT_ID: '164795011', TOV_REMINDER_ENABLED: 'no' })
     expect(r).toBe(reminderForChat('164795011'))
   })
 
-  test('added TOV context stays within ~10 lines', () => {
-    const r = composeReminder({ CHAT_ID: '164795011' })
+  test('added TOV context stays within ~10 lines', async () => {
+    const r = await composeReminder({ CHAT_ID: '164795011' })
     const channelLines = reminderForChat('164795011').split('\n').length
     const added = r.split('\n').length - channelLines
     expect(added).toBeLessThanOrEqual(10)
@@ -207,24 +207,24 @@ import {
 } from '../../src/autonomy/store.js'
 
 describe('autonomyReminder (registry injection)', () => {
-  test('no state dir → undefined (block omitted)', () => {
-    expect(autonomyReminder({ CHAT_ID: '164795011' })).toBeUndefined()
+  test('no state dir → undefined (block omitted)', async () => {
+    expect(await autonomyReminder({ CHAT_ID: '164795011' })).toBeUndefined()
   })
 
-  test('no chat id → undefined', () => {
+  test('no chat id → undefined', async () => {
     const dir = mkdtempSync(joinNode(tmpdir(), 'reminder-autonomy-'))
-    expect(autonomyReminder({ TELEGRAM_STATE_DIR: dir })).toBeUndefined()
+    expect(await autonomyReminder({ TELEGRAM_STATE_DIR: dir })).toBeUndefined()
     rmSyncNode(dir, { recursive: true, force: true })
   })
 
-  test('empty registry → undefined', () => {
+  test('empty registry → undefined', async () => {
     const dir = mkdtempSync(joinNode(tmpdir(), 'reminder-autonomy-'))
     saveAutonomyState({ root: dir }, '164795011', emptyAutonomyState())
-    expect(autonomyReminder({ CHAT_ID: '164795011', TELEGRAM_STATE_DIR: dir })).toBeUndefined()
+    expect(await autonomyReminder({ CHAT_ID: '164795011', TELEGRAM_STATE_DIR: dir })).toBeUndefined()
     rmSyncNode(dir, { recursive: true, force: true })
   })
 
-  test('active mandate → block with Act-with-veto guidance', () => {
+  test('active mandate → block with Act-with-veto guidance', async () => {
     const dir = mkdtempSync(joinNode(tmpdir(), 'reminder-autonomy-'))
     const state = addLease(
       emptyAutonomyState(),
@@ -232,13 +232,13 @@ describe('autonomyReminder (registry injection)', () => {
       Date.now(),
     ).state
     saveAutonomyState({ root: dir }, '164795011', state)
-    const block = autonomyReminder({ CHAT_ID: '164795011', TELEGRAM_STATE_DIR: dir }) as string
+    const block = (await autonomyReminder({ CHAT_ID: '164795011', TELEGRAM_STATE_DIR: dir })) as string
     expect(block).toContain('Активный мандат L-1')
     expect(block).toContain('Act-with-veto')
     rmSyncNode(dir, { recursive: true, force: true })
   })
 
-  test('MULTICHAT_STATE_DIR is honored as a fallback state root', () => {
+  test('MULTICHAT_STATE_DIR is honored as a last-resort fallback root', async () => {
     const dir = mkdtempSync(joinNode(tmpdir(), 'reminder-autonomy-'))
     const state = addLease(
       emptyAutonomyState(),
@@ -246,19 +246,19 @@ describe('autonomyReminder (registry injection)', () => {
       Date.now(),
     ).state
     saveAutonomyState({ root: dir }, '-100999', state)
-    const block = autonomyReminder({ CHAT_ID: '-100999', MULTICHAT_STATE_DIR: dir }) as string
+    const block = (await autonomyReminder({ CHAT_ID: '-100999', MULTICHAT_STATE_DIR: dir })) as string
     expect(block).toContain('L-mc')
     rmSyncNode(dir, { recursive: true, force: true })
   })
 
-  test('corrupt registry file → fail-open (undefined, no throw)', () => {
+  test('corrupt registry file → fail-open (undefined, no throw)', async () => {
     const dir = mkdtempSync(joinNode(tmpdir(), 'reminder-autonomy-'))
     writeFileSyncNode(joinNode(dir, 'autonomy-164795011.json'), '{broken', 'utf8')
-    expect(autonomyReminder({ CHAT_ID: '164795011', TELEGRAM_STATE_DIR: dir })).toBeUndefined()
+    expect(await autonomyReminder({ CHAT_ID: '164795011', TELEGRAM_STATE_DIR: dir })).toBeUndefined()
     rmSyncNode(dir, { recursive: true, force: true })
   })
 
-  test('composeReminder places the autonomy block between channel and TOV', () => {
+  test('composeReminder places the autonomy block between channel and TOV', async () => {
     const dir = mkdtempSync(joinNode(tmpdir(), 'reminder-autonomy-'))
     const state = addLease(
       emptyAutonomyState(),
@@ -266,7 +266,7 @@ describe('autonomyReminder (registry injection)', () => {
       Date.now(),
     ).state
     saveAutonomyState({ root: dir }, '164795011', state)
-    const r = composeReminder({ CHAT_ID: '164795011', TELEGRAM_STATE_DIR: dir })
+    const r = await composeReminder({ CHAT_ID: '164795011', TELEGRAM_STATE_DIR: dir })
     const iChannel = r.indexOf('mcp__dashi-channel__reply')
     const iAutonomy = r.indexOf('Активный мандат L-z')
     const iTov = r.indexOf('по-русски')

--- a/plugin/tests/status/context-hud.test.ts
+++ b/plugin/tests/status/context-hud.test.ts
@@ -1235,3 +1235,66 @@ describe('ContextHud — model-aware window', () => {
     expect(api.sent[0]!.text).toContain("20% (100k / 500k)")
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────
+// Autonomy pin line (PR-1). renderHud takes an optional escaped line; the
+// manager reads the per-chat registry and injects it best-effort.
+// ─────────────────────────────────────────────────────────────────────
+
+import {
+  addLease as addLeaseStore,
+  emptyAutonomyState as emptyAutonomyStateStore,
+  saveAutonomyState as saveAutonomyStateStore,
+} from '../../src/autonomy/store.js'
+
+describe('renderHud autonomy line', () => {
+  test('appends the autonomy line when provided', () => {
+    const { text } = renderHud({ usedTokens: 0 }, WINDOW, undefined, undefined, 'Мандат: L-1 (x, ещё 3ч)')
+    expect(text).toContain('\nМандат: L-1 (x, ещё 3ч)')
+  })
+
+  test('no autonomy line when omitted', () => {
+    const { text } = renderHud({ usedTokens: 0 }, WINDOW)
+    expect(text).not.toContain('Мандат:')
+  })
+})
+
+describe('ContextHud autonomy integration', () => {
+  test('renders the mandate line from the registry file', async () => {
+    const api = new FakeApi()
+    const dir = stateDir()
+    const state = addLeaseStore(
+      emptyAutonomyStateStore(),
+      { id: 'L-hud', scope: 'ship it', expiresAtMs: Date.now() + 3 * 3_600_000, source: 'ask_card' },
+      Date.now(),
+    ).state
+    saveAutonomyStateStore({ root: dir }, OWNER, state)
+
+    const hud = makeHud(api, { dir })
+    await hud.onSessionStart(OWNER)
+    expect(api.sent[0]!.text).toContain('Мандат: L-hud')
+    expect(api.sent[0]!.text).toContain('ship it')
+  })
+
+  test('no line when the registry is empty', async () => {
+    const api = new FakeApi()
+    const dir = stateDir()
+    const hud = makeHud(api, { dir })
+    await hud.onSessionStart(OWNER)
+    expect(api.sent[0]!.text).not.toContain('Мандат:')
+  })
+
+  test('a corrupt registry file never breaks HUD rendering', async () => {
+    const api = new FakeApi()
+    const dir = stateDir()
+    // Write a broken registry file, then confirm the HUD still sends its card.
+    saveAutonomyStateStore({ root: dir }, OWNER, emptyAutonomyStateStore())
+    const { writeFileSync } = await import('node:fs')
+    writeFileSync(join(dir, `autonomy-${OWNER}.json`), '{broken', 'utf8')
+    const hud = makeHud(api, { dir })
+    await hud.onSessionStart(OWNER)
+    expect(api.sent.length).toBe(1)
+    expect(api.sent[0]!.text).toContain('🧠 <b>Контекст</b>:')
+    expect(api.sent[0]!.text).not.toContain('Мандат:')
+  })
+})


### PR DESCRIPTION
Первый милстон архитектуры максимальной автономии (дизайн: autonomy-arch-2026-07-10, Codex Sol + Fable, утверждён вождём).

## Состав
- `src/autonomy/store.ts` — durable per-chat реестр мандатов (leases) и открытых вопросов: atomic tmp+fsync+rename, revision-счётчик с детекцией второго писателя, heartbeat writer-lock, scopeDigest (sha256), состояния consumed/revoked/expired, форензика битых файлов (до 3 улик, монотонный порядок).
- MCP-тул `autonomy` (status/consume/revoke/resolve_question) — grant-пути НЕТ by construction.
- Инъекция активного мандата и возраста вопросов в каждый ход (channel-reminder, lazy-import, fail-open) + baked TELEGRAM_STATE_DIR в команду хука.
- Строка «Мандат» в pin HUD (изолирована — сломанный реестр не ломает доставку).

## Ревью
- Codex GPT-5.6 Sol: BLOCK → фикс-луп 1 (атомарность, sticky-инвариант, канонический ключ, уникальность ID, durability, log hygiene).
- Fable: SHIP-WITH-CHANGES → фикс-луп 1 (state-root rendezvous хука, module-load safety, честный expired-consume).
- Sol архитектурное мнение (по запросу вождя) → фикс-луп 2 (revision, writer-lock, scopeDigest, revoked, форензика).
- Оркестратор: пойман и устранён флак прунинга форензики (монотонный суффикс).

## Верификация
tsc 0; 2405 pass / 0 fail (полный прогон 3+2 раза подряд, форензика 20/20). +101 тест к базе.

🤖 Generated with [Claude Code](https://claude.com/claude-code)