### PR TITLE
Автономия M2: тап вождя = мандат — [LEASE:]-карточки, /lease, durable intent

### DIFF
--- a/plugin/src/autonomy/ask-intents.ts
+++ b/plugin/src/autonomy/ask-intents.ts
@@ -1,0 +1,186 @@
+// src/autonomy/ask-intents.ts
+//
+// Durable per-chat store of CANONICAL lease-grant intents attached to pending
+// AskUserQuestion cards (M2 fix-loop-2 #1, Codex CRITICAL).
+//
+// Why this exists: the ask relay keeps pending cards in memory only, and the
+// first fix-loop's intent snapshot was an in-memory map re-derived by a
+// parser. After a process restart (or a deploy that CHANGES the parser) the
+// owner-visible scope and the granted scope could diverge. This file is the
+// single durable source of truth: the intent is parsed ONCE at card creation,
+// persisted here, and the open render, the closed render and the tap-grant
+// path read ONLY this record — never a re-parse of the question text. A card
+// whose persisted intent is absent (legacy record, save failure, recovery
+// failure) is NOT grant-capable, period.
+//
+// Persistence: one JSON file per chat, `ask-lease-intents-<chatKey>.json`, in
+// the same state root as the autonomy registry, written with the SAME atomic
+// discipline (atomicWriteInRoot). Single writer: the plugin server process's
+// ask UI. Entries are pruned by age on every save (cards live minutes; the
+// TTL is generous) and hard-capped as a safety valve. Loads never throw.
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import {
+  atomicWriteInRoot,
+  canonicalChatKey,
+  type AutonomyPaths,
+} from './store.js'
+import type { Logger } from '../log.js'
+
+// The canonical parsed grant intent of one card question. `displayText` is
+// persisted alongside the grant fields so the renderers need NO re-parse for
+// the marker-stripped question either — every owner-facing surface reads the
+// same record the grant will use.
+export interface PersistedLeaseIntent {
+  scope: string
+  ttlHours: number
+  supersede: boolean
+  scopeDigest: string
+  displayText: string
+  createdAtMs: number
+}
+
+interface AskIntentsFile {
+  version: 1
+  intents: Record<string, PersistedLeaseIntent>
+}
+
+// Cards live at most the relay timeout (minutes). 24h is a generous ceiling
+// that still guarantees strays never accumulate.
+export const ASK_INTENT_TTL_MS = 24 * 3_600_000
+// Safety valve — one chat cannot realistically have more concurrent cards.
+export const ASK_INTENT_MAX_ENTRIES = 50
+
+// Filename (relative to the state root) of the per-chat intents file.
+export function askIntentsFilename(chatId: string): string {
+  return `ask-lease-intents-${canonicalChatKey(chatId)}.json`
+}
+
+function loadFile(paths: AutonomyPaths, chatId: string): AskIntentsFile {
+  const empty: AskIntentsFile = { version: 1, intents: {} }
+  let raw: string
+  try {
+    raw = readFileSync(join(paths.root, askIntentsFilename(chatId)), 'utf8')
+  } catch {
+    return empty // missing file on first use — expected
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return empty
+    const obj = parsed as Record<string, unknown>
+    if (typeof obj.intents !== 'object' || obj.intents === null || Array.isArray(obj.intents)) {
+      return empty
+    }
+    const out: AskIntentsFile = { version: 1, intents: {} }
+    for (const [key, rawIntent] of Object.entries(obj.intents as Record<string, unknown>)) {
+      const intent = coerceIntent(rawIntent)
+      if (intent !== undefined) out.intents[key] = intent
+    }
+    return out
+  } catch {
+    return empty // corrupt — fail-closed (cards become non-grant-capable)
+  }
+}
+
+function coerceIntent(raw: unknown): PersistedLeaseIntent | undefined {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) return undefined
+  const o = raw as Record<string, unknown>
+  if (typeof o.scope !== 'string' || o.scope.length === 0) return undefined
+  if (typeof o.ttlHours !== 'number' || !Number.isFinite(o.ttlHours)) return undefined
+  if (typeof o.scopeDigest !== 'string' || o.scopeDigest.length === 0) return undefined
+  if (typeof o.createdAtMs !== 'number' || !Number.isFinite(o.createdAtMs)) return undefined
+  return {
+    scope: o.scope,
+    ttlHours: o.ttlHours,
+    supersede: o.supersede === true,
+    scopeDigest: o.scopeDigest,
+    displayText: typeof o.displayText === 'string' && o.displayText.length > 0 ? o.displayText : o.scope,
+    createdAtMs: o.createdAtMs,
+  }
+}
+
+function saveFile(paths: AutonomyPaths, chatId: string, file: AskIntentsFile): void {
+  atomicWriteInRoot(paths, askIntentsFilename(chatId), JSON.stringify(file, null, 2))
+}
+
+// Age-prune + hard-cap the entries map (oldest evicted first).
+function pruneIntents(
+  intents: Record<string, PersistedLeaseIntent>,
+  nowMs: number,
+): Record<string, PersistedLeaseIntent> {
+  const entries = Object.entries(intents).filter(
+    ([, v]) => nowMs - v.createdAtMs <= ASK_INTENT_TTL_MS,
+  )
+  entries.sort((a, b) => a[1].createdAtMs - b[1].createdAtMs)
+  const kept = entries.slice(Math.max(0, entries.length - ASK_INTENT_MAX_ENTRIES))
+  return Object.fromEntries(kept)
+}
+
+/**
+ * Persist the canonical intent for a card question (key `<requestId>:<qIdx>`).
+ * Returns true only when the record is durably on disk — the caller treats a
+ * false as «card NOT grant-capable» (fail-closed: a card must never render a
+ * mandate block whose intent would not survive a restart).
+ */
+export function saveLeaseIntent(
+  paths: AutonomyPaths,
+  chatId: string,
+  key: string,
+  intent: PersistedLeaseIntent,
+  log?: Logger,
+): boolean {
+  try {
+    const file = loadFile(paths, chatId)
+    file.intents = pruneIntents(file.intents, intent.createdAtMs)
+    file.intents[key] = intent
+    saveFile(paths, chatId, file)
+    return true
+  } catch (err) {
+    if (log) {
+      log.warn('ask lease intent persist failed — card will not be grant-capable', {
+        chat_id: chatId,
+        key,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+    return false
+  }
+}
+
+/** Read the persisted intent for a card question. Never throws. */
+export function loadLeaseIntent(
+  paths: AutonomyPaths,
+  chatId: string,
+  key: string,
+): PersistedLeaseIntent | undefined {
+  try {
+    return loadFile(paths, chatId).intents[key]
+  } catch {
+    return undefined
+  }
+}
+
+/** Best-effort removal after the card settles / the grant completed. */
+export function deleteLeaseIntent(
+  paths: AutonomyPaths,
+  chatId: string,
+  key: string,
+  log?: Logger,
+): void {
+  try {
+    const file = loadFile(paths, chatId)
+    if (!(key in file.intents)) return
+    delete file.intents[key]
+    saveFile(paths, chatId, file)
+  } catch (err) {
+    if (log) {
+      log.debug('ask lease intent delete failed (ignored)', {
+        chat_id: chatId,
+        key,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+}

--- a/plugin/src/autonomy/grant.ts
+++ b/plugin/src/autonomy/grant.ts
@@ -1,0 +1,233 @@
+// src/autonomy/grant.ts
+//
+// Autonomy M2 — the ONLY two authenticated lease-GRANT paths.
+//
+// SECURITY INVARIANT (do not weaken): nothing the agent can call — no MCP
+// tool, no hook script — may create a lease. A lease is minted only by:
+//   1. the AskUserQuestion tap handler (telegram/ask-user-question.ts), when
+//      the OWNER taps an affirmative option on a `[LEASE: …]` card, and
+//   2. the `/lease` owner command (commands/oob.ts).
+// Both call `grantLease` below, and both run ONLY behind the owner allowlist
+// (resolveAskUserQuestionAllowedUserIds / config.allowed_user_ids). The M1
+// `autonomy` MCP tool deliberately has no grant action; this module is the
+// grant surface that lives OUTSIDE the agent's reach.
+//
+// This file holds the pure marker/label/command parsers (unit-tested in
+// isolation) plus the thin `grantLease` orchestrator that routes the parsed
+// intent through the serialized store writer (updateAutonomyState).
+
+import {
+  type AutonomyLease,
+  type AutonomyPaths,
+  type LeaseGrantOutcome,
+  type LeaseSource,
+  applyLeaseGrant,
+  updateAutonomyState,
+} from './store.js'
+import type { Logger } from '../log.js'
+
+// ─────────────────────────────────────────────────────────────────────
+// TTL policy — shared by the marker and the `/lease` command.
+// ─────────────────────────────────────────────────────────────────────
+
+export const LEASE_DEFAULT_TTL_HOURS = 24
+export const LEASE_MAX_TTL_HOURS = 72
+const MS_PER_HOUR = 3_600_000
+
+/**
+ * Clamp a parsed ttl into policy: default 24h when absent/invalid, hard cap
+ * 72h. A non-finite or ≤0 value falls back to the default (a request for
+ * "0 hours" is a mistake, not a request for an instantly-dead mandate).
+ */
+export function clampTtlHours(parsed: number | undefined): number {
+  if (parsed === undefined || !Number.isFinite(parsed) || parsed <= 0) {
+    return LEASE_DEFAULT_TTL_HOURS
+  }
+  return Math.min(parsed, LEASE_MAX_TTL_HOURS)
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Affirmative option labels. EXACT match (case-insensitive, trimmed) against
+// this closed list — never a substring/heuristic, so «Нет, не сейчас» or
+// «Да позже уточню» never trips a grant. Any non-affirmative label (including
+// «Другое» free text) mints NO lease.
+// ─────────────────────────────────────────────────────────────────────
+
+const AFFIRMATIVE_LABELS: ReadonlySet<string> = new Set(
+  ['Да', 'Да, весь трейн', 'Да, разрешаю', 'Yes'].map((s) => s.toLowerCase()),
+)
+
+export function isAffirmativeLabel(label: string): boolean {
+  return AFFIRMATIVE_LABELS.has(label.trim().toLowerCase())
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Marker parsing. A lease-request card is an agent-authored question whose
+// text BEGINS with `[LEASE: <scope>]`, optionally `[LEASE: <scope>; ttl=<N>h]`
+// and/or `; supersede`. The marker is parsed AND stripped from what the owner
+// sees (the display text).
+// ─────────────────────────────────────────────────────────────────────
+
+export interface ParsedLeaseMarker {
+  // Verbatim scope text (never paraphrased) — the grant's scope + digest anchor.
+  scope: string
+  // Clamped ttl in hours (default 24, cap 72).
+  ttlHours: number
+  // `; supersede` present → revoke a differing active lease before granting.
+  supersede: boolean
+  // What Telegram renders (marker stripped). Falls back to the scope text when
+  // the marker was the whole question, so the owner always sees SOMETHING.
+  displayText: string
+}
+
+// Matches a leading `[LEASE: …]` (case-insensitive on the LEASE keyword),
+// capturing the inner text up to the FIRST closing bracket. Leading whitespace
+// is tolerated so an indented question still parses.
+const LEASE_MARKER_RE = /^\s*\[lease:\s*([^\]]*)\]/i
+
+interface ScopeAndOptions {
+  scope: string
+  ttlHours: number
+  supersede: boolean
+}
+
+// Parse the inner `<scope>[; ttl=Nh][; supersede]` grammar shared by the
+// marker body and the `/lease` command args. Returns null when the scope
+// segment is empty (a malformed marker → treated as a normal question).
+function parseScopeAndOptions(inner: string): ScopeAndOptions | null {
+  const segments = inner.split(';')
+  const scope = (segments[0] ?? '').trim()
+  if (scope.length === 0) return null
+
+  let ttlParsed: number | undefined
+  let supersede = false
+  for (let i = 1; i < segments.length; i++) {
+    const seg = (segments[i] ?? '').trim()
+    if (seg.length === 0) continue
+    const ttlMatch = /^ttl\s*=\s*([0-9]*\.?[0-9]+)\s*h$/i.exec(seg)
+    if (ttlMatch) {
+      ttlParsed = Number.parseFloat(ttlMatch[1] as string)
+      continue
+    }
+    if (/^supersede$/i.test(seg)) {
+      supersede = true
+      continue
+    }
+    // Unknown option segment — ignore it, but the card is still a valid lease
+    // request (we already have a non-empty scope).
+  }
+  return { scope, ttlHours: clampTtlHours(ttlParsed), supersede }
+}
+
+/**
+ * Parse a `[LEASE: …]` marker at the START of a question. Returns null when
+ * there is no marker or the scope is empty (both → render as a normal
+ * question, mint no lease).
+ */
+export function parseLeaseMarker(questionText: string): ParsedLeaseMarker | null {
+  const m = LEASE_MARKER_RE.exec(questionText)
+  if (!m) return null
+  const parsed = parseScopeAndOptions(m[1] ?? '')
+  if (!parsed) return null
+  const remainder = questionText.slice(m[0].length).trim()
+  return {
+    scope: parsed.scope,
+    ttlHours: parsed.ttlHours,
+    supersede: parsed.supersede,
+    displayText: remainder.length > 0 ? remainder : parsed.scope,
+  }
+}
+
+/** The owner-facing question text with any lease marker stripped. Identity for
+ *  a non-lease question. Used by the Telegram renderers so the owner never
+ *  sees the raw `[LEASE: …]` plumbing. */
+export function stripLeaseMarkerForDisplay(questionText: string): string {
+  const parsed = parseLeaseMarker(questionText)
+  return parsed ? parsed.displayText : questionText
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// `/lease` command args parsing.
+// ─────────────────────────────────────────────────────────────────────
+
+export type ParsedLeaseCommand =
+  // Bare `/lease` (no scope) → list active leases + usage, grant nothing.
+  | { kind: 'bare' }
+  // `/lease <scope>` or `/lease <scope>; ttl=48h` → grant.
+  | { kind: 'grant'; scope: string; ttlHours: number }
+
+/** Parse the args of a `/lease` command (the text AFTER the command word).
+ *  An empty scope (bare command, or only options with no scope) → `bare`. */
+export function parseLeaseCommandArgs(args: string): ParsedLeaseCommand {
+  if (args.trim().length === 0) return { kind: 'bare' }
+  const parsed = parseScopeAndOptions(args)
+  // supersede is NOT part of the `/lease` grammar — a differing active lease
+  // coexists (the owner can revoke via the MCP tool). We take scope + ttl only.
+  if (!parsed) return { kind: 'bare' }
+  return { kind: 'grant', scope: parsed.scope, ttlHours: parsed.ttlHours }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// grantLease — the single orchestrator both authenticated paths call.
+// ─────────────────────────────────────────────────────────────────────
+
+export interface GrantLeaseInput {
+  scope: string
+  ttlHours: number
+  source: LeaseSource
+  // Idempotency key: a stable string per grant intent (`ask:<reqId>:<qIdx>` or
+  // `cmd:<chatId>:<msgId>`). A replay carrying the same key mints no second
+  // lease (store-level guard in applyLeaseGrant).
+  grantSourceId: string
+  grantorMessageId?: number
+  supersede?: boolean
+}
+
+export type GrantLeaseResult =
+  | { kind: 'ok'; outcome: LeaseGrantOutcome; lease?: AutonomyLease }
+  | { kind: 'writer_conflict' }
+  | { kind: 'version_unsupported' }
+
+/**
+ * Mint (or idempotently return) a lease for `chatId`, routing through the
+ * serialized store writer. Callers are the two authenticated grant surfaces
+ * ONLY — see the security invariant at the top of this file.
+ */
+export async function grantLease(
+  paths: AutonomyPaths,
+  chatId: string,
+  input: GrantLeaseInput,
+  log?: Logger,
+  nowMs: number = Date.now(),
+): Promise<GrantLeaseResult> {
+  const expiresAtMs = nowMs + input.ttlHours * MS_PER_HOUR
+  const upd = await updateAutonomyState(
+    paths,
+    chatId,
+    (state) => {
+      const r = applyLeaseGrant(
+        state,
+        {
+          scope: input.scope,
+          expiresAtMs,
+          source: input.source,
+          grantSourceId: input.grantSourceId,
+          chatId,
+          ...(input.grantorMessageId !== undefined ? { grantorMessageId: input.grantorMessageId } : {}),
+          ...(input.supersede !== undefined ? { supersede: input.supersede } : {}),
+        },
+        nowMs,
+      )
+      return { state: r.state, result: { outcome: r.outcome, lease: r.lease } }
+    },
+    log,
+    nowMs,
+  )
+  if (upd.kind === 'writer_conflict') return { kind: 'writer_conflict' }
+  if (upd.kind === 'version_unsupported') return { kind: 'version_unsupported' }
+  return {
+    kind: 'ok',
+    outcome: upd.result.outcome,
+    ...(upd.result.lease !== undefined ? { lease: upd.result.lease } : {}),
+  }
+}

--- a/plugin/src/autonomy/grant.ts
+++ b/plugin/src/autonomy/grant.ts
@@ -50,8 +50,11 @@ const MS_PER_HOUR = 3_600_000
 // than validation: an option-like segment that fails the strict form must
 // fail the grant — never fall through as scope text, never be defaulted.
 const TTL_LOOKS_LIKE_RE = /^ttl\s*=/i
-// The strict accepted form: `ttl=<int>h`, 1-2 ASCII digits, no inner spaces.
-const TTL_STRICT_RE = /^ttl=([0-9]{1,2})h$/i
+// The strict accepted form: literal lowercase `ttl=<int>h`, 1-2 ASCII digits,
+// no inner spaces, no case variants (fix-loop-2 #7: `TTL=12H` is INVALID —
+// detection stays case-insensitive so the variant fails the grant instead of
+// silently becoming scope text).
+const TTL_STRICT_RE = /^ttl=([0-9]{1,2})h$/
 
 // Strict ttl segment parse: integer 1..72 → hours; anything else → null.
 function parseTtlSegment(segment: string): number | null {
@@ -66,6 +69,28 @@ function parseTtlSegment(segment: string): number | null {
 // UTF-16 unit counting).
 function codePointLength(s: string): number {
   return Array.from(s).length
+}
+
+// Charset fail-closed (fix-loop-2 #6): a scope containing control (Cc — incl.
+// newlines/tabs) or format (Cf — incl. bidi RLO/LRO/PDF, zero-width joiners)
+// code points is INVALID. Bidi controls can visually REORDER the rendered
+// consent text so what the owner reads differs from the granted bytes even
+// though the digest matches — reject the whole grant instead.
+const SCOPE_FORBIDDEN_RE = /[\p{Cc}\p{Cf}]/u
+
+function scopeCharsetInvalid(scope: string): boolean {
+  return SCOPE_FORBIDDEN_RE.test(scope)
+}
+
+/**
+ * Cheap PREFIX test: does this question text START with something that looks
+ * like a lease marker? Presentation-only helper for the honesty surfaces
+ * («маркер некорректен» note, «intent утерян» closed-card line). It NEVER
+ * influences granting — grants read only the persisted canonical intent
+ * (ask-intents.ts, fix-loop-2 #1).
+ */
+export function looksLikeLeaseMarker(questionText: string): boolean {
+  return /^\s*\[lease:/i.test(questionText)
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -130,6 +155,7 @@ export function parseLeaseMarker(questionText: string): ParsedLeaseMarker | null
   const scope = (segments[0] ?? '').trim()
   if (scope.length === 0) return null
   if (codePointLength(scope) > LEASE_SCOPE_MAX_CODEPOINTS) return null
+  if (scopeCharsetInvalid(scope)) return null // Cc/Cf incl. bidi controls — fail-closed
 
   let ttl: number | undefined
   let supersede = false
@@ -178,7 +204,7 @@ export type ParsedLeaseCommand =
   | { kind: 'grant'; scope: string; ttlHours: number }
   // Present-but-malformed option / over-long scope → usage error, NO grant
   // (fail-closed, fix-loop #3/#6/#8).
-  | { kind: 'invalid'; reason: 'ttl' | 'scope_too_long' }
+  | { kind: 'invalid'; reason: 'ttl' | 'scope_too_long' | 'scope_charset' }
 
 /**
  * Parse the args of a `/lease` command (the text AFTER the command word).
@@ -211,6 +237,9 @@ export function parseLeaseCommandArgs(args: string): ParsedLeaseCommand {
   if (scope.length === 0) return { kind: 'bare' }
   if (codePointLength(scope) > LEASE_SCOPE_MAX_CODEPOINTS) {
     return { kind: 'invalid', reason: 'scope_too_long' }
+  }
+  if (scopeCharsetInvalid(scope)) {
+    return { kind: 'invalid', reason: 'scope_charset' }
   }
   return { kind: 'grant', scope, ttlHours: ttl ?? LEASE_DEFAULT_TTL_HOURS }
 }

--- a/plugin/src/autonomy/grant.ts
+++ b/plugin/src/autonomy/grant.ts
@@ -28,22 +28,44 @@ import type { Logger } from '../log.js'
 
 // ─────────────────────────────────────────────────────────────────────
 // TTL policy — shared by the marker and the `/lease` command.
+//
+// FAIL-CLOSED grammar (M2 fix-loop #3, Codex HIGH): the default of 24h
+// applies ONLY when the ttl is entirely absent. A ttl segment that is PRESENT
+// but malformed — 0, negative, float, NaN, >72, non-ASCII digits, garbage,
+// inner whitespace — makes the whole grant INVALID (marker → the card is a
+// normal question, not grant-capable; /lease → usage error, no grant).
+// Accepted values: ASCII integer 1..72 in the exact form `ttl=<int>h`.
 // ─────────────────────────────────────────────────────────────────────
 
 export const LEASE_DEFAULT_TTL_HOURS = 24
 export const LEASE_MAX_TTL_HOURS = 72
+// Hygiene cap (fix-loop #8): a scope longer than this is INVALID, fail-closed.
+// It is NOT clipped-and-granted: «rendered ≠ granted» must never happen, and a
+// scope that cannot be rendered fully grants nothing.
+export const LEASE_SCOPE_MAX_CODEPOINTS = 400
 const MS_PER_HOUR = 3_600_000
 
-/**
- * Clamp a parsed ttl into policy: default 24h when absent/invalid, hard cap
- * 72h. A non-finite or ≤0 value falls back to the default (a request for
- * "0 hours" is a mistake, not a request for an instantly-dead mandate).
- */
-export function clampTtlHours(parsed: number | undefined): number {
-  if (parsed === undefined || !Number.isFinite(parsed) || parsed <= 0) {
-    return LEASE_DEFAULT_TTL_HOURS
-  }
-  return Math.min(parsed, LEASE_MAX_TTL_HOURS)
+// A segment that LOOKS like a ttl option (starts with `ttl=`, whitespace
+// around `=` tolerated for DETECTION only). Detection is deliberately broader
+// than validation: an option-like segment that fails the strict form must
+// fail the grant — never fall through as scope text, never be defaulted.
+const TTL_LOOKS_LIKE_RE = /^ttl\s*=/i
+// The strict accepted form: `ttl=<int>h`, 1-2 ASCII digits, no inner spaces.
+const TTL_STRICT_RE = /^ttl=([0-9]{1,2})h$/i
+
+// Strict ttl segment parse: integer 1..72 → hours; anything else → null.
+function parseTtlSegment(segment: string): number | null {
+  const m = TTL_STRICT_RE.exec(segment)
+  if (!m) return null
+  const n = Number.parseInt(m[1] as string, 10)
+  if (!Number.isInteger(n) || n < 1 || n > LEASE_MAX_TTL_HOURS) return null
+  return n
+}
+
+// Code-point length (an astral-plane scope must not slip past the cap via
+// UTF-16 unit counting).
+function codePointLength(s: string): number {
+  return Array.from(s).length
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -71,7 +93,7 @@ export function isAffirmativeLabel(label: string): boolean {
 export interface ParsedLeaseMarker {
   // Verbatim scope text (never paraphrased) — the grant's scope + digest anchor.
   scope: string
-  // Clamped ttl in hours (default 24, cap 72).
+  // Validated ttl in hours (default 24 only when the segment is absent).
   ttlHours: number
   // `; supersede` present → revoke a differing active lease before granting.
   supersede: boolean
@@ -85,56 +107,55 @@ export interface ParsedLeaseMarker {
 // is tolerated so an indented question still parses.
 const LEASE_MARKER_RE = /^\s*\[lease:\s*([^\]]*)\]/i
 
-interface ScopeAndOptions {
-  scope: string
-  ttlHours: number
-  supersede: boolean
-}
-
-// Parse the inner `<scope>[; ttl=Nh][; supersede]` grammar shared by the
-// marker body and the `/lease` command args. Returns null when the scope
-// segment is empty (a malformed marker → treated as a normal question).
-function parseScopeAndOptions(inner: string): ScopeAndOptions | null {
-  const segments = inner.split(';')
-  const scope = (segments[0] ?? '').trim()
-  if (scope.length === 0) return null
-
-  let ttlParsed: number | undefined
-  let supersede = false
-  for (let i = 1; i < segments.length; i++) {
-    const seg = (segments[i] ?? '').trim()
-    if (seg.length === 0) continue
-    const ttlMatch = /^ttl\s*=\s*([0-9]*\.?[0-9]+)\s*h$/i.exec(seg)
-    if (ttlMatch) {
-      ttlParsed = Number.parseFloat(ttlMatch[1] as string)
-      continue
-    }
-    if (/^supersede$/i.test(seg)) {
-      supersede = true
-      continue
-    }
-    // Unknown option segment — ignore it, but the card is still a valid lease
-    // request (we already have a non-empty scope).
-  }
-  return { scope, ttlHours: clampTtlHours(ttlParsed), supersede }
-}
-
 /**
- * Parse a `[LEASE: …]` marker at the START of a question. Returns null when
- * there is no marker or the scope is empty (both → render as a normal
- * question, mint no lease).
+ * Parse a `[LEASE: …]` marker at the START of a question. Returns null — the
+ * card is a NORMAL question, not grant-capable, and the raw text (marker
+ * included) is what the owner sees — when ANY of these hold (fail-closed,
+ * fix-loop #3/#8):
+ *   * no marker, or the marker is not at the very start;
+ *   * empty scope;
+ *   * scope longer than LEASE_SCOPE_MAX_CODEPOINTS;
+ *   * a ttl segment present but not a strict `ttl=<int 1..72>h`;
+ *   * duplicate ttl / duplicate supersede segments;
+ *   * ANY unknown or empty option segment (the marker grammar is closed:
+ *     after the scope only `ttl=<int>h` and `supersede` are legal — a scope
+ *     containing `;` is therefore invalid inside a marker rather than being
+ *     silently truncated at the first `;`).
  */
 export function parseLeaseMarker(questionText: string): ParsedLeaseMarker | null {
   const m = LEASE_MARKER_RE.exec(questionText)
   if (!m) return null
-  const parsed = parseScopeAndOptions(m[1] ?? '')
-  if (!parsed) return null
+  const inner = m[1] ?? ''
+  const segments = inner.split(';')
+  const scope = (segments[0] ?? '').trim()
+  if (scope.length === 0) return null
+  if (codePointLength(scope) > LEASE_SCOPE_MAX_CODEPOINTS) return null
+
+  let ttl: number | undefined
+  let supersede = false
+  for (let i = 1; i < segments.length; i++) {
+    const seg = (segments[i] ?? '').trim()
+    if (TTL_LOOKS_LIKE_RE.test(seg)) {
+      if (ttl !== undefined) return null // duplicate ttl — ambiguous, invalid
+      const v = parseTtlSegment(seg)
+      if (v === null) return null // malformed ttl — INVALID, never defaulted
+      ttl = v
+      continue
+    }
+    if (/^supersede$/i.test(seg)) {
+      if (supersede) return null // duplicate — invalid
+      supersede = true
+      continue
+    }
+    // Unknown or empty segment — the whole marker is invalid (fail-closed).
+    return null
+  }
   const remainder = questionText.slice(m[0].length).trim()
   return {
-    scope: parsed.scope,
-    ttlHours: parsed.ttlHours,
-    supersede: parsed.supersede,
-    displayText: remainder.length > 0 ? remainder : parsed.scope,
+    scope,
+    ttlHours: ttl ?? LEASE_DEFAULT_TTL_HOURS,
+    supersede,
+    displayText: remainder.length > 0 ? remainder : scope,
   }
 }
 
@@ -155,16 +176,43 @@ export type ParsedLeaseCommand =
   | { kind: 'bare' }
   // `/lease <scope>` or `/lease <scope>; ttl=48h` → grant.
   | { kind: 'grant'; scope: string; ttlHours: number }
+  // Present-but-malformed option / over-long scope → usage error, NO grant
+  // (fail-closed, fix-loop #3/#6/#8).
+  | { kind: 'invalid'; reason: 'ttl' | 'scope_too_long' }
 
-/** Parse the args of a `/lease` command (the text AFTER the command word).
- *  An empty scope (bare command, or only options with no scope) → `bare`. */
+/**
+ * Parse the args of a `/lease` command (the text AFTER the command word).
+ *
+ * Grammar (fix-loop #6, Codex MED — no silent scope truncation): ONLY a
+ * TRAILING segment matching the strict `ttl=<int>h` form is treated as an
+ * option. Every other `;` belongs to the scope text verbatim — so
+ * `/lease аудит; production` grants the scope «аудит; production», never a
+ * silently-truncated «аудит». A trailing segment that LOOKS option-like
+ * (`ttl=…`) but is malformed → `invalid` (usage error), consistent with the
+ * marker's fail-closed ttl grammar. `supersede` is NOT part of the `/lease`
+ * grammar — differing active leases coexist (revoke via the MCP tool).
+ */
 export function parseLeaseCommandArgs(args: string): ParsedLeaseCommand {
-  if (args.trim().length === 0) return { kind: 'bare' }
-  const parsed = parseScopeAndOptions(args)
-  // supersede is NOT part of the `/lease` grammar — a differing active lease
-  // coexists (the owner can revoke via the MCP tool). We take scope + ttl only.
-  if (!parsed) return { kind: 'bare' }
-  return { kind: 'grant', scope: parsed.scope, ttlHours: parsed.ttlHours }
+  const trimmed = args.trim()
+  if (trimmed.length === 0) return { kind: 'bare' }
+
+  let scope = trimmed
+  let ttl: number | undefined
+  const lastSemi = trimmed.lastIndexOf(';')
+  if (lastSemi !== -1) {
+    const trailing = trimmed.slice(lastSemi + 1).trim()
+    if (TTL_LOOKS_LIKE_RE.test(trailing)) {
+      const v = parseTtlSegment(trailing)
+      if (v === null) return { kind: 'invalid', reason: 'ttl' }
+      ttl = v
+      scope = trimmed.slice(0, lastSemi).trim()
+    }
+  }
+  if (scope.length === 0) return { kind: 'bare' }
+  if (codePointLength(scope) > LEASE_SCOPE_MAX_CODEPOINTS) {
+    return { kind: 'invalid', reason: 'scope_too_long' }
+  }
+  return { kind: 'grant', scope, ttlHours: ttl ?? LEASE_DEFAULT_TTL_HOURS }
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/plugin/src/autonomy/store.ts
+++ b/plugin/src/autonomy/store.ts
@@ -118,6 +118,22 @@ export interface OpenQuestion {
   resolvedAtMs?: number
 }
 
+// Durable replay ledger entry (M2 fix-loop #2, Codex HIGH). EVERY grant
+// attempt that was accepted OR deduped records its grantSourceId here — the
+// dedup check consults this ledger FIRST, so a replayed /lease command or
+// Telegram callback can never mint a fresh lease after the original lease
+// expired / was revoked / was pruned. Ledger entries out-live lease
+// tombstones: prune keeps them for 90 days (GRANT_SOURCE_LEDGER_MAX_AGE_MS),
+// not the 14-day lease retention.
+export interface UsedGrantSource {
+  sourceId: string
+  // Digest of the scope that was granted/deduped for this source. Dedup key
+  // is sourceId AND scopeDigest (Fable): a colliding sourceId with a
+  // DIFFERENT scope is a `source_conflict`, never a silent swallow.
+  scopeDigest: string
+  atMs: number
+}
+
 export interface AutonomyState {
   version: typeof AUTONOMY_STATE_VERSION
   // Monotonic save counter (fix-loop-2 #1): every successful save writes
@@ -126,6 +142,15 @@ export interface AutonomyState {
   revision: number
   leases: AutonomyLease[]
   questions: OpenQuestion[]
+  // Replay ledger — see UsedGrantSource above.
+  usedGrantSources: UsedGrantSource[]
+  // Set by coerceState when the on-disk `version` value is present and is NOT
+  // exactly the integer AUTONOMY_STATE_VERSION (M2 fix-loop #5: `1.9`, `"2"`,
+  // `"abc"` all land here — the raw value is compared BEFORE any coercion).
+  // Presence marks the registry READ-ONLY: updateAutonomyState refuses every
+  // mutation with `version_unsupported` and the file is never overwritten.
+  // Never persisted — saveAutonomyState writes explicit fields only.
+  unsupportedVersion?: number | string
 }
 
 // The subset of StatePaths the store needs — just the state root. Full
@@ -139,7 +164,7 @@ export type AutonomyPaths = Pick<StatePaths, 'root'>
 // ─────────────────────────────────────────────────────────────────────
 
 export function emptyAutonomyState(): AutonomyState {
-  return { version: AUTONOMY_STATE_VERSION, revision: 0, leases: [], questions: [] }
+  return { version: AUTONOMY_STATE_VERSION, revision: 0, leases: [], questions: [], usedGrantSources: [] }
 }
 
 // A lease is active when it has NOT been consumed, NOT been revoked and has
@@ -259,21 +284,33 @@ export function addLease(
 // authenticated grant paths (ask-card tap + `/lease` command — see
 // autonomy/grant.ts). It is NEVER reachable from an agent-callable surface.
 //
-// Idempotency + supersede rules (Sol M2 security):
-//   1. A lease with the SAME grantSourceId already exists (any status) →
-//      idempotent no-op, return it (`duplicate_source`). This absorbs a
-//      double-tap / replayed callback into exactly one lease.
-//   2. An ACTIVE lease with the SAME scopeDigest exists → idempotent no-op,
-//      return it (`duplicate_scope`). A re-grant of an identical scope never
-//      stacks a second mandate.
-//   3. `supersede` set AND active lease(s) with a DIFFERENT scope exist →
+// Idempotency + supersede rules (Sol M2 security + fix-loop #2):
+//   1. The durable replay ledger (`usedGrantSources`) is consulted FIRST:
+//      a sourceId hit with the SAME scopeDigest → idempotent no-op
+//      (`duplicate_source`); a sourceId hit with a DIFFERENT scopeDigest →
+//      `source_conflict` (no grant — a colliding short id across restarts
+//      must never silently swallow a legit grant NOR replay the wrong scope).
+//   2. Legacy lease-record check (pre-ledger files): same rules keyed off the
+//      lease's grantSourceId; a same-scope dedup back-fills the ledger.
+//   3. An ACTIVE lease with the SAME scopeDigest exists → idempotent no-op,
+//      return it (`duplicate_scope`) — and the NEW sourceId is recorded in
+//      the ledger so its replay after the lease dies cannot re-mint.
+//   4. `supersede` set AND active lease(s) with a DIFFERENT scope exist →
 //      revoke them (revokedBy caller, reason 'superseded') then grant
 //      (`superseded`).
-//   4. Otherwise grant a fresh lease (`granted`). Multiple active leases with
+//   5. Otherwise grant a fresh lease (`granted`). Multiple active leases with
 //      DIFFERENT scopes coexist by design.
+// Every accepted-or-deduped attempt (outcomes granted / superseded /
+// duplicate_scope, plus the legacy duplicate_source back-fill) records its
+// sourceId+scopeDigest in the ledger.
 // ─────────────────────────────────────────────────────────────────────
 
-export type LeaseGrantOutcome = 'granted' | 'duplicate_source' | 'duplicate_scope' | 'superseded'
+export type LeaseGrantOutcome =
+  | 'granted'
+  | 'duplicate_source'
+  | 'duplicate_scope'
+  | 'superseded'
+  | 'source_conflict'
 
 export interface LeaseGrantInput {
   scope: string
@@ -287,26 +324,69 @@ export interface LeaseGrantInput {
   revokedBy?: string
 }
 
+// Append a ledger entry unless the sourceId is already recorded.
+function recordGrantSource(
+  state: AutonomyState,
+  sourceId: string,
+  scopeDigest: string,
+  nowMs: number,
+): AutonomyState {
+  if (state.usedGrantSources.some((u) => u.sourceId === sourceId)) return state
+  return {
+    ...state,
+    usedGrantSources: [...state.usedGrantSources, { sourceId, scopeDigest, atMs: nowMs }],
+  }
+}
+
 export function applyLeaseGrant(
   state: AutonomyState,
   input: LeaseGrantInput,
   nowMs: number = Date.now(),
 ): { state: AutonomyState; lease?: AutonomyLease; outcome: LeaseGrantOutcome } {
-  // 1. grantSourceId dedup — a replay of the same grant intent returns the
-  //    existing lease (any status), never mints a second one.
+  const digest = computeScopeDigest(input.scope)
+
+  // 1. Durable replay ledger — checked FIRST (fix-loop #2). Survives lease
+  //    tombstone pruning for 90 days.
+  const ledgerHit = state.usedGrantSources.find((u) => u.sourceId === input.grantSourceId)
+  if (ledgerHit !== undefined) {
+    if (ledgerHit.scopeDigest === digest) {
+      const existing = state.leases.find((l) => l.grantSourceId === input.grantSourceId)
+      return {
+        state,
+        ...(existing !== undefined ? { lease: existing } : {}),
+        outcome: 'duplicate_source',
+      }
+    }
+    // Same sourceId, DIFFERENT scope — honest refusal, no grant.
+    return { state, outcome: 'source_conflict' }
+  }
+
+  // 2. Legacy lease-record dedup (files written before the ledger existed).
   const bySource = state.leases.find((l) => l.grantSourceId === input.grantSourceId)
   if (bySource !== undefined) {
-    return { state, lease: bySource, outcome: 'duplicate_source' }
+    if (bySource.scopeDigest === digest) {
+      // Back-fill the ledger so the dedup survives the lease's pruning.
+      return {
+        state: recordGrantSource(state, input.grantSourceId, digest, nowMs),
+        lease: bySource,
+        outcome: 'duplicate_source',
+      }
+    }
+    return { state, outcome: 'source_conflict' }
   }
 
-  // 2. Identical-scope active lease → idempotent no-op (return existing).
-  const digest = computeScopeDigest(input.scope)
+  // 3. Identical-scope active lease → idempotent no-op, but the NEW sourceId
+  //    is still recorded (its later replay must not re-mint).
   const activeSameScope = activeLeases(state, nowMs).find((l) => l.scopeDigest === digest)
   if (activeSameScope !== undefined) {
-    return { state, lease: activeSameScope, outcome: 'duplicate_scope' }
+    return {
+      state: recordGrantSource(state, input.grantSourceId, digest, nowMs),
+      lease: activeSameScope,
+      outcome: 'duplicate_scope',
+    }
   }
 
-  // 3. supersede: revoke differing active leases first.
+  // 4. supersede: revoke differing active leases first.
   let working = state
   let supersededAny = false
   if (input.supersede === true) {
@@ -320,7 +400,7 @@ export function applyLeaseGrant(
     }
   }
 
-  // 4. Grant.
+  // 5. Grant + record in the ledger.
   const added = addLease(
     working,
     {
@@ -334,7 +414,7 @@ export function applyLeaseGrant(
     nowMs,
   )
   return {
-    state: added.state,
+    state: recordGrantSource(added.state, input.grantSourceId, digest, nowMs),
     ...(added.lease !== undefined ? { lease: added.lease } : {}),
     outcome: supersededAny ? 'superseded' : 'granted',
   }
@@ -493,6 +573,11 @@ export function resolveQuestion(
 
 export const PRUNE_MAX_AGE_MS = 14 * 24 * 3_600_000
 
+// The replay ledger out-lives lease tombstones by design (fix-loop #2): a
+// replayed grant source must stay recognisable long after the 14-day lease
+// retention has dropped the lease record itself.
+export const GRANT_SOURCE_LEDGER_MAX_AGE_MS = 90 * 24 * 3_600_000
+
 // The timestamp at which a lease became terminal, or undefined while it is
 // still active. Revoked wins over consumed (a lease can only be one), and an
 // un-consumed/un-revoked lease past its expiry counts from expiresAtMs.
@@ -514,10 +599,18 @@ export function pruneAutonomyState(state: AutonomyState, nowMs: number = Date.no
     if (q.resolvedAtMs === undefined) return true // defensive — no age to judge
     return nowMs - q.resolvedAtMs <= PRUNE_MAX_AGE_MS
   })
-  if (leases.length === state.leases.length && questions.length === state.questions.length) {
+  // The replay ledger is kept 90 days (fix-loop #2) — deliberately LONGER
+  // than the lease tombstones it protects against re-minting.
+  const sources = state.usedGrantSources ?? []
+  const usedGrantSources = sources.filter((u) => nowMs - u.atMs <= GRANT_SOURCE_LEDGER_MAX_AGE_MS)
+  if (
+    leases.length === state.leases.length
+    && questions.length === state.questions.length
+    && usedGrantSources.length === sources.length
+  ) {
     return state // nothing pruned — preserve reference (skip a needless copy)
   }
-  return { ...state, leases, questions }
+  return { ...state, leases, questions, usedGrantSources }
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -699,14 +792,21 @@ function coerceState(parsed: unknown): AutonomyState {
   const out = emptyAutonomyState()
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return out
   const obj = parsed as Record<string, unknown>
-  // Preserve the on-disk schema version (best-effort coerce, PR-1 leftover 4b):
-  // a file written by a FUTURE build (version > 1) must be DETECTABLE so
+  // Version check on the RAW loaded value BEFORE any coercion (M2 fix-loop
+  // #5): a file written by a different schema must be DETECTABLE so
   // updateAutonomyState can treat the registry as read-only rather than
-  // silently downgrading + clobbering it. saveAutonomyState still stamps the
-  // current version on every write we own, so this only surfaces genuinely
-  // newer files.
-  if (typeof obj.version === 'number' && Number.isFinite(obj.version) && obj.version >= 1) {
-    out.version = Math.floor(obj.version) as AutonomyState['version']
+  // silently downgrading + clobbering it. Anything that is not EXACTLY the
+  // integer AUTONOMY_STATE_VERSION — `1.9`, `"2"`, `"abc"`, `2` — marks the
+  // state unsupported (loads stay best-effort; mutations are refused). An
+  // absent version field is treated as current: every file this store ever
+  // wrote carries the stamp, and a hand-restored legacy file must not brick
+  // the registry.
+  const rawVersion = obj.version
+  if (rawVersion !== undefined && rawVersion !== AUTONOMY_STATE_VERSION) {
+    out.unsupportedVersion =
+      typeof rawVersion === 'number' || typeof rawVersion === 'string'
+        ? rawVersion
+        : String(rawVersion)
   }
   if (typeof obj.revision === 'number' && Number.isFinite(obj.revision) && obj.revision >= 0) {
     out.revision = Math.floor(obj.revision)
@@ -721,6 +821,16 @@ function coerceState(parsed: unknown): AutonomyState {
     for (const raw of obj.questions) {
       const q = coerceQuestion(raw)
       if (q !== undefined) out.questions.push(q)
+    }
+  }
+  if (Array.isArray(obj.usedGrantSources)) {
+    for (const raw of obj.usedGrantSources) {
+      if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) continue
+      const o = raw as Record<string, unknown>
+      if (typeof o.sourceId !== 'string' || o.sourceId.length === 0) continue
+      if (typeof o.scopeDigest !== 'string' || o.scopeDigest.length === 0) continue
+      if (typeof o.atMs !== 'number' || !Number.isFinite(o.atMs)) continue
+      out.usedGrantSources.push({ sourceId: o.sourceId, scopeDigest: o.scopeDigest, atMs: o.atMs })
     }
   }
   return out
@@ -889,6 +999,9 @@ export function saveAutonomyState(
       revision: nextRevision,
       leases: state.leases,
       questions: state.questions,
+      usedGrantSources: state.usedGrantSources ?? [],
+      // `unsupportedVersion` is a load-time flag, never persisted — and a
+      // flagged state never reaches this function (the writer refuses it).
     },
     null,
     2,
@@ -1102,15 +1215,17 @@ export function updateAutonomyState<T>(
       return { kind: 'writer_conflict' }
     }
     let state = loadAutonomyState(paths, chatId, log)
-    // Read-only guard (PR-1 leftover 4b): a file from a NEWER schema must not
-    // be mutated + saved (the save would stamp the current version and drop
+    // Read-only guard (PR-1 leftover 4b + fix-loop #5): a file whose RAW
+    // on-disk `version` is not exactly the supported integer (1.9, "2",
+    // "abc", 2 — coerceState compares before any coercion) must not be
+    // mutated + saved (the save would stamp the current version and drop
     // fields this build doesn't understand). Refuse the whole mutation.
-    if (state.version > AUTONOMY_STATE_VERSION) {
+    if (state.unsupportedVersion !== undefined) {
       if (log) {
         log.warn('autonomy state version unsupported — registry read-only, mutation refused', {
           chat_id: chatId,
           code: 'autonomy_state_version_unsupported',
-          version: state.version,
+          version: String(state.unsupportedVersion),
         })
       }
       return { kind: 'version_unsupported' }
@@ -1126,7 +1241,7 @@ export function updateAutonomyState<T>(
         })
       }
       state = loadAutonomyState(paths, chatId, log)
-      if (state.version > AUTONOMY_STATE_VERSION) return { kind: 'version_unsupported' }
+      if (state.unsupportedVersion !== undefined) return { kind: 'version_unsupported' }
       out = mutator(state)
       if (out.state === state) return { kind: 'ok', result: out.result }
     }

--- a/plugin/src/autonomy/store.ts
+++ b/plugin/src/autonomy/store.ts
@@ -81,6 +81,16 @@ export interface AutonomyLease {
   source: LeaseSource
   // The Telegram message id of the grant, when known (PR-2 button relay).
   grantorMessageId?: number
+  // Idempotency anchor (M2): a stable per-grant-intent key
+  // (`ask:<reqId>:<qIdx>` from the tap card, `cmd:<chatId>:<msgId>` from the
+  // `/lease` command). A replay carrying the SAME key mints no second lease —
+  // applyLeaseGrant returns the existing one. Distinct from `id` (a fresh
+  // random per lease) so a genuine re-grant of the same intent dedupes.
+  grantSourceId?: string
+  // The chat the lease was granted in (binding field, M2). The file is
+  // already per-chat, but stamping the id on the record lets an audit tie a
+  // lease to its origin chat without inferring it from the filename.
+  chatId?: string
   // Set to a timestamp when the lease is consumed; null/undefined while active.
   consumedAtMs?: number | null
   // Revocation is a TERMINAL state distinct from consumption (fix-loop-2 #4):
@@ -190,6 +200,8 @@ export interface NewLeaseInput {
   id?: string
   grantedAtMs?: number
   grantorMessageId?: number
+  grantSourceId?: string
+  chatId?: string
   notes?: string
 }
 
@@ -235,9 +247,97 @@ export function addLease(
     source: input.source,
     consumedAtMs: null,
     ...(input.grantorMessageId !== undefined ? { grantorMessageId: input.grantorMessageId } : {}),
+    ...(input.grantSourceId !== undefined ? { grantSourceId: input.grantSourceId } : {}),
+    ...(input.chatId !== undefined ? { chatId: input.chatId } : {}),
     ...(input.notes !== undefined ? { notes: input.notes } : {}),
   }
   return { state: { ...state, leases: [...state.leases, lease] }, lease, outcome: 'ok' }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Lease GRANT (M2). applyLeaseGrant is the pure core of the two
+// authenticated grant paths (ask-card tap + `/lease` command — see
+// autonomy/grant.ts). It is NEVER reachable from an agent-callable surface.
+//
+// Idempotency + supersede rules (Sol M2 security):
+//   1. A lease with the SAME grantSourceId already exists (any status) →
+//      idempotent no-op, return it (`duplicate_source`). This absorbs a
+//      double-tap / replayed callback into exactly one lease.
+//   2. An ACTIVE lease with the SAME scopeDigest exists → idempotent no-op,
+//      return it (`duplicate_scope`). A re-grant of an identical scope never
+//      stacks a second mandate.
+//   3. `supersede` set AND active lease(s) with a DIFFERENT scope exist →
+//      revoke them (revokedBy caller, reason 'superseded') then grant
+//      (`superseded`).
+//   4. Otherwise grant a fresh lease (`granted`). Multiple active leases with
+//      DIFFERENT scopes coexist by design.
+// ─────────────────────────────────────────────────────────────────────
+
+export type LeaseGrantOutcome = 'granted' | 'duplicate_source' | 'duplicate_scope' | 'superseded'
+
+export interface LeaseGrantInput {
+  scope: string
+  expiresAtMs: number
+  source: LeaseSource
+  grantSourceId: string
+  chatId?: string
+  grantorMessageId?: number
+  supersede?: boolean
+  // Label recorded on a superseded lease's revokedBy. Defaults to 'owner_card'.
+  revokedBy?: string
+}
+
+export function applyLeaseGrant(
+  state: AutonomyState,
+  input: LeaseGrantInput,
+  nowMs: number = Date.now(),
+): { state: AutonomyState; lease?: AutonomyLease; outcome: LeaseGrantOutcome } {
+  // 1. grantSourceId dedup — a replay of the same grant intent returns the
+  //    existing lease (any status), never mints a second one.
+  const bySource = state.leases.find((l) => l.grantSourceId === input.grantSourceId)
+  if (bySource !== undefined) {
+    return { state, lease: bySource, outcome: 'duplicate_source' }
+  }
+
+  // 2. Identical-scope active lease → idempotent no-op (return existing).
+  const digest = computeScopeDigest(input.scope)
+  const activeSameScope = activeLeases(state, nowMs).find((l) => l.scopeDigest === digest)
+  if (activeSameScope !== undefined) {
+    return { state, lease: activeSameScope, outcome: 'duplicate_scope' }
+  }
+
+  // 3. supersede: revoke differing active leases first.
+  let working = state
+  let supersededAny = false
+  if (input.supersede === true) {
+    const toRevoke = activeLeases(working, nowMs).filter((l) => l.scopeDigest !== digest)
+    for (const l of toRevoke) {
+      const r = revokeLease(working, l.id, nowMs, input.revokedBy ?? 'owner_card', 'superseded')
+      if (r.outcome === 'ok') {
+        working = r.state
+        supersededAny = true
+      }
+    }
+  }
+
+  // 4. Grant.
+  const added = addLease(
+    working,
+    {
+      scope: input.scope,
+      expiresAtMs: input.expiresAtMs,
+      source: input.source,
+      grantSourceId: input.grantSourceId,
+      ...(input.chatId !== undefined ? { chatId: input.chatId } : {}),
+      ...(input.grantorMessageId !== undefined ? { grantorMessageId: input.grantorMessageId } : {}),
+    },
+    nowMs,
+  )
+  return {
+    state: added.state,
+    ...(added.lease !== undefined ? { lease: added.lease } : {}),
+    outcome: supersededAny ? 'superseded' : 'granted',
+  }
 }
 
 // Scope-digest scheme v1: sha256 over the RAW utf8 bytes of the verbatim
@@ -381,6 +481,43 @@ export function resolveQuestion(
   const questions = state.questions.slice()
   questions[idx] = { ...q, status, resolvedAtMs: nowMs }
   return { state: { ...state, questions }, outcome: 'ok' }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Retention prune (PR-1 leftover 4a). Applied on the save path so a chat's
+// file never grows without bound: TERMINAL leases (consumed / revoked /
+// expired) and RESOLVED questions older than 14 days are dropped. Active
+// leases and open questions are always kept, whatever their age. Pure — no
+// I/O, no clock unless nowMs passed.
+// ─────────────────────────────────────────────────────────────────────
+
+export const PRUNE_MAX_AGE_MS = 14 * 24 * 3_600_000
+
+// The timestamp at which a lease became terminal, or undefined while it is
+// still active. Revoked wins over consumed (a lease can only be one), and an
+// un-consumed/un-revoked lease past its expiry counts from expiresAtMs.
+function leaseTerminalAtMs(lease: AutonomyLease, nowMs: number): number | undefined {
+  if (lease.revokedAtMs !== undefined) return lease.revokedAtMs
+  if (lease.consumedAtMs !== undefined && lease.consumedAtMs !== null) return lease.consumedAtMs
+  if (lease.expiresAtMs <= nowMs) return lease.expiresAtMs
+  return undefined
+}
+
+export function pruneAutonomyState(state: AutonomyState, nowMs: number = Date.now()): AutonomyState {
+  const leases = state.leases.filter((l) => {
+    const terminalAt = leaseTerminalAtMs(l, nowMs)
+    if (terminalAt === undefined) return true // still active — keep
+    return nowMs - terminalAt <= PRUNE_MAX_AGE_MS
+  })
+  const questions = state.questions.filter((q) => {
+    if (q.status === 'open') return true // still open — keep
+    if (q.resolvedAtMs === undefined) return true // defensive — no age to judge
+    return nowMs - q.resolvedAtMs <= PRUNE_MAX_AGE_MS
+  })
+  if (leases.length === state.leases.length && questions.length === state.questions.length) {
+    return state // nothing pruned — preserve reference (skip a needless copy)
+  }
+  return { ...state, leases, questions }
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -562,6 +699,15 @@ function coerceState(parsed: unknown): AutonomyState {
   const out = emptyAutonomyState()
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return out
   const obj = parsed as Record<string, unknown>
+  // Preserve the on-disk schema version (best-effort coerce, PR-1 leftover 4b):
+  // a file written by a FUTURE build (version > 1) must be DETECTABLE so
+  // updateAutonomyState can treat the registry as read-only rather than
+  // silently downgrading + clobbering it. saveAutonomyState still stamps the
+  // current version on every write we own, so this only surfaces genuinely
+  // newer files.
+  if (typeof obj.version === 'number' && Number.isFinite(obj.version) && obj.version >= 1) {
+    out.version = Math.floor(obj.version) as AutonomyState['version']
+  }
   if (typeof obj.revision === 'number' && Number.isFinite(obj.revision) && obj.revision >= 0) {
     out.revision = Math.floor(obj.revision)
   }
@@ -601,6 +747,8 @@ function coerceLease(raw: unknown): AutonomyLease | undefined {
   if (typeof o.grantorMessageId === 'number' && Number.isFinite(o.grantorMessageId)) {
     lease.grantorMessageId = o.grantorMessageId
   }
+  if (typeof o.grantSourceId === 'string' && o.grantSourceId.length > 0) lease.grantSourceId = o.grantSourceId
+  if (typeof o.chatId === 'string' && o.chatId.length > 0) lease.chatId = o.chatId
   if (o.consumedAtMs === null) lease.consumedAtMs = null
   else if (typeof o.consumedAtMs === 'number' && Number.isFinite(o.consumedAtMs)) {
     lease.consumedAtMs = o.consumedAtMs
@@ -911,7 +1059,13 @@ function peekRevision(paths: AutonomyPaths, chatId: string): number {
 
 // Result of a serialized update. `writer_conflict` = a FRESH writer lock is
 // held by another process — the mutation was refused entirely (fix-loop-2 #2).
-export type UpdateResult<T> = { kind: 'ok'; result: T } | { kind: 'writer_conflict' }
+// `version_unsupported` = the on-disk file was written by a NEWER schema
+// (version > 1); the registry is treated as READ-ONLY and the mutation is
+// refused so we never downgrade + clobber a future format (PR-1 leftover 4b).
+export type UpdateResult<T> =
+  | { kind: 'ok'; result: T }
+  | { kind: 'writer_conflict' }
+  | { kind: 'version_unsupported' }
 
 /**
  * Atomically (within this process) apply `mutator` to the chat's state:
@@ -934,6 +1088,13 @@ export function updateAutonomyState<T>(
   chatId: string,
   mutator: (state: AutonomyState) => { state: AutonomyState; result: T },
   log?: Logger,
+  // Clock for the retention prune ONLY (PR-1 leftover 4a). Defaults to
+  // Date.now(); callers that run the mutation on a fixed/injected clock pass
+  // the SAME clock so the prune's "older than 14 days" judgement matches the
+  // timestamps the mutator wrote (otherwise a synthetic past clock makes every
+  // fresh lease look ancient-expired). The writer-lock + revision checks
+  // deliberately stay on the real wall-clock (lock freshness is real-time).
+  nowMs: number = Date.now(),
 ): Promise<UpdateResult<T>> {
   const key = `${paths.root}|${canonicalChatKey(chatId)}`
   const step = (): UpdateResult<T> => {
@@ -941,6 +1102,19 @@ export function updateAutonomyState<T>(
       return { kind: 'writer_conflict' }
     }
     let state = loadAutonomyState(paths, chatId, log)
+    // Read-only guard (PR-1 leftover 4b): a file from a NEWER schema must not
+    // be mutated + saved (the save would stamp the current version and drop
+    // fields this build doesn't understand). Refuse the whole mutation.
+    if (state.version > AUTONOMY_STATE_VERSION) {
+      if (log) {
+        log.warn('autonomy state version unsupported — registry read-only, mutation refused', {
+          chat_id: chatId,
+          code: 'autonomy_state_version_unsupported',
+          version: state.version,
+        })
+      }
+      return { kind: 'version_unsupported' }
+    }
     let out = mutator(state)
     if (out.state === state) return { kind: 'ok', result: out.result }
     // Detect a cross-process write between our load and this write.
@@ -952,10 +1126,12 @@ export function updateAutonomyState<T>(
         })
       }
       state = loadAutonomyState(paths, chatId, log)
+      if (state.version > AUTONOMY_STATE_VERSION) return { kind: 'version_unsupported' }
       out = mutator(state)
       if (out.state === state) return { kind: 'ok', result: out.result }
     }
-    saveAutonomyState(paths, chatId, out.state)
+    // Prune terminal/aged entries on the way to disk (PR-1 leftover 4a).
+    saveAutonomyState(paths, chatId, pruneAutonomyState(out.state, nowMs))
     return { kind: 'ok', result: out.result }
   }
   const prior = updateChains.get(key) ?? Promise.resolve()

--- a/plugin/src/autonomy/store.ts
+++ b/plugin/src/autonomy/store.ts
@@ -578,6 +578,14 @@ export const PRUNE_MAX_AGE_MS = 14 * 24 * 3_600_000
 // retention has dropped the lease record itself.
 export const GRANT_SOURCE_LEDGER_MAX_AGE_MS = 90 * 24 * 3_600_000
 
+// Hard size cap for the replay ledger (fix-loop-2 #4): a SAFETY VALVE, not a
+// working limit. Realistic grant volume is a few per day; 90 days of that is
+// well under 500, so eviction ~never happens in practice and the replay
+// protection is effectively never weakened. The cap only guards the
+// pathological case (a runaway grant loop) from growing the JSON and its
+// linear lookups without bound. Overflow evicts oldest-first with a warn.
+export const GRANT_SOURCE_LEDGER_MAX_ENTRIES = 500
+
 // The timestamp at which a lease became terminal, or undefined while it is
 // still active. Revoked wins over consumed (a lease can only be one), and an
 // un-consumed/un-revoked lease past its expiry counts from expiresAtMs.
@@ -588,7 +596,11 @@ function leaseTerminalAtMs(lease: AutonomyLease, nowMs: number): number | undefi
   return undefined
 }
 
-export function pruneAutonomyState(state: AutonomyState, nowMs: number = Date.now()): AutonomyState {
+export function pruneAutonomyState(
+  state: AutonomyState,
+  nowMs: number = Date.now(),
+  log?: Logger,
+): AutonomyState {
   const leases = state.leases.filter((l) => {
     const terminalAt = leaseTerminalAtMs(l, nowMs)
     if (terminalAt === undefined) return true // still active — keep
@@ -602,7 +614,21 @@ export function pruneAutonomyState(state: AutonomyState, nowMs: number = Date.no
   // The replay ledger is kept 90 days (fix-loop #2) — deliberately LONGER
   // than the lease tombstones it protects against re-minting.
   const sources = state.usedGrantSources ?? []
-  const usedGrantSources = sources.filter((u) => nowMs - u.atMs <= GRANT_SOURCE_LEDGER_MAX_AGE_MS)
+  let usedGrantSources = sources.filter((u) => nowMs - u.atMs <= GRANT_SOURCE_LEDGER_MAX_AGE_MS)
+  // Hard cap (fix-loop-2 #4): evict oldest beyond GRANT_SOURCE_LEDGER_MAX_ENTRIES.
+  if (usedGrantSources.length > GRANT_SOURCE_LEDGER_MAX_ENTRIES) {
+    const evicted = usedGrantSources.length - GRANT_SOURCE_LEDGER_MAX_ENTRIES
+    usedGrantSources = [...usedGrantSources]
+      .sort((a, b) => a.atMs - b.atMs)
+      .slice(evicted)
+    if (log) {
+      log.warn('autonomy grant ledger over hard cap — oldest entries evicted', {
+        code: 'grant_ledger_evicted',
+        evicted,
+        cap: GRANT_SOURCE_LEDGER_MAX_ENTRIES,
+      })
+    }
+  }
   if (
     leases.length === state.leases.length
     && questions.length === state.questions.length
@@ -1011,8 +1037,9 @@ export function saveAutonomyState(
 
 // Shared atomic writer for files in the state root (state files + the writer
 // lock). tmp('wx') + fchmod 0600 + fsync + rename + tmp cleanup on ANY
-// failure + best-effort directory fsync.
-function atomicWriteInRoot(paths: AutonomyPaths, filename: string, body: string): void {
+// failure + best-effort directory fsync. Exported for sibling autonomy
+// persisters (ask-intents.ts) so the write discipline never forks.
+export function atomicWriteInRoot(paths: AutonomyPaths, filename: string, body: string): void {
   mkdirSync(paths.root, { recursive: true, mode: 0o700 })
   const target = join(paths.root, filename)
   const rand = randomBytes(3).toString('hex')
@@ -1246,7 +1273,7 @@ export function updateAutonomyState<T>(
       if (out.state === state) return { kind: 'ok', result: out.result }
     }
     // Prune terminal/aged entries on the way to disk (PR-1 leftover 4a).
-    saveAutonomyState(paths, chatId, pruneAutonomyState(out.state, nowMs))
+    saveAutonomyState(paths, chatId, pruneAutonomyState(out.state, nowMs, log))
     return { kind: 'ok', result: out.result }
   }
   const prior = updateChains.get(key) ?? Promise.resolve()

--- a/plugin/src/channel/ask-user-question.ts
+++ b/plugin/src/channel/ask-user-question.ts
@@ -100,6 +100,10 @@ export interface AskSettleEvent {
   totalQuestions: number
   // Text of the currently-open question (for the closed-card re-render).
   questionText: string | undefined
+  // Whether the currently-open question is multiSelect (autonomy M2): a
+  // multiSelect card is NEVER grant-capable, so the closed-card renderer
+  // must not present its lease marker as a mandate block either.
+  questionMultiSelect: boolean | undefined
   reason: string | undefined
 }
 
@@ -307,6 +311,7 @@ export function createAskUserQuestionRelay(
           currentIndex: req.currentIndex,
           totalQuestions: req.questions.length,
           questionText: currentQuestion?.question,
+          questionMultiSelect: currentQuestion?.multiSelect,
           reason: result.reason,
         })
       } catch (err) {

--- a/plugin/src/channel/tools.ts
+++ b/plugin/src/channel/tools.ts
@@ -919,6 +919,14 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
             'autonomy registry is write-locked by another live writer process — mutation refused (writer_conflict), retry later',
           )
 
+        // A file from a NEWER schema (version > 1) is read-only — refuse the
+        // mutation rather than downgrade + clobber it (PR-1 leftover 4b).
+        const versionUnsupported = (): CallToolResult =>
+          toolError(
+            name,
+            'autonomy registry was written by a newer plugin version — it is read-only, mutation refused (version_unsupported); upgrade the plugin',
+          )
+
         if (args.action === 'consume') {
           // lease_id presence is enforced by the schema's superRefine. The
           // mutation routes through updateAutonomyState — the serialized
@@ -933,8 +941,10 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
               return { state: r.state, result: r.outcome }
             },
             log,
+            now,
           )
           if (upd.kind === 'writer_conflict') return writerConflict()
+          if (upd.kind === 'version_unsupported') return versionUnsupported()
           switch (upd.result) {
             case 'not_found':
               return toolError(name, `lease not found: ${leaseId}`)
@@ -965,8 +975,10 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
               return { state: r.state, result: r.outcome }
             },
             log,
+            now,
           )
           if (upd.kind === 'writer_conflict') return writerConflict()
+          if (upd.kind === 'version_unsupported') return versionUnsupported()
           switch (upd.result) {
             case 'not_found':
               return toolError(name, `lease not found: ${leaseId}`)
@@ -992,8 +1004,10 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
             return { state: r.state, result: r.outcome }
           },
           log,
+          now,
         )
         if (upd.kind === 'writer_conflict') return writerConflict()
+        if (upd.kind === 'version_unsupported') return versionUnsupported()
         switch (upd.result) {
           case 'not_found':
             return toolError(name, `question not found: ${questionId}`)

--- a/plugin/src/commands/oob.ts
+++ b/plugin/src/commands/oob.ts
@@ -382,6 +382,23 @@ async function handleLeaseCommand(
     }
   }
 
+  // Fail-closed grammar errors (fix-loop #3/#6/#8): a present-but-malformed
+  // trailing ttl option or an over-long scope is a USAGE ERROR — nothing is
+  // granted, nothing is silently defaulted or truncated.
+  if (cmd.kind === 'invalid') {
+    const reason = cmd.reason === 'ttl'
+      ? 'некорректный ttl — допустимо целое 1..72 в форме <code>ttl=48h</code>'
+      : 'scope длиннее 400 символов — сократи формулировку'
+    return {
+      handled: true,
+      command: 'lease',
+      replyToTelegram: {
+        text: `<b>/lease</b> — ${reason}.\n<i>usage: /lease &lt;scope&gt;[; ttl=48h]</i>`,
+        parseMode: 'HTML',
+      },
+    }
+  }
+
   // Grant. Idempotency key ties a replayed /lease command to one lease.
   const grantSourceId = `cmd:${ctx.chatId}:${ctx.messageId ?? Date.now()}`
   const res = await grantLease(
@@ -423,7 +440,33 @@ async function handleLeaseCommand(
     outcome: res.outcome,
     lease_id: lease?.id,
   })
+
+  // Honest refusal on a source-id collision with a DIFFERENT scope
+  // (fix-loop #2, Fable): never silently swallow a legit grant.
+  if (res.outcome === 'source_conflict') {
+    return {
+      handled: true,
+      command: 'lease',
+      replyToTelegram: {
+        text: '<b>мандат НЕ выдан</b> — этот запрос уже обрабатывался с ДРУГИМ scope (source_conflict). Отправь команду новым сообщением.',
+        parseMode: 'HTML',
+      },
+    }
+  }
+
   if (lease === undefined) {
+    // duplicate_source whose lease tombstone was already pruned — the ledger
+    // still remembers the grant. Honest report, no re-mint.
+    if (res.outcome === 'duplicate_source') {
+      return {
+        handled: true,
+        command: 'lease',
+        replyToTelegram: {
+          text: '<b>мандат не выдан повторно</b> — этот грант уже был обработан ранее (запись мандата уже удалена ротацией).',
+          parseMode: 'HTML',
+        },
+      }
+    }
     return {
       handled: true,
       command: 'lease',
@@ -433,15 +476,25 @@ async function handleLeaseCommand(
       },
     }
   }
-  const left = humanizeDurationMs(lease.expiresAtMs - Date.now())
-  const heading = res.outcome === 'duplicate_source' || res.outcome === 'duplicate_scope'
-    ? 'мандат уже активен'
-    : 'мандат выдан'
+
+  // Heading states the REAL status (fix-loop #8): a duplicate against a
+  // TERMINAL lease must not claim «уже активен».
+  const now = Date.now()
+  let heading: string
+  if (res.outcome === 'duplicate_source' || res.outcome === 'duplicate_scope') {
+    if (lease.revokedAtMs !== undefined) heading = 'мандат по этому гранту был ОТОЗВАН — новый не выдан'
+    else if (lease.consumedAtMs !== undefined && lease.consumedAtMs !== null) heading = 'мандат по этому гранту уже ИСПОЛЬЗОВАН — новый не выдан'
+    else if (lease.expiresAtMs <= now) heading = 'мандат по этому гранту ИСТЁК — новый не выдан'
+    else heading = 'мандат уже активен'
+  } else {
+    heading = 'мандат выдан'
+  }
+  const left = humanizeDurationMs(lease.expiresAtMs - now)
   const text =
     `<b>${heading}</b>\n`
     + `<code>${escapeHtml(lease.id)}</code>\n`
     + `scope: «${escapeHtml(lease.scope)}»\n`
-    + `истекает через ${escapeHtml(left)}`
+    + (lease.expiresAtMs > now ? `истекает через ${escapeHtml(left)}` : 'без остатка действия')
   return {
     handled: true,
     command: 'lease',

--- a/plugin/src/commands/oob.ts
+++ b/plugin/src/commands/oob.ts
@@ -387,8 +387,10 @@ async function handleLeaseCommand(
   // granted, nothing is silently defaulted or truncated.
   if (cmd.kind === 'invalid') {
     const reason = cmd.reason === 'ttl'
-      ? 'некорректный ttl — допустимо целое 1..72 в форме <code>ttl=48h</code>'
-      : 'scope длиннее 400 символов — сократи формулировку'
+      ? 'некорректный ttl — допустимо целое 1..72 в форме <code>ttl=48h</code> (строго строчными)'
+      : cmd.reason === 'scope_charset'
+        ? 'scope содержит управляющие/форматирующие символы (перенос строки, bidi) — недопустимо'
+        : 'scope длиннее 400 символов — сократи формулировку'
     return {
       handled: true,
       command: 'lease',

--- a/plugin/src/commands/oob.ts
+++ b/plugin/src/commands/oob.ts
@@ -48,8 +48,16 @@ import { buildNewConfirmCard } from '../telegram/newq-confirm-ui.js'
 import { controlFailureMessage } from '../telegram/control-result.js'
 import { readContextUsage, formatContextUsage } from '../status/context-usage.js'
 import { DEFAULT_CONTEXT_WINDOW_TOKENS, resolveContextWindowForModel } from '../config.js'
+import {
+  activeLeases,
+  humanizeDurationMs,
+  loadAutonomyState,
+  type AutonomyPaths,
+} from '../autonomy/store.js'
+import { grantLease, parseLeaseCommandArgs } from '../autonomy/grant.js'
 
-export type OobCommandName = 'help' | 'status' | 'stop' | 'compact' | 'new' | 'mirror' | 'keys' | 'cc'
+export type OobCommandName =
+  | 'help' | 'status' | 'stop' | 'compact' | 'new' | 'mirror' | 'keys' | 'cc' | 'lease'
 
 const KNOWN_COMMANDS = new Set<OobCommandName>([
   'help',
@@ -60,6 +68,7 @@ const KNOWN_COMMANDS = new Set<OobCommandName>([
   'mirror',
   'keys',
   'cc',
+  'lease',
 ])
 
 // Sub-actions for /mirror. We accept the bare command (= same as `status`),
@@ -188,6 +197,10 @@ export interface OobContext {
   contextWindowOverride?: number
   // Process uptime in seconds (process.uptime()); rendered when present.
   uptimeSeconds?: number
+  // Autonomy M2: inbound message id, used to build the idempotent grantSourceId
+  // (`cmd:<chatId>:<messageId>`) for /lease so a replayed command mints one
+  // lease. Undefined → the grant falls back to a time-based source id.
+  messageId?: number
 }
 
 export interface OobResult {
@@ -215,7 +228,8 @@ function helpText(): string {
     + '<code>/new</code> — начать новый диалог (очистит контекст — спросит подтверждение)\n'
     + '<code>/mirror on|off|status</code> — управлять зеркалом терминала (tmux, обновляется в реальном времени)\n'
     + '<code>/keys</code> — панель кнопок: тап = нажатие в сессии (ответить на нативный диалог Claude Code; есть ⌫ backspace и 🧹 clear)\n'
-    + '<code>/cc</code> — панель команд Claude Code (тап = выполнить); либо <code>/cc &lt;команда&gt;</code>: <code>/cc model opus</code>\n\n'
+    + '<code>/cc</code> — панель команд Claude Code (тап = выполнить); либо <code>/cc &lt;команда&gt;</code>: <code>/cc model opus</code>\n'
+    + '<code>/lease &lt;scope&gt;</code> — выдать мандат автономии (напр. <code>/lease деплой стейджинга; ttl=48h</code>); без аргумента — список активных\n\n'
     + '<i>примечание: /stop — best-effort: посылает Escape в сессию, но не может '
     + 'гарантировать прерывание посреди вызова инструмента.</i>'
   )
@@ -236,6 +250,7 @@ export const BOT_COMMANDS: ReadonlyArray<BotCommandSpec> = [
   { command: 'mirror', description: 'зеркало терминала: on | off | status' },
   { command: 'keys', description: 'панель кнопок для подтверждений (нажатия в сессию)' },
   { command: 'cc', description: 'панель команд Claude Code (тап) или /cc <команда>' },
+  { command: 'lease', description: 'выдать мандат автономии: /lease <scope>[; ttl=48h]' },
 ]
 
 // Format process uptime seconds as a compact human string (e.g. `2h 15m`).
@@ -322,6 +337,119 @@ function escapeHtml(s: string): string {
 }
 
 // ─────────────────────────────────────────────────────────────────────
+// /lease — autonomy M2 owner command. Grants a lease (or lists active ones
+// on a bare command). The store write happens HERE (async side effect),
+// then the confirmation is returned as a normal replyToTelegram. The message
+// is NOT forwarded to the agent session (OOB commands are swallowed in
+// handlers.ts) — it is a control command, not conversation.
+// ─────────────────────────────────────────────────────────────────────
+
+async function handleLeaseCommand(
+  parsed: ParsedOobCommand,
+  ctx: OobContext,
+): Promise<OobResult> {
+  if (ctx.stateDir === undefined) {
+    return {
+      handled: true,
+      command: 'lease',
+      replyToTelegram: {
+        text: '<b>/lease</b> — недоступно: не сконфигурирован каталог состояния.',
+        parseMode: 'HTML',
+      },
+    }
+  }
+  const paths: AutonomyPaths = { root: ctx.stateDir }
+  const cmd = parseLeaseCommandArgs(parsed.args)
+
+  if (cmd.kind === 'bare') {
+    // No scope → list active leases + usage hint, grant nothing.
+    const state = loadAutonomyState(paths, ctx.chatId, ctx.log)
+    const leases = activeLeases(state, Date.now())
+    const lines: string[] = ['<b>активные мандаты</b>']
+    if (leases.length === 0) {
+      lines.push('нет активных мандатов.')
+    } else {
+      for (const l of leases) {
+        const left = humanizeDurationMs(l.expiresAtMs - Date.now())
+        lines.push(`<code>${escapeHtml(l.id)}</code> — «${escapeHtml(l.scope)}» (ещё ${escapeHtml(left)})`)
+      }
+    }
+    lines.push('', '<i>usage: /lease &lt;scope&gt;[; ttl=48h]</i>')
+    return {
+      handled: true,
+      command: 'lease',
+      replyToTelegram: { text: lines.join('\n'), parseMode: 'HTML' },
+    }
+  }
+
+  // Grant. Idempotency key ties a replayed /lease command to one lease.
+  const grantSourceId = `cmd:${ctx.chatId}:${ctx.messageId ?? Date.now()}`
+  const res = await grantLease(
+    paths,
+    ctx.chatId,
+    {
+      scope: cmd.scope,
+      ttlHours: cmd.ttlHours,
+      source: 'owner_cmd',
+      grantSourceId,
+    },
+    ctx.log,
+  )
+
+  if (res.kind === 'writer_conflict') {
+    return {
+      handled: true,
+      command: 'lease',
+      replyToTelegram: {
+        text: '<b>/lease</b> — реестр занят другим процессом, попробуй ещё раз.',
+        parseMode: 'HTML',
+      },
+    }
+  }
+  if (res.kind === 'version_unsupported') {
+    return {
+      handled: true,
+      command: 'lease',
+      replyToTelegram: {
+        text: '<b>/lease</b> — реестр новее этой версии плагина (только чтение). Обнови плагин.',
+        parseMode: 'HTML',
+      },
+    }
+  }
+
+  const lease = res.lease
+  ctx.log.info('oob /lease grant', {
+    chat_id: ctx.chatId,
+    outcome: res.outcome,
+    lease_id: lease?.id,
+  })
+  if (lease === undefined) {
+    return {
+      handled: true,
+      command: 'lease',
+      replyToTelegram: {
+        text: '<b>/lease</b> — не удалось выдать мандат.',
+        parseMode: 'HTML',
+      },
+    }
+  }
+  const left = humanizeDurationMs(lease.expiresAtMs - Date.now())
+  const heading = res.outcome === 'duplicate_source' || res.outcome === 'duplicate_scope'
+    ? 'мандат уже активен'
+    : 'мандат выдан'
+  const text =
+    `<b>${heading}</b>\n`
+    + `<code>${escapeHtml(lease.id)}</code>\n`
+    + `scope: «${escapeHtml(lease.scope)}»\n`
+    + `истекает через ${escapeHtml(left)}`
+  return {
+    handled: true,
+    command: 'lease',
+    replyToTelegram: { text, parseMode: 'HTML' },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────
 // Main dispatcher. Pure data — caller actually issues sendMessage and
 // channel notification calls based on the OobResult. This keeps the
 // function trivially testable.
@@ -356,6 +484,14 @@ export async function handleOobCommand(
         command: 'status',
         replyToTelegram: { text: await statusText(ctx), parseMode: 'HTML' },
       }
+    }
+
+    case 'lease': {
+      // Autonomy M2 — one of only TWO authenticated lease-grant surfaces. The
+      // handlers.ts OOB gate already enforced: private chat + sender in
+      // config.allowed_user_ids + chat in allowed_chat_ids. No agent-callable
+      // path reaches here.
+      return await handleLeaseCommand(parsed, ctx)
     }
 
     case 'stop': {

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -790,6 +790,11 @@ const askUserQuestionUi: AskUserQuestionUi = createAskUserQuestionUi({
   log,
   telegramApi,
   relay: askUserQuestionRelay,
+  // Autonomy M2: the state root for the lease/question registry. An affirmative
+  // tap on a `[LEASE: …]` card mints a lease here (behind the owner allowlist);
+  // a timed-out question is auto-registered. StatePaths is structurally an
+  // AutonomyPaths (both expose `root`).
+  autonomyPaths: statePaths,
 })
 askUserQuestionUiRef = askUserQuestionUi
 // Permission gate (2026-06-09): interactive Allow/Deny confirm relay for the

--- a/plugin/src/telegram/ask-user-question.ts
+++ b/plugin/src/telegram/ask-user-question.ts
@@ -54,14 +54,21 @@ import type {
 import type { InlineKeyboardLike, TelegramApi } from '../channel/tools.js'
 import { escapeHtml } from '../format/html.js'
 import { classifyEditError } from '../safety/telegram-edit-classifier.js'
-import { addQuestion, updateAutonomyState, type AutonomyPaths } from '../autonomy/store.js'
+import { addQuestion, computeScopeDigest, updateAutonomyState, type AutonomyPaths } from '../autonomy/store.js'
 import {
   grantLease,
   isAffirmativeLabel,
+  looksLikeLeaseMarker,
   parseLeaseMarker,
   stripLeaseMarkerForDisplay,
   type ParsedLeaseMarker,
 } from '../autonomy/grant.js'
+import {
+  deleteLeaseIntent,
+  loadLeaseIntent,
+  saveLeaseIntent,
+  type PersistedLeaseIntent,
+} from '../autonomy/ask-intents.js'
 
 // ─────────────────────────────────────────────────────────────────────
 // Autonomy M2 — lease-card helpers (fix-loop #1, CRITICAL).
@@ -76,9 +83,10 @@ import {
 // both the renderers and the tap handler consume the same intent.
 // ─────────────────────────────────────────────────────────────────────
 
-/** Resolve the grant intent for a question. multiSelect cards are NEVER
- *  grant-capable (fail-closed — an accumulating toggle is not an explicit
- *  affirmative tap). */
+/** Parse the grant intent of a question at CARD CREATION — the ONE place a
+ *  marker parse is allowed to feed a grant, and only en route to the durable
+ *  persist (fix-loop-2 #1). multiSelect cards are NEVER grant-capable
+ *  (fail-closed — an accumulating toggle is not an explicit affirmative tap). */
 export function leaseIntentForQuestion(
   questionText: string,
   multiSelect: boolean | undefined,
@@ -87,9 +95,21 @@ export function leaseIntentForQuestion(
   return parseLeaseMarker(questionText)
 }
 
+// The subset of the persisted intent the renderers consume. Structural — a
+// PersistedLeaseIntent is assignable. The renderers take this as INPUT and
+// never parse question text themselves (fix-loop-2 #1: render and grant read
+// the same durable record).
+export interface LeaseIntentView {
+  scope: string
+  ttlHours: number
+  supersede: boolean
+  displayText: string
+}
+
 // The mandate block appended to an OPEN grant-capable card. Built ONLY from
-// parsed fields; scope is escaped. The «Тап "Да"» line names the exact action.
-function renderMandateBlockOpen(intent: ParsedLeaseMarker): string {
+// the persisted intent fields; scope is escaped. The «Тап "Да"» line names
+// the exact action.
+function renderMandateBlockOpen(intent: LeaseIntentView): string {
   const sup = intent.supersede ? '; заменит действующий мандат' : ''
   return (
     `\n\n⚡ Мандат автономии: «${escapeHtml(intent.scope)}» — ttl ${intent.ttlHours}ч${sup}`
@@ -99,10 +119,20 @@ function renderMandateBlockOpen(intent: ParsedLeaseMarker): string {
 
 // The mandate line on a CLOSED card (no tap hint — the card is settled, but
 // the owner must still see exactly what scope the card was about).
-function renderMandateLineClosed(intent: ParsedLeaseMarker): string {
+function renderMandateLineClosed(intent: LeaseIntentView): string {
   const sup = intent.supersede ? '; заменит действующий мандат' : ''
   return `\n⚡ Мандат автономии: «${escapeHtml(intent.scope)}» — ttl ${intent.ttlHours}ч${sup}`
 }
+
+// Honesty note on a card whose text LOOKS like a lease marker but which is
+// not grant-capable (invalid marker, registry unavailable, persist failure) —
+// fix-loop-2 #5. The raw marker stays visible; this line removes any illusion
+// that a tap would grant.
+const INVALID_MARKER_NOTE = '\n\n<i>Маркер мандата некорректен — тап мандат НЕ выдаст.</i>'
+// Closed-card line for a card that WAS grant-capable but whose persisted
+// intent is gone (restart before the durable record, file loss) — fix-loop-2
+// #1: the grant is refused and the owner is told, never a silent divergence.
+const INTENT_LOST_LINE = '\n⚠️ Мандат НЕ выдан: intent утерян (рестарт).'
 
 // ─────────────────────────────────────────────────────────────────────
 // Constants
@@ -129,7 +159,7 @@ const MULTISELECT_PREFIX_UNCHECKED = '[ ] '
 // but our chunker (format/chunk.ts) targets 4000 — staying under that
 // avoids any need to split a question card across two messages, which
 // would break the «one keyboard per question» invariant.
-const MAX_BODY_CHARS = 3800
+export const MAX_BODY_CHARS = 3800
 
 // FIX-T2 F2 — per-field raw caps applied BEFORE HTML rendering. The
 // pre-fix path sliced the rendered HTML at MAX_BODY_CHARS, which could
@@ -181,14 +211,33 @@ export function renderClosedQuestionBody(
   currentIndex: number,
   totalQuestions: number,
   outcomeLineHtml: string,
-  opts: { multiSelect?: boolean } = {},
+  opts: { leaseIntent?: LeaseIntentView; intentLost?: boolean } = {},
 ): string {
   const header = clipRaw(`Вопрос ${currentIndex + 1}/${totalQuestions}`, MAX_HEADER_CHARS)
-  const intent = leaseIntentForQuestion(questionRaw, opts.multiSelect)
+  const headerHtml = `<b>${escapeHtml(header)}</b>`
+  // fix-loop-2 #1: the mandate line comes ONLY from the caller-provided
+  // persisted intent — this function never parses question text.
+  const intent = opts.leaseIntent
+  const mandateLine = intent
+    ? renderMandateLineClosed(intent)
+    : opts.intentLost === true
+      ? INTENT_LOST_LINE
+      : ''
   const display = intent ? intent.displayText : questionRaw
-  const question = escapeHtml(clipRaw(display, MAX_QUESTION_CHARS))
-  const mandateLine = intent ? renderMandateLineClosed(intent) : ''
-  return `<b>${escapeHtml(header)}</b>\n${question}${mandateLine}\n\n${outcomeLineHtml}`
+  // Shared body budget (fix-loop-2 #2): the mandate line + outcome are
+  // reserved UP-FRONT and never truncated; the question text shrinks to fit.
+  // Escape expansion (& → &amp; etc.) can blow a raw cap past the budget, so
+  // the raw cap halves until the ESCAPED text fits — never slicing escaped
+  // HTML. Reserved parts are bounded (scope ≤400cp → ≤2.4k escaped; outcome
+  // answer ≤100cp raw), so the fixed section always leaves question headroom.
+  const fixedLen = headerHtml.length + 1 + mandateLine.length + 2 + outcomeLineHtml.length
+  let rawCap = MAX_QUESTION_CHARS
+  let questionHtml = escapeHtml(clipRaw(display, rawCap))
+  while (fixedLen + questionHtml.length > MAX_BODY_CHARS && rawCap > 8) {
+    rawCap = Math.floor(rawCap / 2)
+    questionHtml = escapeHtml(clipRaw(display, rawCap))
+  }
+  return `${headerHtml}\n${questionHtml}${mandateLine}\n\n${outcomeLineHtml}`
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -375,6 +424,7 @@ function clipRaw(text: string, max: number): string {
 export function renderQuestionBody(
   pending: Readonly<PendingAskRequest>,
   maxPreviewChars: number,
+  renderOpts?: { leaseIntent?: LeaseIntentView },
 ): string {
   const q = pending.questions[pending.currentIndex]
   if (!q) return ''
@@ -385,15 +435,22 @@ export function renderQuestionBody(
     `Вопрос ${pending.currentIndex + 1}/${pending.questions.length}`,
     MAX_HEADER_CHARS,
   )
-  // Autonomy M2 (fix-loop #1, CRITICAL): a grant-capable card renders the
-  // MANDATE BLOCK built from the PARSED intent fields — the owner must see
-  // the exact scope a «Да» tap will grant, never a hidden one. A card whose
-  // intent is invalid (malformed marker/ttl, over-long scope, multiSelect) is
-  // a normal question: raw text shown (marker included — honest), no block,
-  // and a tap grants nothing.
-  const intent = leaseIntentForQuestion(q.question, q.multiSelect)
+  // Autonomy M2 (fix-loop #1 CRITICAL + fix-loop-2 #1): a grant-capable card
+  // renders the MANDATE BLOCK built from the PERSISTED canonical intent the
+  // caller passes in — the owner must see the exact scope a «Да» tap will
+  // grant, never a hidden one, and this function NEVER re-parses question
+  // text. No intent passed (invalid marker, multiSelect, registry
+  // unavailable, persist failure, legacy record) → normal question: raw text
+  // shown (marker included — honest), no block, a tap grants nothing; if the
+  // text still LOOKS like a marker, an explicit «тап мандат НЕ выдаст» note
+  // is appended (fix-loop-2 #5).
+  const intent = renderOpts?.leaseIntent
   const questionRaw = clipRaw(intent ? intent.displayText : q.question, MAX_QUESTION_CHARS)
-  const mandateBlock = intent ? renderMandateBlockOpen(intent) : ''
+  const mandateBlock = intent
+    ? renderMandateBlockOpen(intent)
+    : looksLikeLeaseMarker(q.question)
+      ? INVALID_MARKER_NOTE
+      : ''
   const opts = q.options.slice(0, MAX_KEYBOARD_OPTIONS)
 
   // Assemble piecewise. `pieces` is the running list of fully-formed
@@ -587,14 +644,29 @@ export function createAskUserQuestionUi(
   // of the relay (process restart clears).
   const recoveredOnce = new Set<string>()
 
-  // Autonomy M2 (fix-loop #1): per-question GRANT-INTENT SNAPSHOT, parsed
-  // ONCE at card creation (startQuestion) and keyed `<requestId>:<qIdx>`. The
-  // tap handler reads THIS snapshot (falling back to the same deterministic
-  // parse of the same immutable question text), so the granted intent is
-  // byte-identical to the rendered one. Entries are dropped on settle
-  // (handleSettle) and after a grant attempt; leakage is bounded like
-  // recoveredOnce.
-  const leaseIntents = new Map<string, ParsedLeaseMarker | null>()
+  // Autonomy M2 (fix-loop #1 + fix-loop-2 #1): per-question GRANT-INTENT,
+  // parsed ONCE at card creation (startQuestion), PERSISTED durably
+  // (ask-intents.ts) and keyed `<requestId>:<qIdx>`. This map is only a read
+  // CACHE over the durable record: open render, closed render and the tap
+  // grant all consume the persisted intent — never a re-parse — so the
+  // owner-visible scope and the granted scope cannot diverge across a
+  // restart or a parser change. `null` caches «known absent» (not
+  // grant-capable). Entries are dropped on settle and after a grant attempt.
+  const leaseIntents = new Map<string, PersistedLeaseIntent | null>()
+
+  // Resolve the persisted intent for a card question: cache → disk. Never
+  // creates (creation happens in startQuestion only), never parses.
+  function resolveLeaseIntent(key: string, chatId: string | undefined): PersistedLeaseIntent | null {
+    const cached = leaseIntents.get(key)
+    if (cached !== undefined) return cached
+    if (!deps.autonomyPaths || chatId === undefined) {
+      leaseIntents.set(key, null)
+      return null
+    }
+    const fromDisk = loadLeaseIntent(deps.autonomyPaths, chatId, key) ?? null
+    leaseIntents.set(key, fromDisk)
+    return fromDisk
+  }
 
   async function clearKeyboard(
     requestId: string | undefined,
@@ -681,13 +753,40 @@ export function createAskUserQuestionUi(
       log.warn('ask_user_question startQuestion missing chatId', { request_id: requestId })
       return
     }
-    // Autonomy M2 (fix-loop #1): snapshot the grant intent at card creation —
-    // parsed ONCE per question; the tap handler grants exactly this snapshot.
+    // Autonomy M2 (fix-loop #1 + fix-loop-2 #1/#3): CARD CREATION is the one
+    // place the marker is parsed — and the card is grant-capable ONLY when
+    // the canonical intent was durably persisted. No autonomyPaths (factory
+    // wired without a registry), no chatId, parse-invalid, multiSelect, or a
+    // failed persist → NOT grant-capable: no mandate block, tap grants
+    // nothing. The persisted record is what render + tap consume from here on.
     {
       const q = pending.questions[pending.currentIndex]
       const key = `${requestId}:${pending.currentIndex}`
       if (q !== undefined && !leaseIntents.has(key)) {
-        leaseIntents.set(key, leaseIntentForQuestion(q.question, q.multiSelect))
+        let resolved: PersistedLeaseIntent | null = null
+        const existing = deps.autonomyPaths
+          ? loadLeaseIntent(deps.autonomyPaths, pending.chatId!, key)
+          : undefined
+        if (existing !== undefined) {
+          resolved = existing // recovery: durable record wins, no re-parse
+        } else if (deps.autonomyPaths) {
+          const parsed = leaseIntentForQuestion(q.question, q.multiSelect)
+          if (parsed !== null) {
+            const intent: PersistedLeaseIntent = {
+              scope: parsed.scope,
+              ttlHours: parsed.ttlHours,
+              supersede: parsed.supersede,
+              scopeDigest: computeScopeDigest(parsed.scope),
+              displayText: parsed.displayText,
+              createdAtMs: now(),
+            }
+            if (saveLeaseIntent(deps.autonomyPaths, pending.chatId!, key, intent, log)) {
+              resolved = intent
+            }
+            // persist failed → resolved stays null → card NOT grant-capable
+          }
+        }
+        leaseIntents.set(key, resolved)
       }
     }
     // Phase 5 FIX-T3 F3 (2026-05-27): replay protection. When the webhook
@@ -709,7 +808,10 @@ export function createAskUserQuestionUi(
       await rerenderCurrent(requestId)
       return
     }
-    const body = renderQuestionBody(pending, config.ask_user_question.max_preview_chars)
+    const startIntent = resolveLeaseIntent(`${requestId}:${pending.currentIndex}`, pending.chatId)
+    const body = renderQuestionBody(pending, config.ask_user_question.max_preview_chars, {
+      ...(startIntent !== null ? { leaseIntent: startIntent } : {}),
+    })
     const keyboard = buildQuestionKeyboard(pending)
     try {
       const sent = await telegramApi.sendMessage(pending.chatId, body, {
@@ -785,7 +887,13 @@ export function createAskUserQuestionUi(
       await startQuestion(requestId)
       return
     }
-    const body = renderQuestionBody(pending, config.ask_user_question.max_preview_chars)
+    const rerenderIntent = resolveLeaseIntent(
+      `${requestId}:${pending.currentIndex}`,
+      pending.chatId,
+    )
+    const body = renderQuestionBody(pending, config.ask_user_question.max_preview_chars, {
+      ...(rerenderIntent !== null ? { leaseIntent: rerenderIntent } : {}),
+    })
     const keyboard = buildQuestionKeyboard(pending)
     const chatId = pending.chatId
     const messageId = pending.telegramMessageId
@@ -917,10 +1025,14 @@ export function createAskUserQuestionUi(
     questionIndex: number
     questionText: string
     totalQuestions: number
-    // Whether the answered question was multiSelect — the closed-card
-    // renderer needs it (a multiSelect card is never grant-capable, so its
-    // marker must not render as a mandate line).
-    multiSelect: boolean
+    // The persisted grant intent of the answered question (resolved cache→disk
+    // BEFORE the relay mutation) — the closed-card renderer shows exactly this
+    // scope, and the grant consumes exactly this record (fix-loop-2 #1).
+    leaseIntent?: PersistedLeaseIntent
+    // True when the question LOOKS like a lease card but the persisted intent
+    // is gone (restart before persist, file loss) — closed card then shows
+    // «Мандат НЕ выдан: intent утерян (рестарт)».
+    intentLost: boolean
     // Pre-built, HTML-safe outcome line («✅ Ответ: <label>»).
     outcomeLineHtml: string
   }
@@ -963,17 +1075,35 @@ export function createAskUserQuestionUi(
   // lost), but NEVER silent for the owner (fix-loop #7): every grant attempt
   // ends in an explicit «выдан / НЕ выдан» feedback message.
   async function maybeGrantLeaseFromTap(input: {
-    // The immutable intent SNAPSHOT resolved before the relay mutation —
-    // exactly what the card rendered (fix-loop #1).
-    intent: ParsedLeaseMarker
+    // The PERSISTED canonical intent resolved (cache → disk) before the relay
+    // mutation — exactly the record the card rendered (fix-loop-2 #1).
+    intent: PersistedLeaseIntent
     chosenLabel: string
     requestId: string
     questionIndex: number
     chatId: string | undefined
     grantorMessageId: number | undefined
+    // A chat we can always reach for feedback (ctx.chatId) even when the
+    // pending record's chatId was lost — fix-loop-2 #3: never a silent
+    // failure on a grant-capable card.
+    feedbackChatId: string
   }): Promise<void> {
-    if (!deps.autonomyPaths || input.chatId === undefined) return
     if (!isAffirmativeLabel(input.chosenLabel)) return
+    if (!deps.autonomyPaths || input.chatId === undefined) {
+      // A grant-capable card reached the tap while the registry is not
+      // reachable in THIS process (runtime-only failure — creation-time
+      // gating makes this near-impossible). Fail-closed AND visible.
+      log.warn('autonomy lease grant impossible — registry unavailable at tap', {
+        request_id: input.requestId,
+        has_paths: deps.autonomyPaths !== undefined,
+      })
+      try {
+        await telegramApi.sendMessage(input.feedbackChatId, 'Мандат НЕ выдан: реестр недоступен', { parse_mode: 'HTML' })
+      } catch {
+        // feedback is best-effort
+      }
+      return
+    }
     const intent = input.intent
     let feedback: string
     try {
@@ -1078,7 +1208,10 @@ export function createAskUserQuestionUi(
       snap.questionIndex,
       snap.totalQuestions,
       snap.outcomeLineHtml,
-      { multiSelect: snap.multiSelect },
+      {
+        ...(snap.leaseIntent !== undefined ? { leaseIntent: snap.leaseIntent } : {}),
+        intentLost: snap.intentLost,
+      },
     )
 
     if (!outcome.final) {
@@ -1166,10 +1299,20 @@ export function createAskUserQuestionUi(
   // (internal timeout / external expire). Best-effort — never throws.
   async function handleSettle(event: AskSettleEvent): Promise<void> {
     try {
-      // Drop the request's grant-intent snapshots on ANY terminal settle —
-      // the request is gone, the snapshots must not linger.
+      // Resolve the persisted intent BEFORE any cleanup — the timeout-closed
+      // card must show the same durable scope the open card showed.
+      const settleKey = `${event.requestId}:${event.currentIndex}`
+      const settleIntent = resolveLeaseIntent(settleKey, event.chatId)
+      const settleIntentLost = settleIntent === null
+        && event.questionMultiSelect !== true
+        && looksLikeLeaseMarker(event.questionText ?? '')
+      // Drop the request's grant-intent records on ANY terminal settle —
+      // the request is gone, cache and durable record must not linger.
       for (const key of leaseIntents.keys()) {
         if (key.startsWith(`${event.requestId}:`)) leaseIntents.delete(key)
+      }
+      if (deps.autonomyPaths && event.chatId) {
+        deleteLeaseIntent(deps.autonomyPaths, event.chatId, settleKey, log)
       }
       // `answered` is fully handled by the driven callback path (per-question
       // close + completion message); acting here would double-post. Only the
@@ -1186,7 +1329,10 @@ export function createAskUserQuestionUi(
         event.currentIndex,
         event.totalQuestions,
         TIMEOUT_OUTCOME_LINE,
-        { multiSelect: event.questionMultiSelect === true },
+        {
+          ...(settleIntent !== null ? { leaseIntent: settleIntent } : {}),
+          intentLost: settleIntentLost,
+        },
       )
       // requestId undefined: relay already settled — nothing left to expire.
       await clearKeyboard(undefined, event.chatId, event.telegramMessageId, body)
@@ -1288,15 +1434,18 @@ export function createAskUserQuestionUi(
         // question — afterwards currentIndex points at the next one.
         const chosenLabel = currentQuestion?.options[parsed.optionIndex]?.label ?? ''
         const isMulti = currentQuestion?.multiSelect === true
-        // Autonomy M2 (fix-loop #1): resolve the grant-intent SNAPSHOT BEFORE
+        // Autonomy M2 (fix-loop-2 #1): resolve the PERSISTED intent BEFORE
         // the relay mutation — the final-question settle fires synchronously
-        // inside answerChoice and clears the snapshot map. Prefer the
-        // snapshot stashed at card creation; the fallback parse of the same
-        // immutable question text is deterministic-identical.
+        // inside answerChoice and clears the cache. Cache → disk only; NEVER
+        // a re-parse of the question text (a parser change between deploys
+        // must not alter what an already-rendered card grants).
         const intentKey = `${parsed.requestId}:${pendingBefore.currentIndex}`
-        const leaseIntent = leaseIntents.has(intentKey)
-          ? leaseIntents.get(intentKey) ?? null
-          : leaseIntentForQuestion(currentQuestion?.question ?? '', currentQuestion?.multiSelect)
+        const leaseIntent = resolveLeaseIntent(intentKey, prevChatId ?? ctx.chatId)
+        // «intent lost»: the text looks like a lease card (presentation-only
+        // prefix check) but the durable record is gone — restart before
+        // persist / file loss. Fail-closed + visible on the closed card.
+        const intentLost = leaseIntent === null && !isMulti
+          && looksLikeLeaseMarker(currentQuestion?.question ?? '')
         leaseIntents.delete(intentKey)
         const snap: AnswerSnapshot = {
           requestId: parsed.requestId,
@@ -1305,7 +1454,8 @@ export function createAskUserQuestionUi(
           questionIndex: pendingBefore.currentIndex,
           questionText: currentQuestion?.question ?? '',
           totalQuestions,
-          multiSelect: isMulti,
+          ...(leaseIntent !== null ? { leaseIntent } : {}),
+          intentLost,
           outcomeLineHtml: formatChosenLine(chosenLabel),
         }
         const outcome = relay.answerChoice(parsed.requestId, parsed.questionIndex, parsed.optionIndex)
@@ -1322,15 +1472,35 @@ export function createAskUserQuestionUi(
         //     a grant at all;
         //   * `leaseIntent !== null` — the card must have rendered a valid
         //     mandate block (the same snapshot is what gets granted).
-        if (outcome.applied && outcome.advanced && !isMulti && leaseIntent !== null) {
-          await maybeGrantLeaseFromTap({
-            intent: leaseIntent,
-            chosenLabel,
-            requestId: parsed.requestId,
-            questionIndex: snap.questionIndex,
-            chatId: snap.chatId ?? ctx.chatId,
-            grantorMessageId: snap.messageId,
-          })
+        if (outcome.applied && outcome.advanced && !isMulti) {
+          if (leaseIntent !== null) {
+            await maybeGrantLeaseFromTap({
+              intent: leaseIntent,
+              chosenLabel,
+              requestId: parsed.requestId,
+              questionIndex: snap.questionIndex,
+              chatId: snap.chatId ?? ctx.chatId,
+              grantorMessageId: snap.messageId,
+              feedbackChatId: ctx.chatId,
+            })
+            // The intent is consumed — drop the durable record (idempotency
+            // of the GRANT lives in the registry ledger, not here).
+            if (deps.autonomyPaths) {
+              deleteLeaseIntent(deps.autonomyPaths, snap.chatId ?? ctx.chatId, intentKey, log)
+            }
+          } else if (intentLost && isAffirmativeLabel(chosenLabel)) {
+            // The owner affirmed a card that USED to be grant-capable but
+            // whose durable intent is gone — refuse loudly (fix-loop-2 #1).
+            log.warn('autonomy lease intent lost — grant refused', {
+              request_id: parsed.requestId,
+              question_index: snap.questionIndex,
+            })
+            try {
+              await telegramApi.sendMessage(ctx.chatId, 'Мандат НЕ выдан: intent утерян (рестарт)', { parse_mode: 'HTML' })
+            } catch {
+              // best-effort
+            }
+          }
         }
         await ctx.answerCallbackQuery().catch(() => {})
         return
@@ -1352,8 +1522,9 @@ export function createAskUserQuestionUi(
           questionIndex: pendingBefore.currentIndex,
           questionText: currentQuestion?.question ?? '',
           totalQuestions,
-          // done() commits a multiSelect question — never grant-capable.
-          multiSelect: true,
+          // done() commits a multiSelect question — never grant-capable, so
+          // no intent and no lost-intent warning.
+          intentLost: false,
           outcomeLineHtml: formatChosenLine(committedLabels.join(', ')),
         }
         const outcome = relay.done(parsed.requestId, parsed.questionIndex)
@@ -1476,6 +1647,10 @@ export function createAskUserQuestionUi(
     // exact affirmative single-select TAP can grant.
     const pendingBefore = relay.getPending(entry.requestId)
     const currentQuestion = pendingBefore?.questions[pendingBefore.currentIndex]
+    const otherIntent = resolveLeaseIntent(
+      `${entry.requestId}:${pendingBefore?.currentIndex ?? entry.questionIndex}`,
+      pendingBefore?.chatId ?? input.chatId,
+    )
     const snap: AnswerSnapshot = {
       requestId: entry.requestId,
       chatId: pendingBefore?.chatId,
@@ -1483,7 +1658,10 @@ export function createAskUserQuestionUi(
       questionIndex: pendingBefore?.currentIndex ?? entry.questionIndex,
       questionText: currentQuestion?.question ?? '',
       totalQuestions: pendingBefore?.questions.length ?? 0,
-      multiSelect: currentQuestion?.multiSelect === true,
+      // Closed card of a grant-capable question keeps its mandate line even
+      // though «Другое» free-text NEVER grants (fail-closed by design).
+      ...(otherIntent !== null ? { leaseIntent: otherIntent } : {}),
+      intentLost: false,
       // «Другое» free-text is the chosen answer (truncated in the echo).
       outcomeLineHtml: formatChosenLine(input.text.trim()),
     }

--- a/plugin/src/telegram/ask-user-question.ts
+++ b/plugin/src/telegram/ask-user-question.ts
@@ -60,7 +60,49 @@ import {
   isAffirmativeLabel,
   parseLeaseMarker,
   stripLeaseMarkerForDisplay,
+  type ParsedLeaseMarker,
 } from '../autonomy/grant.js'
+
+// ─────────────────────────────────────────────────────────────────────
+// Autonomy M2 — lease-card helpers (fix-loop #1, CRITICAL).
+//
+// The GRANT INTENT of a card is derived by ONE function from the question's
+// immutable text + multiSelect flag, and the rendered card must ALWAYS show
+// the intent built from the PARSED fields — never from agent free text. A
+// question whose intent cannot be parsed/validated (malformed marker, bad
+// ttl, over-long scope, multiSelect card) is a NORMAL question: nothing is
+// stripped (the owner sees the raw marker — honest), no mandate block is
+// rendered, and a tap grants NOTHING. «rendered ≠ granted» can never happen:
+// both the renderers and the tap handler consume the same intent.
+// ─────────────────────────────────────────────────────────────────────
+
+/** Resolve the grant intent for a question. multiSelect cards are NEVER
+ *  grant-capable (fail-closed — an accumulating toggle is not an explicit
+ *  affirmative tap). */
+export function leaseIntentForQuestion(
+  questionText: string,
+  multiSelect: boolean | undefined,
+): ParsedLeaseMarker | null {
+  if (multiSelect === true) return null
+  return parseLeaseMarker(questionText)
+}
+
+// The mandate block appended to an OPEN grant-capable card. Built ONLY from
+// parsed fields; scope is escaped. The «Тап "Да"» line names the exact action.
+function renderMandateBlockOpen(intent: ParsedLeaseMarker): string {
+  const sup = intent.supersede ? '; заменит действующий мандат' : ''
+  return (
+    `\n\n⚡ Мандат автономии: «${escapeHtml(intent.scope)}» — ttl ${intent.ttlHours}ч${sup}`
+    + '\n<i>Тап «Да» выдаст этот мандат.</i>'
+  )
+}
+
+// The mandate line on a CLOSED card (no tap hint — the card is settled, but
+// the owner must still see exactly what scope the card was about).
+function renderMandateLineClosed(intent: ParsedLeaseMarker): string {
+  const sup = intent.supersede ? '; заменит действующий мандат' : ''
+  return `\n⚡ Мандат автономии: «${escapeHtml(intent.scope)}» — ttl ${intent.ttlHours}ч${sup}`
+}
 
 // ─────────────────────────────────────────────────────────────────────
 // Constants
@@ -127,18 +169,26 @@ const COMPLETION_TEXT = 'Ответы принял, продолжаю ✅'
  * `outcomeLineHtml` is trusted HTML — callers build it via `formatChosenLine`
  * (escapes user content) or a static safe literal. Header + question are
  * escaped here. Exported for tests.
+ *
+ * Autonomy M2 (fix-loop #1): a grant-capable card keeps its mandate line on
+ * the CLOSED body too — the owner must be able to see exactly what scope the
+ * card carried after it settles. `opts.multiSelect` gates grant-capability
+ * (a multiSelect card never is); a non-grant-capable card renders the RAW
+ * question text, marker included.
  */
 export function renderClosedQuestionBody(
   questionRaw: string,
   currentIndex: number,
   totalQuestions: number,
   outcomeLineHtml: string,
+  opts: { multiSelect?: boolean } = {},
 ): string {
   const header = clipRaw(`Вопрос ${currentIndex + 1}/${totalQuestions}`, MAX_HEADER_CHARS)
-  // Strip any `[LEASE: …]` grant marker so the owner sees the clean question,
-  // never the plumbing (autonomy M2).
-  const question = escapeHtml(clipRaw(stripLeaseMarkerForDisplay(questionRaw), MAX_QUESTION_CHARS))
-  return `<b>${escapeHtml(header)}</b>\n${question}\n\n${outcomeLineHtml}`
+  const intent = leaseIntentForQuestion(questionRaw, opts.multiSelect)
+  const display = intent ? intent.displayText : questionRaw
+  const question = escapeHtml(clipRaw(display, MAX_QUESTION_CHARS))
+  const mandateLine = intent ? renderMandateLineClosed(intent) : ''
+  return `<b>${escapeHtml(header)}</b>\n${question}${mandateLine}\n\n${outcomeLineHtml}`
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -335,15 +385,25 @@ export function renderQuestionBody(
     `Вопрос ${pending.currentIndex + 1}/${pending.questions.length}`,
     MAX_HEADER_CHARS,
   )
-  // Strip any `[LEASE: …]` grant marker before display (autonomy M2).
-  const questionRaw = clipRaw(stripLeaseMarkerForDisplay(q.question), MAX_QUESTION_CHARS)
+  // Autonomy M2 (fix-loop #1, CRITICAL): a grant-capable card renders the
+  // MANDATE BLOCK built from the PARSED intent fields — the owner must see
+  // the exact scope a «Да» tap will grant, never a hidden one. A card whose
+  // intent is invalid (malformed marker/ttl, over-long scope, multiSelect) is
+  // a normal question: raw text shown (marker included — honest), no block,
+  // and a tap grants nothing.
+  const intent = leaseIntentForQuestion(q.question, q.multiSelect)
+  const questionRaw = clipRaw(intent ? intent.displayText : q.question, MAX_QUESTION_CHARS)
+  const mandateBlock = intent ? renderMandateBlockOpen(intent) : ''
   const opts = q.options.slice(0, MAX_KEYBOARD_OPTIONS)
 
   // Assemble piecewise. `pieces` is the running list of fully-formed
   // HTML chunks (no half-open tags). `running` is the assembled length.
   // Budget = MAX_BODY_CHARS minus the overflow marker so we always have
-  // room to append it cleanly if we hit the cap.
-  const budget = MAX_BODY_CHARS - OVERFLOW_MARKER.length
+  // room to append it cleanly if we hit the cap. The mandate block's length
+  // is RESERVED up-front so the block is ALWAYS appended in full — the scope
+  // can never be the part that gets truncated (scope ≤400 code points ⇒
+  // escaped block ≤ ~2.1k chars, so the reserve always leaves headroom).
+  const budget = MAX_BODY_CHARS - OVERFLOW_MARKER.length - mandateBlock.length
   const pieces: string[] = []
   let running = 0
   let truncated = false
@@ -422,6 +482,9 @@ export function renderQuestionBody(
     // Self-contained marker — never sliced, never inside another tag.
     body += OVERFLOW_MARKER
   }
+  // The mandate block goes LAST and in full — its budget was reserved above,
+  // so it is never subject to truncation (fix-loop #1).
+  body += mandateBlock
   return body
 }
 
@@ -524,6 +587,15 @@ export function createAskUserQuestionUi(
   // of the relay (process restart clears).
   const recoveredOnce = new Set<string>()
 
+  // Autonomy M2 (fix-loop #1): per-question GRANT-INTENT SNAPSHOT, parsed
+  // ONCE at card creation (startQuestion) and keyed `<requestId>:<qIdx>`. The
+  // tap handler reads THIS snapshot (falling back to the same deterministic
+  // parse of the same immutable question text), so the granted intent is
+  // byte-identical to the rendered one. Entries are dropped on settle
+  // (handleSettle) and after a grant attempt; leakage is bounded like
+  // recoveredOnce.
+  const leaseIntents = new Map<string, ParsedLeaseMarker | null>()
+
   async function clearKeyboard(
     requestId: string | undefined,
     chatId: string,
@@ -608,6 +680,15 @@ export function createAskUserQuestionUi(
     if (!pending.chatId) {
       log.warn('ask_user_question startQuestion missing chatId', { request_id: requestId })
       return
+    }
+    // Autonomy M2 (fix-loop #1): snapshot the grant intent at card creation —
+    // parsed ONCE per question; the tap handler grants exactly this snapshot.
+    {
+      const q = pending.questions[pending.currentIndex]
+      const key = `${requestId}:${pending.currentIndex}`
+      if (q !== undefined && !leaseIntents.has(key)) {
+        leaseIntents.set(key, leaseIntentForQuestion(q.question, q.multiSelect))
+      }
     }
     // Phase 5 FIX-T3 F3 (2026-05-27): replay protection. When the webhook
     // submits the same toolUseId twice in a tight window, the relay
@@ -836,6 +917,10 @@ export function createAskUserQuestionUi(
     questionIndex: number
     questionText: string
     totalQuestions: number
+    // Whether the answered question was multiSelect — the closed-card
+    // renderer needs it (a multiSelect card is never grant-capable, so its
+    // marker must not render as a mandate line).
+    multiSelect: boolean
     // Pre-built, HTML-safe outcome line («✅ Ответ: <label>»).
     outcomeLineHtml: string
   }
@@ -854,6 +939,11 @@ export function createAskUserQuestionUi(
     }
   }
 
+  // Compact UTC stamp for the grant-feedback message.
+  function fmtLeaseUntil(ms: number): string {
+    return `${new Date(ms).toISOString().slice(0, 16).replace('T', ' ')} UTC`
+  }
+
   // Autonomy M2 — mint a lease when the OWNER taps an affirmative option on a
   // `[LEASE: …]` card.
   //
@@ -861,10 +951,21 @@ export function createAskUserQuestionUi(
   // branch, AFTER `isAuthorized(ctx.from.id)` has passed — i.e. behind the
   // owner allowlist. It is one of exactly TWO lease-grant call sites in the
   // whole plugin (the other is the `/lease` owner command); no agent-callable
-  // surface (MCP tool, hook) can reach a grant. Fail-open: any registry error
-  // is logged and swallowed so the ask flow is never broken by the store.
+  // surface (MCP tool, hook) can reach a grant.
+  //
+  // FAIL-CLOSED BY DESIGN (fix-loop #8): multiSelect toggles/«Готово» commits
+  // and «Другое» free-text NEVER grant — the intent resolver returns null for
+  // multiSelect questions, and this helper is not wired into the toggle/done/
+  // other/answerOther paths at all. Only an exact affirmative single-select
+  // tap grants.
+  //
+  // Registry errors are fail-open for the ASK flow (the answer is never
+  // lost), but NEVER silent for the owner (fix-loop #7): every grant attempt
+  // ends in an explicit «выдан / НЕ выдан» feedback message.
   async function maybeGrantLeaseFromTap(input: {
-    questionText: string
+    // The immutable intent SNAPSHOT resolved before the relay mutation —
+    // exactly what the card rendered (fix-loop #1).
+    intent: ParsedLeaseMarker
     chosenLabel: string
     requestId: string
     questionIndex: number
@@ -872,42 +973,77 @@ export function createAskUserQuestionUi(
     grantorMessageId: number | undefined
   }): Promise<void> {
     if (!deps.autonomyPaths || input.chatId === undefined) return
-    const marker = parseLeaseMarker(input.questionText)
-    if (!marker) return
     if (!isAffirmativeLabel(input.chosenLabel)) return
+    const intent = input.intent
+    let feedback: string
     try {
       const res = await grantLease(
         deps.autonomyPaths,
         input.chatId,
         {
-          scope: marker.scope,
-          ttlHours: marker.ttlHours,
+          scope: intent.scope,
+          ttlHours: intent.ttlHours,
           source: 'ask_card',
           // Idempotency: a double-tap / replayed callback carrying the same
-          // requestId+questionIndex mints exactly one lease.
+          // requestId+questionIndex mints exactly one lease (durable ledger
+          // in the store survives lease pruning).
           grantSourceId: `ask:${input.requestId}:${input.questionIndex}`,
-          supersede: marker.supersede,
+          supersede: intent.supersede,
           ...(input.grantorMessageId !== undefined ? { grantorMessageId: input.grantorMessageId } : {}),
         },
         log,
         now(),
       )
       if (res.kind === 'ok') {
-        log.info('autonomy lease granted from ask card', {
+        log.info('autonomy lease grant from ask card', {
           request_id: input.requestId,
           chat_id: input.chatId,
           outcome: res.outcome,
           lease_id: res.lease?.id,
         })
+        switch (res.outcome) {
+          case 'granted':
+          case 'superseded': {
+            const lease = res.lease
+            feedback = lease !== undefined
+              ? `Мандат ${lease.id} выдан до ${fmtLeaseUntil(lease.expiresAtMs)}`
+                + (res.outcome === 'superseded' ? ' (прежний мандат отозван)' : '')
+              : 'Мандат НЕ выдан: реестр не вернул запись мандата'
+            break
+          }
+          case 'duplicate_source':
+          case 'duplicate_scope':
+            feedback = res.lease !== undefined
+              ? `Мандат уже существует: ${res.lease.id} (повторный тап, новый не выдан)`
+              : 'Этот грант уже был обработан ранее — новый мандат не выдан'
+            break
+          case 'source_conflict':
+            feedback = 'Мандат НЕ выдан: конфликт источника гранта (source_conflict) — этот запрос уже обрабатывался с другим scope'
+            break
+        }
       } else {
         log.warn('autonomy lease grant from ask card refused', {
           request_id: input.requestId,
           chat_id: input.chatId,
           reason: res.kind,
         })
+        feedback = res.kind === 'writer_conflict'
+          ? 'Мандат НЕ выдан: реестр занят другим процессом (writer_conflict)'
+          : 'Мандат НЕ выдан: реестр записан более новой версией плагина (version_unsupported)'
       }
     } catch (err) {
-      log.warn('autonomy lease grant from ask card threw (ignored)', {
+      log.warn('autonomy lease grant from ask card threw', {
+        request_id: input.requestId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      feedback = 'Мандат НЕ выдан: внутренняя ошибка реестра автономии'
+    }
+    // Owner feedback — best-effort send, but the attempt itself is mandatory
+    // (fix-loop #7: never silent).
+    try {
+      await telegramApi.sendMessage(input.chatId, feedback, { parse_mode: 'HTML' })
+    } catch (err) {
+      log.warn('autonomy lease grant feedback send failed', {
         request_id: input.requestId,
         error: err instanceof Error ? err.message : String(err),
       })
@@ -942,6 +1078,7 @@ export function createAskUserQuestionUi(
       snap.questionIndex,
       snap.totalQuestions,
       snap.outcomeLineHtml,
+      { multiSelect: snap.multiSelect },
     )
 
     if (!outcome.final) {
@@ -979,11 +1116,17 @@ export function createAskUserQuestionUi(
   // AskUserQuestion payload has no "recommended option" marker to read (the
   // option schema is label+description+preview), so there is nothing to carry.
   // sticky=false. Fail-open — a registry error never breaks settle handling.
+  //
+  // IDEMPOTENT (fix-loop #4, Codex MED): the question id is DERIVED from the
+  // settle identity (`Q-ask-<requestId>-<qIdx>`) via addQuestion's explicit-id
+  // path, so a duplicate settle (replayed event, double expire) is a clean
+  // `duplicate` no-op — exactly one open question per timed-out card.
   const TIMED_OUT_SUMMARY_MAX = 100
   async function maybeRegisterTimedOutQuestion(event: AskSettleEvent): Promise<void> {
     if (!deps.autonomyPaths || !event.chatId) return
     const clean = stripLeaseMarkerForDisplay(event.questionText ?? '')
     const summary = Array.from(clean).slice(0, TIMED_OUT_SUMMARY_MAX).join('')
+    const deterministicId = `Q-ask-${event.requestId}-${event.currentIndex}`
     try {
       const upd = await updateAutonomyState(
         deps.autonomyPaths,
@@ -992,6 +1135,7 @@ export function createAskUserQuestionUi(
           const r = addQuestion(
             state,
             {
+              id: deterministicId,
               summary,
               sticky: false,
               ...(event.telegramMessageId !== undefined ? { messageId: event.telegramMessageId } : {}),
@@ -1004,9 +1148,10 @@ export function createAskUserQuestionUi(
         now(),
       )
       if (upd.kind === 'ok') {
-        log.info('autonomy open question registered on timeout', {
+        log.info('autonomy open question registration on timeout', {
           request_id: event.requestId,
           chat_id: event.chatId,
+          outcome: upd.result,
         })
       }
     } catch (err) {
@@ -1021,6 +1166,11 @@ export function createAskUserQuestionUi(
   // (internal timeout / external expire). Best-effort — never throws.
   async function handleSettle(event: AskSettleEvent): Promise<void> {
     try {
+      // Drop the request's grant-intent snapshots on ANY terminal settle —
+      // the request is gone, the snapshots must not linger.
+      for (const key of leaseIntents.keys()) {
+        if (key.startsWith(`${event.requestId}:`)) leaseIntents.delete(key)
+      }
       // `answered` is fully handled by the driven callback path (per-question
       // close + completion message); acting here would double-post. Only the
       // timeout/expire family leaves a card open with a live keyboard.
@@ -1036,6 +1186,7 @@ export function createAskUserQuestionUi(
         event.currentIndex,
         event.totalQuestions,
         TIMEOUT_OUTCOME_LINE,
+        { multiSelect: event.questionMultiSelect === true },
       )
       // requestId undefined: relay already settled — nothing left to expire.
       await clearKeyboard(undefined, event.chatId, event.telegramMessageId, body)
@@ -1136,6 +1287,17 @@ export function createAskUserQuestionUi(
         // Capture the chosen label BEFORE the relay advances past this
         // question — afterwards currentIndex points at the next one.
         const chosenLabel = currentQuestion?.options[parsed.optionIndex]?.label ?? ''
+        const isMulti = currentQuestion?.multiSelect === true
+        // Autonomy M2 (fix-loop #1): resolve the grant-intent SNAPSHOT BEFORE
+        // the relay mutation — the final-question settle fires synchronously
+        // inside answerChoice and clears the snapshot map. Prefer the
+        // snapshot stashed at card creation; the fallback parse of the same
+        // immutable question text is deterministic-identical.
+        const intentKey = `${parsed.requestId}:${pendingBefore.currentIndex}`
+        const leaseIntent = leaseIntents.has(intentKey)
+          ? leaseIntents.get(intentKey) ?? null
+          : leaseIntentForQuestion(currentQuestion?.question ?? '', currentQuestion?.multiSelect)
+        leaseIntents.delete(intentKey)
         const snap: AnswerSnapshot = {
           requestId: parsed.requestId,
           chatId: prevChatId,
@@ -1143,6 +1305,7 @@ export function createAskUserQuestionUi(
           questionIndex: pendingBefore.currentIndex,
           questionText: currentQuestion?.question ?? '',
           totalQuestions,
+          multiSelect: isMulti,
           outcomeLineHtml: formatChosenLine(chosenLabel),
         }
         const outcome = relay.answerChoice(parsed.requestId, parsed.questionIndex, parsed.optionIndex)
@@ -1150,12 +1313,18 @@ export function createAskUserQuestionUi(
         // trail, while any await placed between the mutation and the
         // follow-up render widens the timeout race window (Codex HIGH).
         await advanceAfterAnswer(snap, outcome)
-        // Autonomy M2: an affirmative tap on a `[LEASE: …]` card mints a lease.
-        // Guarded by `outcome.applied` so a stale/no-op tap grants nothing;
-        // uses the pre-mutation snapshot (raw question text + card message id).
-        if (outcome.applied) {
+        // Autonomy M2: an affirmative single-select tap on a grant-capable
+        // `[LEASE: …]` card mints a lease. Fail-closed gates:
+        //   * `outcome.applied && outcome.advanced` — a stale/no-op tap or a
+        //     multiSelect toggle-accumulation grants nothing;
+        //   * `!isMulti` — multiSelect cards are NEVER grant-capable (their
+        //     `choose` is a toggle), and «Готово»/«Другое» paths never reach
+        //     a grant at all;
+        //   * `leaseIntent !== null` — the card must have rendered a valid
+        //     mandate block (the same snapshot is what gets granted).
+        if (outcome.applied && outcome.advanced && !isMulti && leaseIntent !== null) {
           await maybeGrantLeaseFromTap({
-            questionText: snap.questionText,
+            intent: leaseIntent,
             chosenLabel,
             requestId: parsed.requestId,
             questionIndex: snap.questionIndex,
@@ -1183,6 +1352,8 @@ export function createAskUserQuestionUi(
           questionIndex: pendingBefore.currentIndex,
           questionText: currentQuestion?.question ?? '',
           totalQuestions,
+          // done() commits a multiSelect question — never grant-capable.
+          multiSelect: true,
           outcomeLineHtml: formatChosenLine(committedLabels.join(', ')),
         }
         const outcome = relay.done(parsed.requestId, parsed.questionIndex)
@@ -1299,6 +1470,10 @@ export function createAskUserQuestionUi(
     // Consume — even on empty text (relay drops empty internally and
     // logs at debug). We still clear the awaiting marker so the user
     // is not silently swallowed forever.
+    //
+    // Autonomy M2 (fix-loop #8): the «Другое» free-text path NEVER grants a
+    // lease — no call into maybeGrantLeaseFromTap here, by design. Only an
+    // exact affirmative single-select TAP can grant.
     const pendingBefore = relay.getPending(entry.requestId)
     const currentQuestion = pendingBefore?.questions[pendingBefore.currentIndex]
     const snap: AnswerSnapshot = {
@@ -1308,6 +1483,7 @@ export function createAskUserQuestionUi(
       questionIndex: pendingBefore?.currentIndex ?? entry.questionIndex,
       questionText: currentQuestion?.question ?? '',
       totalQuestions: pendingBefore?.questions.length ?? 0,
+      multiSelect: currentQuestion?.multiSelect === true,
       // «Другое» free-text is the chosen answer (truncated in the echo).
       outcomeLineHtml: formatChosenLine(input.text.trim()),
     }

--- a/plugin/src/telegram/ask-user-question.ts
+++ b/plugin/src/telegram/ask-user-question.ts
@@ -54,6 +54,13 @@ import type {
 import type { InlineKeyboardLike, TelegramApi } from '../channel/tools.js'
 import { escapeHtml } from '../format/html.js'
 import { classifyEditError } from '../safety/telegram-edit-classifier.js'
+import { addQuestion, updateAutonomyState, type AutonomyPaths } from '../autonomy/store.js'
+import {
+  grantLease,
+  isAffirmativeLabel,
+  parseLeaseMarker,
+  stripLeaseMarkerForDisplay,
+} from '../autonomy/grant.js'
 
 // ─────────────────────────────────────────────────────────────────────
 // Constants
@@ -128,7 +135,9 @@ export function renderClosedQuestionBody(
   outcomeLineHtml: string,
 ): string {
   const header = clipRaw(`Вопрос ${currentIndex + 1}/${totalQuestions}`, MAX_HEADER_CHARS)
-  const question = escapeHtml(clipRaw(questionRaw, MAX_QUESTION_CHARS))
+  // Strip any `[LEASE: …]` grant marker so the owner sees the clean question,
+  // never the plumbing (autonomy M2).
+  const question = escapeHtml(clipRaw(stripLeaseMarkerForDisplay(questionRaw), MAX_QUESTION_CHARS))
   return `<b>${escapeHtml(header)}</b>\n${question}\n\n${outcomeLineHtml}`
 }
 
@@ -143,6 +152,12 @@ export interface AskUserQuestionUiDeps {
   relay: AskUserQuestionRelay
   /** Override clock for tests. */
   now?: () => number
+  // Autonomy M2: state root for the durable lease/question registry. When set,
+  // an affirmative tap on a `[LEASE: …]` card mints a lease, and a timed-out
+  // question is auto-registered as an open question. Optional so pre-M2 wiring
+  // (and tests that don't exercise autonomy) still construct the UI. Every
+  // registry access is fail-open — a store error NEVER breaks the ask flow.
+  autonomyPaths?: AutonomyPaths
 }
 
 export interface AskUserQuestionUi {
@@ -320,7 +335,8 @@ export function renderQuestionBody(
     `Вопрос ${pending.currentIndex + 1}/${pending.questions.length}`,
     MAX_HEADER_CHARS,
   )
-  const questionRaw = clipRaw(q.question, MAX_QUESTION_CHARS)
+  // Strip any `[LEASE: …]` grant marker before display (autonomy M2).
+  const questionRaw = clipRaw(stripLeaseMarkerForDisplay(q.question), MAX_QUESTION_CHARS)
   const opts = q.options.slice(0, MAX_KEYBOARD_OPTIONS)
 
   // Assemble piecewise. `pieces` is the running list of fully-formed
@@ -838,6 +854,66 @@ export function createAskUserQuestionUi(
     }
   }
 
+  // Autonomy M2 — mint a lease when the OWNER taps an affirmative option on a
+  // `[LEASE: …]` card.
+  //
+  // SECURITY INVARIANT: this runs ONLY from handleAskCallback's `choose`
+  // branch, AFTER `isAuthorized(ctx.from.id)` has passed — i.e. behind the
+  // owner allowlist. It is one of exactly TWO lease-grant call sites in the
+  // whole plugin (the other is the `/lease` owner command); no agent-callable
+  // surface (MCP tool, hook) can reach a grant. Fail-open: any registry error
+  // is logged and swallowed so the ask flow is never broken by the store.
+  async function maybeGrantLeaseFromTap(input: {
+    questionText: string
+    chosenLabel: string
+    requestId: string
+    questionIndex: number
+    chatId: string | undefined
+    grantorMessageId: number | undefined
+  }): Promise<void> {
+    if (!deps.autonomyPaths || input.chatId === undefined) return
+    const marker = parseLeaseMarker(input.questionText)
+    if (!marker) return
+    if (!isAffirmativeLabel(input.chosenLabel)) return
+    try {
+      const res = await grantLease(
+        deps.autonomyPaths,
+        input.chatId,
+        {
+          scope: marker.scope,
+          ttlHours: marker.ttlHours,
+          source: 'ask_card',
+          // Idempotency: a double-tap / replayed callback carrying the same
+          // requestId+questionIndex mints exactly one lease.
+          grantSourceId: `ask:${input.requestId}:${input.questionIndex}`,
+          supersede: marker.supersede,
+          ...(input.grantorMessageId !== undefined ? { grantorMessageId: input.grantorMessageId } : {}),
+        },
+        log,
+        now(),
+      )
+      if (res.kind === 'ok') {
+        log.info('autonomy lease granted from ask card', {
+          request_id: input.requestId,
+          chat_id: input.chatId,
+          outcome: res.outcome,
+          lease_id: res.lease?.id,
+        })
+      } else {
+        log.warn('autonomy lease grant from ask card refused', {
+          request_id: input.requestId,
+          chat_id: input.chatId,
+          reason: res.kind,
+        })
+      }
+    } catch (err) {
+      log.warn('autonomy lease grant from ask card threw (ignored)', {
+        request_id: input.requestId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
   // Codex HIGH (2026-07-02): the follow-up rendering path is decided by the
   // relay's SYNCHRONOUS mutation outcome, NOT by re-inferring state from
   // `getPending()` after an await. The pre-fix code awaited the callback ack
@@ -897,6 +973,50 @@ export function createAskUserQuestionUi(
     }
   }
 
+  // Autonomy M2 — register a timed-out question in the durable registry so an
+  // un-answered ask survives a compact/restart. summary = first 100 chars of
+  // the (marker-stripped) question. defaultAction is left undefined: the
+  // AskUserQuestion payload has no "recommended option" marker to read (the
+  // option schema is label+description+preview), so there is nothing to carry.
+  // sticky=false. Fail-open — a registry error never breaks settle handling.
+  const TIMED_OUT_SUMMARY_MAX = 100
+  async function maybeRegisterTimedOutQuestion(event: AskSettleEvent): Promise<void> {
+    if (!deps.autonomyPaths || !event.chatId) return
+    const clean = stripLeaseMarkerForDisplay(event.questionText ?? '')
+    const summary = Array.from(clean).slice(0, TIMED_OUT_SUMMARY_MAX).join('')
+    try {
+      const upd = await updateAutonomyState(
+        deps.autonomyPaths,
+        event.chatId,
+        (state) => {
+          const r = addQuestion(
+            state,
+            {
+              summary,
+              sticky: false,
+              ...(event.telegramMessageId !== undefined ? { messageId: event.telegramMessageId } : {}),
+            },
+            now(),
+          )
+          return { state: r.state, result: r.outcome }
+        },
+        log,
+        now(),
+      )
+      if (upd.kind === 'ok') {
+        log.info('autonomy open question registered on timeout', {
+          request_id: event.requestId,
+          chat_id: event.chatId,
+        })
+      }
+    } catch (err) {
+      log.warn('autonomy timeout question registration threw (ignored)', {
+        request_id: event.requestId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
   // Close the currently-open question card on a settle the UI did NOT drive
   // (internal timeout / external expire). Best-effort — never throws.
   async function handleSettle(event: AskSettleEvent): Promise<void> {
@@ -905,6 +1025,11 @@ export function createAskUserQuestionUi(
       // close + completion message); acting here would double-post. Only the
       // timeout/expire family leaves a card open with a live keyboard.
       if (event.status !== 'timeout') return
+      // Autonomy M2: auto-register the un-answered question so it survives a
+      // compact/restart and surfaces in the reminder/HUD until resolved.
+      // Runs even when the card can't be closed (no chatId/messageId) — a
+      // registry write only needs the chat id. Fail-open (never throws).
+      await maybeRegisterTimedOutQuestion(event)
       if (!event.chatId || event.telegramMessageId === undefined) return
       const body = renderClosedQuestionBody(
         event.questionText ?? '',
@@ -1025,6 +1150,19 @@ export function createAskUserQuestionUi(
         // trail, while any await placed between the mutation and the
         // follow-up render widens the timeout race window (Codex HIGH).
         await advanceAfterAnswer(snap, outcome)
+        // Autonomy M2: an affirmative tap on a `[LEASE: …]` card mints a lease.
+        // Guarded by `outcome.applied` so a stale/no-op tap grants nothing;
+        // uses the pre-mutation snapshot (raw question text + card message id).
+        if (outcome.applied) {
+          await maybeGrantLeaseFromTap({
+            questionText: snap.questionText,
+            chosenLabel,
+            requestId: parsed.requestId,
+            questionIndex: snap.questionIndex,
+            chatId: snap.chatId ?? ctx.chatId,
+            grantorMessageId: snap.messageId,
+          })
+        }
         await ctx.answerCallbackQuery().catch(() => {})
         return
       }

--- a/plugin/src/telegram/handlers.ts
+++ b/plugin/src/telegram/handlers.ts
@@ -1287,6 +1287,7 @@ export async function handleInboundText(ctx: Context, deps: HandlerDeps): Promis
         stateDir: deps.statePaths.root,
         contextWindowTokens: resolveContextWindowTokens(deps.config),
         uptimeSeconds: process.uptime(),
+        ...(ctx.message?.message_id !== undefined ? { messageId: ctx.message.message_id } : {}),
         ...(windowOverride !== undefined ? { contextWindowOverride: windowOverride } : {}),
         ...(session?.transcriptPath ? { transcriptPath: session.transcriptPath } : {}),
         ...(session?.model ? { modelName: session.model } : {}),

--- a/plugin/tests/autonomy/ask-lease.test.ts
+++ b/plugin/tests/autonomy/ask-lease.test.ts
@@ -10,7 +10,7 @@
 //   * timeout → open question auto-registered (marker-stripped summary)
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -174,12 +174,89 @@ describe('ask-card lease grant', () => {
     expect(Math.round(ttlH)).toBe(48)
   })
 
-  test('marker is stripped from the rendered Telegram card', async () => {
+  test('OPEN card shows the mandate block built from parsed fields (fix-loop #1 CRITICAL)', async () => {
     const h = mkHarness()
-    await submitAndRender(h, '[LEASE: deploy] Разрешаешь?', [{ label: 'Да' }, { label: 'Нет' }])
+    await submitAndRender(
+      h,
+      '[LEASE: полный прод-доступ; ttl=72h; supersede] Разрешаешь проверить staging?',
+      [{ label: 'Да' }, { label: 'Нет' }],
+    )
     const body = h.send.sendCalls[0]!.text
+    // The raw marker is stripped…
     expect(body).not.toContain('[LEASE')
-    expect(body).toContain('Разрешаешь?')
+    // …but the GRANTED scope is explicitly visible — the exploit (hidden
+    // scope behind an innocuous question) is dead.
+    expect(body).toContain('Мандат автономии')
+    expect(body).toContain('полный прод-доступ')
+    expect(body).toContain('ttl 72ч')
+    expect(body).toContain('заменит действующий мандат')
+    expect(body).toContain('Тап «Да» выдаст этот мандат')
+    expect(body).toContain('Разрешаешь проверить staging?')
+  })
+
+  test('CLOSED card (after tap) still shows the granted scope', async () => {
+    const h = mkHarness()
+    const { requestId, messageId } = await submitAndRender(
+      h,
+      '[LEASE: деплой стейджинга] Разрешаешь?',
+      [{ label: 'Да' }, { label: 'Нет' }],
+    )
+    await h.ui.handleAskCallback(tap(requestId, 0, messageId))
+    const closed = h.send.editCalls.find((e) => e.messageId === messageId)
+    expect(closed).toBeDefined()
+    expect(closed!.text).toContain('Мандат автономии')
+    expect(closed!.text).toContain('деплой стейджинга')
+    expect(closed!.text).not.toContain('[LEASE')
+  })
+
+  test('tap grants EXACTLY the rendered snapshot scope', async () => {
+    const h = mkHarness()
+    const { requestId, messageId } = await submitAndRender(
+      h,
+      '[LEASE: аудит платежей] Разрешаешь?',
+      [{ label: 'Да' }, { label: 'Нет' }],
+    )
+    const rendered = h.send.sendCalls[0]!.text
+    await h.ui.handleAskCallback(tap(requestId, 0, messageId))
+    const lease = activeLeases(loadAutonomyState({ root }, CHAT), Date.now())[0]!
+    // The granted scope is byte-identical to the parsed intent the card showed.
+    expect(lease.scope).toBe('аудит платежей')
+    expect(rendered).toContain(`«${lease.scope}»`)
+  })
+
+  test('INVALID marker (bad ttl / unknown segment) → normal question: raw text shown, tap grants NOTHING', async () => {
+    const h = mkHarness()
+    for (const [i, q] of [
+      '[LEASE: deploy; ttl=200h] Разрешаешь?', // ttl over cap — invalid, not clamped
+      '[LEASE: аудит; production] Разрешаешь?', // unknown segment — invalid
+    ].entries()) {
+      const { requestId, messageId } = await submitAndRender(h, q, [{ label: 'Да' }, { label: 'Нет' }])
+      const body = h.send.sendCalls.at(-1)!.text
+      // Honest raw render — the owner SEES the malformed marker, no block.
+      expect(body).toContain('[LEASE')
+      expect(body).not.toContain('Мандат автономии')
+      await h.ui.handleAskCallback(tap(requestId, 0, messageId))
+      expect(loadAutonomyState({ root }, CHAT).leases.length).toBe(0)
+      void i
+    }
+  })
+
+  test('multiSelect card with a marker is NEVER grant-capable (fail-closed)', async () => {
+    const h = mkHarness()
+    const q: AskQuestion = {
+      question: '[LEASE: deploy] Что разрешаешь?',
+      multiSelect: true,
+      options: [{ label: 'Да' }, { label: 'Нет' }],
+    }
+    const { requestId } = h.relay.submit({ toolUseId: 't-ms', sessionId: 's', questions: [q], chatId: CHAT })
+    await h.ui.startQuestion(requestId!)
+    const body = h.send.sendCalls.at(-1)!.text
+    expect(body).toContain('[LEASE') // raw — not grant-capable
+    expect(body).not.toContain('Мандат автономии')
+    const messageId = h.relay.getPending(requestId!)!.telegramMessageId!
+    // A `choose` tap on a multiSelect question is a toggle — must not grant.
+    await h.ui.handleAskCallback(tap(requestId!, 0, messageId))
+    expect(loadAutonomyState({ root }, CHAT).leases.length).toBe(0)
   })
 
   test('non-affirmative tap → no lease', async () => {
@@ -221,6 +298,42 @@ describe('ask-card lease grant', () => {
   })
 })
 
+describe('grant outcome feedback (fix-loop #7 — never silent)', () => {
+  test('successful grant → owner gets «Мандат L-… выдан до …»', async () => {
+    const h = mkHarness()
+    const { requestId, messageId } = await submitAndRender(
+      h,
+      '[LEASE: deploy] Разрешаешь?',
+      [{ label: 'Да' }, { label: 'Нет' }],
+    )
+    await h.ui.handleAskCallback(tap(requestId, 0, messageId))
+    const lease = loadAutonomyState({ root }, CHAT).leases[0]!
+    const feedback = h.send.sendCalls.map((c) => c.text).find((t) => t.includes('выдан до'))
+    expect(feedback).toBeDefined()
+    expect(feedback!).toContain(`Мандат ${lease.id} выдан до `)
+    expect(feedback!).toContain('UTC')
+  })
+
+  test('registry failure → owner gets «Мандат НЕ выдан: …»', async () => {
+    const h = mkHarness()
+    const { requestId, messageId } = await submitAndRender(
+      h,
+      '[LEASE: deploy] Разрешаешь?',
+      [{ label: 'Да' }, { label: 'Нет' }],
+    )
+    // Make the registry read-only AFTER the card is up: unsupported version.
+    writeFileSync(
+      join(root, `autonomy-${CHAT}.json`),
+      JSON.stringify({ version: 2, revision: 1, leases: [], questions: [] }),
+      'utf8',
+    )
+    await h.ui.handleAskCallback(tap(requestId, 0, messageId))
+    const feedback = h.send.sendCalls.map((c) => c.text).find((t) => t.includes('Мандат НЕ выдан'))
+    expect(feedback).toBeDefined()
+    expect(feedback!).toContain('version_unsupported')
+  })
+})
+
 describe('ask-card timeout → open question registered', () => {
   test('a timed-out question is registered with a marker-stripped summary', async () => {
     const h = mkHarness()
@@ -241,5 +354,27 @@ describe('ask-card timeout → open question registered', () => {
     expect(qs[0]!.summary).not.toContain('[LEASE')
     expect(qs[0]!.sticky).not.toBe(true)
     expect(qs[0]!.defaultAction).toBeUndefined()
+  })
+
+  test('IDEMPOTENT: a duplicate settle registers exactly one question (fix-loop #4)', async () => {
+    const h = mkHarness()
+    const event = {
+      requestId: 'abcde',
+      toolUseId: 't-1',
+      status: 'timeout' as const,
+      chatId: CHAT,
+      telegramMessageId: undefined,
+      currentIndex: 0,
+      totalQuestions: 1,
+      questionText: 'Вопрос без ответа?',
+      questionMultiSelect: undefined,
+      reason: 'test',
+    }
+    await h.ui.handleSettle(event)
+    await h.ui.handleSettle(event) // replayed settle → no-op
+    const qs = openQuestions(loadAutonomyState({ root }, CHAT))
+    expect(qs.length).toBe(1)
+    // Deterministic id derived from the settle identity.
+    expect(qs[0]!.id).toBe('Q-ask-abcde-0')
   })
 })

--- a/plugin/tests/autonomy/ask-lease.test.ts
+++ b/plugin/tests/autonomy/ask-lease.test.ts
@@ -1,0 +1,245 @@
+// Autonomy M2 — AskUserQuestion lease-card grant path + timeout registration.
+//
+// Drives the real relay + UI (createAskUserQuestionUi) against a fake Telegram
+// and a real on-disk autonomy registry (temp dir). Covers:
+//   * affirmative tap on a [LEASE:] card → lease minted (scope/ttl/binding)
+//   * marker stripped from what Telegram renders
+//   * non-affirmative tap → no lease
+//   * non-lease card → no lease
+//   * idempotent double-relay-submit → one lease (grantSourceId guard)
+//   * timeout → open question auto-registered (marker-stripped summary)
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  createAskUserQuestionUi,
+  type AskCallbackContext,
+  type AskUserQuestionUi,
+} from '../../src/telegram/ask-user-question.js'
+import {
+  createAskUserQuestionRelay,
+  type AskQuestion,
+  type AskUserQuestionRelay,
+} from '../../src/channel/ask-user-question.js'
+import { activeLeases, loadAutonomyState, openQuestions } from '../../src/autonomy/store.js'
+import type { AppConfig } from '../../src/config.js'
+import type { Logger } from '../../src/log.js'
+import type {
+  ChatAction,
+  DownloadResult,
+  EditOpts,
+  SendDocumentOpts,
+  SendMessageOpts,
+  TelegramApi,
+} from '../../src/channel/tools.js'
+
+const OWNER = 164795011
+const CHAT = String(OWNER)
+
+function silentLog(): Logger {
+  return { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }
+}
+
+interface Sends {
+  sendCalls: { chatId: string; text: string; opts: SendMessageOpts }[]
+  editCalls: { chatId: string; messageId: number; text: string; opts: EditOpts }[]
+  nextMessageId: number
+}
+
+function fakeTelegram(state: Sends): TelegramApi {
+  return {
+    async sendMessage(chatId, text, opts) {
+      state.sendCalls.push({ chatId, text, opts })
+      const id = state.nextMessageId++
+      return { message_id: id }
+    },
+    async sendRichMessage() {
+      return { fallback: true as const }
+    },
+    async editMessageText(chatId, messageId, text, opts) {
+      state.editCalls.push({ chatId, messageId, text, opts })
+    },
+    async setMessageReaction() {},
+    async sendChatAction(_c: string, _a: ChatAction) {},
+    async sendDocument(_c: string, _f: string, _o: SendDocumentOpts) {
+      return { message_id: 0 }
+    },
+    async sendPhoto(_c: string, _f: string, _o: SendDocumentOpts) {
+      return { message_id: 0 }
+    },
+    async downloadFile(_id: string, _d: string): Promise<DownloadResult> {
+      return { path: '/tmp/x' }
+    },
+    async answerGuestQuery() {},
+    async deleteMessage() {},
+  }
+}
+
+function mkConfig(): AppConfig {
+  return {
+    bot_id: 8507713167,
+    dm_only: true,
+    allowed_user_ids: [OWNER],
+    allowed_chat_ids: [OWNER],
+    permission_relay: { enabled: true, allowed_user_ids: [OWNER], bash_only_proof: true },
+    ask_user_question: { enabled: true, timeout_ms: 300_000, max_preview_chars: 1000 },
+  } as unknown as AppConfig
+}
+
+let root: string
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'dashi-ask-lease-'))
+})
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+interface Harness {
+  ui: AskUserQuestionUi
+  relay: AskUserQuestionRelay
+  send: Sends
+}
+
+function mkHarness(): Harness {
+  const send: Sends = { sendCalls: [], editCalls: [], nextMessageId: 5000 }
+  const api = fakeTelegram(send)
+  let uiRef: AskUserQuestionUi | undefined
+  const relay = createAskUserQuestionRelay({
+    log: silentLog(),
+    onSettle: (e) => {
+      void uiRef?.handleSettle(e)
+    },
+  })
+  const ui = createAskUserQuestionUi({
+    config: mkConfig(),
+    log: silentLog(),
+    telegramApi: api,
+    relay,
+    autonomyPaths: { root },
+  })
+  uiRef = ui
+  return { ui, relay, send }
+}
+
+// Submit a question and render it; returns the requestId + the sent message id.
+async function submitAndRender(
+  h: Harness,
+  question: string,
+  options: { label: string }[],
+): Promise<{ requestId: string; messageId: number }> {
+  const q: AskQuestion = { question, options }
+  const { requestId } = h.relay.submit({ toolUseId: `t-${Math.random()}`, sessionId: 's', questions: [q], chatId: CHAT })
+  if (requestId === undefined) throw new Error('no requestId')
+  await h.ui.startQuestion(requestId)
+  const messageId = h.relay.getPending(requestId)!.telegramMessageId!
+  return { requestId, messageId }
+}
+
+function tap(requestId: string, optionIndex: number, messageId: number): AskCallbackContext {
+  const acks: unknown[] = []
+  return {
+    callbackQuery: { data: `ask:choose:${requestId}:0:${optionIndex}` },
+    from: { id: OWNER },
+    chatId: CHAT,
+    callbackMessageId: messageId,
+    answerCallbackQuery: async (arg?: { text?: string }) => {
+      acks.push(arg)
+    },
+  }
+}
+
+describe('ask-card lease grant', () => {
+  test('affirmative tap on a [LEASE:] card mints a lease with scope/ttl/binding', async () => {
+    const h = mkHarness()
+    const { requestId, messageId } = await submitAndRender(
+      h,
+      '[LEASE: деплой стейджинга; ttl=48h] Разрешаешь деплой?',
+      [{ label: 'Да' }, { label: 'Нет' }],
+    )
+    await h.ui.handleAskCallback(tap(requestId, 0, messageId))
+
+    const state = loadAutonomyState({ root }, CHAT)
+    const leases = activeLeases(state, Date.now())
+    expect(leases.length).toBe(1)
+    expect(leases[0]!.scope).toBe('деплой стейджинга')
+    expect(leases[0]!.source).toBe('ask_card')
+    expect(leases[0]!.grantSourceId).toBe(`ask:${requestId}:0`)
+    expect(leases[0]!.chatId).toBe(CHAT)
+    expect(leases[0]!.grantorMessageId).toBe(messageId)
+    // ttl≈48h.
+    const ttlH = (leases[0]!.expiresAtMs - leases[0]!.grantedAtMs) / 3_600_000
+    expect(Math.round(ttlH)).toBe(48)
+  })
+
+  test('marker is stripped from the rendered Telegram card', async () => {
+    const h = mkHarness()
+    await submitAndRender(h, '[LEASE: deploy] Разрешаешь?', [{ label: 'Да' }, { label: 'Нет' }])
+    const body = h.send.sendCalls[0]!.text
+    expect(body).not.toContain('[LEASE')
+    expect(body).toContain('Разрешаешь?')
+  })
+
+  test('non-affirmative tap → no lease', async () => {
+    const h = mkHarness()
+    const { requestId, messageId } = await submitAndRender(
+      h,
+      '[LEASE: deploy] Разрешаешь?',
+      [{ label: 'Да' }, { label: 'Нет' }],
+    )
+    await h.ui.handleAskCallback(tap(requestId, 1, messageId)) // «Нет»
+    expect(loadAutonomyState({ root }, CHAT).leases.length).toBe(0)
+  })
+
+  test('affirmative tap on a NON-lease card → no lease', async () => {
+    const h = mkHarness()
+    const { requestId, messageId } = await submitAndRender(
+      h,
+      'Обычный вопрос без маркера?',
+      [{ label: 'Да' }, { label: 'Нет' }],
+    )
+    await h.ui.handleAskCallback(tap(requestId, 0, messageId))
+    expect(loadAutonomyState({ root }, CHAT).leases.length).toBe(0)
+  })
+
+  test('supersede marker revokes a differing active lease', async () => {
+    const h = mkHarness()
+    // First lease.
+    {
+      const { requestId, messageId } = await submitAndRender(h, '[LEASE: old scope] q1?', [{ label: 'Да' }, { label: 'Нет' }])
+      await h.ui.handleAskCallback(tap(requestId, 0, messageId))
+    }
+    // Second lease with ; supersede.
+    {
+      const { requestId, messageId } = await submitAndRender(h, '[LEASE: new scope; supersede] q2?', [{ label: 'Да' }, { label: 'Нет' }])
+      await h.ui.handleAskCallback(tap(requestId, 0, messageId))
+    }
+    const active = activeLeases(loadAutonomyState({ root }, CHAT), Date.now())
+    expect(active.map((l) => l.scope)).toEqual(['new scope'])
+  })
+})
+
+describe('ask-card timeout → open question registered', () => {
+  test('a timed-out question is registered with a marker-stripped summary', async () => {
+    const h = mkHarness()
+    const q: AskQuestion = {
+      question: '[LEASE: deploy] Разрешаешь деплой прямо сейчас?',
+      options: [{ label: 'Да' }, { label: 'Нет' }],
+    }
+    const { requestId } = h.relay.submit({ toolUseId: 't-timeout', sessionId: 's', questions: [q], chatId: CHAT })
+    await h.ui.startQuestion(requestId!)
+    // Force the timeout path (settles + fires onSettle → handleSettle).
+    h.relay.expire(requestId!, 'test timeout')
+    // onSettle is fire-and-forget; give the microtask queue a tick to flush.
+    await new Promise((r) => setTimeout(r, 20))
+
+    const qs = openQuestions(loadAutonomyState({ root }, CHAT))
+    expect(qs.length).toBe(1)
+    expect(qs[0]!.summary).toBe('Разрешаешь деплой прямо сейчас?')
+    expect(qs[0]!.summary).not.toContain('[LEASE')
+    expect(qs[0]!.sticky).not.toBe(true)
+    expect(qs[0]!.defaultAction).toBeUndefined()
+  })
+})

--- a/plugin/tests/autonomy/ask-lease.test.ts
+++ b/plugin/tests/autonomy/ask-lease.test.ts
@@ -10,11 +10,13 @@
 //   * timeout → open question auto-registered (marker-stripped summary)
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import {
+  MAX_BODY_CHARS,
+  renderClosedQuestionBody,
   createAskUserQuestionUi,
   type AskCallbackContext,
   type AskUserQuestionUi,
@@ -24,7 +26,7 @@ import {
   type AskQuestion,
   type AskUserQuestionRelay,
 } from '../../src/channel/ask-user-question.js'
-import { activeLeases, loadAutonomyState, openQuestions } from '../../src/autonomy/store.js'
+import { activeLeases, computeScopeDigest, loadAutonomyState, openQuestions } from '../../src/autonomy/store.js'
 import type { AppConfig } from '../../src/config.js'
 import type { Logger } from '../../src/log.js'
 import type {
@@ -103,7 +105,7 @@ interface Harness {
   send: Sends
 }
 
-function mkHarness(): Harness {
+function mkHarness(opts: { withAutonomy?: boolean } = {}): Harness {
   const send: Sends = { sendCalls: [], editCalls: [], nextMessageId: 5000 }
   const api = fakeTelegram(send)
   let uiRef: AskUserQuestionUi | undefined
@@ -118,10 +120,26 @@ function mkHarness(): Harness {
     log: silentLog(),
     telegramApi: api,
     relay,
-    autonomyPaths: { root },
+    ...(opts.withAutonomy === false ? {} : { autonomyPaths: { root } }),
   })
   uiRef = ui
   return { ui, relay, send }
+}
+
+// Simulated RESTART of the UI layer (fix-loop-2 #1): a FRESH factory (empty
+// in-memory cache) over the SAME relay and the SAME state root — the durable
+// ask-intents file is the only carrier of the grant intent across it.
+function restartUi(h: Harness): Harness {
+  const send: Sends = { sendCalls: [], editCalls: [], nextMessageId: 9000 }
+  const api = fakeTelegram(send)
+  const ui = createAskUserQuestionUi({
+    config: mkConfig(),
+    log: silentLog(),
+    telegramApi: api,
+    relay: h.relay,
+    autonomyPaths: { root },
+  })
+  return { ui, relay: h.relay, send }
 }
 
 // Submit a question and render it; returns the requestId + the sent message id.
@@ -376,5 +394,143 @@ describe('ask-card timeout → open question registered', () => {
     expect(qs.length).toBe(1)
     // Deterministic id derived from the settle identity.
     expect(qs[0]!.id).toBe('Q-ask-abcde-0')
+  })
+})
+
+describe('durable intent — restart survival (fix-loop-2 #1 CRITICAL)', () => {
+  test('after a UI restart the tap grants EXACTLY the persisted scope and the closed card shows it', async () => {
+    const h = mkHarness()
+    const { requestId, messageId } = await submitAndRender(
+      h,
+      '[LEASE: деплой стейджинга; ttl=48h] Разрешаешь?',
+      [{ label: 'Да' }, { label: 'Нет' }],
+    )
+    // RESTART: fresh factory, empty in-memory cache, same state root.
+    const h2 = restartUi(h)
+    await h2.ui.handleAskCallback(tap(requestId, 0, messageId))
+    const leases = activeLeases(loadAutonomyState({ root }, CHAT), Date.now())
+    expect(leases.length).toBe(1)
+    expect(leases[0]!.scope).toBe('деплой стейджинга')
+    // Closed card rendered by the restarted UI still shows the same scope.
+    const closed = h2.send.editCalls.find((e) => e.messageId === messageId)
+    expect(closed).toBeDefined()
+    expect(closed!.text).toContain('деплой стейджинга')
+  })
+
+  test('the DISK record is the only grant source — an edited record wins over the question text', async () => {
+    const h = mkHarness()
+    const { requestId, messageId } = await submitAndRender(
+      h,
+      '[LEASE: original scope] Разрешаешь?',
+      [{ label: 'Да' }, { label: 'Нет' }],
+    )
+    // Simulate a parser/deploy divergence: rewrite the persisted intent.
+    const file = join(root, `ask-lease-intents-${CHAT}.json`)
+    const parsed = JSON.parse(readFileSync(file, 'utf8')) as {
+      intents: Record<string, { scope: string; scopeDigest: string }>
+    }
+    const key = `${requestId}:0`
+    parsed.intents[key]!.scope = 'edited scope'
+    parsed.intents[key]!.scopeDigest = computeScopeDigest('edited scope')
+    writeFileSync(file, JSON.stringify(parsed), 'utf8')
+    const h2 = restartUi(h)
+    await h2.ui.handleAskCallback(tap(requestId, 0, messageId))
+    const leases = activeLeases(loadAutonomyState({ root }, CHAT), Date.now())
+    // Granted from the persisted record, NOT from re-parsing the question.
+    expect(leases.map((l) => l.scope)).toEqual(['edited scope'])
+  })
+
+  test('legacy/lost intent → fail-closed: no grant, «intent утерян» on closed card and as feedback', async () => {
+    const h = mkHarness()
+    const { requestId, messageId } = await submitAndRender(
+      h,
+      '[LEASE: deploy] Разрешаешь?',
+      [{ label: 'Да' }, { label: 'Нет' }],
+    )
+    // Lose the durable record (restart happened before/without persist).
+    rmSync(join(root, `ask-lease-intents-${CHAT}.json`), { force: true })
+    const h2 = restartUi(h)
+    await h2.ui.handleAskCallback(tap(requestId, 0, messageId))
+    expect(loadAutonomyState({ root }, CHAT).leases.length).toBe(0)
+    const closed = h2.send.editCalls.find((e) => e.messageId === messageId)
+    expect(closed).toBeDefined()
+    expect(closed!.text).toContain('Мандат НЕ выдан: intent утерян (рестарт)')
+    const feedback = h2.send.sendCalls.map((c) => c.text).find((t) => t.includes('intent утерян'))
+    expect(feedback).toBeDefined()
+  })
+})
+
+describe('no silent grant-capable cards (fix-loop-2 #3)', () => {
+  test('factory WITHOUT autonomyPaths → card is a normal question (no block), tap grants nothing', async () => {
+    const h = mkHarness({ withAutonomy: false })
+    const { requestId, messageId } = await submitAndRender(
+      h,
+      '[LEASE: deploy] Разрешаешь?',
+      [{ label: 'Да' }, { label: 'Нет' }],
+    )
+    const body = h.send.sendCalls[0]!.text
+    expect(body).not.toContain('Мандат автономии') // NOT grant-capable
+    expect(body).toContain('[LEASE') // honest raw render
+    expect(body).toContain('тап мандат НЕ выдаст')
+    await h.ui.handleAskCallback(tap(requestId, 0, messageId))
+    expect(loadAutonomyState({ root }, CHAT).leases.length).toBe(0)
+  })
+})
+
+describe('runtime registry failure on tap (fix-loop-2 #3)', () => {
+  test('grant-capable card + registry gone at tap → «Мандат НЕ выдан: реестр недоступен»', async () => {
+    // Build a UI whose deps object we keep, so autonomyPaths can vanish
+    // AFTER card creation (runtime-only failure — impossible via config, but
+    // must still be visible, never silent).
+    const send: Sends = { sendCalls: [], editCalls: [], nextMessageId: 7000 }
+    const api = fakeTelegram(send)
+    const relay = createAskUserQuestionRelay({ log: silentLog() })
+    const deps = {
+      config: mkConfig(),
+      log: silentLog(),
+      telegramApi: api,
+      relay,
+      autonomyPaths: { root } as { root: string } | undefined,
+    }
+    const ui = createAskUserQuestionUi(deps as Parameters<typeof createAskUserQuestionUi>[0])
+    const q: AskQuestion = { question: '[LEASE: deploy] Разрешаешь?', options: [{ label: 'Да' }, { label: 'Нет' }] }
+    const { requestId } = relay.submit({ toolUseId: 't-rt', sessionId: 's', questions: [q], chatId: CHAT })
+    await ui.startQuestion(requestId!)
+    const body = send.sendCalls[0]!.text
+    expect(body).toContain('Мандат автономии') // card WAS grant-capable
+    const messageId = relay.getPending(requestId!)!.telegramMessageId!
+    // Registry vanishes at runtime.
+    deps.autonomyPaths = undefined
+    await ui.handleAskCallback(tap(requestId!, 0, messageId))
+    expect(loadAutonomyState({ root }, CHAT).leases.length).toBe(0)
+    const feedback = send.sendCalls.map((c) => c.text).find((t) => t.includes('реестр недоступен'))
+    expect(feedback).toBeDefined()
+    expect(feedback!).toContain('Мандат НЕ выдан')
+  })
+})
+
+describe('closed-card body budget (fix-loop-2 #2)', () => {
+  test('maximally-escaping 400cp scope: closed body stays under MAX_BODY_CHARS', () => {
+    const scope = '&'.repeat(400) // escapes 5x → 2000 chars
+    const intent = {
+      scope,
+      ttlHours: 24,
+      supersede: false,
+      displayText: '&'.repeat(900), // question text also expands hard
+    }
+    const outcome = `✅ Ответ: <b>${'&amp;'.repeat(100)}</b>`
+    const body = renderClosedQuestionBody('raw?', 0, 1, outcome, { leaseIntent: intent })
+    expect(body.length).toBeLessThanOrEqual(MAX_BODY_CHARS)
+    // The mandate scope is NEVER the truncated part.
+    expect(body).toContain('&amp;'.repeat(400))
+    expect(body).toContain('ttl 24ч')
+  })
+
+  test('quote-heavy scope (6x escape expansion) also fits', () => {
+    const scope = '"'.repeat(400) // &quot; → 2400 chars
+    const intent = { scope, ttlHours: 24, supersede: false, displayText: 'q?' }
+    const body = renderClosedQuestionBody('raw?', 0, 1, '✅ Ответ: <b>Да</b>', { leaseIntent: intent })
+    expect(body.length).toBeLessThanOrEqual(MAX_BODY_CHARS)
+    expect(body).toContain('&quot;'.repeat(400))
   })
 })

--- a/plugin/tests/autonomy/grant.test.ts
+++ b/plugin/tests/autonomy/grant.test.ts
@@ -1,0 +1,417 @@
+// Autonomy M2 — lease GRANT paths.
+//
+// Covers the pure parsers (marker parse/strip, ttl cap, malformed markers,
+// affirmative label matrix, `/lease` command args), the store-level grant core
+// (applyLeaseGrant: grantSourceId idempotency, identical-scope no-op, supersede),
+// the grantLease orchestrator, the retention prune, and the version>1 read-only
+// guard.
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  clampTtlHours,
+  grantLease,
+  isAffirmativeLabel,
+  LEASE_DEFAULT_TTL_HOURS,
+  LEASE_MAX_TTL_HOURS,
+  parseLeaseCommandArgs,
+  parseLeaseMarker,
+  stripLeaseMarkerForDisplay,
+} from '../../src/autonomy/grant.js'
+import {
+  activeLeases,
+  addLease,
+  applyLeaseGrant,
+  autonomyStatePath,
+  computeScopeDigest,
+  emptyAutonomyState,
+  loadAutonomyState,
+  PRUNE_MAX_AGE_MS,
+  pruneAutonomyState,
+  resolveQuestion,
+  addQuestion,
+  consumeLease,
+  revokeLease,
+  updateAutonomyState,
+  type AutonomyState,
+} from '../../src/autonomy/store.js'
+
+const HOUR = 3_600_000
+const DAY = 24 * HOUR
+const NOW = 1_752_000_000_000
+
+let root: string
+const paths = () => ({ root })
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'dashi-grant-'))
+})
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// parseLeaseMarker + stripLeaseMarkerForDisplay
+// ─────────────────────────────────────────────────────────────────────
+
+describe('parseLeaseMarker', () => {
+  test('bare marker → scope, default ttl, no supersede, display falls back to scope', () => {
+    const m = parseLeaseMarker('[LEASE: deploy staging] Разрешаешь?')
+    expect(m).not.toBeNull()
+    expect(m!.scope).toBe('deploy staging')
+    expect(m!.ttlHours).toBe(LEASE_DEFAULT_TTL_HOURS)
+    expect(m!.supersede).toBe(false)
+    expect(m!.displayText).toBe('Разрешаешь?')
+  })
+
+  test('marker with no trailing question → display is the scope text', () => {
+    const m = parseLeaseMarker('[LEASE: catch up the wave]')
+    expect(m!.displayText).toBe('catch up the wave')
+  })
+
+  test('ttl parsed and clamped at 72h', () => {
+    expect(parseLeaseMarker('[LEASE: x; ttl=48h] q')!.ttlHours).toBe(48)
+    expect(parseLeaseMarker('[LEASE: x; ttl=200h] q')!.ttlHours).toBe(LEASE_MAX_TTL_HOURS)
+    // ttl=0h or negative → default (a dead-on-arrival mandate is a mistake).
+    expect(parseLeaseMarker('[LEASE: x; ttl=0h] q')!.ttlHours).toBe(LEASE_DEFAULT_TTL_HOURS)
+  })
+
+  test('supersede flag recognised (order-independent)', () => {
+    expect(parseLeaseMarker('[LEASE: x; supersede] q')!.supersede).toBe(true)
+    expect(parseLeaseMarker('[LEASE: x; ttl=12h; supersede] q')).toMatchObject({
+      scope: 'x', ttlHours: 12, supersede: true,
+    })
+    expect(parseLeaseMarker('[LEASE: x; supersede; ttl=12h] q')).toMatchObject({
+      scope: 'x', ttlHours: 12, supersede: true,
+    })
+  })
+
+  test('case-insensitive LEASE keyword', () => {
+    expect(parseLeaseMarker('[lease: x] q')!.scope).toBe('x')
+  })
+
+  test('malformed — empty scope → null (treated as a normal question)', () => {
+    expect(parseLeaseMarker('[LEASE: ] real question?')).toBeNull()
+    expect(parseLeaseMarker('[LEASE:] q')).toBeNull()
+  })
+
+  test('no closing bracket → null', () => {
+    expect(parseLeaseMarker('[LEASE: x q')).toBeNull()
+  })
+
+  test('marker not at the start → null (normal question)', () => {
+    expect(parseLeaseMarker('please [LEASE: x] approve')).toBeNull()
+  })
+
+  test('a plain question → null', () => {
+    expect(parseLeaseMarker('деплой на staging?')).toBeNull()
+  })
+
+  test('leading whitespace tolerated', () => {
+    expect(parseLeaseMarker('   [LEASE: x] q')!.scope).toBe('x')
+  })
+
+  test('unknown option segments are ignored but the card is still valid', () => {
+    const m = parseLeaseMarker('[LEASE: scope; frobnicate; ttl=5h] q')
+    expect(m).toMatchObject({ scope: 'scope', ttlHours: 5 })
+  })
+})
+
+describe('stripLeaseMarkerForDisplay', () => {
+  test('strips a marker', () => {
+    expect(stripLeaseMarkerForDisplay('[LEASE: x] Разрешаешь?')).toBe('Разрешаешь?')
+  })
+  test('identity for a non-lease question', () => {
+    expect(stripLeaseMarkerForDisplay('обычный вопрос')).toBe('обычный вопрос')
+  })
+})
+
+describe('clampTtlHours', () => {
+  test('default / cap / floor', () => {
+    expect(clampTtlHours(undefined)).toBe(24)
+    expect(clampTtlHours(48)).toBe(48)
+    expect(clampTtlHours(1000)).toBe(72)
+    expect(clampTtlHours(0)).toBe(24)
+    expect(clampTtlHours(-5)).toBe(24)
+    expect(clampTtlHours(Number.NaN)).toBe(24)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// isAffirmativeLabel
+// ─────────────────────────────────────────────────────────────────────
+
+describe('isAffirmativeLabel', () => {
+  test('exact affirmative labels match (case-insensitive, trimmed)', () => {
+    for (const l of ['Да', 'да', '  Да  ', 'Да, весь трейн', 'Да, разрешаю', 'Yes', 'yes']) {
+      expect(isAffirmativeLabel(l)).toBe(true)
+    }
+  })
+  test('non-affirmative labels never match', () => {
+    for (const l of ['Нет', 'Нет, не сейчас', 'Да позже', 'Yeah', 'Ок', 'Другое', '', 'Разрешаю']) {
+      expect(isAffirmativeLabel(l)).toBe(false)
+    }
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// parseLeaseCommandArgs
+// ─────────────────────────────────────────────────────────────────────
+
+describe('parseLeaseCommandArgs', () => {
+  test('empty args → bare', () => {
+    expect(parseLeaseCommandArgs('')).toEqual({ kind: 'bare' })
+    expect(parseLeaseCommandArgs('   ')).toEqual({ kind: 'bare' })
+  })
+  test('scope only → grant with default ttl', () => {
+    expect(parseLeaseCommandArgs('деплой стейджинга')).toEqual({
+      kind: 'grant', scope: 'деплой стейджинга', ttlHours: 24,
+    })
+  })
+  test('scope + ttl', () => {
+    expect(parseLeaseCommandArgs('деплой; ttl=48h')).toEqual({
+      kind: 'grant', scope: 'деплой', ttlHours: 48,
+    })
+  })
+  test('only a ttl option with no scope → bare', () => {
+    expect(parseLeaseCommandArgs('; ttl=48h')).toEqual({ kind: 'bare' })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// applyLeaseGrant — store core
+// ─────────────────────────────────────────────────────────────────────
+
+describe('applyLeaseGrant', () => {
+  const base = { expiresAtMs: NOW + DAY, source: 'ask_card' as const, chatId: '1' }
+
+  test('grants a fresh lease with scopeDigest + binding fields', () => {
+    const r = applyLeaseGrant(emptyAutonomyState(), { ...base, scope: 's', grantSourceId: 'ask:aaaaa:0', grantorMessageId: 42 }, NOW)
+    expect(r.outcome).toBe('granted')
+    expect(r.lease!.scope).toBe('s')
+    expect(r.lease!.scopeDigest).toBe(computeScopeDigest('s'))
+    expect(r.lease!.grantSourceId).toBe('ask:aaaaa:0')
+    expect(r.lease!.chatId).toBe('1')
+    expect(r.lease!.grantorMessageId).toBe(42)
+    expect(r.state.leases.length).toBe(1)
+  })
+
+  test('same grantSourceId → idempotent no-op (duplicate_source), one lease', () => {
+    let state = emptyAutonomyState()
+    const first = applyLeaseGrant(state, { ...base, scope: 's', grantSourceId: 'ask:aaaaa:0' }, NOW)
+    state = first.state
+    const second = applyLeaseGrant(state, { ...base, scope: 'DIFFERENT scope', grantSourceId: 'ask:aaaaa:0' }, NOW)
+    expect(second.outcome).toBe('duplicate_source')
+    expect(second.lease!.id).toBe(first.lease!.id) // returns the existing lease
+    expect(second.state.leases.length).toBe(1)
+    expect(second.state).toBe(state) // unchanged reference
+  })
+
+  test('identical ACTIVE scope (different source) → duplicate_scope no-op', () => {
+    let state = emptyAutonomyState()
+    const first = applyLeaseGrant(state, { ...base, scope: 'same', grantSourceId: 'src-1' }, NOW)
+    state = first.state
+    const second = applyLeaseGrant(state, { ...base, scope: 'same', grantSourceId: 'src-2' }, NOW)
+    expect(second.outcome).toBe('duplicate_scope')
+    expect(second.lease!.id).toBe(first.lease!.id)
+    expect(second.state.leases.length).toBe(1)
+  })
+
+  test('different scopes coexist (no supersede)', () => {
+    let state = emptyAutonomyState()
+    state = applyLeaseGrant(state, { ...base, scope: 'a', grantSourceId: 's-a' }, NOW).state
+    const r = applyLeaseGrant(state, { ...base, scope: 'b', grantSourceId: 's-b' }, NOW)
+    expect(r.outcome).toBe('granted')
+    expect(activeLeases(r.state, NOW).length).toBe(2)
+  })
+
+  test('supersede revokes differing active leases then grants (superseded)', () => {
+    let state = emptyAutonomyState()
+    const old = applyLeaseGrant(state, { ...base, scope: 'old', grantSourceId: 's-old' }, NOW)
+    state = old.state
+    const r = applyLeaseGrant(state, { ...base, scope: 'new', grantSourceId: 's-new', supersede: true }, NOW)
+    expect(r.outcome).toBe('superseded')
+    const active = activeLeases(r.state, NOW)
+    expect(active.map((l) => l.scope)).toEqual(['new'])
+    const revoked = r.state.leases.find((l) => l.id === old.lease!.id)!
+    expect(revoked.revokedAtMs).toBe(NOW)
+    expect(revoked.revokedBy).toBe('owner_card')
+    expect(revoked.revokeReason).toBe('superseded')
+  })
+
+  test('supersede with identical scope is the duplicate_scope no-op (never revokes itself)', () => {
+    let state = emptyAutonomyState()
+    const first = applyLeaseGrant(state, { ...base, scope: 'same', grantSourceId: 's-1' }, NOW)
+    state = first.state
+    const r = applyLeaseGrant(state, { ...base, scope: 'same', grantSourceId: 's-2', supersede: true }, NOW)
+    expect(r.outcome).toBe('duplicate_scope')
+    expect(r.lease!.id).toBe(first.lease!.id)
+  })
+
+  test('supersede with no other active lease → plain granted', () => {
+    const r = applyLeaseGrant(emptyAutonomyState(), { ...base, scope: 'x', grantSourceId: 's-x', supersede: true }, NOW)
+    expect(r.outcome).toBe('granted')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// grantLease — orchestrator over the serialized writer
+// ─────────────────────────────────────────────────────────────────────
+
+describe('grantLease', () => {
+  test('persists a lease with the computed expiry', async () => {
+    const res = await grantLease(paths(), '1', {
+      scope: 's', ttlHours: 48, source: 'owner_cmd', grantSourceId: 'cmd:1:99',
+    }, undefined, NOW)
+    expect(res.kind).toBe('ok')
+    if (res.kind !== 'ok') throw new Error('unreachable')
+    expect(res.outcome).toBe('granted')
+    expect(res.lease!.expiresAtMs).toBe(NOW + 48 * HOUR)
+    const loaded = loadAutonomyState(paths(), '1')
+    expect(loaded.leases.length).toBe(1)
+    expect(loaded.leases[0]!.source).toBe('owner_cmd')
+  })
+
+  test('replayed grantSourceId mints exactly one lease', async () => {
+    const g = () => grantLease(paths(), '1', {
+      scope: 's', ttlHours: 24, source: 'ask_card', grantSourceId: 'ask:aaaaa:0',
+    }, undefined, NOW)
+    const first = await g()
+    const second = await g()
+    expect(first.kind).toBe('ok')
+    expect(second.kind).toBe('ok')
+    if (second.kind === 'ok') expect(second.outcome).toBe('duplicate_source')
+    expect(loadAutonomyState(paths(), '1').leases.length).toBe(1)
+  })
+
+  test('concurrent double-tap of the same grant → one lease', async () => {
+    const g = () => grantLease(paths(), '1', {
+      scope: 's', ttlHours: 24, source: 'ask_card', grantSourceId: 'ask:aaaaa:0',
+    }, undefined, NOW)
+    await Promise.all([g(), g(), g()])
+    expect(loadAutonomyState(paths(), '1').leases.length).toBe(1)
+  })
+
+  test('version_unsupported when the on-disk file is a newer schema', async () => {
+    writeFileSync(
+      autonomyStatePath(paths(), '1'),
+      JSON.stringify({ version: 2, revision: 5, leases: [], questions: [] }),
+      'utf8',
+    )
+    const res = await grantLease(paths(), '1', {
+      scope: 's', ttlHours: 24, source: 'owner_cmd', grantSourceId: 'cmd:1:1',
+    }, undefined, NOW)
+    expect(res.kind).toBe('version_unsupported')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// pruneAutonomyState (PR-1 leftover 4a)
+// ─────────────────────────────────────────────────────────────────────
+
+describe('pruneAutonomyState', () => {
+  function withLease(state: AutonomyState, over: Partial<Parameters<typeof addLease>[1]> & { id: string }): AutonomyState {
+    return addLease(state, { scope: 's', expiresAtMs: NOW + DAY, source: 'manual', ...over }, NOW).state
+  }
+
+  test('keeps active leases and open questions regardless of age', () => {
+    let s = emptyAutonomyState()
+    s = withLease(s, { id: 'L-active', expiresAtMs: NOW + DAY })
+    s = addQuestion(s, { id: 'Q-open', summary: 'q', askedAtMs: NOW - 100 * DAY }, NOW).state
+    const pruned = pruneAutonomyState(s, NOW)
+    expect(pruned.leases.map((l) => l.id)).toEqual(['L-active'])
+    expect(pruned.questions.map((q) => q.id)).toEqual(['Q-open'])
+    expect(pruned).toBe(s) // nothing pruned → same reference
+  })
+
+  test('drops consumed/revoked/expired leases older than 14 days; keeps recent ones', () => {
+    let s = emptyAutonomyState()
+    // consumed long ago
+    s = withLease(s, { id: 'L-old-consumed', expiresAtMs: NOW + DAY })
+    s = consumeLease(s, 'L-old-consumed', NOW - 20 * DAY).state
+    // revoked long ago
+    s = withLease(s, { id: 'L-old-revoked', expiresAtMs: NOW + DAY })
+    s = revokeLease(s, 'L-old-revoked', NOW - 20 * DAY, 'owner').state
+    // expired long ago (never consumed/revoked)
+    s = withLease(s, { id: 'L-old-expired', expiresAtMs: NOW - 20 * DAY })
+    // consumed recently — kept
+    s = withLease(s, { id: 'L-recent-consumed', expiresAtMs: NOW + DAY })
+    s = consumeLease(s, 'L-recent-consumed', NOW - 2 * DAY).state
+
+    const pruned = pruneAutonomyState(s, NOW)
+    const ids = pruned.leases.map((l) => l.id).sort()
+    expect(ids).toEqual(['L-recent-consumed'])
+  })
+
+  test('drops resolved questions older than 14 days; keeps recent resolved + open', () => {
+    let s = emptyAutonomyState()
+    s = addQuestion(s, { id: 'Q-old', summary: 'a', askedAtMs: NOW - 30 * DAY }, NOW).state
+    s = resolveQuestion(s, 'Q-old', 'answered', NOW - 20 * DAY).state
+    s = addQuestion(s, { id: 'Q-recent', summary: 'b', askedAtMs: NOW - 5 * DAY }, NOW).state
+    s = resolveQuestion(s, 'Q-recent', 'answered', NOW - 3 * DAY).state
+    s = addQuestion(s, { id: 'Q-open', summary: 'c', askedAtMs: NOW - 40 * DAY }, NOW).state
+
+    const pruned = pruneAutonomyState(s, NOW)
+    expect(pruned.questions.map((q) => q.id).sort()).toEqual(['Q-open', 'Q-recent'])
+  })
+
+  test('boundary: exactly 14 days old is kept (inclusive)', () => {
+    let s = emptyAutonomyState()
+    s = withLease(s, { id: 'L-edge', expiresAtMs: NOW - PRUNE_MAX_AGE_MS })
+    expect(pruneAutonomyState(s, NOW).leases.map((l) => l.id)).toEqual(['L-edge'])
+  })
+
+  test('applied on the save path via updateAutonomyState', async () => {
+    // Seed an old consumed lease directly on disk, then trigger any mutation.
+    let seed = emptyAutonomyState()
+    seed = withLease(seed, { id: 'L-stale', expiresAtMs: NOW + DAY })
+    seed = consumeLease(seed, 'L-stale', NOW - 30 * DAY).state
+    // Persist via a first mutation that adds a fresh active lease.
+    await updateAutonomyState(paths(), '1', () => ({ state: seed, result: null }), undefined, NOW)
+    // A second mutation prunes the stale one on the way to disk.
+    await updateAutonomyState(paths(), '1', (state) => {
+      const r = addLease(state, { id: 'L-fresh', scope: 'f', expiresAtMs: NOW + DAY, source: 'manual' }, NOW)
+      return { state: r.state, result: r.outcome }
+    }, undefined, NOW)
+    const ids = loadAutonomyState(paths(), '1').leases.map((l) => l.id).sort()
+    expect(ids).toEqual(['L-fresh'])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// version>1 read-only (PR-1 leftover 4b)
+// ─────────────────────────────────────────────────────────────────────
+
+describe('version>1 read-only', () => {
+  test('loads (coerces) a future-version file best-effort', () => {
+    writeFileSync(
+      autonomyStatePath(paths(), '1'),
+      JSON.stringify({
+        version: 2,
+        revision: 7,
+        leases: [{ id: 'L-x', scope: 's', grantedAtMs: NOW, expiresAtMs: NOW + DAY, source: 'manual' }],
+        questions: [],
+      }),
+      'utf8',
+    )
+    const loaded = loadAutonomyState(paths(), '1')
+    expect(loaded.version as number).toBe(2) // preserved so the guard can see it
+    expect(loaded.leases.length).toBe(1)
+  })
+
+  test('mutation on a future-version file is refused and NEVER overwrites it', async () => {
+    const file = autonomyStatePath(paths(), '1')
+    const body = JSON.stringify({ version: 2, revision: 7, leases: [], questions: [] })
+    writeFileSync(file, body, 'utf8')
+    const res = await updateAutonomyState(paths(), '1', (state) => {
+      const r = addLease(state, { id: 'L-x', scope: 's', expiresAtMs: NOW + DAY, source: 'manual' }, NOW)
+      return { state: r.state, result: r.outcome }
+    }, undefined, NOW)
+    expect(res.kind).toBe('version_unsupported')
+    // File byte-identical — no downgrade write happened.
+    const { readFileSync } = await import('node:fs')
+    expect(readFileSync(file, 'utf8')).toBe(body)
+  })
+})

--- a/plugin/tests/autonomy/grant.test.ts
+++ b/plugin/tests/autonomy/grant.test.ts
@@ -12,11 +12,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import {
-  clampTtlHours,
   grantLease,
   isAffirmativeLabel,
   LEASE_DEFAULT_TTL_HOURS,
-  LEASE_MAX_TTL_HOURS,
+  LEASE_SCOPE_MAX_CODEPOINTS,
   parseLeaseCommandArgs,
   parseLeaseMarker,
   stripLeaseMarkerForDisplay,
@@ -28,6 +27,7 @@ import {
   autonomyStatePath,
   computeScopeDigest,
   emptyAutonomyState,
+  GRANT_SOURCE_LEDGER_MAX_AGE_MS,
   loadAutonomyState,
   PRUNE_MAX_AGE_MS,
   pruneAutonomyState,
@@ -71,11 +71,35 @@ describe('parseLeaseMarker', () => {
     expect(m!.displayText).toBe('catch up the wave')
   })
 
-  test('ttl parsed and clamped at 72h', () => {
+  test('valid ttl values: integer 1..72', () => {
     expect(parseLeaseMarker('[LEASE: x; ttl=48h] q')!.ttlHours).toBe(48)
-    expect(parseLeaseMarker('[LEASE: x; ttl=200h] q')!.ttlHours).toBe(LEASE_MAX_TTL_HOURS)
-    // ttl=0h or negative → default (a dead-on-arrival mandate is a mistake).
-    expect(parseLeaseMarker('[LEASE: x; ttl=0h] q')!.ttlHours).toBe(LEASE_DEFAULT_TTL_HOURS)
+    expect(parseLeaseMarker('[LEASE: x; ttl=1h] q')!.ttlHours).toBe(1)
+    expect(parseLeaseMarker('[LEASE: x; ttl=72h] q')!.ttlHours).toBe(72)
+    expect(parseLeaseMarker('[LEASE: x; TTL=12H] q')!.ttlHours).toBe(12)
+  })
+
+  test('FAIL-CLOSED ttl matrix — present but malformed → whole marker invalid (null)', () => {
+    const bad = [
+      'ttl=0h', // zero
+      'ttl=-5h', // negative
+      'ttl=4.5h', // float
+      'ttl=200h', // >72 — NOT clamped, invalid
+      'ttl=73h', // just over the cap
+      'ttl=xh', // garbage
+      'ttl=h', // no digits
+      'ttl=48', // missing h
+      'ttl = 48h', // inner whitespace
+      'ttl=４８h', // non-ASCII (fullwidth) digits
+      'ttl=٤٨h', // non-ASCII (arabic-indic) digits
+    ]
+    for (const seg of bad) {
+      expect(parseLeaseMarker(`[LEASE: x; ${seg}] q`)).toBeNull()
+    }
+  })
+
+  test('duplicate ttl / duplicate supersede → invalid', () => {
+    expect(parseLeaseMarker('[LEASE: x; ttl=2h; ttl=3h] q')).toBeNull()
+    expect(parseLeaseMarker('[LEASE: x; supersede; supersede] q')).toBeNull()
   })
 
   test('supersede flag recognised (order-independent)', () => {
@@ -113,9 +137,24 @@ describe('parseLeaseMarker', () => {
     expect(parseLeaseMarker('   [LEASE: x] q')!.scope).toBe('x')
   })
 
-  test('unknown option segments are ignored but the card is still valid', () => {
-    const m = parseLeaseMarker('[LEASE: scope; frobnicate; ttl=5h] q')
-    expect(m).toMatchObject({ scope: 'scope', ttlHours: 5 })
+  test('unknown option segment → whole marker invalid (closed grammar, fail-closed)', () => {
+    expect(parseLeaseMarker('[LEASE: scope; frobnicate; ttl=5h] q')).toBeNull()
+    // A scope containing `;` inside the marker → invalid rather than silently
+    // truncated at the first `;`.
+    expect(parseLeaseMarker('[LEASE: аудит; production] q')).toBeNull()
+    // Empty option segment (trailing `;`) → invalid.
+    expect(parseLeaseMarker('[LEASE: x;] q')).toBeNull()
+  })
+
+  test('scope over 400 code points → invalid (fail-closed, never clipped)', () => {
+    const okScope = 'а'.repeat(LEASE_SCOPE_MAX_CODEPOINTS)
+    expect(parseLeaseMarker(`[LEASE: ${okScope}] q`)!.scope).toBe(okScope)
+    const longScope = 'а'.repeat(LEASE_SCOPE_MAX_CODEPOINTS + 1)
+    expect(parseLeaseMarker(`[LEASE: ${longScope}] q`)).toBeNull()
+    // Astral-plane characters counted as code points, not UTF-16 units.
+    const astral = '𝕏'.repeat(LEASE_SCOPE_MAX_CODEPOINTS)
+    expect(parseLeaseMarker(`[LEASE: ${astral}] q`)!.scope).toBe(astral)
+    expect(parseLeaseMarker(`[LEASE: ${astral}𝕏] q`)).toBeNull()
   })
 })
 
@@ -128,14 +167,10 @@ describe('stripLeaseMarkerForDisplay', () => {
   })
 })
 
-describe('clampTtlHours', () => {
-  test('default / cap / floor', () => {
-    expect(clampTtlHours(undefined)).toBe(24)
-    expect(clampTtlHours(48)).toBe(48)
-    expect(clampTtlHours(1000)).toBe(72)
-    expect(clampTtlHours(0)).toBe(24)
-    expect(clampTtlHours(-5)).toBe(24)
-    expect(clampTtlHours(Number.NaN)).toBe(24)
+describe('default ttl', () => {
+  test('24h applies ONLY when ttl is entirely absent', () => {
+    expect(parseLeaseMarker('[LEASE: x] q')!.ttlHours).toBe(LEASE_DEFAULT_TTL_HOURS)
+    expect(parseLeaseCommandArgs('scope')).toEqual({ kind: 'grant', scope: 'scope', ttlHours: LEASE_DEFAULT_TTL_HOURS })
   })
 })
 
@@ -170,10 +205,32 @@ describe('parseLeaseCommandArgs', () => {
       kind: 'grant', scope: 'деплой стейджинга', ttlHours: 24,
     })
   })
-  test('scope + ttl', () => {
+  test('trailing ttl option is parsed off', () => {
     expect(parseLeaseCommandArgs('деплой; ttl=48h')).toEqual({
       kind: 'grant', scope: 'деплой', ttlHours: 48,
     })
+  })
+  test('non-option `;` segments BELONG to the scope — no silent truncation (fix-loop #6)', () => {
+    expect(parseLeaseCommandArgs('аудит; production')).toEqual({
+      kind: 'grant', scope: 'аудит; production', ttlHours: 24,
+    })
+    // `;` in the middle + trailing ttl: only the TRAILING option is stripped.
+    expect(parseLeaseCommandArgs('аудит; production; ttl=12h')).toEqual({
+      kind: 'grant', scope: 'аудит; production', ttlHours: 12,
+    })
+    // Trailing non-option segment → everything (incl. an inner ttl=…) is scope.
+    expect(parseLeaseCommandArgs('x; ttl=48h; y')).toEqual({
+      kind: 'grant', scope: 'x; ttl=48h; y', ttlHours: 24,
+    })
+  })
+  test('trailing option-like but MALFORMED ttl → invalid (usage error, no grant)', () => {
+    for (const bad of ['ttl=200h', 'ttl=0h', 'ttl=4.5h', 'ttl=abch', 'ttl = 48h', 'ttl=-1h', 'ttl=48']) {
+      expect(parseLeaseCommandArgs(`аудит; ${bad}`)).toEqual({ kind: 'invalid', reason: 'ttl' })
+    }
+  })
+  test('scope over 400 code points → invalid', () => {
+    const long = 'x'.repeat(LEASE_SCOPE_MAX_CODEPOINTS + 1)
+    expect(parseLeaseCommandArgs(long)).toEqual({ kind: 'invalid', reason: 'scope_too_long' })
   })
   test('only a ttl option with no scope → bare', () => {
     expect(parseLeaseCommandArgs('; ttl=48h')).toEqual({ kind: 'bare' })
@@ -198,18 +255,34 @@ describe('applyLeaseGrant', () => {
     expect(r.state.leases.length).toBe(1)
   })
 
-  test('same grantSourceId → idempotent no-op (duplicate_source), one lease', () => {
+  test('grant records the sourceId in the durable ledger', () => {
+    const r = applyLeaseGrant(emptyAutonomyState(), { ...base, scope: 's', grantSourceId: 'src-1' }, NOW)
+    expect(r.state.usedGrantSources).toEqual([
+      { sourceId: 'src-1', scopeDigest: computeScopeDigest('s'), atMs: NOW },
+    ])
+  })
+
+  test('same grantSourceId + same scope → idempotent no-op (duplicate_source), one lease', () => {
     let state = emptyAutonomyState()
     const first = applyLeaseGrant(state, { ...base, scope: 's', grantSourceId: 'ask:aaaaa:0' }, NOW)
     state = first.state
-    const second = applyLeaseGrant(state, { ...base, scope: 'DIFFERENT scope', grantSourceId: 'ask:aaaaa:0' }, NOW)
+    const second = applyLeaseGrant(state, { ...base, scope: 's', grantSourceId: 'ask:aaaaa:0' }, NOW)
     expect(second.outcome).toBe('duplicate_source')
     expect(second.lease!.id).toBe(first.lease!.id) // returns the existing lease
     expect(second.state.leases.length).toBe(1)
     expect(second.state).toBe(state) // unchanged reference
   })
 
-  test('identical ACTIVE scope (different source) → duplicate_scope no-op', () => {
+  test('same grantSourceId + DIFFERENT scope → source_conflict, no grant (Fable)', () => {
+    let state = emptyAutonomyState()
+    state = applyLeaseGrant(state, { ...base, scope: 's', grantSourceId: 'ask:aaaaa:0' }, NOW).state
+    const second = applyLeaseGrant(state, { ...base, scope: 'DIFFERENT scope', grantSourceId: 'ask:aaaaa:0' }, NOW)
+    expect(second.outcome).toBe('source_conflict')
+    expect(second.lease).toBeUndefined()
+    expect(second.state.leases.length).toBe(1) // nothing minted
+  })
+
+  test('identical ACTIVE scope (different source) → duplicate_scope, NEW sourceId recorded in ledger', () => {
     let state = emptyAutonomyState()
     const first = applyLeaseGrant(state, { ...base, scope: 'same', grantSourceId: 'src-1' }, NOW)
     state = first.state
@@ -217,6 +290,45 @@ describe('applyLeaseGrant', () => {
     expect(second.outcome).toBe('duplicate_scope')
     expect(second.lease!.id).toBe(first.lease!.id)
     expect(second.state.leases.length).toBe(1)
+    // fix-loop #2: the deduped attempt's sourceId is ALSO in the ledger.
+    expect(second.state.usedGrantSources.map((u) => u.sourceId).sort()).toEqual(['src-1', 'src-2'])
+  })
+
+  test('LEDGER blocks re-mint after the lease died (revoked → replayed sourceId)', () => {
+    // Grant via src-2 as a duplicate_scope against src-1's lease, then revoke
+    // the lease and prune its tombstone — the src-2 replay must STILL be
+    // recognised (Codex HIGH exploit: replay after expiry/revoke re-minted).
+    let state = emptyAutonomyState()
+    const first = applyLeaseGrant(state, { ...base, scope: 'same', grantSourceId: 'src-1' }, NOW)
+    state = first.state
+    state = applyLeaseGrant(state, { ...base, scope: 'same', grantSourceId: 'src-2' }, NOW).state
+    state = revokeLease(state, first.lease!.id, NOW + HOUR, 'owner').state
+    // 20 days later the lease tombstone is pruned; the ledger survives.
+    const pruned = pruneAutonomyState(state, NOW + 20 * DAY)
+    expect(pruned.leases.length).toBe(0)
+    expect(pruned.usedGrantSources.length).toBe(2)
+    const replay = applyLeaseGrant(pruned, { ...base, scope: 'same', grantSourceId: 'src-2' }, NOW + 20 * DAY)
+    expect(replay.outcome).toBe('duplicate_source')
+    expect(replay.state.leases.length).toBe(0) // NO fresh lease minted
+    // And a replayed sourceId with a different scope is still a conflict.
+    const conflict = applyLeaseGrant(pruned, { ...base, scope: 'other', grantSourceId: 'src-2' }, NOW + 20 * DAY)
+    expect(conflict.outcome).toBe('source_conflict')
+  })
+
+  test('legacy pre-ledger lease record dedups and back-fills the ledger', () => {
+    // Simulate a pre-ledger file: a lease with grantSourceId but no ledger.
+    let state = emptyAutonomyState()
+    state = addLease(state, {
+      scope: 's', expiresAtMs: NOW + DAY, source: 'ask_card', grantSourceId: 'legacy-1',
+    }, NOW).state
+    expect(state.usedGrantSources.length).toBe(0)
+    const replay = applyLeaseGrant(state, { ...base, scope: 's', grantSourceId: 'legacy-1' }, NOW)
+    expect(replay.outcome).toBe('duplicate_source')
+    expect(replay.state.leases.length).toBe(1)
+    expect(replay.state.usedGrantSources.map((u) => u.sourceId)).toEqual(['legacy-1'])
+    // Legacy record with a different scope → conflict.
+    const conflict = applyLeaseGrant(state, { ...base, scope: 'other', grantSourceId: 'legacy-1' }, NOW)
+    expect(conflict.outcome).toBe('source_conflict')
   })
 
   test('different scopes coexist (no supersede)', () => {
@@ -363,6 +475,20 @@ describe('pruneAutonomyState', () => {
     expect(pruneAutonomyState(s, NOW).leases.map((l) => l.id)).toEqual(['L-edge'])
   })
 
+  test('replay ledger kept 90 days — out-living the 14-day lease tombstones', () => {
+    let s = emptyAutonomyState()
+    s = applyLeaseGrant(s, {
+      scope: 's', expiresAtMs: NOW + HOUR, source: 'ask_card', grantSourceId: 'src-old',
+    }, NOW).state
+    // 60 days later: lease tombstone gone, ledger entry KEPT.
+    const at60 = pruneAutonomyState(s, NOW + 60 * DAY)
+    expect(at60.leases.length).toBe(0)
+    expect(at60.usedGrantSources.map((u) => u.sourceId)).toEqual(['src-old'])
+    // Past 90 days: ledger entry dropped too.
+    const at91 = pruneAutonomyState(s, NOW + GRANT_SOURCE_LEDGER_MAX_AGE_MS + DAY)
+    expect(at91.usedGrantSources.length).toBe(0)
+  })
+
   test('applied on the save path via updateAutonomyState', async () => {
     // Seed an old consumed lease directly on disk, then trigger any mutation.
     let seed = emptyAutonomyState()
@@ -384,8 +510,8 @@ describe('pruneAutonomyState', () => {
 // version>1 read-only (PR-1 leftover 4b)
 // ─────────────────────────────────────────────────────────────────────
 
-describe('version>1 read-only', () => {
-  test('loads (coerces) a future-version file best-effort', () => {
+describe('unsupported-version read-only (raw value compared BEFORE coercion)', () => {
+  test('loads (coerces) an unsupported-version file best-effort', () => {
     writeFileSync(
       autonomyStatePath(paths(), '1'),
       JSON.stringify({
@@ -397,21 +523,36 @@ describe('version>1 read-only', () => {
       'utf8',
     )
     const loaded = loadAutonomyState(paths(), '1')
-    expect(loaded.version as number).toBe(2) // preserved so the guard can see it
+    expect(loaded.unsupportedVersion).toBe(2) // raw value preserved for the guard
     expect(loaded.leases.length).toBe(1)
   })
 
-  test('mutation on a future-version file is refused and NEVER overwrites it', async () => {
+  // fix-loop #5 (Codex MED): 1.9 used to coerce to 1 and get OVERWRITTEN as
+  // v1. Anything that is not exactly the integer 1 is read-only now.
+  for (const rawVersion of [2, 1.9, '2', 'abc'] as const) {
+    test(`version ${JSON.stringify(rawVersion)} → mutation refused, file byte-identical`, async () => {
+      const file = autonomyStatePath(paths(), '1')
+      const body = JSON.stringify({ version: rawVersion, revision: 7, leases: [], questions: [] })
+      writeFileSync(file, body, 'utf8')
+      const res = await updateAutonomyState(paths(), '1', (state) => {
+        const r = addLease(state, { id: 'L-x', scope: 's', expiresAtMs: NOW + DAY, source: 'manual' }, NOW)
+        return { state: r.state, result: r.outcome }
+      }, undefined, NOW)
+      expect(res.kind).toBe('version_unsupported')
+      // File byte-identical — no downgrade write happened.
+      const { readFileSync } = await import('node:fs')
+      expect(readFileSync(file, 'utf8')).toBe(body)
+    })
+  }
+
+  test('exactly integer 1 stays writable', async () => {
     const file = autonomyStatePath(paths(), '1')
-    const body = JSON.stringify({ version: 2, revision: 7, leases: [], questions: [] })
-    writeFileSync(file, body, 'utf8')
+    writeFileSync(file, JSON.stringify({ version: 1, revision: 7, leases: [], questions: [] }), 'utf8')
     const res = await updateAutonomyState(paths(), '1', (state) => {
       const r = addLease(state, { id: 'L-x', scope: 's', expiresAtMs: NOW + DAY, source: 'manual' }, NOW)
       return { state: r.state, result: r.outcome }
     }, undefined, NOW)
-    expect(res.kind).toBe('version_unsupported')
-    // File byte-identical — no downgrade write happened.
-    const { readFileSync } = await import('node:fs')
-    expect(readFileSync(file, 'utf8')).toBe(body)
+    expect(res.kind).toBe('ok')
+    expect(loadAutonomyState(paths(), '1').leases.length).toBe(1)
   })
 })

--- a/plugin/tests/autonomy/grant.test.ts
+++ b/plugin/tests/autonomy/grant.test.ts
@@ -71,11 +71,27 @@ describe('parseLeaseMarker', () => {
     expect(m!.displayText).toBe('catch up the wave')
   })
 
-  test('valid ttl values: integer 1..72', () => {
+  test('valid ttl values: integer 1..72, literal lowercase form only', () => {
     expect(parseLeaseMarker('[LEASE: x; ttl=48h] q')!.ttlHours).toBe(48)
     expect(parseLeaseMarker('[LEASE: x; ttl=1h] q')!.ttlHours).toBe(1)
     expect(parseLeaseMarker('[LEASE: x; ttl=72h] q')!.ttlHours).toBe(72)
-    expect(parseLeaseMarker('[LEASE: x; TTL=12H] q')!.ttlHours).toBe(12)
+  })
+
+  test('case variants are INVALID — contract is literal lowercase ttl=<int>h (fix-loop-2 #7)', () => {
+    expect(parseLeaseMarker('[LEASE: x; TTL=12H] q')).toBeNull()
+    expect(parseLeaseMarker('[LEASE: x; Ttl=12h] q')).toBeNull()
+    expect(parseLeaseMarker('[LEASE: x; ttl=12H] q')).toBeNull()
+    expect(parseLeaseCommandArgs('аудит; TTL=12H')).toEqual({ kind: 'invalid', reason: 'ttl' })
+  })
+
+  test('scope with control/format chars (newline, bidi RLO) → invalid (fix-loop-2 #6)', () => {
+    // U+202E RIGHT-TO-LEFT OVERRIDE — visual reordering attack on consent text.
+    expect(parseLeaseMarker('[LEASE: deploy \u202Egnigats] q')).toBeNull()
+    expect(parseLeaseMarker('[LEASE: a\u0000b] q')).toBeNull()
+    expect(parseLeaseCommandArgs('deploy \u202Egnigats')).toEqual({ kind: 'invalid', reason: 'scope_charset' })
+    expect(parseLeaseCommandArgs('строка1\nстрока2')).toEqual({ kind: 'invalid', reason: 'scope_charset' })
+    // Zero-width joiner (Cf) is rejected too.
+    expect(parseLeaseCommandArgs('a\u200Db')).toEqual({ kind: 'invalid', reason: 'scope_charset' })
   })
 
   test('FAIL-CLOSED ttl matrix — present but malformed → whole marker invalid (null)', () => {
@@ -473,6 +489,28 @@ describe('pruneAutonomyState', () => {
     let s = emptyAutonomyState()
     s = withLease(s, { id: 'L-edge', expiresAtMs: NOW - PRUNE_MAX_AGE_MS })
     expect(pruneAutonomyState(s, NOW).leases.map((l) => l.id)).toEqual(['L-edge'])
+  })
+
+  test('replay ledger hard cap 500: oldest evicted with grant_ledger_evicted warn (fix-loop-2 #4)', () => {
+    let s = emptyAutonomyState()
+    const sources = Array.from({ length: 520 }, (_, i) => ({
+      sourceId: `src-${i}`,
+      scopeDigest: 'sha256:x',
+      atMs: NOW - (520 - i) * 1000, // src-0 oldest … src-519 newest
+    }))
+    s = { ...s, usedGrantSources: sources }
+    const warns: string[] = []
+    const log = {
+      debug: () => {}, info: () => {},
+      warn: (_m: string, f?: Record<string, unknown>) => warns.push(String(f?.code ?? '')),
+      error: () => {},
+    }
+    const pruned = pruneAutonomyState(s, NOW, log)
+    expect(pruned.usedGrantSources.length).toBe(500)
+    // Oldest 20 evicted, newest kept.
+    expect(pruned.usedGrantSources[0]!.sourceId).toBe('src-20')
+    expect(pruned.usedGrantSources.at(-1)!.sourceId).toBe('src-519')
+    expect(warns).toContain('grant_ledger_evicted')
   })
 
   test('replay ledger kept 90 days — out-living the 14-day lease tombstones', () => {

--- a/plugin/tests/autonomy/store.test.ts
+++ b/plugin/tests/autonomy/store.test.ts
@@ -330,7 +330,7 @@ describe('updateAutonomyState — serialized read-modify-write', () => {
       updateAutonomyState(paths(), '1', (state) => {
         const r = consumeLease(state, 'L-race', NOW)
         return { state: r.state, result: r.outcome }
-      })
+      }, undefined, NOW)
     const [ua, ub] = await Promise.all([consume(), consume()])
     expect(ua.kind).toBe('ok')
     expect(ub.kind).toBe('ok')
@@ -348,7 +348,7 @@ describe('updateAutonomyState — serialized read-modify-write', () => {
         updateAutonomyState(paths(), '2', (state) => {
           const r = addLease(state, { id: `L-${i}`, scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW)
           return { state: r.state, result: r.outcome }
-        }),
+        }, undefined, NOW),
       ),
     )
     expect(loadAutonomyState(paths(), '2').leases.length).toBe(10)
@@ -494,7 +494,7 @@ describe('revision counter (fix-loop-2 #1)', () => {
       }
       const r = addLease(state, { id: 'L-MINE', scope: 'm', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW)
       return { state: r.state, result: r.outcome }
-    })
+    }, undefined, NOW)
     expect(upd).toEqual({ kind: 'ok', result: 'ok' })
     // The mutator ran TWICE: stale apply detected, fresh re-apply persisted.
     expect(mutatorCalls).toBe(2)
@@ -513,7 +513,7 @@ describe('writer heartbeat lock (fix-loop-2 #2)', () => {
     const upd = await updateAutonomyState(paths(), '1', (state) => {
       const r = addLease(state, { id: 'L-x', scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW)
       return { state: r.state, result: r.outcome }
-    })
+    }, undefined, NOW)
     expect(upd).toEqual({ kind: 'writer_conflict' })
     // Nothing was written; the foreign lock still stands.
     expect(loadAutonomyState(paths(), '1').leases).toEqual([])
@@ -525,7 +525,7 @@ describe('writer heartbeat lock (fix-loop-2 #2)', () => {
     const upd = await updateAutonomyState(paths(), '1', (state) => {
       const r = addLease(state, { id: 'L-x', scope: 's', expiresAtMs: NOW + HOUR, source: 'manual' }, NOW)
       return { state: r.state, result: r.outcome }
-    })
+    }, undefined, NOW)
     expect(upd).toEqual({ kind: 'ok', result: 'ok' })
     expect((JSON.parse(rfs(lockPath(), 'utf8')) as { writerId: string }).writerId).toBe(AUTONOMY_WRITER_ID)
     expect(loadAutonomyState(paths(), '1').leases.length).toBe(1)

--- a/plugin/tests/autonomy/store.test.ts
+++ b/plugin/tests/autonomy/store.test.ts
@@ -63,7 +63,7 @@ function seedState(): AutonomyState {
 
 describe('emptyAutonomyState', () => {
   test('is a versioned empty registry', () => {
-    expect(emptyAutonomyState()).toEqual({ version: AUTONOMY_STATE_VERSION, revision: 0, leases: [], questions: [] })
+    expect(emptyAutonomyState()).toEqual({ version: AUTONOMY_STATE_VERSION, revision: 0, leases: [], questions: [], usedGrantSources: [] })
   })
 })
 
@@ -98,7 +98,7 @@ describe('round-trip persistence', () => {
   })
 
   test('save always stamps the current schema version', () => {
-    const state = { version: 999 as unknown as typeof AUTONOMY_STATE_VERSION, revision: 0, leases: [], questions: [] }
+    const state = { version: 999 as unknown as typeof AUTONOMY_STATE_VERSION, revision: 0, leases: [], questions: [], usedGrantSources: [] }
     saveAutonomyState(paths(), '1', state)
     expect(loadAutonomyState(paths(), '1').version).toBe(AUTONOMY_STATE_VERSION)
   })

--- a/plugin/tests/commands/oob-lease.test.ts
+++ b/plugin/tests/commands/oob-lease.test.ts
@@ -157,6 +157,12 @@ describe('/lease fail-closed grammar (fix-loop #3/#6)', () => {
     expect(res.replyToTelegram!.text).toContain('400')
     expect(loadAutonomyState({ root }, CHAT).leases.length).toBe(0)
   })
+
+  test('scope with bidi/control chars → usage error, NO lease (fix-loop-2 #6)', async () => {
+    const res = await handleOobCommand(parse('/lease deploy \u202Egnigats'), mkCtx())
+    expect(res.replyToTelegram!.text).toContain('управляющие')
+    expect(loadAutonomyState({ root }, CHAT).leases.length).toBe(0)
+  })
 })
 
 describe('/lease duplicate against a TERMINAL lease states the real status (fix-loop #8)', () => {

--- a/plugin/tests/commands/oob-lease.test.ts
+++ b/plugin/tests/commands/oob-lease.test.ts
@@ -11,7 +11,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { handleOobCommand, parseOobCommand, type OobContext } from '../../src/commands/oob.js'
-import { activeLeases, loadAutonomyState } from '../../src/autonomy/store.js'
+import { activeLeases, loadAutonomyState, revokeLease, updateAutonomyState } from '../../src/autonomy/store.js'
 import type { AppConfig } from '../../src/config.js'
 import type { Logger } from '../../src/log.js'
 import type { TelegramApi } from '../../src/channel/tools.js'
@@ -131,5 +131,47 @@ describe('/lease misconfig', () => {
     delete (ctx as { stateDir?: string }).stateDir
     const res = await handleOobCommand(parse('/lease deploy'), ctx)
     expect(res.replyToTelegram!.text).toContain('недоступно')
+  })
+})
+
+describe('/lease fail-closed grammar (fix-loop #3/#6)', () => {
+  test('malformed trailing ttl → usage error, NO lease', async () => {
+    for (const bad of ['/lease аудит; ttl=200h', '/lease аудит; ttl=0h', '/lease аудит; ttl=4.5h', '/lease аудит; ttl=abch']) {
+      const res = await handleOobCommand(parse(bad), mkCtx())
+      expect(res.replyToTelegram!.text).toContain('некорректный ttl')
+      expect(res.replyToTelegram!.text).toContain('usage')
+    }
+    expect(loadAutonomyState({ root }, CHAT).leases.length).toBe(0)
+  })
+
+  test('non-option `;` belongs to the scope — no silent truncation, echoed in full', async () => {
+    const res = await handleOobCommand(parse('/lease аудит; production'), mkCtx())
+    const lease = activeLeases(loadAutonomyState({ root }, CHAT), Date.now())[0]!
+    expect(lease.scope).toBe('аудит; production')
+    // The confirmation echoes the EXACT granted scope.
+    expect(res.replyToTelegram!.text).toContain('аудит; production')
+  })
+
+  test('scope over 400 code points → usage error, NO lease', async () => {
+    const res = await handleOobCommand(parse(`/lease ${'x'.repeat(401)}`), mkCtx())
+    expect(res.replyToTelegram!.text).toContain('400')
+    expect(loadAutonomyState({ root }, CHAT).leases.length).toBe(0)
+  })
+})
+
+describe('/lease duplicate against a TERMINAL lease states the real status (fix-loop #8)', () => {
+  test('revoked lease → «ОТОЗВАН», not «уже активен»; no re-mint', async () => {
+    await handleOobCommand(parse('/lease deploy'), mkCtx({ messageId: 5 }))
+    // Revoke the minted lease through the store.
+    const minted = loadAutonomyState({ root }, CHAT).leases[0]!
+    await updateAutonomyState({ root }, CHAT, (state) => {
+      const r = revokeLease(state, minted.id, Date.now(), 'owner', 'test')
+      return { state: r.state, result: r.outcome }
+    })
+    // Replay the SAME command message.
+    const res = await handleOobCommand(parse('/lease deploy'), mkCtx({ messageId: 5 }))
+    expect(res.replyToTelegram!.text).toContain('ОТОЗВАН')
+    expect(res.replyToTelegram!.text).not.toContain('уже активен')
+    expect(loadAutonomyState({ root }, CHAT).leases.length).toBe(1) // no second lease
   })
 })

--- a/plugin/tests/commands/oob-lease.test.ts
+++ b/plugin/tests/commands/oob-lease.test.ts
@@ -1,0 +1,135 @@
+// Autonomy M2 — /lease OOB command handler.
+//
+// Exercises handleOobCommand's `lease` case directly (the OOB auth gate is
+// tested in tests/telegram/handlers.test.ts). Covers: grant + confirmation
+// reply, ttl parsing, bare /lease listing, and idempotency by grantSourceId
+// (`cmd:<chatId>:<messageId>`).
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { handleOobCommand, parseOobCommand, type OobContext } from '../../src/commands/oob.js'
+import { activeLeases, loadAutonomyState } from '../../src/autonomy/store.js'
+import type { AppConfig } from '../../src/config.js'
+import type { Logger } from '../../src/log.js'
+import type { TelegramApi } from '../../src/channel/tools.js'
+
+const CHAT = '164795011'
+
+function silentLog(): Logger {
+  return { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }
+}
+
+// The lease handler never calls telegramApi (it returns replyToTelegram data);
+// a throwing stub proves that.
+function throwingApi(): TelegramApi {
+  return new Proxy({} as TelegramApi, {
+    get() {
+      return async () => {
+        throw new Error('telegramApi must not be called by handleLeaseCommand')
+      }
+    },
+  })
+}
+
+let root: string
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'dashi-oob-lease-'))
+})
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+function mkCtx(over: Partial<OobContext> = {}): OobContext {
+  return {
+    chatId: CHAT,
+    senderId: CHAT,
+    config: {} as unknown as AppConfig,
+    telegramApi: throwingApi(),
+    log: silentLog(),
+    stateDir: root,
+    messageId: 42,
+    ...over,
+  }
+}
+
+function parse(text: string) {
+  const p = parseOobCommand(text)
+  if (!p) throw new Error(`not an OOB command: ${text}`)
+  return p
+}
+
+describe('/lease parsing wiring', () => {
+  test('parseOobCommand recognises /lease as a known command', () => {
+    expect(parse('/lease deploy').name).toBe('lease')
+    expect(parse('/lease').name).toBe('lease')
+    expect(parse('/lease@trallvibecoderbot x').name).toBe('lease')
+  })
+})
+
+describe('/lease grant', () => {
+  test('grants a lease and replies with id/scope/expiry', async () => {
+    const res = await handleOobCommand(parse('/lease деплой стейджинга; ttl=48h'), mkCtx())
+    expect(res.command).toBe('lease')
+    const leases = activeLeases(loadAutonomyState({ root }, CHAT), Date.now())
+    expect(leases.length).toBe(1)
+    expect(leases[0]!.scope).toBe('деплой стейджинга')
+    expect(leases[0]!.source).toBe('owner_cmd')
+    expect(leases[0]!.grantSourceId).toBe(`cmd:${CHAT}:42`)
+    const ttlH = (leases[0]!.expiresAtMs - leases[0]!.grantedAtMs) / 3_600_000
+    expect(Math.round(ttlH)).toBe(48)
+    const text = res.replyToTelegram!.text
+    expect(text).toContain('мандат выдан')
+    expect(text).toContain(leases[0]!.id)
+    expect(text).toContain('деплой стейджинга')
+  })
+
+  test('default ttl 24h when unspecified', async () => {
+    await handleOobCommand(parse('/lease catch the wave'), mkCtx())
+    const l = activeLeases(loadAutonomyState({ root }, CHAT), Date.now())[0]!
+    expect(Math.round((l.expiresAtMs - l.grantedAtMs) / 3_600_000)).toBe(24)
+  })
+
+  test('replayed command (same messageId) mints exactly one lease', async () => {
+    await handleOobCommand(parse('/lease deploy'), mkCtx({ messageId: 7 }))
+    const res2 = await handleOobCommand(parse('/lease deploy'), mkCtx({ messageId: 7 }))
+    expect(loadAutonomyState({ root }, CHAT).leases.length).toBe(1)
+    expect(res2.replyToTelegram!.text).toContain('мандат уже активен')
+  })
+})
+
+describe('/lease bare — list active + usage', () => {
+  test('empty registry → "нет активных мандатов" + usage', async () => {
+    const res = await handleOobCommand(parse('/lease'), mkCtx())
+    const text = res.replyToTelegram!.text
+    expect(text).toContain('нет активных мандатов')
+    expect(text).toContain('usage')
+    // Bare command grants nothing.
+    expect(loadAutonomyState({ root }, CHAT).leases.length).toBe(0)
+  })
+
+  test('lists an existing active lease', async () => {
+    await handleOobCommand(parse('/lease деплой; ttl=12h'), mkCtx({ messageId: 1 }))
+    const res = await handleOobCommand(parse('/lease'), mkCtx({ messageId: 2 }))
+    const text = res.replyToTelegram!.text
+    expect(text).toContain('деплой')
+    expect(text).toContain('активные мандаты')
+  })
+
+  test('args that are only options with no scope → treated as bare (no grant)', async () => {
+    const res = await handleOobCommand(parse('/lease ; ttl=48h'), mkCtx())
+    expect(res.replyToTelegram!.text).toContain('нет активных мандатов')
+    expect(loadAutonomyState({ root }, CHAT).leases.length).toBe(0)
+  })
+})
+
+describe('/lease misconfig', () => {
+  test('missing stateDir → graceful message, no throw', async () => {
+    const ctx = mkCtx()
+    delete (ctx as { stateDir?: string }).stateDir
+    const res = await handleOobCommand(parse('/lease deploy'), ctx)
+    expect(res.replyToTelegram!.text).toContain('недоступно')
+  })
+})

--- a/plugin/tests/telegram/ask-user-question.test.ts
+++ b/plugin/tests/telegram/ask-user-question.test.ts
@@ -957,6 +957,7 @@ describe('handleSettle — timeout closes the open card (relay onSettle seam)', 
       currentIndex: 0,
       totalQuestions: 1,
       questionText: 'Q',
+      questionMultiSelect: undefined,
       reason: undefined,
     })
     expect(send.editCalls.length).toBe(0)
@@ -974,6 +975,7 @@ describe('handleSettle — timeout closes the open card (relay onSettle seam)', 
         currentIndex: 0,
         totalQuestions: 1,
         questionText: 'Q',
+        questionMultiSelect: undefined,
         reason: 'ask_user_question timed out',
       }),
     ).resolves.toBeUndefined()

--- a/plugin/tests/telegram/handlers.test.ts
+++ b/plugin/tests/telegram/handlers.test.ts
@@ -25,6 +25,7 @@ import {
   type ProgressReporterForWatcher,
 } from '../../src/telegram/watcher.js'
 import type { AppConfig, StatePaths } from '../../src/config.js'
+import { activeLeases, loadAutonomyState } from '../../src/autonomy/store.js'
 import { createLogger } from '../../src/log.js'
 import type {
   PendingPermission,
@@ -395,6 +396,50 @@ describe('handleInboundText — OOB allowed_chat_ids gate (Fix 6)', () => {
 
     // OOB handled inline — no channel notify for /help.
     expect(serverSpy.calls.length).toBe(0)
+    rmSync(statePaths.root, { recursive: true, force: true })
+  })
+
+  // Autonomy M2: /lease is one of only two authenticated lease-grant surfaces.
+  // The OOB gate is its authorization boundary — a non-allowed chat must mint
+  // NO lease, an allowed chat must.
+  test('/lease from a chat NOT in allowed_chat_ids: NO lease minted', async () => {
+    const config = makeConfig({ allowed_user_ids: [164795011], allowed_chat_ids: [164795011] })
+    const serverSpy = makeServerSpy()
+    const { deps, statePaths } = makeDeps({ config, server: serverSpy.server })
+    const ctx = makeCtx({ text: '/lease деплой', chatId: 99999, chatType: 'private', fromId: 164795011 })
+
+    await handleInboundText(ctx, deps)
+
+    // Gate rejected the OOB command → no grant happened for chat 99999.
+    expect(loadAutonomyState({ root: statePaths.root }, '99999').leases.length).toBe(0)
+    rmSync(statePaths.root, { recursive: true, force: true })
+  })
+
+  test('/lease from the allowed owner chat mints a lease and replies', async () => {
+    const config = makeConfig()
+    const serverSpy = makeServerSpy()
+    const sends: string[] = []
+    const tg = makeTelegramApi()
+    const api: TelegramApi = {
+      ...tg.api,
+      sendMessage: async (_c, text) => {
+        sends.push(text)
+        return { message_id: 100 }
+      },
+    }
+    const { deps, statePaths } = makeDeps({ config, server: serverSpy.server, telegramApi: api })
+    const ctx = makeCtx({ text: '/lease деплой стейджинга; ttl=48h', chatId: 164795011, chatType: 'private', fromId: 164795011 })
+
+    await handleInboundText(ctx, deps)
+
+    const leases = activeLeases(loadAutonomyState({ root: statePaths.root }, '164795011'), Date.now())
+    expect(leases.length).toBe(1)
+    expect(leases[0]!.scope).toBe('деплой стейджинга')
+    expect(leases[0]!.source).toBe('owner_cmd')
+    // Control command is swallowed — no channel notification to the session.
+    expect(serverSpy.calls.length).toBe(0)
+    // The owner got a confirmation reply.
+    expect(sends.some((t) => t.includes('мандат выдан'))).toBe(true)
     rmSync(statePaths.root, { recursive: true, force: true })
   })
 })


### PR DESCRIPTION
Второй милстон архитектуры автономии (gbrain #136). Строит ЕДИНСТВЕННЫЕ два аутентифицированных пути выдачи мандата.

## Состав
- [LEASE: scope; ttl=Nh; supersede]-маркер в AskUserQuestion-карточках: intent парсится ОДИН раз при создании, персистится (ask-lease-intents-*.json), рендер и грант читают только durable-запись — показанный и выданный scope не могут разойтись даже через рестарт. Карточка явно рендерит блок «Мандат автономии: scope, ttl»; тап по точному «Да» минтит ровно snapshot.
- /lease команда (за owner-гейтом, не инжектится в сессию): trailing-строгий ttl=<int>h, «;» внутри scope легален, echo распарсенного scope.
- Durable replay-леджер usedGrantSources (90д, кэп 500): дедуп sourceId+scopeDigest, source_conflict при расхождении.
- Fail-closed везде: TTL строго 1..72 (malformed → не grant-capable), scope без Cc/Cf/bidi/переносов, кэп 400 cp, multiselect и «Другое» не грантят, исход каждого тапа виден владельцу.
- Хвосты M1: prune 14д/90д, version>1 read-only по raw-значению, идемпотентная регистрация вопроса на таймауте.

## Ревью (grant-путь = security-ядро)
Codex BLOCK + Fable BLOCK (сошлись на скрытом scope) → фикс-луп 1 (8 пунктов) → контрольная Codex-верификация: BLOCK (in-memory intent умирал на рестарте) → фикс-луп 2 (7 пунктов: persisted intent, бюджет закрытой карточки, no-silent-paths, кэп леджера, charset, строгий ttl).

## Верификация
tsc 0 ×2; 2555 pass / 0 fail ×2 (моя независимая сверка ×2 + построчная проверка invariant'а «парс только при создании»). +150 тестов к пре-M2 базе.

🤖 Generated with [Claude Code](https://claude.com/claude-code)