### PR TITLE
Автономия M4: надёжная доставка + heartbeat + dead-man

### DIFF
--- a/plugin/src/channel/tools.ts
+++ b/plugin/src/channel/tools.ts
@@ -102,6 +102,13 @@ export interface SendMessageOpts {
   reply_to_message_id?: number
   parse_mode?: 'MarkdownV2' | 'HTML'
   reply_markup?: InlineKeyboardLike
+  // M4 fix-loop-1 #6: opt OUT of the reliable layer's outbound-activity stamp.
+  // Set by INTERNAL status surfaces (context-HUD sends, heartbeat nudges)
+  // whose messages must not count as «the owner heard a real report» —
+  // otherwise a pin self-heal would silently reset the heartbeat silence
+  // window. Consumed and STRIPPED by createReliableTelegramApi; never reaches
+  // the wire.
+  skipOutboundStamp?: boolean
 }
 
 export interface EditOpts {

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -658,6 +658,11 @@ export type StatePaths = {
   sessionIds: string
   deadLetterUpdates: string
   deadLetterWebhook: string
+  // M4 (2026-07-10): quarantine bucket for OUTBOUND Telegram sends that failed
+  // after the bounded retry policy exhausted (network / 5xx / 429). Distinct
+  // from the inbound `updates`/`webhook` buckets so operators can triage
+  // delivery failures separately.
+  deadLetterOutbound: string
   logs: {
     server: string
     telegram: string
@@ -696,6 +701,7 @@ export function getStatePaths(_config: AppConfig, env: RuntimeEnv): StatePaths {
     sessionIds: join(root, 'session-ids'),
     deadLetterUpdates: join(root, 'dead-letter', 'updates'),
     deadLetterWebhook: join(root, 'dead-letter', 'webhook'),
+    deadLetterOutbound: join(root, 'dead-letter', 'outbound'),
     logs: {
       server: join(root, 'logs', 'server.log'),
       telegram: join(root, 'logs', 'telegram.log'),

--- a/plugin/src/safety/reliable-telegram-api.ts
+++ b/plugin/src/safety/reliable-telegram-api.ts
@@ -1,0 +1,340 @@
+// Reliable outbound wrapper around TelegramApi — bounded retry + dead-letter
+// + last-outbound tracking (M4, 2026-07-10 communication audit).
+//
+// The audit found ~12 delivery failures/week (transient network / 5xx / 429)
+// that silently dropped a reply and forced the owner to ping «Статус?». This
+// wrapper makes delivery mechanical: it is the OUTERMOST send layer (caller →
+// reliable → safe(redact/validate) → rateLimited(queue+429) → raw(grammY)), so
+// EVERY caller send passes through one choke point.
+//
+// What it does, per send-ish method (sendMessage / editMessageText /
+// sendDocument / sendPhoto — sendRichMessage is tracked but NOT retried, see
+// its handler):
+//   1. Retry on TRANSIENT failure (network error, 5xx, 429) up to `maxRetries`
+//      (default 2) with backoff (1s, 5s). A 429 honours `retry_after` when it
+//      is larger than the scheduled backoff, capped at 30s.
+//   2. Non-transient 4xx (except 429) → NO retry (the body is bad, not the
+//      link) — rethrown so the caller can recover (the reply tool's plain-text
+//      retry on an HTML parse 400) or surface an honest tool error.
+//   3. On TRANSIENT EXHAUSTION → write a dead-letter record (chat_id, method,
+//      payload hash, error) and rethrow so the tool result is honest.
+//      Deliberately NOT on permanent 4xx: those are routine (parse errors the
+//      reply tool recovers, a deleted HUD pin the HUD recreates, a blocked
+//      bot) — dead-lettering them would be noise and, worse, could race the
+//      recovery. The dead-letter targets exactly the audit's transient drops.
+//   4. On a SUCCESSFUL new-message send (not editMessageText) → stamp the
+//      outbound-activity tracker so the heartbeat/dead-man know when the owner
+//      last heard from us. editMessageText is excluded: pin edits don't ping.
+//
+// ISOLATION: pass-through methods that never carry an owner reply
+// (setMessageReaction / sendChatAction / deleteMessage / downloadFile /
+// answerGuestQuery) are forwarded verbatim — no retry, no dead-letter — so
+// this layer only governs primary delivery and never changes their semantics.
+//
+// Test seams: `now` and `sleep` replace the clock + setTimeout so the retry
+// backoff runs in virtual time with no real waits; `deadLetter` and
+// `recordOutbound` are injected callbacks (server wires them to writeDeadLetter
+// and the OutboundActivityTracker) so unit tests observe them without I/O.
+
+import { createHash } from 'node:crypto'
+
+import type { Logger } from '../log.js'
+import type {
+  AnswerGuestQueryOpts,
+  ChatAction,
+  DownloadResult,
+  EditOpts,
+  SendDocumentOpts,
+  SendMessageOpts,
+  SendRichMessageOpts,
+  SendRichMessageResult,
+  TelegramApi,
+} from '../channel/tools.js'
+
+// ─────────────────────────────────────────────────────────────────────
+// Error classification.
+// ─────────────────────────────────────────────────────────────────────
+
+export type SendErrorClass =
+  | { kind: 'permanent' }
+  | { kind: 'transient' }
+  | { kind: 'rate_limited'; retryAfterMs: number }
+
+// Pull an HTTP-ish status code from the many shapes an error can take (grammY
+// GrammyError.error_code, a fetch Response-ish .status/.statusCode).
+function extractStatusCode(err: unknown): number | undefined {
+  if (typeof err !== 'object' || err === null) return undefined
+  const e = err as Record<string, unknown>
+  if (typeof e.error_code === 'number') return e.error_code
+  if (typeof e.status === 'number') return e.status
+  if (typeof e.statusCode === 'number') return e.statusCode
+  return undefined
+}
+
+function extractRetryAfterSec(err: unknown): number | undefined {
+  if (typeof err !== 'object' || err === null) return undefined
+  const e = err as { parameters?: { retry_after?: unknown }; retry_after?: unknown }
+  const raw = e.parameters?.retry_after ?? e.retry_after
+  if (typeof raw === 'number' && Number.isFinite(raw) && raw > 0) return raw
+  return undefined
+}
+
+function looksLikeNetworkError(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false
+  const e = err as { name?: unknown; message?: unknown; code?: unknown }
+  const name = typeof e.name === 'string' ? e.name.toLowerCase() : ''
+  // grammY wraps transport failures in HttpError; undici/node surface fetch
+  // failures as TypeError('fetch failed') / AbortError, or a syscall code.
+  if (name === 'httperror' || name === 'aborterror' || name === 'fetcherror') return true
+  const code = typeof e.code === 'string' ? e.code.toUpperCase() : ''
+  if (
+    code === 'ECONNRESET' ||
+    code === 'ECONNREFUSED' ||
+    code === 'ETIMEDOUT' ||
+    code === 'ENOTFOUND' ||
+    code === 'EAI_AGAIN' ||
+    code === 'EPIPE' ||
+    code === 'UND_ERR_CONNECT_TIMEOUT' ||
+    code === 'UND_ERR_SOCKET'
+  ) {
+    return true
+  }
+  const msg = typeof e.message === 'string' ? e.message.toLowerCase() : ''
+  return (
+    msg.includes('fetch failed') ||
+    msg.includes('network') ||
+    msg.includes('timeout') ||
+    msg.includes('timed out') ||
+    msg.includes('socket hang up') ||
+    msg.includes('econnreset') ||
+    msg.includes('connection')
+  )
+}
+
+/**
+ * Classify a send failure. 429 → rate_limited (with a clamped retry_after);
+ * 5xx or a network-looking error → transient; every 4xx (except 429) and any
+ * unreadable/plain error → permanent (no retry — retrying a bad body or a
+ * genuine bug only wastes attempts and delays the honest error).
+ *
+ * `retryAfterCapMs` clamps a hostile / huge retry_after so one 429 can't stall
+ * a send for minutes.
+ */
+export function classifySendError(err: unknown, retryAfterCapMs: number): SendErrorClass {
+  const code = extractStatusCode(err)
+  if (code === 429) {
+    const sec = extractRetryAfterSec(err)
+    const ms = sec !== undefined ? Math.min(retryAfterCapMs, Math.ceil(sec) * 1000) : 0
+    return { kind: 'rate_limited', retryAfterMs: ms }
+  }
+  if (typeof code === 'number' && code >= 500 && code <= 599) return { kind: 'transient' }
+  if (typeof code === 'number' && code >= 400 && code <= 499) return { kind: 'permanent' }
+  // No HTTP code: a network/transport error is transient; anything else
+  // (a plain Error — likely a programming bug) is permanent so we never
+  // retry+dead-letter a non-delivery failure.
+  if (looksLikeNetworkError(err)) return { kind: 'transient' }
+  return { kind: 'permanent' }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Dead-letter record shape (the `value` written under the `outbound` bucket).
+// ─────────────────────────────────────────────────────────────────────
+
+export interface OutboundDeadLetter {
+  method: string
+  chat_id: string
+  // sha256 (first 16 hex) of the payload body — enough to correlate without
+  // ever writing the (possibly still-sensitive) message text to disk.
+  payload_sha256: string
+  payload_bytes: number
+  attempts: number
+  error: string
+  error_class: SendErrorClass['kind']
+}
+
+function payloadHash(body: string): { sha: string; bytes: number } {
+  const bytes = Buffer.byteLength(body, 'utf8')
+  const sha = createHash('sha256').update(body, 'utf8').digest('hex').slice(0, 16)
+  return { sha, bytes }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Wrapper.
+// ─────────────────────────────────────────────────────────────────────
+
+export interface ReliableOptions {
+  /** Max RETRIES after the first attempt (default 2 → up to 3 attempts). */
+  maxRetries?: number
+  /** Backoff before retry N (0-indexed). Default [1000, 5000] ms. */
+  backoffsMs?: number[]
+  /** Clamp for a 429 retry_after. Default 30_000 ms. */
+  retryAfterCapMs?: number
+  /** Test seam: replace Date.now(). */
+  now?: () => number
+  /** Test seam: replace setTimeout-based sleep. */
+  sleep?: (ms: number) => Promise<void>
+  /** Write a dead-letter record (server wires writeDeadLetter(paths,'outbound',r)). */
+  deadLetter?: (record: OutboundDeadLetter) => void
+  /** Stamp the outbound-activity clock on a successful NEW-message send. */
+  recordOutbound?: (chatId: string, atMs: number) => void
+}
+
+const DEFAULT_BACKOFFS_MS = [1000, 5000]
+const DEFAULT_RETRY_AFTER_CAP_MS = 30_000
+
+export function createReliableTelegramApi(
+  raw: TelegramApi,
+  log: Logger,
+  opts: ReliableOptions = {},
+): TelegramApi {
+  const maxRetries = opts.maxRetries ?? 2
+  const backoffs = opts.backoffsMs ?? DEFAULT_BACKOFFS_MS
+  const retryAfterCapMs = opts.retryAfterCapMs ?? DEFAULT_RETRY_AFTER_CAP_MS
+  const now = opts.now ?? ((): number => Date.now())
+  const sleep =
+    opts.sleep ??
+    ((ms: number): Promise<void> =>
+      ms <= 0 ? Promise.resolve() : new Promise((r) => setTimeout(r, ms)))
+
+  // The retry engine. `op` performs one attempt; `describe` supplies the
+  // dead-letter identity (method + chat + payload) used ONLY on transient
+  // exhaustion. Permanent failures rethrow immediately (no retry, no
+  // dead-letter). Returns the op's result on success.
+  async function withRetry<T>(
+    op: () => Promise<T>,
+    describe: () => { method: string; chatId: string; body: string },
+  ): Promise<T> {
+    let attempt = 0
+    for (;;) {
+      attempt += 1
+      try {
+        return await op()
+      } catch (err) {
+        const cls = classifySendError(err, retryAfterCapMs)
+        if (cls.kind === 'permanent') {
+          // Bad body / genuine error — the caller recovers (reply-tool plain
+          // retry) or surfaces it. No retry, no dead-letter.
+          throw err
+        }
+        if (attempt > maxRetries) {
+          // Transient exhaustion — quarantine + rethrow an honest error.
+          const d = describe()
+          const { sha, bytes } = payloadHash(d.body)
+          const record: OutboundDeadLetter = {
+            method: d.method,
+            chat_id: d.chatId,
+            payload_sha256: sha,
+            payload_bytes: bytes,
+            attempts: attempt,
+            error: err instanceof Error ? err.message : String(err),
+            error_class: cls.kind,
+          }
+          try {
+            opts.deadLetter?.(record)
+          } catch (dlErr) {
+            log.warn('outbound dead-letter write failed (ignored)', {
+              method: d.method,
+              chat_id: d.chatId,
+              error: dlErr instanceof Error ? dlErr.message : String(dlErr),
+            })
+          }
+          log.warn('outbound send failed after retries — dead-lettered', {
+            method: d.method,
+            chat_id: d.chatId,
+            attempts: attempt,
+            error_class: cls.kind,
+          })
+          throw err
+        }
+        // Schedule the next attempt. 429 honours retry_after when larger than
+        // the scheduled backoff; both are capped by retryAfterCapMs.
+        const backoff = backoffs[attempt - 1] ?? backoffs[backoffs.length - 1] ?? 1000
+        const wait =
+          cls.kind === 'rate_limited'
+            ? Math.min(retryAfterCapMs, Math.max(backoff, cls.retryAfterMs))
+            : backoff
+        const d = describe()
+        log.warn('outbound send transient failure — retrying', {
+          method: d.method,
+          chat_id: d.chatId,
+          attempt,
+          error_class: cls.kind,
+          wait_ms: wait,
+        })
+        await sleep(wait)
+      }
+    }
+  }
+
+  return {
+    async sendMessage(chatId, text, sendOpts: SendMessageOpts): Promise<{ message_id: number }> {
+      const res = await withRetry(
+        () => raw.sendMessage(chatId, text, sendOpts),
+        () => ({ method: 'sendMessage', chatId, body: text }),
+      )
+      opts.recordOutbound?.(chatId, now())
+      return res
+    },
+
+    async sendRichMessage(
+      chatId,
+      rawMarkdown,
+      richOpts: SendRichMessageOpts,
+    ): Promise<SendRichMessageResult> {
+      // NOT retried here (deliberately not in item 1's method list): a rich
+      // send is non-idempotent and a transient error AFTER Telegram accepted it
+      // would double-post on retry; the safe wrapper already rethrows rich
+      // transients and 429s are handled by the rate-limiter's queue. We only
+      // stamp the outbound clock on a REAL send (message_id) — a transparent
+      // { fallback: true } means the HTML path (sendMessage) ships and stamps.
+      const res = await raw.sendRichMessage(chatId, rawMarkdown, richOpts)
+      if ('message_id' in res) opts.recordOutbound?.(chatId, now())
+      return res
+    },
+
+    async editMessageText(chatId, messageId, text, editOpts: EditOpts): Promise<void> {
+      // Retried like a send, but NOT stamped as outbound: an edit does not ping
+      // and the pins re-edit every tick — counting them would starve the
+      // heartbeat window forever.
+      await withRetry(
+        () => raw.editMessageText(chatId, messageId, text, editOpts),
+        () => ({ method: 'editMessageText', chatId, body: text }),
+      )
+    },
+
+    async sendDocument(chatId, filePath, docOpts: SendDocumentOpts): Promise<{ message_id: number }> {
+      const res = await withRetry(
+        () => raw.sendDocument(chatId, filePath, docOpts),
+        () => ({ method: 'sendDocument', chatId, body: filePath }),
+      )
+      opts.recordOutbound?.(chatId, now())
+      return res
+    },
+
+    async sendPhoto(chatId, filePath, photoOpts: SendDocumentOpts): Promise<{ message_id: number }> {
+      const res = await withRetry(
+        () => raw.sendPhoto(chatId, filePath, photoOpts),
+        () => ({ method: 'sendPhoto', chatId, body: filePath }),
+      )
+      opts.recordOutbound?.(chatId, now())
+      return res
+    },
+
+    // ─── pass-through (never carry an owner reply) ───────────────────────
+    async setMessageReaction(chatId, messageId, emoji): Promise<void> {
+      return raw.setMessageReaction(chatId, messageId, emoji)
+    },
+    async sendChatAction(chatId, action: ChatAction): Promise<void> {
+      return raw.sendChatAction(chatId, action)
+    },
+    async downloadFile(fileId, destDir): Promise<DownloadResult> {
+      return raw.downloadFile(fileId, destDir)
+    },
+    async deleteMessage(chatId, messageId): Promise<void> {
+      return raw.deleteMessage(chatId, messageId)
+    },
+    async answerGuestQuery(guestQueryId, text, guestOpts: AnswerGuestQueryOpts): Promise<void> {
+      return raw.answerGuestQuery(guestQueryId, text, guestOpts)
+    },
+  }
+}

--- a/plugin/src/safety/reliable-telegram-api.ts
+++ b/plugin/src/safety/reliable-telegram-api.ts
@@ -1,5 +1,6 @@
 // Reliable outbound wrapper around TelegramApi — bounded retry + dead-letter
-// + last-outbound tracking (M4, 2026-07-10 communication audit).
+// + last-outbound tracking (M4, 2026-07-10 communication audit; hardened in
+// fix-loop 1 after the Codex/Fable dual review).
 //
 // The audit found ~12 delivery failures/week (transient network / 5xx / 429)
 // that silently dropped a reply and forced the owner to ping «Статус?». This
@@ -7,24 +8,47 @@
 // reliable → safe(redact/validate) → rateLimited(queue+429) → raw(grammY)), so
 // EVERY caller send passes through one choke point.
 //
-// What it does, per send-ish method (sendMessage / editMessageText /
-// sendDocument / sendPhoto — sendRichMessage is tracked but NOT retried, see
-// its handler):
-//   1. Retry on TRANSIENT failure (network error, 5xx, 429) up to `maxRetries`
-//      (default 2) with backoff (1s, 5s). A 429 honours `retry_after` when it
-//      is larger than the scheduled backoff, capped at 30s.
-//   2. Non-transient 4xx (except 429) → NO retry (the body is bad, not the
-//      link) — rethrown so the caller can recover (the reply tool's plain-text
-//      retry on an HTML parse 400) or surface an honest tool error.
-//   3. On TRANSIENT EXHAUSTION → write a dead-letter record (chat_id, method,
-//      payload hash, error) and rethrow so the tool result is honest.
-//      Deliberately NOT on permanent 4xx: those are routine (parse errors the
-//      reply tool recovers, a deleted HUD pin the HUD recreates, a blocked
-//      bot) — dead-lettering them would be noise and, worse, could race the
-//      recovery. The dead-letter targets exactly the audit's transient drops.
-//   4. On a SUCCESSFUL new-message send (not editMessageText) → stamp the
-//      outbound-activity tracker so the heartbeat/dead-man know when the owner
-//      last heard from us. editMessageText is excluded: pin edits don't ping.
+// ── LOSS vs DUPLICATE (the fix-loop-1 CRITICAL) ──────────────────────
+// A failed send is only safely retryable when we can PROVE Telegram never
+// received it. Errors therefore classify into:
+//   • pre_send   — delivery provably did NOT happen: the connection was never
+//                  established (ECONNREFUSED, ENOTFOUND, EAI_AGAIN / DNS,
+//                  connect-phase timeouts). Retrying can never duplicate.
+//   • ambiguous  — the request MAY have reached Telegram before the failure
+//                  (ECONNRESET, ETIMEDOUT, socket hang up, generic «fetch
+//                  failed», 5xx — the API may have processed the send and died
+//                  answering). Retrying a NON-IDEMPOTENT method here risks the
+//                  owner seeing the same message twice.
+// Policy: non-idempotent methods (sendMessage / sendDocument / sendPhoto)
+// retry ONLY pre_send; on ambiguous they dead-letter + rethrow immediately —
+// we prefer a LOUD possible-loss (honest tool error, quarantined record, the
+// agent can decide to resend) over a SILENT duplicate (spammy, confusing, and
+// unfixable after the fact). Idempotent editMessageText retries BOTH classes
+// (re-editing to the same content is harmless; Telegram's «message is not
+// modified» response is normalized to success).
+//
+// 429 (rate_limited) is NEVER retried here (fix-loop-1 #2): the INNER
+// rate-limited layer already owns 429s (3 attempts, retry_after ≤60s each) —
+// by the time one escapes to this layer ~3 minutes of backoff are already
+// burned, and looping the whole inner stack again would amplify the stall to
+// ~10 minutes of head-of-line blocking. Escaped 429 → immediate dead-letter +
+// rethrow.
+//
+// On a transient failure we don't retry, or on pre_send exhaustion → write a
+// dead-letter record (chat_id, method, payload hash, error) under the
+// `outbound` bucket and rethrow so the tool result is honest. Permanent 4xx
+// (except 429) are NOT dead-lettered: those are routine (parse errors the
+// reply tool recovers, a deleted HUD pin the HUD recreates, a blocked bot) —
+// quarantining them would be noise racing the recovery.
+//
+// On a SUCCESSFUL new-message send (not editMessageText) the wrapper stamps
+// the outbound-activity tracker so the heartbeat/dead-man know when the owner
+// last heard from us. `SendMessageOpts.skipOutboundStamp` opts a call OUT of
+// the stamp — used by INTERNAL surfaces (context-HUD self-heal, heartbeat
+// nudges) whose sends must not silently reset the heartbeat silence window.
+// ALL post-success bookkeeping (stamp) and dead-letter writes are wrapped in
+// try/catch: a delivered message must NEVER turn into a tool error because a
+// callback threw (fix-loop-1 #5).
 //
 // ISOLATION: pass-through methods that never carry an owner reply
 // (setMessageReaction / sendChatAction / deleteMessage / downloadFile /
@@ -57,8 +81,12 @@ import type {
 
 export type SendErrorClass =
   | { kind: 'permanent' }
-  | { kind: 'transient' }
+  | { kind: 'pre_send' }
+  | { kind: 'ambiguous' }
   | { kind: 'rate_limited'; retryAfterMs: number }
+
+/** The transient classes a dead-letter record can carry. */
+export type OutboundErrorClass = 'pre_send' | 'ambiguous' | 'rate_limited'
 
 // Pull an HTTP-ish status code from the many shapes an error can take (grammY
 // GrammyError.error_code, a fetch Response-ish .status/.statusCode).
@@ -79,46 +107,73 @@ function extractRetryAfterSec(err: unknown): number | undefined {
   return undefined
 }
 
-function looksLikeNetworkError(err: unknown): boolean {
-  if (typeof err !== 'object' || err === null) return false
-  const e = err as { name?: unknown; message?: unknown; code?: unknown }
-  const name = typeof e.name === 'string' ? e.name.toLowerCase() : ''
-  // grammY wraps transport failures in HttpError; undici/node surface fetch
-  // failures as TypeError('fetch failed') / AbortError, or a syscall code.
-  if (name === 'httperror' || name === 'aborterror' || name === 'fetcherror') return true
-  const code = typeof e.code === 'string' ? e.code.toUpperCase() : ''
-  if (
-    code === 'ECONNRESET' ||
-    code === 'ECONNREFUSED' ||
-    code === 'ETIMEDOUT' ||
-    code === 'ENOTFOUND' ||
-    code === 'EAI_AGAIN' ||
-    code === 'EPIPE' ||
-    code === 'UND_ERR_CONNECT_TIMEOUT' ||
-    code === 'UND_ERR_SOCKET'
-  ) {
-    return true
+// Syscall-level error codes, checked on the error itself and one level into
+// `cause` / `error` (grammY HttpError stores the transport failure in .error;
+// undici uses .cause).
+function extractSyscallCodes(err: unknown): string[] {
+  const out: string[] = []
+  const grab = (o: unknown): void => {
+    if (typeof o !== 'object' || o === null) return
+    const c = (o as { code?: unknown }).code
+    if (typeof c === 'string' && c.length > 0) out.push(c.toUpperCase())
   }
-  const msg = typeof e.message === 'string' ? e.message.toLowerCase() : ''
-  return (
-    msg.includes('fetch failed') ||
-    msg.includes('network') ||
-    msg.includes('timeout') ||
-    msg.includes('timed out') ||
-    msg.includes('socket hang up') ||
-    msg.includes('econnreset') ||
-    msg.includes('connection')
-  )
+  grab(err)
+  if (typeof err === 'object' && err !== null) {
+    const e = err as { cause?: unknown; error?: unknown }
+    grab(e.cause)
+    grab(e.error)
+  }
+  return out
 }
 
+// Lowercased message text, gathered from the error and one nesting level.
+function extractMessage(err: unknown): string {
+  if (typeof err === 'string') return err.toLowerCase()
+  if (typeof err !== 'object' || err === null) return ''
+  const e = err as Record<string, unknown>
+  const parts: string[] = []
+  if (typeof e.description === 'string') parts.push(e.description)
+  if (typeof e.message === 'string') parts.push(e.message)
+  for (const key of ['cause', 'error'] as const) {
+    const nested = e[key]
+    if (typeof nested === 'object' && nested !== null) {
+      const m = (nested as { message?: unknown }).message
+      if (typeof m === 'string') parts.push(m)
+    }
+  }
+  return parts.join(' ').toLowerCase()
+}
+
+// Connection provably never established → the request never left us.
+const PRE_SEND_CODES: ReadonlySet<string> = new Set([
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'UND_ERR_CONNECT_TIMEOUT',
+])
+// Connection existed (or state unknown) when it died → Telegram may have
+// already processed the request.
+const AMBIGUOUS_CODES: ReadonlySet<string> = new Set([
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EPIPE',
+  'UND_ERR_SOCKET',
+])
+
 /**
- * Classify a send failure. 429 → rate_limited (with a clamped retry_after);
- * 5xx or a network-looking error → transient; every 4xx (except 429) and any
- * unreadable/plain error → permanent (no retry — retrying a bad body or a
- * genuine bug only wastes attempts and delays the honest error).
+ * Classify a send failure (see the module header for the loss-vs-duplicate
+ * policy each class drives):
+ *   429                        → rate_limited (never retried here);
+ *   5xx                        → ambiguous (the API may have processed it);
+ *   other 4xx                  → permanent (bad body / auth — no retry);
+ *   connect-phase syscall/DNS  → pre_send (provably not delivered);
+ *   reset / timeout / hang-up  → ambiguous;
+ *   anything unreadable        → permanent (likely a programming bug — never
+ *                                retry or dead-letter a non-delivery failure).
+ * NOTE: deliberately NO loose `includes('connection')` match (fix-loop-1 #1) —
+ * any Error merely mentioning the word must not become retryable.
  *
- * `retryAfterCapMs` clamps a hostile / huge retry_after so one 429 can't stall
- * a send for minutes.
+ * `retryAfterCapMs` clamps a hostile / huge retry_after in the recorded value.
  */
 export function classifySendError(err: unknown, retryAfterCapMs: number): SendErrorClass {
   const code = extractStatusCode(err)
@@ -127,13 +182,52 @@ export function classifySendError(err: unknown, retryAfterCapMs: number): SendEr
     const ms = sec !== undefined ? Math.min(retryAfterCapMs, Math.ceil(sec) * 1000) : 0
     return { kind: 'rate_limited', retryAfterMs: ms }
   }
-  if (typeof code === 'number' && code >= 500 && code <= 599) return { kind: 'transient' }
+  if (typeof code === 'number' && code >= 500 && code <= 599) return { kind: 'ambiguous' }
   if (typeof code === 'number' && code >= 400 && code <= 499) return { kind: 'permanent' }
-  // No HTTP code: a network/transport error is transient; anything else
-  // (a plain Error — likely a programming bug) is permanent so we never
-  // retry+dead-letter a non-delivery failure.
-  if (looksLikeNetworkError(err)) return { kind: 'transient' }
+
+  const sys = extractSyscallCodes(err)
+  if (sys.some((c) => PRE_SEND_CODES.has(c))) return { kind: 'pre_send' }
+  if (sys.some((c) => AMBIGUOUS_CODES.has(c))) return { kind: 'ambiguous' }
+
+  const msg = extractMessage(err)
+  if (
+    msg.includes('econnrefused') ||
+    msg.includes('enotfound') ||
+    msg.includes('eai_again') ||
+    msg.includes('getaddrinfo')
+  ) {
+    return { kind: 'pre_send' }
+  }
+  if (
+    msg.includes('econnreset') ||
+    msg.includes('etimedout') ||
+    msg.includes('timed out') ||
+    msg.includes('timeout') ||
+    msg.includes('socket hang up') ||
+    msg.includes('fetch failed') ||
+    msg.includes('network')
+  ) {
+    return { kind: 'ambiguous' }
+  }
+  // Transport-wrapper names without a readable code/message detail: the HTTP
+  // exchange failed at an unknown phase — cannot prove pre-send.
+  if (typeof err === 'object' && err !== null) {
+    const name = (err as { name?: unknown }).name
+    if (typeof name === 'string') {
+      const n = name.toLowerCase()
+      if (n === 'httperror' || n === 'aborterror' || n === 'fetcherror') {
+        return { kind: 'ambiguous' }
+      }
+    }
+  }
   return { kind: 'permanent' }
+}
+
+// Telegram's «message is not modified» on editMessageText: the remote content
+// ALREADY equals what we tried to write — for an idempotent edit that IS
+// success (fix-loop-1 #1). Same phrase check classifyEditError leads with.
+function isNotModifiedError(err: unknown): boolean {
+  return extractMessage(err).includes('message is not modified')
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -149,7 +243,7 @@ export interface OutboundDeadLetter {
   payload_bytes: number
   attempts: number
   error: string
-  error_class: SendErrorClass['kind']
+  error_class: OutboundErrorClass
 }
 
 function payloadHash(body: string): { sha: string; bytes: number } {
@@ -167,7 +261,7 @@ export interface ReliableOptions {
   maxRetries?: number
   /** Backoff before retry N (0-indexed). Default [1000, 5000] ms. */
   backoffsMs?: number[]
-  /** Clamp for a 429 retry_after. Default 30_000 ms. */
+  /** Clamp for a recorded 429 retry_after. Default 30_000 ms. */
   retryAfterCapMs?: number
   /** Test seam: replace Date.now(). */
   now?: () => number
@@ -196,11 +290,61 @@ export function createReliableTelegramApi(
     ((ms: number): Promise<void> =>
       ms <= 0 ? Promise.resolve() : new Promise((r) => setTimeout(r, ms)))
 
-  // The retry engine. `op` performs one attempt; `describe` supplies the
-  // dead-letter identity (method + chat + payload) used ONLY on transient
-  // exhaustion. Permanent failures rethrow immediately (no retry, no
-  // dead-letter). Returns the op's result on success.
+  // Post-success bookkeeping — MUST be swallowed (fix-loop-1 #5): the message
+  // is already delivered; a throwing tracker cannot be allowed to turn that
+  // delivery into a tool error (which could push the agent into a duplicate
+  // resend — the exact failure mode this layer exists to kill).
+  function stampOutbound(chatId: string): void {
+    try {
+      opts.recordOutbound?.(chatId, now())
+    } catch (err) {
+      log.warn('outbound activity stamp failed (ignored)', {
+        chat_id: chatId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  function writeDeadLetterRecord(
+    d: { method: string; chatId: string; body: string },
+    attempts: number,
+    err: unknown,
+    errorClass: OutboundErrorClass,
+  ): void {
+    const { sha, bytes } = payloadHash(d.body)
+    const record: OutboundDeadLetter = {
+      method: d.method,
+      chat_id: d.chatId,
+      payload_sha256: sha,
+      payload_bytes: bytes,
+      attempts,
+      error: err instanceof Error ? err.message : String(err),
+      error_class: errorClass,
+    }
+    try {
+      opts.deadLetter?.(record)
+    } catch (dlErr) {
+      log.warn('outbound dead-letter write failed (ignored)', {
+        method: d.method,
+        chat_id: d.chatId,
+        error: dlErr instanceof Error ? dlErr.message : String(dlErr),
+      })
+    }
+    log.warn('outbound send failed — dead-lettered', {
+      method: d.method,
+      chat_id: d.chatId,
+      attempts,
+      error_class: errorClass,
+    })
+  }
+
+  // The retry engine. `idempotent` selects the retry policy (see module
+  // header): non-idempotent ops retry ONLY pre_send; idempotent ops (edits)
+  // also retry ambiguous. rate_limited is never retried (fix-loop-1 #2).
+  // Permanent failures rethrow immediately (no retry, no dead-letter);
+  // non-retried / exhausted transients dead-letter + rethrow honestly.
   async function withRetry<T>(
+    idempotent: boolean,
     op: () => Promise<T>,
     describe: () => { method: string; chatId: string; body: string },
   ): Promise<T> {
@@ -216,43 +360,13 @@ export function createReliableTelegramApi(
           // retry) or surfaces it. No retry, no dead-letter.
           throw err
         }
-        if (attempt > maxRetries) {
-          // Transient exhaustion — quarantine + rethrow an honest error.
-          const d = describe()
-          const { sha, bytes } = payloadHash(d.body)
-          const record: OutboundDeadLetter = {
-            method: d.method,
-            chat_id: d.chatId,
-            payload_sha256: sha,
-            payload_bytes: bytes,
-            attempts: attempt,
-            error: err instanceof Error ? err.message : String(err),
-            error_class: cls.kind,
-          }
-          try {
-            opts.deadLetter?.(record)
-          } catch (dlErr) {
-            log.warn('outbound dead-letter write failed (ignored)', {
-              method: d.method,
-              chat_id: d.chatId,
-              error: dlErr instanceof Error ? dlErr.message : String(dlErr),
-            })
-          }
-          log.warn('outbound send failed after retries — dead-lettered', {
-            method: d.method,
-            chat_id: d.chatId,
-            attempts: attempt,
-            error_class: cls.kind,
-          })
+        const retryable =
+          cls.kind === 'pre_send' || (idempotent && cls.kind === 'ambiguous')
+        if (!retryable || attempt > maxRetries) {
+          writeDeadLetterRecord(describe(), attempt, err, cls.kind)
           throw err
         }
-        // Schedule the next attempt. 429 honours retry_after when larger than
-        // the scheduled backoff; both are capped by retryAfterCapMs.
-        const backoff = backoffs[attempt - 1] ?? backoffs[backoffs.length - 1] ?? 1000
-        const wait =
-          cls.kind === 'rate_limited'
-            ? Math.min(retryAfterCapMs, Math.max(backoff, cls.retryAfterMs))
-            : backoff
+        const wait = backoffs[attempt - 1] ?? backoffs[backoffs.length - 1] ?? 1000
         const d = describe()
         log.warn('outbound send transient failure — retrying', {
           method: d.method,
@@ -268,11 +382,15 @@ export function createReliableTelegramApi(
 
   return {
     async sendMessage(chatId, text, sendOpts: SendMessageOpts): Promise<{ message_id: number }> {
+      // Strip the wrapper-only flag so it never travels downstream (the safe
+      // wrapper spreads opts; grammY must never see a foreign field).
+      const { skipOutboundStamp, ...rest } = sendOpts
       const res = await withRetry(
-        () => raw.sendMessage(chatId, text, sendOpts),
+        false,
+        () => raw.sendMessage(chatId, text, rest),
         () => ({ method: 'sendMessage', chatId, body: text }),
       )
-      opts.recordOutbound?.(chatId, now())
+      if (skipOutboundStamp !== true) stampOutbound(chatId)
       return res
     },
 
@@ -281,42 +399,52 @@ export function createReliableTelegramApi(
       rawMarkdown,
       richOpts: SendRichMessageOpts,
     ): Promise<SendRichMessageResult> {
-      // NOT retried here (deliberately not in item 1's method list): a rich
-      // send is non-idempotent and a transient error AFTER Telegram accepted it
-      // would double-post on retry; the safe wrapper already rethrows rich
-      // transients and 429s are handled by the rate-limiter's queue. We only
-      // stamp the outbound clock on a REAL send (message_id) — a transparent
-      // { fallback: true } means the HTML path (sendMessage) ships and stamps.
+      // NOT retried (deliberately not in item 1's method list): a rich send is
+      // non-idempotent and its transient errors are ambiguous by nature; the
+      // safe wrapper already rethrows rich transients and 429s are handled by
+      // the rate-limiter's queue. We only stamp the outbound clock on a REAL
+      // send (message_id) — a transparent { fallback: true } means the HTML
+      // path (sendMessage) ships and stamps.
       const res = await raw.sendRichMessage(chatId, rawMarkdown, richOpts)
-      if ('message_id' in res) opts.recordOutbound?.(chatId, now())
+      if ('message_id' in res) stampOutbound(chatId)
       return res
     },
 
     async editMessageText(chatId, messageId, text, editOpts: EditOpts): Promise<void> {
-      // Retried like a send, but NOT stamped as outbound: an edit does not ping
-      // and the pins re-edit every tick — counting them would starve the
-      // heartbeat window forever.
-      await withRetry(
-        () => raw.editMessageText(chatId, messageId, text, editOpts),
-        () => ({ method: 'editMessageText', chatId, body: text }),
-      )
+      // IDEMPOTENT: re-editing to the same content is harmless, so both
+      // pre_send AND ambiguous retry. «message is not modified» — thrown when
+      // a retry follows a delivered-but-unanswered first attempt — IS success.
+      // NOT stamped as outbound: an edit does not ping and the pins re-edit
+      // every tick — counting them would starve the heartbeat window forever.
+      try {
+        await withRetry(
+          true,
+          () => raw.editMessageText(chatId, messageId, text, editOpts),
+          () => ({ method: 'editMessageText', chatId, body: text }),
+        )
+      } catch (err) {
+        if (isNotModifiedError(err)) return
+        throw err
+      }
     },
 
     async sendDocument(chatId, filePath, docOpts: SendDocumentOpts): Promise<{ message_id: number }> {
       const res = await withRetry(
+        false,
         () => raw.sendDocument(chatId, filePath, docOpts),
         () => ({ method: 'sendDocument', chatId, body: filePath }),
       )
-      opts.recordOutbound?.(chatId, now())
+      stampOutbound(chatId)
       return res
     },
 
     async sendPhoto(chatId, filePath, photoOpts: SendDocumentOpts): Promise<{ message_id: number }> {
       const res = await withRetry(
+        false,
         () => raw.sendPhoto(chatId, filePath, photoOpts),
         () => ({ method: 'sendPhoto', chatId, body: filePath }),
       )
-      opts.recordOutbound?.(chatId, now())
+      stampOutbound(chatId)
       return res
     },
 

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -431,21 +431,18 @@ if (!tokenLock.acquire(statePaths)) {
 // ─────────────────────────────────────────────────────────────────────
 
 const bot = new Bot(env.TELEGRAM_BOT_TOKEN)
-// Raw API talks to grammy. Safe wrapper sits in front of every downstream
-// consumer (StatusManager, oob, handlers, poller, webhook). The wrapper:
-//   1. redactSecrets(text, logSecrets) before delegating to raw API.
-//   2. validateTelegramHtml(text) when parse_mode=='HTML'; downgrade on
-//      invalid markup (strip parse_mode, ship escaped plain).
-// No call site can bypass — the raw `telegramApi` reference is shadowed
-// after this line. Anything that imports TelegramApi from channel/tools
-// receives the wrapped instance via toolDeps / handlerDeps / StatusManager.
+// Raw API talks to grammy. Every downstream consumer (StatusManager, oob,
+// handlers, poller, webhook) receives the fully layered instance built below.
+// Composition (fix-loop-1 #9 — this comment is the canonical map):
+//   caller → reliableTelegramApi (bounded retry + dead-letter + outbound clock)
+//          → safeTelegramApi     (redactSecrets + validateTelegramHtml downgrade)
+//          → rateLimitedTelegramApi (per-chat FIFO + token buckets + 429 retry)
+//          → rawTelegramApi      (grammY).
+// Sanitize runs before the queue so it holds already-redacted/validated
+// payloads (no secret leak if a queued op gets logged); the reliable layer is
+// OUTERMOST so its verdict reflects the final outcome of the whole stack.
+// No call site can bypass — the raw reference is shadowed below.
 const rawTelegramApi = createTelegramApi(bot, env.TELEGRAM_BOT_TOKEN)
-// Composition: caller → safeTelegramApi (sanitize) → rateLimitedTelegramApi
-// (queue + 429 retry) → rawTelegramApi (grammY). Sanitize runs FIRST so the
-// queue holds already-redacted/validated payloads (no secret leak if a
-// queued op gets logged; no time wasted enqueueing text that would later be
-// downgraded). A burst of replies now paces itself instead of surfacing as
-// a 429 to the agent.
 const rateLimitedTelegramApi = createRateLimitedTelegramApi(rawTelegramApi, log)
 // The bot token itself is included in extraSecrets so any code path that
 // accidentally tries to ship the token (e.g. error message including a
@@ -459,16 +456,24 @@ const apiSecrets: string[] = [...logSecrets, env.TELEGRAM_BOT_TOKEN]
 const richLatch = createRichLatch()
 const safeTelegramApi = createSafeTelegramApi(rateLimitedTelegramApi, log, apiSecrets, richLatch)
 // M4 (2026-07-10): OUTERMOST reliability layer. Every caller send passes
-// through here first — it retries transient failures (network / 5xx / 429),
-// dead-letters a transient exhaustion under the `outbound` bucket, and stamps
-// the outbound-activity clock on every successful NEW-message send. That clock
-// is what the mechanical heartbeat/dead-man read to know when the owner last
-// heard from us. editMessageText is retried but NOT stamped (pin edits don't
-// ping — see the wrapper header). Composition:
-//   caller → reliable → safe(redact/validate) → rateLimited(queue+429) → raw.
+// through here first — it retries provably-undelivered transient failures
+// (pre_send; ambiguous ones dead-letter without retry — see the wrapper's
+// loss-vs-duplicate header), dead-letters non-retried/exhausted transients
+// under the `outbound` bucket, and stamps the outbound-activity clock on every
+// successful NEW-message send (unless the call opts out via skipOutboundStamp
+// — internal HUD/heartbeat sends). That clock is what the mechanical
+// heartbeat/dead-man read to know when the owner last heard from us.
+// editMessageText is retried but NOT stamped (pin edits don't ping).
+// The dead-letter error text is redacted (fix-loop-1 #7a) — a transport error
+// can embed the api.telegram.org/bot<token>/ URL, and the quarantine files,
+// while 0600, must never store the token.
 const outboundTracker = new OutboundActivityTracker()
 const telegramApi = createReliableTelegramApi(safeTelegramApi, log, {
-  deadLetter: (record) => writeDeadLetter(statePaths, 'outbound', record),
+  deadLetter: (record) =>
+    writeDeadLetter(statePaths, 'outbound', {
+      ...record,
+      error: redactSecrets(record.error, apiSecrets),
+    }),
   recordOutbound: (chatId, atMs) => outboundTracker.record(chatId, atMs),
 })
 
@@ -538,7 +543,11 @@ const sessionInfoStore = new SessionInfoStore()
 // DM pane.
 const hudOwnerChatIds: ReadonlyArray<number | string> = resolveOwnerChatIds(config)
 const hudApi: HudTelegramApi = {
-  sendMessage: (chatId, text, opts) => telegramApi.sendMessage(chatId, text, opts),
+  // skipOutboundStamp (fix-loop-1 #6): a HUD pin (re)creation is an INTERNAL
+  // surface, not a report to the owner — it must never reset the heartbeat
+  // silence window, or a pin self-heal would silently starve the heartbeat.
+  sendMessage: (chatId, text, opts) =>
+    telegramApi.sendMessage(chatId, text, { ...opts, skipOutboundStamp: true }),
   editMessageText: (chatId, messageId, text, opts) =>
     telegramApi.editMessageText(chatId, messageId, text, opts),
   pinChatMessage: (chatId, messageId, opts) =>
@@ -668,8 +677,11 @@ if (resolveTaskReconcilerEnabled()) {
   // api and edits the context pin via the HUD's heartbeat suffix.
   const heartbeatMonitor = new HeartbeatMonitor({
     log,
+    // skipOutboundStamp (fix-loop-1 #6): a heartbeat nudge / dead-man alert /
+    // question reminder is not a real report — it must not reset the very
+    // silence window it measures (the monitor rate-limits itself instead).
     send: (chatId: string, text: string): Promise<void> =>
-      telegramApi.sendMessage(chatId, text, {}).then(() => undefined),
+      telegramApi.sendMessage(chatId, text, { skipOutboundStamp: true }).then(() => undefined),
     pinHeartbeat: (chatId: string, suffix: string | null): Promise<void> =>
       contextHud.setHeartbeatSuffix(chatId, suffix),
     autonomyPaths: { root: statePaths.root },

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -37,7 +37,7 @@ import {
   type StatePaths,
 } from './config.js'
 import { createLogger } from './log.js'
-import { ensureStateDirs, migrateLegacyAllowlist } from './state/store.js'
+import { ensureStateDirs, migrateLegacyAllowlist, writeDeadLetter } from './state/store.js'
 import {
   callTool,
   createTelegramApi,
@@ -46,6 +46,9 @@ import {
 } from './channel/tools.js'
 import { createSafeTelegramApi } from './safety/safe-telegram-api.js'
 import { createRateLimitedTelegramApi } from './safety/rate-limited-telegram-api.js'
+import { createReliableTelegramApi } from './safety/reliable-telegram-api.js'
+import { OutboundActivityTracker } from './status/outbound-activity.js'
+import { HeartbeatMonitor } from './status/heartbeat-monitor.js'
 import { createRichLatch } from './safety/rich-latch.js'
 import { redactSecrets } from './safety/redact.js'
 import { StatusManager } from './status/status-manager.js'
@@ -454,7 +457,20 @@ const apiSecrets: string[] = [...logSecrets, env.TELEGRAM_BOT_TOKEN]
 // restart re-probes capability, which is correct — Telegram may roll the
 // method out between restarts.
 const richLatch = createRichLatch()
-const telegramApi = createSafeTelegramApi(rateLimitedTelegramApi, log, apiSecrets, richLatch)
+const safeTelegramApi = createSafeTelegramApi(rateLimitedTelegramApi, log, apiSecrets, richLatch)
+// M4 (2026-07-10): OUTERMOST reliability layer. Every caller send passes
+// through here first — it retries transient failures (network / 5xx / 429),
+// dead-letters a transient exhaustion under the `outbound` bucket, and stamps
+// the outbound-activity clock on every successful NEW-message send. That clock
+// is what the mechanical heartbeat/dead-man read to know when the owner last
+// heard from us. editMessageText is retried but NOT stamped (pin edits don't
+// ping — see the wrapper header). Composition:
+//   caller → reliable → safe(redact/validate) → rateLimited(queue+429) → raw.
+const outboundTracker = new OutboundActivityTracker()
+const telegramApi = createReliableTelegramApi(safeTelegramApi, log, {
+  deadLetter: (record) => writeDeadLetter(statePaths, 'outbound', record),
+  recordOutbound: (chatId, atMs) => outboundTracker.record(chatId, atMs),
+})
 
 const mcp = new Server(
   // Single version source: package.json (kept in lockstep with the repo-root
@@ -638,6 +654,29 @@ let taskRealityMirror: TaskRealityMirror | undefined
 if (resolveTaskReconcilerEnabled()) {
   const paneTarget = config.tmux_mirror.pane_target || resolveDefaultPaneTarget()
   const ownerSet = new Set(hudOwnerChatIds.map(String))
+  // Owner DM only (positive numeric chat id in the owner set) — the pane is the
+  // single global DM session; a group chat must never be reconciled or nudged.
+  const isReconcilerOwnerChat = (chatId: string): boolean => {
+    if (!ownerSet.has(chatId)) return false
+    const n = Number(chatId)
+    return Number.isInteger(n) && n > 0
+  }
+  // M4 mechanical liveness. Runs inside the reality-mirror loop (fed pane
+  // captures for the dead-man, evaluated each ~20s tick for heartbeat +
+  // open-question reminders). Reads the outbound clock + the autonomy registry
+  // (open questions ONLY, read-only — never lease TTLs); sends via the reliable
+  // api and edits the context pin via the HUD's heartbeat suffix.
+  const heartbeatMonitor = new HeartbeatMonitor({
+    log,
+    send: (chatId: string, text: string): Promise<void> =>
+      telegramApi.sendMessage(chatId, text, {}).then(() => undefined),
+    pinHeartbeat: (chatId: string, suffix: string | null): Promise<void> =>
+      contextHud.setHeartbeatSuffix(chatId, suffix),
+    autonomyPaths: { root: statePaths.root },
+    lastOutboundAt: (chatId: string): number | undefined =>
+      outboundTracker.lastOutboundAt(chatId),
+    isOwnerChat: isReconcilerOwnerChat,
+  })
   taskRealityMirror = new TaskRealityMirror({
     exec: defaultTmuxExec,
     capture: {
@@ -650,13 +689,8 @@ if (resolveTaskReconcilerEnabled()) {
     // Session-epoch persistence (active + tombstones) — survives restarts so
     // late lifecycle stragglers can't roll the epoch back (review r3 #1).
     stateDir: statePaths.root,
-    // Owner DM only (positive numeric chat id in the owner set) — the pane is
-    // the single global DM session; a group chat must never be reconciled.
-    isOwnerChat: (chatId: string): boolean => {
-      if (!ownerSet.has(chatId)) return false
-      const n = Number(chatId)
-      return Number.isInteger(n) && n > 0
-    },
+    isOwnerChat: isReconcilerOwnerChat,
+    liveness: heartbeatMonitor,
   })
   log.info('task reality mirror configured', { pane_target: paneTarget })
   const shutdownReality = (): void => taskRealityMirror?.stop()

--- a/plugin/src/state/store.ts
+++ b/plugin/src/state/store.ts
@@ -46,6 +46,7 @@ export function ensureStateDirs(paths: StatePaths): void {
   mkdirSync(paths.sessionIds, { recursive: true })
   mkdirSync(paths.deadLetterUpdates, { recursive: true })
   mkdirSync(paths.deadLetterWebhook, { recursive: true })
+  mkdirSync(paths.deadLetterOutbound, { recursive: true })
   // logs/ — server.log etc. live here; create parent so first log write succeeds.
   mkdirSync(dirname(paths.logs.server), { recursive: true })
 }
@@ -115,7 +116,7 @@ export function migrateLegacyAllowlist(paths: StatePaths): boolean {
 // writeDeadLetter — quarantine bucket for un-processable inputs
 // ─────────────────────────────────────────────────────────────────────
 
-export type DeadLetterBucket = 'updates' | 'webhook'
+export type DeadLetterBucket = 'updates' | 'webhook' | 'outbound'
 
 /**
  * Wrap a value as `{ ts, bucket, value }` and write it to the bucket's
@@ -131,7 +132,12 @@ export function writeDeadLetter(
   value: unknown,
 ): string {
   const ts = new Date().toISOString()
-  const dir = bucket === 'updates' ? paths.deadLetterUpdates : paths.deadLetterWebhook
+  const dir =
+    bucket === 'updates'
+      ? paths.deadLetterUpdates
+      : bucket === 'webhook'
+        ? paths.deadLetterWebhook
+        : paths.deadLetterOutbound
   const safeTs = ts.replace(/[:.]/g, '-')
   const rand = Math.random().toString(36).slice(2, 8)
   const file = join(dir, `${safeTs}-${process.pid}-${rand}.json`)

--- a/plugin/src/state/store.ts
+++ b/plugin/src/state/store.ts
@@ -20,6 +20,7 @@ import {
   fsyncSync,
   mkdirSync,
   openSync,
+  readdirSync,
   readFileSync,
   renameSync,
   unlinkSync,
@@ -118,13 +119,29 @@ export function migrateLegacyAllowlist(paths: StatePaths): boolean {
 
 export type DeadLetterBucket = 'updates' | 'webhook' | 'outbound'
 
+// Cap for the `outbound` bucket (fix-loop-1 #7b): a persistent delivery
+// problem (bot blocked, network flap) would otherwise grow the quarantine
+// without bound. Newest 50 kept; older pruned on write (the pattern of the
+// autonomy store's corrupt-evidence prune). Inbound buckets are NOT capped —
+// their volume is operator-triaged and historically tiny.
+const MAX_OUTBOUND_DEAD_LETTERS = 50
+
+// Per-process monotonic sequence baked into dead-letter filenames so a
+// lexicographic sort is chronological even for several writes within the SAME
+// millisecond (mirrors the autonomy store's corrupt-evidence seq — a random
+// tie-breaker would let the prune delete the newest record of a same-ms burst).
+let deadLetterSeq = 0
+
 /**
  * Wrap a value as `{ ts, bucket, value }` and write it to the bucket's
  * directory under a timestamped filename. Returns the full file path.
  *
- * Filename format: `<isoTs>-<pid>-<rand>.json` — ISO timestamp first so
- * `ls` sorts chronologically; pid + rand for collision-resistance under
- * concurrent writes.
+ * Filename format: `<isoTs>-<pid>-<seq>-<rand>.json` — ISO timestamp first so
+ * `ls` sorts chronologically; the zero-padded per-process seq orders same-ms
+ * writes; pid + rand for collision-resistance across processes/restarts.
+ *
+ * The `outbound` bucket is capped at MAX_OUTBOUND_DEAD_LETTERS: after each
+ * write the oldest surplus records are pruned (best-effort).
  */
 export function writeDeadLetter(
   paths: StatePaths,
@@ -139,9 +156,33 @@ export function writeDeadLetter(
         ? paths.deadLetterWebhook
         : paths.deadLetterOutbound
   const safeTs = ts.replace(/[:.]/g, '-')
+  const seq = (deadLetterSeq++).toString(36).padStart(4, '0')
   const rand = Math.random().toString(36).slice(2, 8)
-  const file = join(dir, `${safeTs}-${process.pid}-${rand}.json`)
+  const file = join(dir, `${safeTs}-${process.pid}-${seq}-${rand}.json`)
   const payload = JSON.stringify({ ts, bucket, value }, null, 2)
   writeFileSync(file, payload, { mode: 0o600 })
+  if (bucket === 'outbound') pruneOutboundDeadLetters(dir)
   return file
+}
+
+// Best-effort oldest-first prune of the outbound bucket. Lexicographic sort of
+// the timestamp-seq filenames IS chronological (see writeDeadLetter docstring);
+// every step is allowed to fail — pruning must never break the write path.
+function pruneOutboundDeadLetters(dir: string): void {
+  try {
+    const files = readdirSync(dir)
+      .filter((f) => f.endsWith('.json'))
+      .sort()
+    while (files.length > MAX_OUTBOUND_DEAD_LETTERS) {
+      const oldest = files.shift()
+      if (oldest === undefined) break
+      try {
+        unlinkSync(join(dir, oldest))
+      } catch {
+        // best-effort
+      }
+    }
+  } catch {
+    // best-effort — a readdir failure must not fail the dead-letter write
+  }
 }

--- a/plugin/src/status/context-hud.ts
+++ b/plugin/src/status/context-hud.ts
@@ -355,6 +355,11 @@ export class ContextHud {
   // bump() debounce per chat — a burst of inbound messages collapses to one
   // delete+resend (same rationale as TmuxMirror.BUMP_DEBOUNCE_MS).
   private readonly lastBumpAt = new Map<string, number>()
+  // M4 heartbeat: an ephemeral no-ping «работаю: …» suffix appended to the pin
+  // while the owner has heard nothing for >25 min. Set/cleared by the
+  // HeartbeatMonitor via setHeartbeatSuffix; rendered as a tail line so pin
+  // edits (which don't ping) keep the owner reassured without a message.
+  private readonly heartbeatSuffix = new Map<string, string>()
   // FIX-9 (both reviews): per-chat serialization. A concurrent SessionStart +
   // Stop (both firing before the first send persists an id) would each see an
   // empty cache and sendFresh → TWO pinned HUDs. Chaining every HUD operation
@@ -440,6 +445,8 @@ export class ContextHud {
       // «НЕ СВЕРЕНО» view for the new session immediately after.
       this.reconciled.delete(chatId)
       this.lastReconciledRender.delete(chatId)
+      // M4: a stale heartbeat suffix must not leak into the new session's pin.
+      this.heartbeatSuffix.delete(chatId)
     }
     // Compact / resume / first-ever start (same or unknown id) preserve the
     // snapshot. Track the latest known id for the next comparison. A resume
@@ -581,6 +588,25 @@ export class ContextHud {
     const renderKey = `${view.sessionId}|${renderStatusTasks(view.todos, view.freshness)}`
     if (this.lastReconciledRender.get(chatId) === renderKey) return Promise.resolve()
     this.lastReconciledRender.set(chatId, renderKey)
+    return this.updateNow(chatId)
+  }
+
+  // M4 heartbeat pin suffix. Store (or clear with null) the ephemeral
+  // «работаю: <task> · HH:MM» line and refresh the pin in place. Pin edits do
+  // NOT ping, so this reassures the owner during long silent work without a
+  // message. Best-effort + serialized like every other HUD op; owner-gated.
+  // Idempotent: an unchanged suffix still calls updateNow, whose edit no-ops on
+  // Telegram's «not modified» (benign) — the HeartbeatMonitor only re-sets the
+  // suffix when the minute (HH:MM) changes, so real edits stay ~1/min.
+  setHeartbeatSuffix(chatId: string, suffix: string | null): Promise<void> {
+    if (!this.enabled || !this.isOwner(chatId)) return Promise.resolve()
+    if (suffix === null || suffix.length === 0) {
+      if (!this.heartbeatSuffix.has(chatId)) return Promise.resolve() // already clear — no churn
+      this.heartbeatSuffix.delete(chatId)
+    } else {
+      if (this.heartbeatSuffix.get(chatId) === suffix) return Promise.resolve() // unchanged — no churn
+      this.heartbeatSuffix.set(chatId, suffix)
+    }
     return this.updateNow(chatId)
   }
 
@@ -740,7 +766,14 @@ export class ContextHud {
       })
       autonomyLine = undefined
     }
-    return renderHud(usage, windowTokens, model, work, autonomyLine)
+    const rendered = renderHud(usage, windowTokens, model, work, autonomyLine)
+    // M4 heartbeat suffix (append last so it is always the final line). Escaped
+    // for the card's HTML parse mode — the task text is user/tool-supplied.
+    const suffix = this.heartbeatSuffix.get(chatId)
+    if (suffix !== undefined && suffix.length > 0) {
+      return { text: `${rendered.text}\n<i>${escapeHtml(suffix)}</i>`, keyboard: rendered.keyboard }
+    }
+    return rendered
   }
 
   // Resolve the HUD message id for a chat: in-memory cache → persisted file →

--- a/plugin/src/status/context-hud.ts
+++ b/plugin/src/status/context-hud.ts
@@ -592,14 +592,27 @@ export class ContextHud {
   }
 
   // M4 heartbeat pin suffix. Store (or clear with null) the ephemeral
-  // «работаю: <task> · HH:MM» line and refresh the pin in place. Pin edits do
+  // «работаю: <task> · HH:MM» line and refresh the pin IN PLACE. Pin edits do
   // NOT ping, so this reassures the owner during long silent work without a
   // message. Best-effort + serialized like every other HUD op; owner-gated.
-  // Idempotent: an unchanged suffix still calls updateNow, whose edit no-ops on
-  // Telegram's «not modified» (benign) — the HeartbeatMonitor only re-sets the
-  // suffix when the minute (HH:MM) changes, so real edits stay ~1/min.
+  //
+  // EDIT-ONLY (fix-loop-1 #6): the heartbeat may only EDIT an existing pin.
+  // When no pin message exists — or the edit reports message_gone — the
+  // heartbeat is SKIPPED entirely: it must never create (and thereby surface)
+  // a fresh message on its own, and it must never route through updateNow,
+  // whose self-heal would send one. Creation stays the exclusive job of the
+  // session-lifecycle paths (onSessionStart / updateNow / bump).
+  //
+  // Idempotent: an unchanged suffix short-circuits; the HeartbeatMonitor only
+  // re-sets the suffix when the minute (HH:MM) changes, so edits stay ~1/min.
   setHeartbeatSuffix(chatId: string, suffix: string | null): Promise<void> {
     if (!this.enabled || !this.isOwner(chatId)) return Promise.resolve()
+    // No pin to edit → skip (and drop any stale suffix so a later lifecycle
+    // render can't resurrect it).
+    if (this.messageIds.get(chatId) === undefined && this.loadPersisted(chatId) === undefined) {
+      this.heartbeatSuffix.delete(chatId)
+      return Promise.resolve()
+    }
     if (suffix === null || suffix.length === 0) {
       if (!this.heartbeatSuffix.has(chatId)) return Promise.resolve() // already clear — no churn
       this.heartbeatSuffix.delete(chatId)
@@ -607,7 +620,40 @@ export class ContextHud {
       if (this.heartbeatSuffix.get(chatId) === suffix) return Promise.resolve() // unchanged — no churn
       this.heartbeatSuffix.set(chatId, suffix)
     }
-    return this.updateNow(chatId)
+    return this.runSerialized(chatId, async () => {
+      try {
+        const id = this.messageIds.get(chatId) ?? this.loadPersisted(chatId)
+        if (id === undefined) return // raced away (bump deleted it) — skip
+        this.messageIds.set(chatId, id)
+        const { text, keyboard } = await this.renderCurrent(chatId)
+        try {
+          await this.api.editMessageText(chatId, id, text, {
+            parse_mode: 'HTML',
+            reply_markup: keyboard,
+          })
+        } catch (err) {
+          const cls = classifyEditError(err)
+          if (cls.kind === 'benign') return
+          if (cls.kind === 'message_gone') {
+            // The pin was deleted. Unlike edit()'s self-heal, the heartbeat
+            // path must NOT recreate — drop the stale ids and stand down.
+            this.messageIds.delete(chatId)
+            this.clearPersisted(chatId)
+            this.heartbeatSuffix.delete(chatId)
+            return
+          }
+          this.log.warn('context hud heartbeat edit failed (ignored)', {
+            chat_id: chatId,
+            kind: cls.kind,
+          })
+        }
+      } catch (err) {
+        this.log.warn('context hud setHeartbeatSuffix failed (ignored)', {
+          chat_id: chatId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    })
   }
 
   // Re-anchor the pinned card at the BOTTOM of the chat (just above the tmux

--- a/plugin/src/status/heartbeat-monitor.ts
+++ b/plugin/src/status/heartbeat-monitor.ts
@@ -1,0 +1,338 @@
+// HeartbeatMonitor — mechanical liveness for the owner channel (M4, 2026-07-10
+// communication audit). Three failure modes the audit surfaced become
+// automatic, so the owner stops having to ask «Статус?»:
+//
+//   1. HEARTBEAT — during an active turn, when the owner has heard nothing for
+//      >25 min, append a no-ping «работаю: <task> · HH:MM» suffix to the
+//      context pin; past >60 min send ONE real message «Работаю дольше часа без
+//      отчёта: <task>. Продолжаю.» (rate-limited to ~one per hour per turn).
+//   2. DEAD-MAN — during an active turn, when the tmux pane hash has not
+//      changed for >10 min (a likely OOM / hang) and no Stop arrived, send ONE
+//      alert «Сессия молчит >10 мин при активном ходе — возможно OOM/зависание».
+//   3. OPEN-QUESTION REMINDER — when a question to the owner crosses 2h unanswered
+//      send ONE reminder naming the default; a sticky (security) question is
+//      instead re-reminded at most every 6h. This only REMINDS — bypassing an
+//      open question is the agent's own protocol action, never taken here.
+//
+// Architectural invariants (binding, from the M4 brief):
+//   • This path NEVER reads or touches lease TTLs / scope — it only reads open
+//     QUESTIONS, read-only via loadAutonomyState (no writer lock taken).
+//   • Best-effort + isolated: every public method swallows its own errors and
+//     every send/pin callback is fire-and-forget with `.catch`, so a failure
+//     here can NEVER break normal reply delivery.
+//   • The pane hash + capture are supplied by the caller (TaskRealityMirror,
+//     the single pane-capture owner) — this module adds NO second capture path.
+//
+// State is in-memory only. Persistence is deliberately omitted: after a plugin
+// restart a 2h reminder or a heartbeat may re-fire once — an acceptable
+// duplicate, and the safe direction (a redundant nudge, never a missed one).
+
+import { createHash } from 'node:crypto'
+
+import type { Logger } from '../log.js'
+import type { AutonomyPaths } from '../autonomy/store.js'
+import { loadAutonomyState, openQuestions, questionAgeMs } from '../autonomy/store.js'
+import { formatUtcHm } from './task-freshness.js'
+
+// The narrow surface TaskRealityMirror drives. Kept as an interface so the
+// mirror depends on a stub in tests and never imports the concrete class.
+export interface LivenessMonitor {
+  /** Feed one pane capture (raw text) taken during an active/idle session. */
+  observePane(chatId: string, paneText: string, nowMs: number, turnActive: boolean): void
+  /** Per-tick evaluation of the heartbeat + open-question reminders. */
+  evaluate(
+    chatId: string,
+    ctx: { turnActive: boolean; inProgressTask: string | null; nowMs: number },
+  ): void
+  /** A turn ended (Stop) — clear the pin suffix + reset the per-turn budget. */
+  onTurnEnd(chatId: string): void
+  /** The chat's session is gone (SessionEnd / TTL evict) — drop all state. */
+  onChatGone(chatId: string): void
+}
+
+const DEFAULTS = {
+  pinAfterMs: 25 * 60 * 1000,
+  messageAfterMs: 60 * 60 * 1000,
+  messageMinIntervalMs: 60 * 60 * 1000,
+  deadmanMs: 10 * 60 * 1000,
+  questionReminderMs: 2 * 60 * 60 * 1000,
+  stickyReminderMs: 6 * 60 * 60 * 1000,
+} as const
+
+const TASK_LABEL_MAX = 80
+
+export interface HeartbeatMonitorOptions {
+  log: Logger
+  /** Send a real (pinging) message — server wires the rate-limited/reliable api. */
+  send: (chatId: string, text: string) => Promise<void>
+  /** Set/clear the no-ping pin suffix — server wires ContextHud.setHeartbeatSuffix. */
+  pinHeartbeat?: (chatId: string, suffix: string | null) => void | Promise<void>
+  /** Read-only autonomy state root (for open questions). */
+  autonomyPaths: AutonomyPaths
+  /** How long since the owner last heard from us (OutboundActivityTracker). */
+  lastOutboundAt: (chatId: string) => number | undefined
+  /** Owner-chat gate. Defaults to always-true (the mirror already gates). */
+  isOwnerChat?: (chatId: string) => boolean
+  now?: () => number
+  // Thresholds — overridable for deterministic tests.
+  pinAfterMs?: number
+  messageAfterMs?: number
+  messageMinIntervalMs?: number
+  deadmanMs?: number
+  questionReminderMs?: number
+  stickyReminderMs?: number
+}
+
+interface ChatHb {
+  // ── dead-man ──
+  lastPaneHash?: string
+  paneChangedAtMs: number
+  deadmanAlerted: boolean
+  // ── heartbeat ──
+  pinSuffixActive: boolean
+  lastHeartbeatMsgAtMs: number
+  // ── question reminders ── key `${questionId}:2h` | `${questionId}:sticky` → last sent ms
+  questionReminders: Map<string, number>
+}
+
+function truncate(s: string, maxCps: number): string {
+  const cps = Array.from(s)
+  if (cps.length <= maxCps) return s
+  return `${cps.slice(0, Math.max(0, maxCps - 1)).join('')}…`
+}
+
+function taskLabel(task: string | null): string {
+  const t = task !== null ? task.trim() : ''
+  return t.length > 0 ? truncate(t, TASK_LABEL_MAX) : '(задача не указана)'
+}
+
+export class HeartbeatMonitor implements LivenessMonitor {
+  private readonly log: Logger
+  private readonly send: (chatId: string, text: string) => Promise<void>
+  private readonly pinHeartbeat?: (chatId: string, suffix: string | null) => void | Promise<void>
+  private readonly autonomyPaths: AutonomyPaths
+  private readonly lastOutboundAt: (chatId: string) => number | undefined
+  private readonly isOwnerChat: (chatId: string) => boolean
+  private readonly now: () => number
+  private readonly pinAfterMs: number
+  private readonly messageAfterMs: number
+  private readonly messageMinIntervalMs: number
+  private readonly deadmanMs: number
+  private readonly questionReminderMs: number
+  private readonly stickyReminderMs: number
+  private readonly recs = new Map<string, ChatHb>()
+
+  constructor(opts: HeartbeatMonitorOptions) {
+    this.log = opts.log
+    this.send = opts.send
+    if (opts.pinHeartbeat !== undefined) this.pinHeartbeat = opts.pinHeartbeat
+    this.autonomyPaths = opts.autonomyPaths
+    this.lastOutboundAt = opts.lastOutboundAt
+    this.isOwnerChat = opts.isOwnerChat ?? ((): boolean => true)
+    this.now = opts.now ?? ((): number => Date.now())
+    this.pinAfterMs = opts.pinAfterMs ?? DEFAULTS.pinAfterMs
+    this.messageAfterMs = opts.messageAfterMs ?? DEFAULTS.messageAfterMs
+    this.messageMinIntervalMs = opts.messageMinIntervalMs ?? DEFAULTS.messageMinIntervalMs
+    this.deadmanMs = opts.deadmanMs ?? DEFAULTS.deadmanMs
+    this.questionReminderMs = opts.questionReminderMs ?? DEFAULTS.questionReminderMs
+    this.stickyReminderMs = opts.stickyReminderMs ?? DEFAULTS.stickyReminderMs
+  }
+
+  private rec(chatId: string): ChatHb {
+    let r = this.recs.get(chatId)
+    if (r === undefined) {
+      r = {
+        paneChangedAtMs: this.now(),
+        deadmanAlerted: false,
+        pinSuffixActive: false,
+        lastHeartbeatMsgAtMs: Number.NEGATIVE_INFINITY,
+        questionReminders: new Map(),
+      }
+      this.recs.set(chatId, r)
+    }
+    return r
+  }
+
+  observePane(chatId: string, paneText: string, nowMs: number, turnActive: boolean): void {
+    if (!this.isOwnerChat(chatId)) return
+    try {
+      const rec = this.rec(chatId)
+      const hash = createHash('sha256').update(paneText, 'utf8').digest('hex')
+      // Idle (no active turn): keep the baseline fresh so the dead-man clock
+      // only ever accumulates across a CONTINUOUSLY active turn with a frozen
+      // pane — an idle gap between turns must not count as a hang.
+      if (!turnActive) {
+        rec.lastPaneHash = hash
+        rec.paneChangedAtMs = nowMs
+        rec.deadmanAlerted = false
+        return
+      }
+      if (rec.lastPaneHash !== hash) {
+        rec.lastPaneHash = hash
+        rec.paneChangedAtMs = nowMs
+        rec.deadmanAlerted = false
+        return
+      }
+      // Unchanged AND a turn is active: candidate hang.
+      if (rec.deadmanAlerted) return
+      if (nowMs - rec.paneChangedAtMs > this.deadmanMs) {
+        rec.deadmanAlerted = true // once per incident; reset on pane change / turn end
+        this.fireSend(
+          chatId,
+          'Сессия молчит >10 мин при активном ходе — возможно OOM/зависание',
+        )
+      }
+    } catch (err) {
+      this.warn('observePane', chatId, err)
+    }
+  }
+
+  evaluate(
+    chatId: string,
+    ctx: { turnActive: boolean; inProgressTask: string | null; nowMs: number },
+  ): void {
+    if (!this.isOwnerChat(chatId)) return
+    try {
+      const rec = this.rec(chatId)
+      if (ctx.turnActive) {
+        this.evaluateHeartbeat(chatId, rec, ctx.inProgressTask, ctx.nowMs)
+      } else {
+        this.clearPin(chatId, rec)
+      }
+      // Reminders are independent of turnActive — an unanswered question must
+      // be chased even between turns.
+      this.remindQuestions(chatId, rec, ctx.nowMs)
+    } catch (err) {
+      this.warn('evaluate', chatId, err)
+    }
+  }
+
+  onTurnEnd(chatId: string): void {
+    try {
+      const rec = this.recs.get(chatId)
+      if (rec === undefined) return
+      this.clearPin(chatId, rec)
+      // A fresh turn gets a fresh per-turn heartbeat-message budget and a fresh
+      // dead-man incident.
+      rec.lastHeartbeatMsgAtMs = Number.NEGATIVE_INFINITY
+      rec.deadmanAlerted = false
+      rec.paneChangedAtMs = this.now()
+    } catch (err) {
+      this.warn('onTurnEnd', chatId, err)
+    }
+  }
+
+  onChatGone(chatId: string): void {
+    this.recs.delete(chatId)
+  }
+
+  // ─── internals ───────────────────────────────────────────────────────
+
+  private evaluateHeartbeat(
+    chatId: string,
+    rec: ChatHb,
+    inProgressTask: string | null,
+    nowMs: number,
+  ): void {
+    const last = this.lastOutboundAt(chatId)
+    // No outbound baseline yet (nothing ever sent this process) — we cannot
+    // measure silence, so do nothing (the safe direction).
+    if (last === undefined) {
+      this.clearPin(chatId, rec)
+      return
+    }
+    const silence = nowMs - last
+    if (
+      silence >= this.messageAfterMs &&
+      nowMs - rec.lastHeartbeatMsgAtMs >= this.messageMinIntervalMs
+    ) {
+      rec.lastHeartbeatMsgAtMs = nowMs
+      // A real message supersedes the pin suffix.
+      this.clearPin(chatId, rec)
+      this.fireSend(
+        chatId,
+        `Работаю дольше часа без отчёта: ${taskLabel(inProgressTask)}. Продолжаю.`,
+      )
+      return
+    }
+    if (silence >= this.pinAfterMs) {
+      const suffix = `работаю: ${taskLabel(inProgressTask)} · ${formatUtcHm(nowMs)}`
+      rec.pinSuffixActive = true
+      this.firePin(chatId, suffix)
+      return
+    }
+    // Silence back under 25 min (owner replied / heartbeat fired) — drop any
+    // stale pin suffix.
+    this.clearPin(chatId, rec)
+  }
+
+  private remindQuestions(chatId: string, rec: ChatHb, nowMs: number): void {
+    let state
+    try {
+      // READ-ONLY — no writer lock (the heartbeat path must never mutate the
+      // registry). Best-effort: a broken registry degrades to no reminders.
+      state = loadAutonomyState(this.autonomyPaths, chatId, this.log)
+    } catch (err) {
+      this.warn('remindQuestions.load', chatId, err)
+      return
+    }
+    const questions = openQuestions(state)
+    const liveKeys = new Set<string>()
+    for (const q of questions) {
+      const age = questionAgeMs(q, nowMs)
+      if (q.sticky === true) {
+        const key = `${q.id}:sticky`
+        liveKeys.add(key)
+        if (age < this.stickyReminderMs) continue
+        const prev = rec.questionReminders.get(key)
+        if (prev === undefined || nowMs - prev >= this.stickyReminderMs) {
+          rec.questionReminders.set(key, nowMs)
+          this.fireSend(chatId, `Security-вопрос всё ещё без ответа: "${q.summary}"`)
+        }
+      } else {
+        const key = `${q.id}:2h`
+        liveKeys.add(key)
+        if (age < this.questionReminderMs) continue
+        if (rec.questionReminders.has(key)) continue // ONE 2h reminder per question
+        rec.questionReminders.set(key, nowMs)
+        const tail =
+          q.defaultAction !== undefined
+            ? `Беру дефолт: ${q.defaultAction}. Скажи стоп, если против.`
+            : 'Жду или беру безопасный дефолт по ситуации.'
+        this.fireSend(chatId, `Вопрос без ответа 2ч: "${q.summary}". ${tail}`)
+      }
+    }
+    // Forget reminder bookkeeping for questions that are no longer open, so the
+    // map cannot grow without bound across a long-lived session.
+    for (const key of [...rec.questionReminders.keys()]) {
+      if (!liveKeys.has(key)) rec.questionReminders.delete(key)
+    }
+  }
+
+  private clearPin(chatId: string, rec: ChatHb): void {
+    if (!rec.pinSuffixActive) return
+    rec.pinSuffixActive = false
+    this.firePin(chatId, null)
+  }
+
+  private firePin(chatId: string, suffix: string | null): void {
+    if (this.pinHeartbeat === undefined) return
+    try {
+      const r = this.pinHeartbeat(chatId, suffix)
+      if (r instanceof Promise) r.catch((err: unknown) => this.warn('pinHeartbeat', chatId, err))
+    } catch (err) {
+      this.warn('pinHeartbeat', chatId, err)
+    }
+  }
+
+  private fireSend(chatId: string, text: string): void {
+    this.send(chatId, text).catch((err: unknown) => this.warn('send', chatId, err))
+  }
+
+  private warn(where: string, chatId: string, err: unknown): void {
+    this.log.warn(`heartbeat monitor ${where} failed (ignored)`, {
+      chat_id: chatId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}

--- a/plugin/src/status/heartbeat-monitor.ts
+++ b/plugin/src/status/heartbeat-monitor.ts
@@ -5,10 +5,15 @@
 //   1. HEARTBEAT — during an active turn, when the owner has heard nothing for
 //      >25 min, append a no-ping «работаю: <task> · HH:MM» suffix to the
 //      context pin; past >60 min send ONE real message «Работаю дольше часа без
-//      отчёта: <task>. Продолжаю.» (rate-limited to ~one per hour per turn).
+//      отчёта: <task>. Продолжаю.» — rate-limited to at most one per hour PER
+//      CHAT, persistent across turns within the process (fix-loop-1 #3: a
+//      per-turn budget would let back-to-back turns each fire a message
+//      minutes apart). When no outbound record exists yet (fresh process /
+//      first turn), the silence window is SEEDED from the first evaluate of an
+//      active turn (fix-loop-1 #4) — a restart never disables the heartbeat.
 //   2. DEAD-MAN — during an active turn, when the tmux pane hash has not
-//      changed for >10 min (a likely OOM / hang) and no Stop arrived, send ONE
-//      alert «Сессия молчит >10 мин при активном ходе — возможно OOM/зависание».
+//      changed for >10 min and no Stop arrived, send ONE alert (possible
+//      OOM/hang — or an unanswered confirmation card; the text says both).
 //   3. OPEN-QUESTION REMINDER — when a question to the owner crosses 2h unanswered
 //      send ONE reminder naming the default; a sticky (security) question is
 //      instead re-reminded at most every 6h. This only REMINDS — bypassing an
@@ -22,10 +27,18 @@
 //     here can NEVER break normal reply delivery.
 //   • The pane hash + capture are supplied by the caller (TaskRealityMirror,
 //     the single pane-capture owner) — this module adds NO second capture path.
+//   • Heartbeat/reminder sends go out with `skipOutboundStamp` (wired in
+//     server.ts) so a nudge never counts as «the owner heard a real report».
 //
-// State is in-memory only. Persistence is deliberately omitted: after a plugin
-// restart a 2h reminder or a heartbeat may re-fire once — an acceptable
-// duplicate, and the safe direction (a redundant nudge, never a missed one).
+// State is in-memory only; persistence is deliberately omitted. Restart
+// semantics (fix-loop-1 #8): on the FIRST evaluation of a chat, reminder
+// bookkeeping is SEEDED to «now» for every already-open question — a restart
+// therefore never fires a burst of immediate 2h/6h reminders; each pre-restart
+// question re-arms a FRESH full window and reminds only on its next threshold
+// crossing (a question that already reminded before the restart may remind at
+// most once more, one full window later). The heartbeat silence window resets
+// the same way (seeded from the first active evaluate) — a delayed nudge, never
+// a spurious immediate one.
 
 import { createHash } from 'node:crypto'
 
@@ -44,7 +57,9 @@ export interface LivenessMonitor {
     chatId: string,
     ctx: { turnActive: boolean; inProgressTask: string | null; nowMs: number },
   ): void
-  /** A turn ended (Stop) — clear the pin suffix + reset the per-turn budget. */
+  /** A turn ended (Stop) — clear the pin suffix + reset the dead-man incident.
+   *  The hourly heartbeat-message budget deliberately SURVIVES turn ends
+   *  (fix-loop-1 #3). */
   onTurnEnd(chatId: string): void
   /** The chat's session is gone (SessionEnd / TTL evict) — drop all state. */
   onChatGone(chatId: string): void
@@ -83,6 +98,13 @@ export interface HeartbeatMonitorOptions {
   stickyReminderMs?: number
 }
 
+// Per-question reminder bookkeeping: `at` = the window anchor (seed time or
+// last reminder time), `fired` = the one-shot 2h reminder already went out.
+interface ReminderEntry {
+  at: number
+  fired: boolean
+}
+
 interface ChatHb {
   // ── dead-man ──
   lastPaneHash?: string
@@ -90,9 +112,18 @@ interface ChatHb {
   deadmanAlerted: boolean
   // ── heartbeat ──
   pinSuffixActive: boolean
+  // Per-CHAT hourly budget — survives turn ends (fix-loop-1 #3); dropped only
+  // with the whole rec (onChatGone).
   lastHeartbeatMsgAtMs: number
-  // ── question reminders ── key `${questionId}:2h` | `${questionId}:sticky` → last sent ms
-  questionReminders: Map<string, number>
+  // Fallback silence anchor when no outbound record exists yet (fix-loop-1
+  // #4): set on the first evaluate of an active turn, so the 25/60-min
+  // thresholds still fire after a restart / before the first real report.
+  silenceBaselineMs?: number
+  // ── question reminders ── key `${questionId}:2h` | `${questionId}:sticky`
+  questionReminders: Map<string, ReminderEntry>
+  // First remindQuestions run for this chat seeds entries for every
+  // already-open question (fix-loop-1 #8) — restart burst protection.
+  remindersSeeded: boolean
 }
 
 function truncate(s: string, maxCps: number): string {
@@ -138,15 +169,19 @@ export class HeartbeatMonitor implements LivenessMonitor {
     this.stickyReminderMs = opts.stickyReminderMs ?? DEFAULTS.stickyReminderMs
   }
 
-  private rec(chatId: string): ChatHb {
+  // `nowMs` is the CALLER's clock reading (fix-loop-1 #9) — every entry point
+  // already carries one; mixing in this.now() here could stamp a baseline
+  // ahead of / behind the timestamps the same call then compares against.
+  private rec(chatId: string, nowMs: number): ChatHb {
     let r = this.recs.get(chatId)
     if (r === undefined) {
       r = {
-        paneChangedAtMs: this.now(),
+        paneChangedAtMs: nowMs,
         deadmanAlerted: false,
         pinSuffixActive: false,
         lastHeartbeatMsgAtMs: Number.NEGATIVE_INFINITY,
         questionReminders: new Map(),
+        remindersSeeded: false,
       }
       this.recs.set(chatId, r)
     }
@@ -156,7 +191,7 @@ export class HeartbeatMonitor implements LivenessMonitor {
   observePane(chatId: string, paneText: string, nowMs: number, turnActive: boolean): void {
     if (!this.isOwnerChat(chatId)) return
     try {
-      const rec = this.rec(chatId)
+      const rec = this.rec(chatId, nowMs)
       const hash = createHash('sha256').update(paneText, 'utf8').digest('hex')
       // Idle (no active turn): keep the baseline fresh so the dead-man clock
       // only ever accumulates across a CONTINUOUSLY active turn with a frozen
@@ -179,7 +214,7 @@ export class HeartbeatMonitor implements LivenessMonitor {
         rec.deadmanAlerted = true // once per incident; reset on pane change / turn end
         this.fireSend(
           chatId,
-          'Сессия молчит >10 мин при активном ходе — возможно OOM/зависание',
+          'Сессия молчит >10 мин при активном ходе — возможно OOM/зависание или жду подтверждения (карточка/гейт)',
         )
       }
     } catch (err) {
@@ -193,7 +228,7 @@ export class HeartbeatMonitor implements LivenessMonitor {
   ): void {
     if (!this.isOwnerChat(chatId)) return
     try {
-      const rec = this.rec(chatId)
+      const rec = this.rec(chatId, ctx.nowMs)
       if (ctx.turnActive) {
         this.evaluateHeartbeat(chatId, rec, ctx.inProgressTask, ctx.nowMs)
       } else {
@@ -212,9 +247,11 @@ export class HeartbeatMonitor implements LivenessMonitor {
       const rec = this.recs.get(chatId)
       if (rec === undefined) return
       this.clearPin(chatId, rec)
-      // A fresh turn gets a fresh per-turn heartbeat-message budget and a fresh
-      // dead-man incident.
-      rec.lastHeartbeatMsgAtMs = Number.NEGATIVE_INFINITY
+      // A fresh turn gets a fresh dead-man incident. The hourly heartbeat
+      // MESSAGE budget deliberately does NOT reset here (fix-loop-1 #3): the
+      // limiter is per chat and persistent across turns within the process,
+      // otherwise back-to-back turns could each fire a «работаю дольше часа»
+      // message minutes apart.
       rec.deadmanAlerted = false
       rec.paneChangedAtMs = this.now()
     } catch (err) {
@@ -235,13 +272,18 @@ export class HeartbeatMonitor implements LivenessMonitor {
     nowMs: number,
   ): void {
     const last = this.lastOutboundAt(chatId)
-    // No outbound baseline yet (nothing ever sent this process) — we cannot
-    // measure silence, so do nothing (the safe direction).
-    if (last === undefined) {
-      this.clearPin(chatId, rec)
-      return
+    // No outbound record yet (fresh process / first turn) — seed the silence
+    // window from THIS first evaluate of an active turn (fix-loop-1 #4).
+    // Pre-fix the heartbeat was silently disabled forever until the first
+    // real send; now a restart merely delays the nudge by a full window.
+    let anchor: number
+    if (last !== undefined) {
+      anchor = last
+    } else {
+      if (rec.silenceBaselineMs === undefined) rec.silenceBaselineMs = nowMs
+      anchor = rec.silenceBaselineMs
     }
-    const silence = nowMs - last
+    const silence = nowMs - anchor
     if (
       silence >= this.messageAfterMs &&
       nowMs - rec.lastHeartbeatMsgAtMs >= this.messageMinIntervalMs
@@ -277,24 +319,45 @@ export class HeartbeatMonitor implements LivenessMonitor {
       return
     }
     const questions = openQuestions(state)
+    // Restart-burst protection (fix-loop-1 #8): the FIRST reminder pass for a
+    // chat only SEEDS bookkeeping for every already-open question — each
+    // re-arms a fresh full window anchored at «now» and reminds on its NEXT
+    // threshold crossing, never immediately. Questions opened after this pass
+    // get no entry and fire on their normal age-based threshold.
+    if (!rec.remindersSeeded) {
+      rec.remindersSeeded = true
+      for (const q of questions) {
+        const key = q.sticky === true ? `${q.id}:sticky` : `${q.id}:2h`
+        rec.questionReminders.set(key, { at: nowMs, fired: false })
+      }
+    }
     const liveKeys = new Set<string>()
     for (const q of questions) {
       const age = questionAgeMs(q, nowMs)
       if (q.sticky === true) {
         const key = `${q.id}:sticky`
         liveKeys.add(key)
-        if (age < this.stickyReminderMs) continue
-        const prev = rec.questionReminders.get(key)
-        if (prev === undefined || nowMs - prev >= this.stickyReminderMs) {
-          rec.questionReminders.set(key, nowMs)
-          this.fireSend(chatId, `Security-вопрос всё ещё без ответа: "${q.summary}"`)
-        }
+        const entry = rec.questionReminders.get(key)
+        // Cadence anchor: the seed / last reminder when present, else the
+        // question's own age. At most one reminder per stickyReminderMs.
+        const due =
+          entry !== undefined
+            ? nowMs - entry.at >= this.stickyReminderMs
+            : age >= this.stickyReminderMs
+        if (!due) continue
+        rec.questionReminders.set(key, { at: nowMs, fired: true })
+        this.fireSend(chatId, `Security-вопрос всё ещё без ответа: "${q.summary}"`)
       } else {
         const key = `${q.id}:2h`
         liveKeys.add(key)
-        if (age < this.questionReminderMs) continue
-        if (rec.questionReminders.has(key)) continue // ONE 2h reminder per question
-        rec.questionReminders.set(key, nowMs)
+        const entry = rec.questionReminders.get(key)
+        if (entry?.fired === true) continue // ONE 2h reminder per question
+        const due =
+          entry !== undefined
+            ? nowMs - entry.at >= this.questionReminderMs // seeded: fresh window
+            : age >= this.questionReminderMs
+        if (!due) continue
+        rec.questionReminders.set(key, { at: nowMs, fired: true })
         const tail =
           q.defaultAction !== undefined
             ? `Беру дефолт: ${q.defaultAction}. Скажи стоп, если против.`
@@ -326,7 +389,13 @@ export class HeartbeatMonitor implements LivenessMonitor {
   }
 
   private fireSend(chatId: string, text: string): void {
-    this.send(chatId, text).catch((err: unknown) => this.warn('send', chatId, err))
+    // Guard BOTH a sync throw and an async rejection from the injected sender
+    // — a broken nudge must never escape into the mirror's capture loop.
+    try {
+      this.send(chatId, text).catch((err: unknown) => this.warn('send', chatId, err))
+    } catch (err) {
+      this.warn('send', chatId, err)
+    }
   }
 
   private warn(where: string, chatId: string, err: unknown): void {

--- a/plugin/src/status/outbound-activity.ts
+++ b/plugin/src/status/outbound-activity.ts
@@ -1,0 +1,46 @@
+// OutboundActivityTracker — the single in-memory record of "when did we last
+// send the owner a NEW message on this chat".
+//
+// Why (2026-07-10 communication audit): the mechanical heartbeat (item 2) and
+// the dead-man alert need one honest answer to "how long has the owner heard
+// nothing?". The reliable-telegram-api wrapper is the choke point every
+// outbound send flows through, so it stamps this tracker on each SUCCESSFUL
+// NEW-message send (sendMessage / sendRichMessage / sendDocument / sendPhoto).
+//
+// Deliberately NOT stamped on editMessageText: an edit does not ping the user
+// and the HUD/task-mirror re-edit their pins every ~20s — counting those as
+// "outbound" would reset the heartbeat window on every tick and it would never
+// fire. Only a fresh message the owner's device could surface counts.
+//
+// In-memory only (persistence not required — a restart resets the window,
+// which is the safe direction: it delays a heartbeat rather than firing a
+// spurious one). No timers, no I/O — a plain Map with a clock-injectable write.
+
+/** Read side consumed by the heartbeat monitor. */
+export interface OutboundActivityReader {
+  /** Epoch-ms of the last new-message send to `chatId`, or undefined if none. */
+  lastOutboundAt(chatId: string): number | undefined
+}
+
+/** Write side consumed by the reliable-telegram-api wrapper. */
+export interface OutboundActivityRecorder {
+  /** Stamp `chatId`'s last-outbound clock. Idempotent, monotonic-latest. */
+  record(chatId: string, atMs: number): void
+}
+
+export class OutboundActivityTracker
+  implements OutboundActivityReader, OutboundActivityRecorder
+{
+  private readonly lastAt = new Map<string, number>()
+
+  record(chatId: string, atMs: number): void {
+    // Monotonic-latest: never move the clock backwards (a late-completing send
+    // must not undo a newer one's stamp).
+    const prev = this.lastAt.get(chatId)
+    if (prev === undefined || atMs > prev) this.lastAt.set(chatId, atMs)
+  }
+
+  lastOutboundAt(chatId: string): number | undefined {
+    return this.lastAt.get(chatId)
+  }
+}

--- a/plugin/src/status/task-reality-mirror.ts
+++ b/plugin/src/status/task-reality-mirror.ts
@@ -63,6 +63,7 @@ import {
   type ToolTaskEvent,
 } from './task-reconciler.js'
 import { formatUtcHm, type TaskFreshness } from './task-freshness.js'
+import type { LivenessMonitor } from './heartbeat-monitor.js'
 
 // ─────────────────────────────────────────────────────────────────────
 // Sink contract — the surfaces the reconciled view is pushed into.
@@ -101,6 +102,11 @@ export interface TaskRealityMirrorOptions {
   ttlMs?: number
   /** Owner-chat gate — the reconciler acts ONLY for owner DM chats. */
   isOwnerChat?: (chatId: string) => boolean
+  /** M4 mechanical liveness (heartbeat + dead-man + open-question reminders).
+   *  Optional and best-effort: when omitted the reconciler behaves exactly as
+   *  before. Fed the pane captures (its dead-man diffs the SAME capture this
+   *  file already runs — no second capture path) and evaluated once per tick. */
+  liveness?: LivenessMonitor
   /** Plugin state dir. When set, the session-epoch state (active + retired
    *  tombstones) is persisted per chat (`task-reality-epoch-<chat>.json`) so a
    *  plugin restart cannot be rolled back by late lifecycle stragglers
@@ -161,6 +167,7 @@ export class TaskRealityMirror {
   private readonly coalesceWindowMs: number
   private readonly ttlMs: number
   private readonly isOwnerChat: (chatId: string) => boolean
+  private readonly liveness: LivenessMonitor | undefined
   private readonly now: () => number
   private readonly setTimer: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>
   private readonly clearTimer: (handle: ReturnType<typeof setTimeout>) => void
@@ -187,6 +194,7 @@ export class TaskRealityMirror {
     this.coalesceWindowMs = opts.coalesceWindowMs ?? DEFAULT_COALESCE_WINDOW_MS
     this.ttlMs = opts.ttlMs ?? DEFAULT_TTL_MS
     this.isOwnerChat = opts.isOwnerChat ?? ((): boolean => true)
+    this.liveness = opts.liveness
     this.stateDir = opts.stateDir
     this.now = opts.now ?? ((): number => Date.now())
     this.setTimer = opts.setTimer ?? ((cb, ms): ReturnType<typeof setTimeout> => setTimeout(cb, ms))
@@ -261,6 +269,9 @@ export class TaskRealityMirror {
       rec.turnActive = false
       rec.lastActivityMs = this.now()
       this.pushView(rec)
+      // M4: the turn ended — clear the heartbeat pin suffix and reset the
+      // per-turn heartbeat/dead-man budget. Best-effort (the monitor swallows).
+      this.liveness?.onTurnEnd(chatId)
     } catch (err) {
       this.warn('onStop', chatId, err)
     }
@@ -413,6 +424,10 @@ export class TaskRealityMirror {
     this.disarm(rec)
     rec.revision += 1
     if (this.recs.get(rec.chatId) === rec) this.recs.delete(rec.chatId)
+    // M4: the session is gone (SessionEnd / hard TTL / shutdown) — drop the
+    // liveness state for this chat so no heartbeat/dead-man fires for a dead
+    // session. Best-effort.
+    this.liveness?.onChatGone(rec.chatId)
   }
 
   // ─── tombstones ──────────────────────────────────────────────────────
@@ -550,6 +565,14 @@ export class TaskRealityMirror {
     // Advance the freshness indicator (minute buckets) even if the capture is
     // async / a no-op; the sinks dedup identical renders.
     this.pushView(rec)
+    // M4: per-tick heartbeat + open-question reminder evaluation. Dead-man is
+    // driven separately from doCapture (it needs the fresh pane hash). Passes
+    // the reconciled in-progress task so a heartbeat names what we're doing.
+    this.liveness?.evaluate(rec.chatId, {
+      turnActive: rec.turnActive,
+      inProgressTask: currentInProgressTask(rec.state),
+      nowMs: this.now(),
+    })
     this.scheduleTick(rec)
   }
 
@@ -585,6 +608,12 @@ export class TaskRealityMirror {
     try {
       const cap = await capturePaneText(this.exec, this.capture)
       if (rec.revision !== rev || rec.ended) return
+      // M4 dead-man: feed the SAME capture to the liveness monitor (no second
+      // capture path). Only meaningful when the pane was actually read (ok);
+      // a failed capture yields no hash to diff. Best-effort.
+      if (this.liveness !== undefined && cap.ok) {
+        this.liveness.observePane(rec.chatId, cap.text, this.now(), rec.turnActive)
+      }
       // Stamp capturedAt NOW — the moment capture-pane returned — so an event
       // landing during the cwd resolution below can never be out-ranked by
       // this (older) pane text (review 2026-07-10 #3).
@@ -754,6 +783,16 @@ export function applyEventToEventMap(map: Map<string, TodoItem>, event: TaskMuta
       applyTaskUpdateToMap(map, event)
       return
   }
+}
+
+/**
+ * The description of the FIRST in-progress reconciled task (what the heartbeat
+ * names as «работаю: …»), or null when nothing is marked in-progress. Uses the
+ * same projection the surfaces render so the label matches the pin exactly.
+ */
+export function currentInProgressTask(state: ReconciledState): string | null {
+  const hit = reconciledToTodos(state).find((t) => t.status === 'in_progress')
+  return hit !== undefined ? hit.content : null
 }
 
 /** Project the reconciled state into the TodoItem list the surfaces render. */

--- a/plugin/tests/channel/permissions.test.ts
+++ b/plugin/tests/channel/permissions.test.ts
@@ -40,6 +40,7 @@ function mkStatePaths(): StatePaths {
     sessionIds: join(root, 'session-ids'),
     deadLetterUpdates: join(root, 'dead-letter', 'updates'),
     deadLetterWebhook: join(root, 'dead-letter', 'webhook'),
+    deadLetterOutbound: join(root, 'dead-letter', 'outbound'),
     logs: {
       server: join(root, 'logs', 'server.log'),
       telegram: join(root, 'logs', 'telegram.log'),

--- a/plugin/tests/channel/tools.guest.test.ts
+++ b/plugin/tests/channel/tools.guest.test.ts
@@ -80,6 +80,7 @@ function makeStatePaths(): StatePaths {
     sessionIds: join(root, 'session-ids'),
     deadLetterUpdates: join(root, 'dead-letter', 'updates'),
     deadLetterWebhook: join(root, 'dead-letter', 'webhook'),
+    deadLetterOutbound: join(root, 'dead-letter', 'outbound'),
     logs: {
       server: join(root, 'logs', 'server.log'),
       telegram: join(root, 'logs', 'telegram.log'),

--- a/plugin/tests/channel/tools.test.ts
+++ b/plugin/tests/channel/tools.test.ts
@@ -112,6 +112,7 @@ function makeStatePaths(): StatePaths {
     sessionIds: join(root, 'session-ids'),
     deadLetterUpdates: join(root, 'dead-letter', 'updates'),
     deadLetterWebhook: join(root, 'dead-letter', 'webhook'),
+    deadLetterOutbound: join(root, 'dead-letter', 'outbound'),
     logs: {
       server: join(root, 'logs', 'server.log'),
       telegram: join(root, 'logs', 'telegram.log'),

--- a/plugin/tests/safety/reliable-telegram-api.test.ts
+++ b/plugin/tests/safety/reliable-telegram-api.test.ts
@@ -1,7 +1,19 @@
 // Tests for createReliableTelegramApi — bounded retry + dead-letter +
-// outbound-activity tracking (M4). A hand-rolled stub raw TelegramApi lets us
-// program failures; an immediate-resolve `sleep` that RECORDS its argument
-// gives deterministic retry-timing assertions with no real waits.
+// outbound-activity tracking (M4, fix-loop 1). A hand-rolled stub raw
+// TelegramApi lets us program failures; an immediate-resolve `sleep` that
+// RECORDS its argument gives deterministic retry-timing assertions with no
+// real waits.
+//
+// Fix-loop-1 policy under test:
+//   • pre_send (conn provably never established) — retried on ALL methods;
+//   • ambiguous (may have reached Telegram) — retried ONLY on the idempotent
+//     editMessageText; non-idempotent sends dead-letter + rethrow at once;
+//   • rate_limited (429) — NEVER retried here (inner layer owns 429s);
+//     immediate dead-letter + rethrow;
+//   • permanent (4xx / unreadable) — no retry, no dead-letter;
+//   • «message is not modified» on edit — normalized to success;
+//   • skipOutboundStamp — send succeeds without stamping, flag stripped;
+//   • post-success bookkeeping (stamp) throwing NEVER fails the send.
 
 import { describe, expect, test } from 'bun:test'
 import type {
@@ -16,6 +28,7 @@ import {
   type OutboundDeadLetter,
   type ReliableOptions,
 } from '../../src/safety/reliable-telegram-api.js'
+import { redactSecrets } from '../../src/safety/redact.js'
 
 const silentLog: Logger = {
   debug: () => {},
@@ -36,9 +49,19 @@ function grammyError(code: number, description = 'err', retryAfter?: number): Er
   if (retryAfter !== undefined) e.parameters = { retry_after: retryAfter }
   return e
 }
-function networkError(): Error {
-  const e = new Error('fetch failed') as Error & { name: string }
+function sysError(code: string, message = code.toLowerCase()): Error {
+  const e = new Error(message) as Error & { code: string }
+  e.code = code
+  return e
+}
+// grammY HttpError shape: transport failure nested under `.error`.
+function httpWrapped(inner: Error): Error {
+  const e = new Error('Network request for sendMessage failed!') as Error & {
+    name: string
+    error: Error
+  }
   e.name = 'HttpError'
+  e.error = inner
   return e
 }
 
@@ -47,11 +70,12 @@ interface Stub {
   api: TelegramApi
   sendMessageCalls: number
   editCalls: number
+  lastSendOpts?: SendMessageOpts
 }
 function makeStub(program: {
   sendMessage?: () => { message_id: number } | Error
   sendMessageSeq?: Array<{ message_id: number } | Error>
-  editMessageText?: () => void | Error
+  editMessageTextSeq?: Array<Error | undefined>
   sendRichMessage?: () => SendRichMessageResult | Error
 }): Stub {
   const stub: Stub = { api: null as unknown as TelegramApi, sendMessageCalls: 0, editCalls: 0 }
@@ -60,17 +84,20 @@ function makeStub(program: {
     return v
   }
   stub.api = {
-    async sendMessage(): Promise<{ message_id: number }> {
+    async sendMessage(_c, _t, opts): Promise<{ message_id: number }> {
       const i = stub.sendMessageCalls++
-      if (program.sendMessageSeq) return throwIf(program.sendMessageSeq[i] as { message_id: number } | Error)
+      stub.lastSendOpts = opts
+      if (program.sendMessageSeq) {
+        return throwIf(program.sendMessageSeq[i] as { message_id: number } | Error)
+      }
       return throwIf(program.sendMessage?.() ?? { message_id: 1 })
     },
     async sendRichMessage(): Promise<SendRichMessageResult> {
       return throwIf(program.sendRichMessage?.() ?? { fallback: true })
     },
     async editMessageText(): Promise<void> {
-      stub.editCalls++
-      const r = program.editMessageText?.()
+      const i = stub.editCalls++
+      const r = program.editMessageTextSeq?.[i]
       if (r instanceof Error) throw r
     },
     async setMessageReaction(): Promise<void> {},
@@ -112,31 +139,58 @@ function harness(extra: Partial<ReliableOptions> = {}): Harness {
 }
 
 const OPTS: SendMessageOpts = {}
+const CAP = 30_000
 
 describe('classifySendError', () => {
   test('429 → rate_limited with clamped retry_after', () => {
-    expect(classifySendError(grammyError(429, 'x', 5), 30_000)).toEqual({
+    expect(classifySendError(grammyError(429, 'x', 5), CAP)).toEqual({
       kind: 'rate_limited',
       retryAfterMs: 5000,
     })
-    // cap
-    expect(classifySendError(grammyError(429, 'x', 999), 30_000)).toEqual({
+    expect(classifySendError(grammyError(429, 'x', 999), CAP)).toEqual({
       kind: 'rate_limited',
-      retryAfterMs: 30_000,
+      retryAfterMs: CAP,
     })
   })
-  test('5xx → transient, 4xx → permanent, network → transient, plain → permanent', () => {
-    expect(classifySendError(grammyError(503), 30_000).kind).toBe('transient')
-    expect(classifySendError(grammyError(400, 'bad entities'), 30_000).kind).toBe('permanent')
-    expect(classifySendError(grammyError(403), 30_000).kind).toBe('permanent')
-    expect(classifySendError(networkError(), 30_000).kind).toBe('transient')
-    expect(classifySendError(new Error('sendRichMessage returned no message_id'), 30_000).kind).toBe(
+  test('5xx → ambiguous (Telegram may have processed the send)', () => {
+    expect(classifySendError(grammyError(500), CAP).kind).toBe('ambiguous')
+    expect(classifySendError(grammyError(502), CAP).kind).toBe('ambiguous')
+  })
+  test('4xx (non-429) → permanent', () => {
+    expect(classifySendError(grammyError(400, 'bad entities'), CAP).kind).toBe('permanent')
+    expect(classifySendError(grammyError(403), CAP).kind).toBe('permanent')
+  })
+  test('connect-phase / DNS syscalls → pre_send (provably not delivered)', () => {
+    expect(classifySendError(sysError('ECONNREFUSED'), CAP).kind).toBe('pre_send')
+    expect(classifySendError(sysError('ENOTFOUND'), CAP).kind).toBe('pre_send')
+    expect(classifySendError(sysError('EAI_AGAIN'), CAP).kind).toBe('pre_send')
+    expect(classifySendError(new Error('getaddrinfo ENOTFOUND api.telegram.org'), CAP).kind).toBe(
+      'pre_send',
+    )
+    // Nested one level (grammY HttpError wraps the transport failure).
+    expect(classifySendError(httpWrapped(sysError('ECONNREFUSED')), CAP).kind).toBe('pre_send')
+  })
+  test('reset / timeout / hang-up / generic fetch failure → ambiguous', () => {
+    expect(classifySendError(sysError('ECONNRESET'), CAP).kind).toBe('ambiguous')
+    expect(classifySendError(sysError('ETIMEDOUT'), CAP).kind).toBe('ambiguous')
+    expect(classifySendError(new Error('socket hang up'), CAP).kind).toBe('ambiguous')
+    expect(classifySendError(new TypeError('fetch failed'), CAP).kind).toBe('ambiguous')
+    expect(classifySendError(httpWrapped(new Error('socket hang up')), CAP).kind).toBe('ambiguous')
+  })
+  test('loose «connection» wording is NOT retryable (fix-loop-1 #1)', () => {
+    expect(classifySendError(new Error('connection lost to internal service'), CAP).kind).toBe(
       'permanent',
     )
   })
+  test('unreadable / plain errors → permanent', () => {
+    expect(classifySendError(new Error('sendRichMessage returned no message_id'), CAP).kind).toBe(
+      'permanent',
+    )
+    expect(classifySendError('boom', CAP).kind).toBe('permanent')
+  })
 })
 
-describe('createReliableTelegramApi retry matrix', () => {
+describe('non-idempotent send retry policy', () => {
   test('success on first try — no retry, outbound recorded, no dead-letter', async () => {
     const stub = makeStub({ sendMessage: () => ({ message_id: 42 }) })
     const h = harness()
@@ -149,8 +203,8 @@ describe('createReliableTelegramApi retry matrix', () => {
     expect(h.outbound).toEqual([{ chatId: '100', at: 1000 }])
   })
 
-  test('transient then success — retried with 1s backoff, then recorded', async () => {
-    const stub = makeStub({ sendMessageSeq: [networkError(), { message_id: 7 }] })
+  test('pre_send then success — retried with 1s backoff, then recorded', async () => {
+    const stub = makeStub({ sendMessageSeq: [sysError('ECONNREFUSED'), { message_id: 7 }] })
     const h = harness()
     const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
     const res = await api.sendMessage('100', 'hi', OPTS)
@@ -161,8 +215,8 @@ describe('createReliableTelegramApi retry matrix', () => {
     expect(h.outbound.length).toBe(1)
   })
 
-  test('transient exhaustion — 3 attempts, backoffs 1s/5s, dead-letter, throws, no outbound', async () => {
-    const stub = makeStub({ sendMessage: () => grammyError(502) })
+  test('pre_send exhaustion — 3 attempts, backoffs 1s/5s, dead-letter, throws, no outbound', async () => {
+    const stub = makeStub({ sendMessage: () => sysError('ECONNREFUSED') })
     const h = harness()
     const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
     await expect(api.sendMessage('100', 'body', OPTS)).rejects.toThrow()
@@ -173,21 +227,46 @@ describe('createReliableTelegramApi retry matrix', () => {
     expect(dl.method).toBe('sendMessage')
     expect(dl.chat_id).toBe('100')
     expect(dl.attempts).toBe(3)
-    expect(dl.error_class).toBe('transient')
+    expect(dl.error_class).toBe('pre_send')
     expect(dl.payload_sha256.length).toBe(16)
     expect(dl.payload_bytes).toBe(4) // "body"
     expect(h.outbound).toEqual([]) // nothing shipped
   })
 
-  test('429 retry honours retry_after when larger than backoff', async () => {
-    const stub = makeStub({ sendMessageSeq: [grammyError(429, 'slow', 9), { message_id: 1 }] })
+  test('ambiguous (5xx) — NO retry, immediate dead-letter + rethrow (duplicate risk)', async () => {
+    const stub = makeStub({ sendMessage: () => grammyError(502) })
     const h = harness()
     const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
-    await api.sendMessage('100', 'hi', OPTS)
-    expect(h.waits).toEqual([9000]) // max(1000 backoff, 9000 retry_after)
+    await expect(api.sendMessage('100', 'hi', OPTS)).rejects.toThrow()
+    expect(stub.sendMessageCalls).toBe(1)
+    expect(h.waits).toEqual([])
+    expect(h.deadLetters.length).toBe(1)
+    expect(h.deadLetters[0]?.error_class).toBe('ambiguous')
+    expect(h.deadLetters[0]?.attempts).toBe(1)
+    expect(h.outbound).toEqual([])
   })
 
-  test('non-transient 4xx — no retry, no dead-letter, throws', async () => {
+  test('ambiguous (ECONNRESET) — NO retry on a non-idempotent send', async () => {
+    const stub = makeStub({ sendMessage: () => sysError('ECONNRESET') })
+    const h = harness()
+    const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
+    await expect(api.sendMessage('100', 'hi', OPTS)).rejects.toThrow()
+    expect(stub.sendMessageCalls).toBe(1)
+    expect(h.deadLetters[0]?.error_class).toBe('ambiguous')
+  })
+
+  test('429 — NEVER retried here (inner layer owns 429s): dead-letter + rethrow (fix-loop-1 #2)', async () => {
+    const stub = makeStub({ sendMessage: () => grammyError(429, 'slow', 9) })
+    const h = harness()
+    const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
+    await expect(api.sendMessage('100', 'hi', OPTS)).rejects.toThrow()
+    expect(stub.sendMessageCalls).toBe(1)
+    expect(h.waits).toEqual([]) // no amplification of the inner layer's ~3min
+    expect(h.deadLetters.length).toBe(1)
+    expect(h.deadLetters[0]?.error_class).toBe('rate_limited')
+  })
+
+  test('permanent 4xx — no retry, no dead-letter, throws', async () => {
     const stub = makeStub({ sendMessage: () => grammyError(400, "can't parse entities") })
     const h = harness()
     const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
@@ -199,16 +278,109 @@ describe('createReliableTelegramApi retry matrix', () => {
   })
 })
 
-describe('outbound recording rules', () => {
-  test('editMessageText is retried but NOT recorded as outbound', async () => {
-    const stub = makeStub({ editMessageText: () => grammyError(503) })
+describe('idempotent editMessageText policy', () => {
+  test('ambiguous (5xx) IS retried on edits; exhaustion dead-letters; never stamps', async () => {
+    const stub = makeStub({
+      editMessageTextSeq: [grammyError(503), grammyError(503), grammyError(503)],
+    })
     const h = harness()
     const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
     await expect(api.editMessageText('100', 5, 'x', {})).rejects.toThrow()
     expect(stub.editCalls).toBe(3)
+    expect(h.waits).toEqual([1000, 5000])
     expect(h.deadLetters.length).toBe(1)
     expect(h.deadLetters[0]?.method).toBe('editMessageText')
+    expect(h.deadLetters[0]?.error_class).toBe('ambiguous')
     expect(h.outbound).toEqual([]) // edits never stamp the heartbeat clock
+  })
+
+  test('pre_send then success on edit — retried', async () => {
+    const stub = makeStub({ editMessageTextSeq: [sysError('ECONNREFUSED'), undefined] })
+    const h = harness()
+    const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
+    await api.editMessageText('100', 5, 'x', {})
+    expect(stub.editCalls).toBe(2)
+    expect(h.deadLetters).toEqual([])
+  })
+
+  test('«message is not modified» normalizes to SUCCESS (no throw, no dead-letter)', async () => {
+    const stub = makeStub({
+      editMessageTextSeq: [grammyError(400, 'Bad Request: message is not modified')],
+    })
+    const h = harness()
+    const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
+    await api.editMessageText('100', 5, 'same text', {}) // resolves
+    expect(stub.editCalls).toBe(1)
+    expect(h.deadLetters).toEqual([])
+  })
+
+  test('ambiguous retry landing on «not modified» proves the first edit delivered — success', async () => {
+    const stub = makeStub({
+      editMessageTextSeq: [
+        sysError('ETIMEDOUT'), // delivered but unanswered
+        grammyError(400, 'Bad Request: message is not modified'),
+      ],
+    })
+    const h = harness()
+    const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
+    await api.editMessageText('100', 5, 'x', {}) // resolves
+    expect(stub.editCalls).toBe(2)
+    expect(h.deadLetters).toEqual([])
+  })
+})
+
+describe('outbound recording rules', () => {
+  test('skipOutboundStamp: send succeeds without stamping; flag stripped downstream', async () => {
+    const stub = makeStub({ sendMessage: () => ({ message_id: 9 }) })
+    const h = harness()
+    const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
+    await api.sendMessage('100', 'pin self-heal', { skipOutboundStamp: true })
+    expect(h.outbound).toEqual([])
+    expect(stub.lastSendOpts).toBeDefined()
+    expect('skipOutboundStamp' in (stub.lastSendOpts as SendMessageOpts)).toBe(false)
+  })
+
+  test('a THROWING outbound tracker never fails a delivered send (fix-loop-1 #5)', async () => {
+    const stub = makeStub({ sendMessage: () => ({ message_id: 11 }) })
+    const h = harness({
+      recordOutbound: () => {
+        throw new Error('tracker boom')
+      },
+    })
+    const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
+    const res = await api.sendMessage('100', 'hi', OPTS)
+    expect(res.message_id).toBe(11)
+  })
+
+  test('server-style dead-letter callback redacts secrets from the error text (fix-loop-1 #7a)', async () => {
+    // Mirrors the server.ts composition: the deadLetter callback runs the
+    // record's error through redactSecrets with the bot token as an extra
+    // secret — a transport error embedding the api.telegram.org/bot<token>/
+    // URL must never land in a quarantine file verbatim.
+    const token = '123456789:AAH-fake_bot_token_ABCDEFGH1234567890abc'
+    const stub = makeStub({
+      sendMessage: () =>
+        grammyError(502, `network error calling https://api.telegram.org/bot${token}/sendMessage`),
+    })
+    const stored: OutboundDeadLetter[] = []
+    const h = harness({
+      deadLetter: (r) => stored.push({ ...r, error: redactSecrets(r.error, [token]) }),
+    })
+    const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
+    await expect(api.sendMessage('100', 'hi', OPTS)).rejects.toThrow()
+    expect(stored.length).toBe(1)
+    expect(stored[0]?.error).not.toContain(token)
+  })
+
+  test('a THROWING dead-letter callback never masks the honest error', async () => {
+    const stub = makeStub({ sendMessage: () => grammyError(502, 'bad gateway') })
+    const h = harness({
+      deadLetter: () => {
+        throw new Error('disk full')
+      },
+    })
+    const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
+    await expect(api.sendMessage('100', 'hi', OPTS)).rejects.toThrow('bad gateway')
   })
 
   test('sendRichMessage fallback does NOT record; real send does', async () => {
@@ -231,7 +403,7 @@ describe('outbound recording rules', () => {
     const stub = makeStub({})
     stub.api.setMessageReaction = async (): Promise<void> => {
       reactionCalls++
-      throw grammyError(503)
+      throw sysError('ECONNREFUSED')
     }
     const h = harness()
     const api = createReliableTelegramApi(stub.api, silentLog, h.opts)

--- a/plugin/tests/safety/reliable-telegram-api.test.ts
+++ b/plugin/tests/safety/reliable-telegram-api.test.ts
@@ -1,0 +1,242 @@
+// Tests for createReliableTelegramApi — bounded retry + dead-letter +
+// outbound-activity tracking (M4). A hand-rolled stub raw TelegramApi lets us
+// program failures; an immediate-resolve `sleep` that RECORDS its argument
+// gives deterministic retry-timing assertions with no real waits.
+
+import { describe, expect, test } from 'bun:test'
+import type {
+  SendMessageOpts,
+  SendRichMessageResult,
+  TelegramApi,
+} from '../../src/channel/tools.js'
+import type { Logger } from '../../src/log.js'
+import {
+  classifySendError,
+  createReliableTelegramApi,
+  type OutboundDeadLetter,
+  type ReliableOptions,
+} from '../../src/safety/reliable-telegram-api.js'
+
+const silentLog: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as unknown as Logger
+
+// ── error factories ──────────────────────────────────────────────────
+function grammyError(code: number, description = 'err', retryAfter?: number): Error {
+  const e = new Error(description) as Error & {
+    error_code: number
+    description: string
+    parameters?: { retry_after?: number }
+  }
+  e.error_code = code
+  e.description = description
+  if (retryAfter !== undefined) e.parameters = { retry_after: retryAfter }
+  return e
+}
+function networkError(): Error {
+  const e = new Error('fetch failed') as Error & { name: string }
+  e.name = 'HttpError'
+  return e
+}
+
+// ── stub raw api ─────────────────────────────────────────────────────
+interface Stub {
+  api: TelegramApi
+  sendMessageCalls: number
+  editCalls: number
+}
+function makeStub(program: {
+  sendMessage?: () => { message_id: number } | Error
+  sendMessageSeq?: Array<{ message_id: number } | Error>
+  editMessageText?: () => void | Error
+  sendRichMessage?: () => SendRichMessageResult | Error
+}): Stub {
+  const stub: Stub = { api: null as unknown as TelegramApi, sendMessageCalls: 0, editCalls: 0 }
+  const throwIf = <T>(v: T | Error): T => {
+    if (v instanceof Error) throw v
+    return v
+  }
+  stub.api = {
+    async sendMessage(): Promise<{ message_id: number }> {
+      const i = stub.sendMessageCalls++
+      if (program.sendMessageSeq) return throwIf(program.sendMessageSeq[i] as { message_id: number } | Error)
+      return throwIf(program.sendMessage?.() ?? { message_id: 1 })
+    },
+    async sendRichMessage(): Promise<SendRichMessageResult> {
+      return throwIf(program.sendRichMessage?.() ?? { fallback: true })
+    },
+    async editMessageText(): Promise<void> {
+      stub.editCalls++
+      const r = program.editMessageText?.()
+      if (r instanceof Error) throw r
+    },
+    async setMessageReaction(): Promise<void> {},
+    async sendChatAction(): Promise<void> {},
+    async sendDocument(): Promise<{ message_id: number }> {
+      return { message_id: 2 }
+    },
+    async sendPhoto(): Promise<{ message_id: number }> {
+      return { message_id: 3 }
+    },
+    async downloadFile() {
+      return { path: '/x' }
+    },
+    async deleteMessage(): Promise<void> {},
+    async answerGuestQuery(): Promise<void> {},
+  }
+  return stub
+}
+
+interface Harness {
+  waits: number[]
+  deadLetters: OutboundDeadLetter[]
+  outbound: Array<{ chatId: string; at: number }>
+  opts: ReliableOptions
+}
+function harness(extra: Partial<ReliableOptions> = {}): Harness {
+  const h: Harness = { waits: [], deadLetters: [], outbound: [], opts: {} }
+  h.opts = {
+    now: () => 1000,
+    sleep: (ms: number) => {
+      h.waits.push(ms)
+      return Promise.resolve()
+    },
+    deadLetter: (r) => h.deadLetters.push(r),
+    recordOutbound: (chatId, at) => h.outbound.push({ chatId, at }),
+    ...extra,
+  }
+  return h
+}
+
+const OPTS: SendMessageOpts = {}
+
+describe('classifySendError', () => {
+  test('429 → rate_limited with clamped retry_after', () => {
+    expect(classifySendError(grammyError(429, 'x', 5), 30_000)).toEqual({
+      kind: 'rate_limited',
+      retryAfterMs: 5000,
+    })
+    // cap
+    expect(classifySendError(grammyError(429, 'x', 999), 30_000)).toEqual({
+      kind: 'rate_limited',
+      retryAfterMs: 30_000,
+    })
+  })
+  test('5xx → transient, 4xx → permanent, network → transient, plain → permanent', () => {
+    expect(classifySendError(grammyError(503), 30_000).kind).toBe('transient')
+    expect(classifySendError(grammyError(400, 'bad entities'), 30_000).kind).toBe('permanent')
+    expect(classifySendError(grammyError(403), 30_000).kind).toBe('permanent')
+    expect(classifySendError(networkError(), 30_000).kind).toBe('transient')
+    expect(classifySendError(new Error('sendRichMessage returned no message_id'), 30_000).kind).toBe(
+      'permanent',
+    )
+  })
+})
+
+describe('createReliableTelegramApi retry matrix', () => {
+  test('success on first try — no retry, outbound recorded, no dead-letter', async () => {
+    const stub = makeStub({ sendMessage: () => ({ message_id: 42 }) })
+    const h = harness()
+    const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
+    const res = await api.sendMessage('100', 'hi', OPTS)
+    expect(res.message_id).toBe(42)
+    expect(stub.sendMessageCalls).toBe(1)
+    expect(h.waits).toEqual([])
+    expect(h.deadLetters).toEqual([])
+    expect(h.outbound).toEqual([{ chatId: '100', at: 1000 }])
+  })
+
+  test('transient then success — retried with 1s backoff, then recorded', async () => {
+    const stub = makeStub({ sendMessageSeq: [networkError(), { message_id: 7 }] })
+    const h = harness()
+    const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
+    const res = await api.sendMessage('100', 'hi', OPTS)
+    expect(res.message_id).toBe(7)
+    expect(stub.sendMessageCalls).toBe(2)
+    expect(h.waits).toEqual([1000])
+    expect(h.deadLetters).toEqual([])
+    expect(h.outbound.length).toBe(1)
+  })
+
+  test('transient exhaustion — 3 attempts, backoffs 1s/5s, dead-letter, throws, no outbound', async () => {
+    const stub = makeStub({ sendMessage: () => grammyError(502) })
+    const h = harness()
+    const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
+    await expect(api.sendMessage('100', 'body', OPTS)).rejects.toThrow()
+    expect(stub.sendMessageCalls).toBe(3) // 1 + 2 retries
+    expect(h.waits).toEqual([1000, 5000])
+    expect(h.deadLetters.length).toBe(1)
+    const dl = h.deadLetters[0] as OutboundDeadLetter
+    expect(dl.method).toBe('sendMessage')
+    expect(dl.chat_id).toBe('100')
+    expect(dl.attempts).toBe(3)
+    expect(dl.error_class).toBe('transient')
+    expect(dl.payload_sha256.length).toBe(16)
+    expect(dl.payload_bytes).toBe(4) // "body"
+    expect(h.outbound).toEqual([]) // nothing shipped
+  })
+
+  test('429 retry honours retry_after when larger than backoff', async () => {
+    const stub = makeStub({ sendMessageSeq: [grammyError(429, 'slow', 9), { message_id: 1 }] })
+    const h = harness()
+    const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
+    await api.sendMessage('100', 'hi', OPTS)
+    expect(h.waits).toEqual([9000]) // max(1000 backoff, 9000 retry_after)
+  })
+
+  test('non-transient 4xx — no retry, no dead-letter, throws', async () => {
+    const stub = makeStub({ sendMessage: () => grammyError(400, "can't parse entities") })
+    const h = harness()
+    const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
+    await expect(api.sendMessage('100', 'hi', OPTS)).rejects.toThrow()
+    expect(stub.sendMessageCalls).toBe(1)
+    expect(h.waits).toEqual([])
+    expect(h.deadLetters).toEqual([])
+    expect(h.outbound).toEqual([])
+  })
+})
+
+describe('outbound recording rules', () => {
+  test('editMessageText is retried but NOT recorded as outbound', async () => {
+    const stub = makeStub({ editMessageText: () => grammyError(503) })
+    const h = harness()
+    const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
+    await expect(api.editMessageText('100', 5, 'x', {})).rejects.toThrow()
+    expect(stub.editCalls).toBe(3)
+    expect(h.deadLetters.length).toBe(1)
+    expect(h.deadLetters[0]?.method).toBe('editMessageText')
+    expect(h.outbound).toEqual([]) // edits never stamp the heartbeat clock
+  })
+
+  test('sendRichMessage fallback does NOT record; real send does', async () => {
+    const fallbackStub = makeStub({ sendRichMessage: () => ({ fallback: true }) })
+    const h1 = harness()
+    const api1 = createReliableTelegramApi(fallbackStub.api, silentLog, h1.opts)
+    const r1 = await api1.sendRichMessage('100', 'md', {})
+    expect(r1).toEqual({ fallback: true })
+    expect(h1.outbound).toEqual([])
+
+    const realStub = makeStub({ sendRichMessage: () => ({ message_id: 9 }) })
+    const h2 = harness()
+    const api2 = createReliableTelegramApi(realStub.api, silentLog, h2.opts)
+    await api2.sendRichMessage('100', 'md', {})
+    expect(h2.outbound).toEqual([{ chatId: '100', at: 1000 }])
+  })
+
+  test('pass-through methods are not retried', async () => {
+    let reactionCalls = 0
+    const stub = makeStub({})
+    stub.api.setMessageReaction = async (): Promise<void> => {
+      reactionCalls++
+      throw grammyError(503)
+    }
+    const h = harness()
+    const api = createReliableTelegramApi(stub.api, silentLog, h.opts)
+    await expect(api.setMessageReaction('100', 1, '👍')).rejects.toThrow()
+    expect(reactionCalls).toBe(1) // no retry wrapper on reactions
+    expect(h.deadLetters).toEqual([])
+  })
+})

--- a/plugin/tests/safety/rich-path.test.ts
+++ b/plugin/tests/safety/rich-path.test.ts
@@ -131,6 +131,7 @@ function makeStatePaths(): StatePaths {
     sessionIds: join(root, 'session-ids'),
     deadLetterUpdates: join(root, 'dead-letter', 'updates'),
     deadLetterWebhook: join(root, 'dead-letter', 'webhook'),
+    deadLetterOutbound: join(root, 'dead-letter', 'outbound'),
     logs: {
       server: join(root, 'logs', 'server.log'),
       telegram: join(root, 'logs', 'telegram.log'),

--- a/plugin/tests/state.test.ts
+++ b/plugin/tests/state.test.ts
@@ -136,4 +136,26 @@ describe('writeDeadLetter', () => {
     expect(typeof parsed.ts).toBe('string')
     expect(parsed.ts.length).toBeGreaterThan(10)
   })
+
+  test('outbound bucket is capped at 50 — oldest pruned, newest kept (fix-loop-1 #7b)', () => {
+    const written: string[] = []
+    for (let i = 0; i < 55; i++) {
+      written.push(writeDeadLetter(paths, 'outbound', { i }))
+    }
+    const files = readdirSync(paths.deadLetterOutbound).filter((f) => f.endsWith('.json'))
+    expect(files.length).toBe(50)
+    // The per-process seq makes lexicographic order chronological even within
+    // one millisecond: the FIRST five writes are gone, the LAST one survives.
+    expect(existsSync(written[0] as string)).toBe(false)
+    expect(existsSync(written[4] as string)).toBe(false)
+    expect(existsSync(written[54] as string)).toBe(true)
+  })
+
+  test('inbound buckets are NOT capped', () => {
+    for (let i = 0; i < 55; i++) {
+      writeDeadLetter(paths, 'updates', { i })
+    }
+    const files = readdirSync(paths.deadLetterUpdates).filter((f) => f.endsWith('.json'))
+    expect(files.length).toBe(55)
+  })
 })

--- a/plugin/tests/state.test.ts
+++ b/plugin/tests/state.test.ts
@@ -47,6 +47,7 @@ describe('ensureStateDirs', () => {
     expect(existsSync(paths.sessionIds)).toBe(true)
     expect(existsSync(paths.deadLetterUpdates)).toBe(true)
     expect(existsSync(paths.deadLetterWebhook)).toBe(true)
+    expect(existsSync(paths.deadLetterOutbound)).toBe(true)
   })
 })
 
@@ -120,6 +121,10 @@ describe('writeDeadLetter', () => {
 
     const webhookPath = writeDeadLetter(paths, 'webhook', { foo: 'bar' })
     expect(webhookPath.startsWith(paths.deadLetterWebhook)).toBe(true)
+
+    const outboundPath = writeDeadLetter(paths, 'outbound', { method: 'sendMessage' })
+    expect(outboundPath.startsWith(paths.deadLetterOutbound)).toBe(true)
+    expect(existsSync(outboundPath)).toBe(true)
   })
 
   test('file content has wrapper with ts/bucket/value', () => {

--- a/plugin/tests/status/context-hud.heartbeat.test.ts
+++ b/plugin/tests/status/context-hud.heartbeat.test.ts
@@ -1,6 +1,9 @@
-// M4: ContextHud.setHeartbeatSuffix — the no-ping «работаю: …» pin heartbeat.
-// Verifies the suffix is appended as the final line, cleared on null, escaped
-// for HTML, and idempotent (no churn when unchanged).
+// M4 (fix-loop 1): ContextHud.setHeartbeatSuffix — the no-ping «работаю: …»
+// pin heartbeat. EDIT-ONLY semantics (fix-loop-1 #6): the heartbeat may only
+// edit an EXISTING pin — with no pin it is a strict no-op (never creates a
+// message), and a message_gone edit stands down without recreating. Also
+// verifies the suffix renders as the final line, clears on null, escapes
+// HTML, and is idempotent.
 
 import { afterEach, describe, expect, test } from 'bun:test'
 import { mkdtempSync, rmSync } from 'node:fs'
@@ -8,7 +11,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { ContextHud, type HudTelegramApi, type SessionInfoReader } from '../../src/status/context-hud.js'
-import type { EditOpts, InlineKeyboardLike, SendMessageOpts } from '../../src/channel/tools.js'
+import type { EditOpts, SendMessageOpts } from '../../src/channel/tools.js'
 import type { Logger } from '../../src/log.js'
 
 const log = { info() {}, warn() {}, error() {}, debug() {} } as unknown as Logger
@@ -24,15 +27,27 @@ afterEach(() => {
   for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
 })
 
+function grammyGone(): Error {
+  const e = new Error('Bad Request: message to edit not found') as Error & {
+    error_code: number
+    description: string
+  }
+  e.error_code = 400
+  e.description = 'Bad Request: message to edit not found'
+  return e
+}
+
 class FakeApi implements HudTelegramApi {
   sent: Array<{ text: string }> = []
   edited: Array<{ text: string }> = []
   nextId = 100
+  editError: unknown
   async sendMessage(_c: string, text: string, _o: SendMessageOpts): Promise<{ message_id: number }> {
     this.sent.push({ text })
     return { message_id: this.nextId++ }
   }
   async editMessageText(_c: string, _m: number, text: string, _o: EditOpts): Promise<void> {
+    if (this.editError) throw this.editError
     this.edited.push({ text })
   }
   async pinChatMessage(): Promise<void> {}
@@ -55,46 +70,74 @@ function makeHud(api: HudTelegramApi, enabled = true): ContextHud {
   })
 }
 
-const _kb: InlineKeyboardLike = { inline_keyboard: [] }
-void _kb
+// Create the pin the lifecycle way (SessionStart sends + pins the card).
+async function withPin(api: FakeApi): Promise<ContextHud> {
+  const hud = makeHud(api)
+  await hud.onSessionStart(OWNER, { sessionId: 's1' })
+  expect(api.sent.length).toBe(1) // the pinned card
+  return hud
+}
 
-describe('setHeartbeatSuffix', () => {
-  test('appends the suffix as the final line of the pin', async () => {
+describe('setHeartbeatSuffix (edit-only)', () => {
+  test('NO pin exists → strict no-op: never creates a message (fix-loop-1 #6)', async () => {
     const api = new FakeApi()
     const hud = makeHud(api)
     await hud.setHeartbeatSuffix(OWNER, 'работаю: сборка · 12:00')
-    // No message existed → the fresh send carries the suffix.
-    expect(api.sent.length).toBe(1)
-    const text = api.sent[0]?.text ?? ''
+    expect(api.sent.length).toBe(0)
+    expect(api.edited.length).toBe(0)
+  })
+
+  test('edits the existing pin — suffix is the final line', async () => {
+    const api = new FakeApi()
+    const hud = await withPin(api)
+    await hud.setHeartbeatSuffix(OWNER, 'работаю: сборка · 12:00')
+    expect(api.sent.length).toBe(1) // STILL only the lifecycle send
+    const text = api.edited.at(-1)?.text ?? ''
     expect(text).toContain('🧠 <b>Контекст</b>:')
     expect(text.endsWith('<i>работаю: сборка · 12:00</i>')).toBe(true)
   })
 
   test('clears the suffix on null', async () => {
     const api = new FakeApi()
-    const hud = makeHud(api)
-    await hud.setHeartbeatSuffix(OWNER, 'работаю: x · 12:00') // send #1 (with suffix)
-    await hud.setHeartbeatSuffix(OWNER, null) // edit — suffix gone
+    const hud = await withPin(api)
+    await hud.setHeartbeatSuffix(OWNER, 'работаю: x · 12:00')
+    await hud.setHeartbeatSuffix(OWNER, null)
     const lastEdit = api.edited.at(-1)?.text ?? ''
     expect(lastEdit).not.toContain('работаю')
   })
 
   test('escapes HTML in the task text', async () => {
     const api = new FakeApi()
-    const hud = makeHud(api)
+    const hud = await withPin(api)
     await hud.setHeartbeatSuffix(OWNER, 'работаю: <b>x</b> · 12:00')
-    const text = api.sent[0]?.text ?? ''
+    const text = api.edited.at(-1)?.text ?? ''
     expect(text).toContain('&lt;b&gt;x&lt;/b&gt;')
     expect(text).not.toContain('<b>x</b>')
   })
 
   test('idempotent — setting the same suffix twice does not churn', async () => {
     const api = new FakeApi()
-    const hud = makeHud(api)
-    await hud.setHeartbeatSuffix(OWNER, 'работаю: y · 12:00') // send
+    const hud = await withPin(api)
+    await hud.setHeartbeatSuffix(OWNER, 'работаю: y · 12:00')
     const editsAfterFirst = api.edited.length
     await hud.setHeartbeatSuffix(OWNER, 'работаю: y · 12:00') // same → no-op
     expect(api.edited.length).toBe(editsAfterFirst)
+  })
+
+  test('message_gone during the heartbeat edit → stand down, NO recreate', async () => {
+    const api = new FakeApi()
+    const hud = await withPin(api)
+    api.editError = grammyGone()
+    await hud.setHeartbeatSuffix(OWNER, 'работаю: z · 12:00')
+    // The self-heal path (updateNow/edit) would have sent a fresh card here —
+    // the heartbeat path must NOT (only the lifecycle send exists).
+    expect(api.sent.length).toBe(1)
+    // The stale id was dropped — a follow-up heartbeat is a strict no-op.
+    api.editError = undefined
+    const editsBefore = api.edited.length
+    await hud.setHeartbeatSuffix(OWNER, 'работаю: z · 12:05')
+    expect(api.sent.length).toBe(1)
+    expect(api.edited.length).toBe(editsBefore)
   })
 
   test('disabled HUD → no-op', async () => {

--- a/plugin/tests/status/context-hud.heartbeat.test.ts
+++ b/plugin/tests/status/context-hud.heartbeat.test.ts
@@ -1,0 +1,113 @@
+// M4: ContextHud.setHeartbeatSuffix — the no-ping «работаю: …» pin heartbeat.
+// Verifies the suffix is appended as the final line, cleared on null, escaped
+// for HTML, and idempotent (no churn when unchanged).
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { ContextHud, type HudTelegramApi, type SessionInfoReader } from '../../src/status/context-hud.js'
+import type { EditOpts, InlineKeyboardLike, SendMessageOpts } from '../../src/channel/tools.js'
+import type { Logger } from '../../src/log.js'
+
+const log = { info() {}, warn() {}, error() {}, debug() {} } as unknown as Logger
+const OWNER = '164795011'
+
+const dirs: string[] = []
+function stateDir(): string {
+  const d = mkdtempSync(join(tmpdir(), 'hud-hb-'))
+  dirs.push(d)
+  return d
+}
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+class FakeApi implements HudTelegramApi {
+  sent: Array<{ text: string }> = []
+  edited: Array<{ text: string }> = []
+  nextId = 100
+  async sendMessage(_c: string, text: string, _o: SendMessageOpts): Promise<{ message_id: number }> {
+    this.sent.push({ text })
+    return { message_id: this.nextId++ }
+  }
+  async editMessageText(_c: string, _m: number, text: string, _o: EditOpts): Promise<void> {
+    this.edited.push({ text })
+  }
+  async pinChatMessage(): Promise<void> {}
+  async deleteMessage(): Promise<void> {}
+  async unpinChatMessage(): Promise<void> {}
+}
+
+const session: SessionInfoReader = { get: () => ({ transcriptPath: '/t/a.jsonl', model: 'opus' }) }
+
+function makeHud(api: HudTelegramApi, enabled = true): ContextHud {
+  return new ContextHud({
+    api,
+    log,
+    sessionInfo: session,
+    windowTokens: 200_000,
+    ownerChatIds: [OWNER],
+    stateDir: stateDir(),
+    enabled,
+    readContextUsage: async () => ({ usedTokens: 100_000, pct: 0.5 }),
+  })
+}
+
+const _kb: InlineKeyboardLike = { inline_keyboard: [] }
+void _kb
+
+describe('setHeartbeatSuffix', () => {
+  test('appends the suffix as the final line of the pin', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.setHeartbeatSuffix(OWNER, 'работаю: сборка · 12:00')
+    // No message existed → the fresh send carries the suffix.
+    expect(api.sent.length).toBe(1)
+    const text = api.sent[0]?.text ?? ''
+    expect(text).toContain('🧠 <b>Контекст</b>:')
+    expect(text.endsWith('<i>работаю: сборка · 12:00</i>')).toBe(true)
+  })
+
+  test('clears the suffix on null', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.setHeartbeatSuffix(OWNER, 'работаю: x · 12:00') // send #1 (with suffix)
+    await hud.setHeartbeatSuffix(OWNER, null) // edit — suffix gone
+    const lastEdit = api.edited.at(-1)?.text ?? ''
+    expect(lastEdit).not.toContain('работаю')
+  })
+
+  test('escapes HTML in the task text', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.setHeartbeatSuffix(OWNER, 'работаю: <b>x</b> · 12:00')
+    const text = api.sent[0]?.text ?? ''
+    expect(text).toContain('&lt;b&gt;x&lt;/b&gt;')
+    expect(text).not.toContain('<b>x</b>')
+  })
+
+  test('idempotent — setting the same suffix twice does not churn', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.setHeartbeatSuffix(OWNER, 'работаю: y · 12:00') // send
+    const editsAfterFirst = api.edited.length
+    await hud.setHeartbeatSuffix(OWNER, 'работаю: y · 12:00') // same → no-op
+    expect(api.edited.length).toBe(editsAfterFirst)
+  })
+
+  test('disabled HUD → no-op', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api, false)
+    await hud.setHeartbeatSuffix(OWNER, 'работаю: z · 12:00')
+    expect(api.sent.length).toBe(0)
+  })
+
+  test('non-owner chat → no-op', async () => {
+    const api = new FakeApi()
+    const hud = makeHud(api)
+    await hud.setHeartbeatSuffix('-100999', 'работаю: q · 12:00')
+    expect(api.sent.length).toBe(0)
+  })
+})

--- a/plugin/tests/status/heartbeat-monitor.test.ts
+++ b/plugin/tests/status/heartbeat-monitor.test.ts
@@ -1,0 +1,307 @@
+// Tests for HeartbeatMonitor (M4): mechanical heartbeat (pin @25m / message
+// @60m), dead-man (pane frozen >10m), and open-question reminders (2h once /
+// sticky 6h cadence). Deterministic clock + injected send/pin callbacks; the
+// autonomy registry is a real on-disk file so we can also prove the heartbeat
+// path NEVER mutates it (byte-identical assertion — no lease field touched).
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { Logger } from '../../src/log.js'
+import { HeartbeatMonitor, type HeartbeatMonitorOptions } from '../../src/status/heartbeat-monitor.js'
+import {
+  addLease,
+  addQuestion,
+  emptyAutonomyState,
+  saveAutonomyState,
+  type AutonomyState,
+} from '../../src/autonomy/store.js'
+
+const silentLog: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as unknown as Logger
+
+const CHAT = '164795011'
+const MIN = 60 * 1000
+const HOUR = 60 * MIN
+
+let root: string
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'hb-monitor-'))
+})
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+interface Harness {
+  sends: Array<{ chatId: string; text: string }>
+  pins: Array<{ chatId: string; suffix: string | null }>
+  now: number
+  outbound: number | undefined
+  monitor: HeartbeatMonitor
+}
+function make(overrides: Partial<HeartbeatMonitorOptions> = {}): Harness {
+  // NB: the object we return IS the one the callbacks close over, so a test
+  // mutating h.now / h.outbound is seen by the live monitor (no spread copy).
+  const h: Harness = {
+    sends: [],
+    pins: [],
+    now: 100 * HOUR,
+    outbound: undefined,
+    monitor: undefined as unknown as HeartbeatMonitor,
+  }
+  h.monitor = new HeartbeatMonitor({
+    log: silentLog,
+    send: (chatId, text) => {
+      h.sends.push({ chatId, text })
+      return Promise.resolve()
+    },
+    pinHeartbeat: (chatId, suffix) => {
+      h.pins.push({ chatId, suffix })
+    },
+    autonomyPaths: { root },
+    lastOutboundAt: () => h.outbound,
+    now: () => h.now,
+    ...overrides,
+  })
+  return h
+}
+
+// ── heartbeat ─────────────────────────────────────────────────────────
+
+describe('heartbeat pin / message thresholds', () => {
+  test('no pin before 25 min of silence', () => {
+    const h = make()
+    h.outbound = h.now - 24 * MIN
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 'билд', nowMs: h.now })
+    expect(h.pins).toEqual([])
+    expect(h.sends).toEqual([])
+  })
+
+  test('pin suffix at 25 min', () => {
+    const h = make()
+    h.outbound = h.now - 26 * MIN
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 'сборка воркера', nowMs: h.now })
+    expect(h.sends).toEqual([])
+    expect(h.pins.length).toBe(1)
+    expect(h.pins[0]?.suffix).toContain('работаю: сборка воркера ·')
+  })
+
+  test('real message at 60 min supersedes pin, once per hour per turn', () => {
+    const h = make()
+    h.outbound = h.now - 61 * MIN
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 'миграция', nowMs: h.now })
+    expect(h.sends.length).toBe(1)
+    expect(h.sends[0]?.text).toBe('Работаю дольше часа без отчёта: миграция. Продолжаю.')
+    // pin cleared (message supersedes) — nothing set this call
+    expect(h.pins.every((p) => p.suffix === null)).toBe(true)
+    // 20s later, still >60m silent (stub outbound unchanged) — NOT re-sent (hourly cap)
+    h.now += 20 * 1000
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 'миграция', nowMs: h.now })
+    expect(h.sends.length).toBe(1)
+  })
+
+  test('recent outbound → silent (no pin, no message)', () => {
+    const h = make()
+    h.outbound = h.now - 5 * MIN
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 'x', nowMs: h.now })
+    expect(h.sends).toEqual([])
+    expect(h.pins).toEqual([])
+  })
+
+  test('no outbound baseline → no heartbeat', () => {
+    const h = make()
+    h.outbound = undefined
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 'x', nowMs: h.now })
+    expect(h.sends).toEqual([])
+    expect(h.pins).toEqual([])
+  })
+
+  test('pin cleared when silence drops back under 25m', () => {
+    const h = make()
+    h.outbound = h.now - 30 * MIN
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 'x', nowMs: h.now })
+    expect(h.pins.at(-1)?.suffix).toContain('работаю')
+    // owner replied — outbound fresh now
+    h.outbound = h.now
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 'x', nowMs: h.now })
+    expect(h.pins.at(-1)?.suffix).toBeNull()
+  })
+
+  test('idle turn clears any pin', () => {
+    const h = make()
+    h.outbound = h.now - 30 * MIN
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 'x', nowMs: h.now })
+    expect(h.pins.at(-1)?.suffix).toContain('работаю')
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: 'x', nowMs: h.now })
+    expect(h.pins.at(-1)?.suffix).toBeNull()
+  })
+
+  test('onTurnEnd resets the per-turn message budget', () => {
+    const h = make()
+    h.outbound = h.now - 61 * MIN
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 't', nowMs: h.now })
+    expect(h.sends.length).toBe(1)
+    h.monitor.onTurnEnd(CHAT)
+    // new turn, still >60m silent → allowed to message again
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 't', nowMs: h.now })
+    expect(h.sends.length).toBe(2)
+  })
+})
+
+// ── dead-man ──────────────────────────────────────────────────────────
+
+describe('dead-man alert', () => {
+  test('fires once when pane frozen >10m during active turn, resets on change', () => {
+    const h = make()
+    h.outbound = h.now // fresh outbound so heartbeat stays quiet
+    // baseline
+    h.monitor.observePane(CHAT, 'frame-A', h.now, true)
+    expect(h.sends).toEqual([])
+    // 11 min later, same frame → alert once
+    h.now += 11 * MIN
+    h.monitor.observePane(CHAT, 'frame-A', h.now, true)
+    expect(h.sends.length).toBe(1)
+    expect(h.sends[0]?.text).toBe('Сессия молчит >10 мин при активном ходе — возможно OOM/зависание')
+    // another observe, still frozen → NOT re-alerted
+    h.now += 5 * MIN
+    h.monitor.observePane(CHAT, 'frame-A', h.now, true)
+    expect(h.sends.length).toBe(1)
+    // pane changes → incident resets
+    h.now += 1 * MIN
+    h.monitor.observePane(CHAT, 'frame-B', h.now, true)
+    // frozen again >10m → alert again
+    h.now += 11 * MIN
+    h.monitor.observePane(CHAT, 'frame-B', h.now, true)
+    expect(h.sends.length).toBe(2)
+  })
+
+  test('does not fire while idle (no active turn)', () => {
+    const h = make()
+    h.monitor.observePane(CHAT, 'frame-A', h.now, false)
+    h.now += 30 * MIN
+    h.monitor.observePane(CHAT, 'frame-A', h.now, false)
+    expect(h.sends).toEqual([])
+  })
+
+  test('idle gap between turns does not count toward the hang clock', () => {
+    const h = make()
+    h.monitor.observePane(CHAT, 'frame-A', h.now, true) // turn active baseline
+    h.now += 20 * MIN
+    h.monitor.observePane(CHAT, 'frame-A', h.now, false) // idle refreshes baseline
+    h.now += 5 * MIN
+    h.monitor.observePane(CHAT, 'frame-A', h.now, true) // new turn, only 5m of freeze
+    expect(h.sends).toEqual([])
+  })
+})
+
+// ── open-question reminders ───────────────────────────────────────────
+
+function seed(mutate: (s: AutonomyState, now: number) => AutonomyState, now: number): void {
+  const s = mutate(emptyAutonomyState(), now)
+  saveAutonomyState({ root }, CHAT, s)
+}
+
+describe('open-question reminders', () => {
+  test('2h reminder fires once with default', () => {
+    const h = make()
+    seed((s, now) => addQuestion(s, { summary: 'катить прод?', defaultAction: 'катить', askedAtMs: now - 3 * HOUR }, now).state, h.now)
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    expect(h.sends.length).toBe(1)
+    expect(h.sends[0]?.text).toBe('Вопрос без ответа 2ч: "катить прод?". Беру дефолт: катить. Скажи стоп, если против.')
+    // re-evaluated → NOT repeated
+    h.now += 20 * 1000
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    expect(h.sends.length).toBe(1)
+  })
+
+  test('2h reminder without default uses the fallback phrasing', () => {
+    const h = make()
+    seed((s, now) => addQuestion(s, { summary: 'что дальше?', askedAtMs: now - 3 * HOUR }, now).state, h.now)
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    expect(h.sends[0]?.text).toBe('Вопрос без ответа 2ч: "что дальше?". Жду или беру безопасный дефолт по ситуации.')
+  })
+
+  test('question younger than 2h → no reminder', () => {
+    const h = make()
+    seed((s, now) => addQuestion(s, { summary: 'x', askedAtMs: now - 1 * HOUR }, now).state, h.now)
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    expect(h.sends).toEqual([])
+  })
+
+  test('sticky (security) question re-reminds at most every 6h', () => {
+    const h = make()
+    seed((s, now) => addQuestion(s, { summary: 'дать доступ root?', sticky: true, askedAtMs: now - 7 * HOUR }, now).state, h.now)
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    expect(h.sends.length).toBe(1)
+    expect(h.sends[0]?.text).toBe('Security-вопрос всё ещё без ответа: "дать доступ root?"')
+    // 3h later — within the 6h cadence → NOT repeated
+    h.now += 3 * HOUR
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    expect(h.sends.length).toBe(1)
+    // 6h+ after the first → repeats
+    h.now += 4 * HOUR
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    expect(h.sends.length).toBe(2)
+  })
+
+  test('reminder path NEVER mutates the registry (leases untouched, byte-identical)', () => {
+    const h = make()
+    seed((s, now) => {
+      let st = addLease(s, { scope: 'do X', expiresAtMs: now + HOUR, source: 'manual' }, now).state
+      st = addQuestion(st, { summary: 'q?', defaultAction: 'd', askedAtMs: now - 3 * HOUR }, now).state
+      return st
+    }, h.now)
+    const path = join(root, `autonomy-${CHAT}.json`)
+    const before = readFileSync(path, 'utf8')
+    // Multiple evaluations (reminder fires, dead-man observed) — all read-only.
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 'X', nowMs: h.now })
+    h.monitor.observePane(CHAT, 'p', h.now, true)
+    h.now += 7 * HOUR
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 'X', nowMs: h.now })
+    const after = readFileSync(path, 'utf8')
+    expect(after).toBe(before)
+  })
+})
+
+// ── isolation ─────────────────────────────────────────────────────────
+
+describe('isolation — best-effort, never throws', () => {
+  test('a throwing send callback does not escape evaluate', () => {
+    const h = make({
+      send: () => {
+        throw new Error('boom')
+      },
+    })
+    h.outbound = h.now - 61 * MIN
+    expect(() =>
+      h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 't', nowMs: h.now }),
+    ).not.toThrow()
+  })
+
+  test('a throwing pin callback does not escape evaluate', () => {
+    const h = make({
+      pinHeartbeat: () => {
+        throw new Error('boom')
+      },
+    })
+    h.outbound = h.now - 30 * MIN
+    expect(() =>
+      h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 't', nowMs: h.now }),
+    ).not.toThrow()
+  })
+
+  test('non-owner chat is a no-op', () => {
+    const h = make({ isOwnerChat: () => false })
+    h.outbound = h.now - 61 * MIN
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 't', nowMs: h.now })
+    h.monitor.observePane(CHAT, 'p', h.now, true)
+    expect(h.sends).toEqual([])
+    expect(h.pins).toEqual([])
+  })
+})

--- a/plugin/tests/status/heartbeat-monitor.test.ts
+++ b/plugin/tests/status/heartbeat-monitor.test.ts
@@ -1,8 +1,10 @@
-// Tests for HeartbeatMonitor (M4): mechanical heartbeat (pin @25m / message
-// @60m), dead-man (pane frozen >10m), and open-question reminders (2h once /
-// sticky 6h cadence). Deterministic clock + injected send/pin callbacks; the
-// autonomy registry is a real on-disk file so we can also prove the heartbeat
-// path NEVER mutates it (byte-identical assertion — no lease field touched).
+// Tests for HeartbeatMonitor (M4, fix-loop 1): mechanical heartbeat (pin @25m
+// / message @60m, hourly budget PER CHAT persistent across turns, silence
+// window seeded when no outbound record exists), dead-man (pane frozen >10m),
+// and open-question reminders (2h once / sticky 6h cadence, restart-burst
+// seeding). Deterministic clock + injected send/pin callbacks; the autonomy
+// registry is a real on-disk file so we can also prove the heartbeat path
+// NEVER mutates it (byte-identical assertion — no lease field touched).
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
@@ -92,7 +94,7 @@ describe('heartbeat pin / message thresholds', () => {
     expect(h.pins[0]?.suffix).toContain('работаю: сборка воркера ·')
   })
 
-  test('real message at 60 min supersedes pin, once per hour per turn', () => {
+  test('real message at 60 min supersedes pin, at most once per hour per chat', () => {
     const h = make()
     h.outbound = h.now - 61 * MIN
     h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 'миграция', nowMs: h.now })
@@ -114,12 +116,24 @@ describe('heartbeat pin / message thresholds', () => {
     expect(h.pins).toEqual([])
   })
 
-  test('no outbound baseline → no heartbeat', () => {
+  test('no outbound record → silence window SEEDED from first active evaluate (fix-loop-1 #4)', () => {
     const h = make()
     h.outbound = undefined
+    // First evaluate seeds the baseline — nothing fires immediately.
     h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 'x', nowMs: h.now })
     expect(h.sends).toEqual([])
     expect(h.pins).toEqual([])
+    // 26 min later, still no outbound → the pin heartbeat DOES fire (pre-fix
+    // the heartbeat was disabled forever until the first real send).
+    h.now += 26 * MIN
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 'x', nowMs: h.now })
+    expect(h.pins.length).toBe(1)
+    expect(h.pins[0]?.suffix).toContain('работаю: x ·')
+    // 61 min after the seed → the real message fires.
+    h.now += 35 * MIN
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 'x', nowMs: h.now })
+    expect(h.sends.length).toBe(1)
+    expect(h.sends[0]?.text).toBe('Работаю дольше часа без отчёта: x. Продолжаю.')
   })
 
   test('pin cleared when silence drops back under 25m', () => {
@@ -142,13 +156,19 @@ describe('heartbeat pin / message thresholds', () => {
     expect(h.pins.at(-1)?.suffix).toBeNull()
   })
 
-  test('onTurnEnd resets the per-turn message budget', () => {
+  test('hourly message budget PERSISTS across turn ends (fix-loop-1 #3)', () => {
     const h = make()
     h.outbound = h.now - 61 * MIN
     h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 't', nowMs: h.now })
     expect(h.sends.length).toBe(1)
+    // Turn ends; a new turn begins seconds later, still >60m silent — the
+    // budget must NOT reset (pre-fix: an immediate second message here).
     h.monitor.onTurnEnd(CHAT)
-    // new turn, still >60m silent → allowed to message again
+    h.now += 20 * 1000
+    h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 't', nowMs: h.now })
+    expect(h.sends.length).toBe(1)
+    // A full hour after the first message the budget re-opens.
+    h.now += 61 * MIN
     h.monitor.evaluate(CHAT, { turnActive: true, inProgressTask: 't', nowMs: h.now })
     expect(h.sends.length).toBe(2)
   })
@@ -167,7 +187,9 @@ describe('dead-man alert', () => {
     h.now += 11 * MIN
     h.monitor.observePane(CHAT, 'frame-A', h.now, true)
     expect(h.sends.length).toBe(1)
-    expect(h.sends[0]?.text).toBe('Сессия молчит >10 мин при активном ходе — возможно OOM/зависание')
+    expect(h.sends[0]?.text).toBe(
+      'Сессия молчит >10 мин при активном ходе — возможно OOM/зависание или жду подтверждения (карточка/гейт)',
+    )
     // another observe, still frozen → NOT re-alerted
     h.now += 5 * MIN
     h.monitor.observePane(CHAT, 'frame-A', h.now, true)
@@ -208,9 +230,15 @@ function seed(mutate: (s: AutonomyState, now: number) => AutonomyState, now: num
 }
 
 describe('open-question reminders', () => {
+  // Normal (non-restart) flow: the monitor sees the question while it is
+  // FRESH (first evaluate seeds it at ~asked time), so the 2h window is
+  // effectively age-based.
   test('2h reminder fires once with default', () => {
     const h = make()
-    seed((s, now) => addQuestion(s, { summary: 'катить прод?', defaultAction: 'катить', askedAtMs: now - 3 * HOUR }, now).state, h.now)
+    seed((s, now) => addQuestion(s, { summary: 'катить прод?', defaultAction: 'катить', askedAtMs: now }, now).state, h.now)
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    expect(h.sends).toEqual([]) // fresh question — nothing yet
+    h.now += 3 * HOUR
     h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
     expect(h.sends.length).toBe(1)
     expect(h.sends[0]?.text).toBe('Вопрос без ответа 2ч: "катить прод?". Беру дефолт: катить. Скажи стоп, если против.')
@@ -222,21 +250,40 @@ describe('open-question reminders', () => {
 
   test('2h reminder without default uses the fallback phrasing', () => {
     const h = make()
-    seed((s, now) => addQuestion(s, { summary: 'что дальше?', askedAtMs: now - 3 * HOUR }, now).state, h.now)
+    seed((s, now) => addQuestion(s, { summary: 'что дальше?', askedAtMs: now }, now).state, h.now)
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    h.now += 3 * HOUR
     h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
     expect(h.sends[0]?.text).toBe('Вопрос без ответа 2ч: "что дальше?". Жду или беру безопасный дефолт по ситуации.')
   })
 
   test('question younger than 2h → no reminder', () => {
     const h = make()
-    seed((s, now) => addQuestion(s, { summary: 'x', askedAtMs: now - 1 * HOUR }, now).state, h.now)
+    seed((s, now) => addQuestion(s, { summary: 'x', askedAtMs: now }, now).state, h.now)
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    h.now += 1 * HOUR
     h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
     expect(h.sends).toEqual([])
   })
 
+  test('question appearing AFTER the seed pass fires on its normal age threshold', () => {
+    const h = make()
+    // First evaluate on an EMPTY registry consumes the seed pass.
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    // A question asked 3h ago materialises later (no seed entry for it).
+    seed((s, now) => addQuestion(s, { summary: 'late?', defaultAction: 'да', askedAtMs: now - 3 * HOUR }, now).state, h.now)
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    expect(h.sends.length).toBe(1)
+    expect(h.sends[0]?.text).toContain('Вопрос без ответа 2ч: "late?"')
+  })
+
   test('sticky (security) question re-reminds at most every 6h', () => {
     const h = make()
-    seed((s, now) => addQuestion(s, { summary: 'дать доступ root?', sticky: true, askedAtMs: now - 7 * HOUR }, now).state, h.now)
+    seed((s, now) => addQuestion(s, { summary: 'дать доступ root?', sticky: true, askedAtMs: now }, now).state, h.now)
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    expect(h.sends).toEqual([])
+    // 7h after the seed → first sticky reminder.
+    h.now += 7 * HOUR
     h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
     expect(h.sends.length).toBe(1)
     expect(h.sends[0]?.text).toBe('Security-вопрос всё ещё без ответа: "дать доступ root?"')
@@ -248,6 +295,34 @@ describe('open-question reminders', () => {
     h.now += 4 * HOUR
     h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
     expect(h.sends.length).toBe(2)
+  })
+
+  test('restart burst protection (fix-loop-1 #8): pre-existing questions re-arm a fresh window', () => {
+    const h = make()
+    // Simulated restart: BOTH questions were already long past their
+    // thresholds when this (fresh) monitor first sees them.
+    seed((s, now) => {
+      let st = addQuestion(s, { summary: 'старый?', defaultAction: 'д', askedAtMs: now - 5 * HOUR }, now).state
+      st = addQuestion(st, { summary: 'root?', sticky: true, askedAtMs: now - 9 * HOUR }, now).state
+      return st
+    }, h.now)
+    // First pass → NO burst.
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    expect(h.sends).toEqual([])
+    // 20s later still nothing (window re-armed, not skipped by one tick).
+    h.now += 20 * 1000
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    expect(h.sends).toEqual([])
+    // 2h after the seed → the 2h question reminds (its NEXT threshold crossing).
+    h.now += 2 * HOUR
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    expect(h.sends.length).toBe(1)
+    expect(h.sends[0]?.text).toContain('старый?')
+    // 6h after the seed → the sticky question reminds too.
+    h.now += 4 * HOUR
+    h.monitor.evaluate(CHAT, { turnActive: false, inProgressTask: null, nowMs: h.now })
+    expect(h.sends.length).toBe(2)
+    expect(h.sends[1]?.text).toContain('root?')
   })
 
   test('reminder path NEVER mutates the registry (leases untouched, byte-identical)', () => {

--- a/plugin/tests/status/outbound-activity.test.ts
+++ b/plugin/tests/status/outbound-activity.test.ts
@@ -1,0 +1,28 @@
+// Tests for OutboundActivityTracker — the monotonic-latest last-outbound clock.
+
+import { describe, expect, test } from 'bun:test'
+import { OutboundActivityTracker } from '../../src/status/outbound-activity.js'
+
+describe('OutboundActivityTracker', () => {
+  test('undefined before any send', () => {
+    const t = new OutboundActivityTracker()
+    expect(t.lastOutboundAt('1')).toBeUndefined()
+  })
+
+  test('records and reads per chat', () => {
+    const t = new OutboundActivityTracker()
+    t.record('1', 1000)
+    t.record('2', 2000)
+    expect(t.lastOutboundAt('1')).toBe(1000)
+    expect(t.lastOutboundAt('2')).toBe(2000)
+  })
+
+  test('monotonic-latest — never moves backwards', () => {
+    const t = new OutboundActivityTracker()
+    t.record('1', 5000)
+    t.record('1', 3000) // late-completing older send
+    expect(t.lastOutboundAt('1')).toBe(5000)
+    t.record('1', 6000)
+    expect(t.lastOutboundAt('1')).toBe(6000)
+  })
+})

--- a/plugin/tests/status/task-reality-mirror.test.ts
+++ b/plugin/tests/status/task-reality-mirror.test.ts
@@ -1078,3 +1078,87 @@ describe('r3 #4 — descriptions duplicated in the SNAPSHOT do not participate',
     expect(next.tasks.some((t) => t.description === 'Задача X')).toBe(false)
   })
 })
+
+// ── M4: liveness monitor wiring ────────────────────────────────────────
+
+interface LivenessCall {
+  m: 'observePane' | 'evaluate' | 'onTurnEnd' | 'onChatGone'
+  chatId: string
+  turnActive?: boolean
+  inProgressTask?: string | null
+  paneText?: string
+}
+function makeLiveness(): {
+  spy: import('../../src/status/heartbeat-monitor.js').LivenessMonitor
+  calls: LivenessCall[]
+} {
+  const calls: LivenessCall[] = []
+  const spy = {
+    observePane: (chatId: string, paneText: string, _now: number, turnActive: boolean): void => {
+      calls.push({ m: 'observePane', chatId, paneText, turnActive })
+    },
+    evaluate: (
+      chatId: string,
+      ctx: { turnActive: boolean; inProgressTask: string | null; nowMs: number },
+    ): void => {
+      calls.push({
+        m: 'evaluate',
+        chatId,
+        turnActive: ctx.turnActive,
+        inProgressTask: ctx.inProgressTask,
+      })
+    },
+    onTurnEnd: (chatId: string): void => {
+      calls.push({ m: 'onTurnEnd', chatId })
+    },
+    onChatGone: (chatId: string): void => {
+      calls.push({ m: 'onChatGone', chatId })
+    },
+  }
+  return { spy, calls }
+}
+
+describe('liveness monitor wiring', () => {
+  test('drives observePane / evaluate / onTurnEnd / onChatGone across the lifecycle', async () => {
+    const clock = new FakeClock()
+    const fx = makeExec(() => VALID_PANE)
+    const { sink } = makeSink()
+    const { spy, calls } = makeLiveness()
+    const rm = new TaskRealityMirror({
+      exec: fx.exec,
+      capture: { paneTarget: 'p', lineCount: 200 },
+      log: nullLog,
+      sinks: [sink],
+      now: () => clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+      liveness: spy,
+    })
+
+    // A turn begins → immediate capture feeds observePane(turnActive=true).
+    rm.onUserPromptSubmit(CHAT, { sessionId: 's1', cwd: '/repo' })
+    await flush()
+    const obs = calls.filter((c) => c.m === 'observePane')
+    expect(obs.length).toBeGreaterThanOrEqual(1)
+    expect(obs.at(-1)?.turnActive).toBe(true)
+    expect(obs.at(-1)?.paneText).toContain('Написать тесты')
+
+    // A periodic tick evaluates the heartbeat with the reconciled in-progress task.
+    clock.advance(20_000)
+    await flush()
+    const evals = calls.filter((c) => c.m === 'evaluate')
+    expect(evals.length).toBeGreaterThanOrEqual(1)
+    expect(evals.at(-1)?.turnActive).toBe(true)
+    expect(evals.at(-1)?.inProgressTask).toBe('Написать тесты')
+
+    // Stop ends the turn.
+    rm.onStop(CHAT)
+    await flush()
+    expect(calls.some((c) => c.m === 'onTurnEnd' && c.chatId === CHAT)).toBe(true)
+
+    // SessionEnd evicts → the chat's liveness state is dropped.
+    rm.onSessionEnd(CHAT, { sessionId: 's1' })
+    await flush()
+    expect(calls.some((c) => c.m === 'onChatGone' && c.chatId === CHAT)).toBe(true)
+  })
+})

--- a/plugin/tests/telegram/handlers.addressing.test.ts
+++ b/plugin/tests/telegram/handlers.addressing.test.ts
@@ -108,6 +108,7 @@ function makeStatePaths(): StatePaths {
     sessionIds: join(root, 'session-ids'),
     deadLetterUpdates: join(root, 'dead-letter', 'updates'),
     deadLetterWebhook: join(root, 'dead-letter', 'webhook'),
+    deadLetterOutbound: join(root, 'dead-letter', 'outbound'),
     logs: {
       server: join(root, 'logs', 'server.log'),
       telegram: join(root, 'logs', 'telegram.log'),

--- a/plugin/tests/telegram/handlers.album.test.ts
+++ b/plugin/tests/telegram/handlers.album.test.ts
@@ -125,6 +125,7 @@ function makeStatePaths(): StatePaths {
     sessionIds: join(root, 'session-ids'),
     deadLetterUpdates: join(root, 'dead-letter', 'updates'),
     deadLetterWebhook: join(root, 'dead-letter', 'webhook'),
+    deadLetterOutbound: join(root, 'dead-letter', 'outbound'),
     logs: {
       server: join(root, 'logs', 'server.log'),
       telegram: join(root, 'logs', 'telegram.log'),

--- a/plugin/tests/telegram/handlers.guest.test.ts
+++ b/plugin/tests/telegram/handlers.guest.test.ts
@@ -72,6 +72,7 @@ function makeStatePaths(): StatePaths {
     sessionIds: join(root, 'session-ids'),
     deadLetterUpdates: join(root, 'dead-letter', 'updates'),
     deadLetterWebhook: join(root, 'dead-letter', 'webhook'),
+    deadLetterOutbound: join(root, 'dead-letter', 'outbound'),
     logs: {
       server: join(root, 'logs', 'server.log'),
       telegram: join(root, 'logs', 'telegram.log'),

--- a/plugin/tests/telegram/handlers.test.ts
+++ b/plugin/tests/telegram/handlers.test.ts
@@ -98,6 +98,7 @@ function makeStatePaths(): StatePaths {
     sessionIds: join(root, 'session-ids'),
     deadLetterUpdates: join(root, 'dead-letter', 'updates'),
     deadLetterWebhook: join(root, 'dead-letter', 'webhook'),
+    deadLetterOutbound: join(root, 'dead-letter', 'outbound'),
     logs: {
       server: join(root, 'logs', 'server.log'),
       telegram: join(root, 'logs', 'telegram.log'),

--- a/plugin/tests/telegram/handlers.voice-multichat.test.ts
+++ b/plugin/tests/telegram/handlers.voice-multichat.test.ts
@@ -95,6 +95,7 @@ function makeStatePaths(): StatePaths {
     sessionIds: join(root, 'session-ids'),
     deadLetterUpdates: join(root, 'dead-letter', 'updates'),
     deadLetterWebhook: join(root, 'dead-letter', 'webhook'),
+    deadLetterOutbound: join(root, 'dead-letter', 'outbound'),
     logs: {
       server: join(root, 'logs', 'server.log'),
       telegram: join(root, 'logs', 'telegram.log'),


### PR DESCRIPTION
Четвёртый милстон архитектуры автономии (дизайн autonomy-arch-2026-07-10, задача gbrain #138).

## Состав
- `src/safety/reliable-telegram-api.ts` — внешний send-слой: классификация pre_send/ambiguous (неидемпотентные методы ретраятся ТОЛЬКО на доказуемо pre-send сбоях — дубли владельцу исключены), editMessageText идемпотентен («not modified» = успех), 429 не реамплифицируется, dead-letter с redactSecrets и кэпом 50.
- `src/status/heartbeat-monitor.ts` — heartbeat 25 мин (edit-only суффикс пина, без пересоздания/пинга) / 60 мин (одно сообщение в час per-chat, бюджет не сбрасывается между ходами), dead-man на замороженный pane (alert-only), напоминания по открытым вопросам 2ч/6ч с anti-burst seed после рестарта.
- HUD/heartbeat-отправки не штампуют «реальный outbound» (skipOutboundStamp) — окно тишины сбрасывает только настоящий отчёт.
- Heartbeat-путь читает autonomy store read-only, lease-поля не трогает (byte-identical тест).

## Ревью
Codex GPT-5.6 Sol: BLOCK (Critical: дубль-доставка при ambiguous-ошибках; High: сброс часового бюджета, мёртвый heartbeat без baseline, изоляция post-success) + Fable: SHIP-WITH-CHANGES (429-амплификация слоёв, redact в dead-letter, edit-only пин) → сведённый фикс-луп, все пункты закрыты.

## Верификация
tsc 0 ×2; 2464 pass / 0 fail ×2 (моя независимая сверка тоже ×2). +59 тестов к базе.

🤖 Generated with [Claude Code](https://claude.com/claude-code)