### PR TITLE
Автономия M3: ask-guard на reply-пути (advisory → block)

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -134,6 +134,8 @@ bash plugin/scripts/install-hooks.sh \
 | `FALLBACK_REPLY_RETRY_ATTEMPTS` / `FALLBACK_REPLY_RETRY_DELAY_MS` | Ограниченный retry на пустую экстракцию (гонка extended-thinking: [thinking] и [text] в двух строках). Defaults 4 / 120ms, оба клампятся сверху. |
 | `TELEGRAM_MEMORY_*` | Memory hook config (см. секцию ниже). |
 | `TELEGRAM_MULTICHAT_*` | Multichat router config (см. секцию ниже). |
+| `ASK_GUARD_MODE` | Ask-guard (autonomy M3): `off` \| `advisory` \| `block`. Перекрывает `config.json` → `ask_guard.mode` (default `advisory`). При активном мандате перехватывает self-gating «жду го / дай добро»: `advisory` — шлёт ответ + hint, `block` — отказывает в отправке (агент действует сам или спрашивает карточкой AskUserQuestion). |
+| `ASK_GUARD_ENABLED` | Kill-switch ask-guard: `0`/`false`/`no`/`off` → полностью `off` (бьёт любой режим). |
 | `GROQ_API_KEY` | Whisper transcription для голосовых (опционально). |
 
 ## Memory hooks (опционально)

--- a/plugin/scripts/fallback-reply-hook.ts
+++ b/plugin/scripts/fallback-reply-hook.ts
@@ -20,7 +20,11 @@
 //
 // Suppression invariants (no duplicate to the warchief):
 //   * If the turn called mcp__dashi-channel__reply OR
-//     mcp__dashi-channel__edit_message → a reply already reached him → silent.
+//     mcp__dashi-channel__edit_message AND that call SUCCEEDED → a reply already
+//     reached him → silent. fix-loop #7: a reply whose tool_result came back
+//     isError (e.g. blocked by the ask-guard) did NOT reach him, so it does NOT
+//     suppress the fallback — the turn's final text is still forwarded, and the
+//     fallback route re-runs the same guard on it.
 //   * If the turn has no final assistant text (pure tool / pure thinking) →
 //     nothing to forward → silent.
 //   * If the turn was not answering a Telegram message (no `<channel
@@ -164,17 +168,43 @@ interface TranscriptLine {
   readonly uuid?: unknown
 }
 
-/** True when a content array contains a tool_use block whose name is a reply tool. */
-function contentCallsReplyTool(content: unknown): boolean {
-  if (!Array.isArray(content)) return false
+/**
+ * The `id`s of reply-tool tool_use blocks in an assistant content array. A
+ * block with no string `id` (legacy/synthetic transcripts) yields the sentinel
+ * '' so it is still counted as a reply (it can never match an is_error result,
+ * which always carries a real tool_use_id) — preserving the pre-fix behaviour
+ * for transcripts that omit ids.
+ */
+function replyToolUseIds(content: unknown): string[] {
+  if (!Array.isArray(content)) return []
+  const ids: string[] = []
   for (const block of content) {
     if (block === null || typeof block !== 'object') continue
     const b = block as Record<string, unknown>
     if (b.type === 'tool_use' && typeof b.name === 'string' && REPLY_TOOL_NAMES.has(b.name)) {
-      return true
+      ids.push(typeof b.id === 'string' ? b.id : '')
     }
   }
-  return false
+  return ids
+}
+
+/**
+ * The `tool_use_id`s of tool_result blocks flagged `is_error: true` in a
+ * user-role tool_result echo. fix-loop #7: a reply that the choke point BLOCKED
+ * returns an isError tool_result — it did NOT reach the owner, so it must not
+ * suppress the fallback.
+ */
+function errorToolResultIds(content: unknown): string[] {
+  if (!Array.isArray(content)) return []
+  const ids: string[] = []
+  for (const block of content) {
+    if (block === null || typeof block !== 'object') continue
+    const b = block as Record<string, unknown>
+    if (b.type === 'tool_result' && b.is_error === true && typeof b.tool_use_id === 'string') {
+      ids.push(b.tool_use_id)
+    }
+  }
+  return ids
 }
 
 /** Collect the joined text blocks of an assistant content array (empty when none). */
@@ -247,6 +277,11 @@ export function analyzeCurrentTurn(transcript: string): TurnResult {
   let text: string | undefined
   let uuid: string | undefined
   let replied = false
+  // fix-loop #7: tool_use_ids of reply results that came back isError. We walk
+  // BACKWARD, so a tool_result echo (later in the transcript) is seen BEFORE
+  // its tool_use (earlier) — this set is populated by the time we reach the
+  // reply tool_use, so a BLOCKED reply never sets `replied`.
+  const erroredReplyIds = new Set<string>()
   for (let i = lines.length - 1; i >= 0; i--) {
     let obj: unknown
     try {
@@ -274,11 +309,18 @@ export function analyzeCurrentTurn(transcript: string): TurnResult {
           promptText !== undefined ? extractLeadingTelegramChatId(promptText) : undefined
         return { text, uuid, replied, chatId, promptText }
       }
+      // tool_result echo — record any isError reply results before continuing.
+      for (const id of errorToolResultIds(content)) erroredReplyIds.add(id)
       continue
     }
 
     if (role !== 'assistant') continue
-    if (contentCallsReplyTool(content)) replied = true
+    // A reply counts as delivered ONLY if its result was NOT isError. A blocked
+    // reply (ask-guard isError) leaves the owner unanswered → the turn's final
+    // text must still be eligible for the fallback (which re-guards it).
+    for (const id of replyToolUseIds(content)) {
+      if (!erroredReplyIds.has(id)) replied = true
+    }
     if (text === undefined) {
       const t = assistantText(content)
       if (t.length > 0) {

--- a/plugin/scripts/fallback-reply-hook.ts
+++ b/plugin/scripts/fallback-reply-hook.ts
@@ -21,10 +21,13 @@
 // Suppression invariants (no duplicate to the warchief):
 //   * If the turn called mcp__dashi-channel__reply OR
 //     mcp__dashi-channel__edit_message AND that call SUCCEEDED → a reply already
-//     reached him → silent. fix-loop #7: a reply whose tool_result came back
-//     isError (e.g. blocked by the ask-guard) did NOT reach him, so it does NOT
-//     suppress the fallback — the turn's final text is still forwarded, and the
-//     fallback route re-runs the same guard on it.
+//     reached him → silent. fix-loop #7 / fix-loop-2: ONLY a reply whose
+//     tool_result came back as an explicit ASK-GUARD BLOCK (isError + the
+//     ASK_GUARD marker) is treated as "did NOT reach him" — its final text is
+//     still forwarded and the fallback route re-runs the same guard on it. A
+//     GENERIC reply error (network/HTTP timeout) is ambiguous — the send may
+//     have reached Telegram before the client saw the error — so it KEEPS the
+//     suppression to avoid a duplicate delivery.
 //   * If the turn has no final assistant text (pure tool / pure thinking) →
 //     nothing to forward → silent.
 //   * If the turn was not answering a Telegram message (no `<channel
@@ -65,6 +68,14 @@ import {
   loadChannelEnvFile,
   parseEnvFile,
 } from './read-receipt-hook.js'
+
+// The machine-readable marker that leads every ask-guard block-mode refusal
+// (`askGuardBlockMessage`). It is the ONLY isError shape that unsuppresses the
+// fallback (owner NOT reached → forward the final text, re-guarded downstream);
+// every other reply error is ambiguous (the send may have reached Telegram
+// before the client saw the error) and KEEPS the old suppression to avoid a
+// duplicate delivery. Imported from the guard so the two stay in lockstep.
+import { ASK_GUARD_BLOCK_MARKER } from '../src/safety/ask-guard.js'
 
 // Re-export the borrowed helpers under this module too, so tests importing
 // from this hook get a single surface. (parseEnvFile is used transitively by
@@ -188,19 +199,42 @@ function replyToolUseIds(content: unknown): string[] {
   return ids
 }
 
+/** The joined text of a tool_result `content` (string, or `{type:'text'}` blocks). */
+function toolResultText(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  const parts: string[] = []
+  for (const block of content) {
+    if (block === null || typeof block !== 'object') continue
+    const b = block as Record<string, unknown>
+    if (typeof b.text === 'string') parts.push(b.text)
+  }
+  return parts.join('\n')
+}
+
 /**
- * The `tool_use_id`s of tool_result blocks flagged `is_error: true` in a
- * user-role tool_result echo. fix-loop #7: a reply that the choke point BLOCKED
- * returns an isError tool_result — it did NOT reach the owner, so it must not
- * suppress the fallback.
+ * The `tool_use_id`s of reply tool_result blocks that came back as an
+ * ASK-GUARD BLOCK (`is_error: true` AND the result text carries
+ * `ASK_GUARD_BLOCK_MARKER`). fix-loop #7 first unsuppressed on ANY isError
+ * reply; fix-loop-2 (Codex round-2 HIGH) narrows that: an ask-guard block
+ * provably did NOT reach the owner, so its final text MUST still be forwarded,
+ * but a generic reply error (network/HTTP timeout) is AMBIGUOUS — the send may
+ * have reached Telegram before the client saw the error — so forwarding it too
+ * would DOUBLE-deliver. Only the explicit block marker unsuppresses; every
+ * other isError keeps the pre-fix suppression (reply counts as delivered).
  */
-function errorToolResultIds(content: unknown): string[] {
+function askGuardBlockedReplyIds(content: unknown): string[] {
   if (!Array.isArray(content)) return []
   const ids: string[] = []
   for (const block of content) {
     if (block === null || typeof block !== 'object') continue
     const b = block as Record<string, unknown>
-    if (b.type === 'tool_result' && b.is_error === true && typeof b.tool_use_id === 'string') {
+    if (
+      b.type === 'tool_result' &&
+      b.is_error === true &&
+      typeof b.tool_use_id === 'string' &&
+      toolResultText(b.content).includes(ASK_GUARD_BLOCK_MARKER)
+    ) {
       ids.push(b.tool_use_id)
     }
   }
@@ -277,11 +311,13 @@ export function analyzeCurrentTurn(transcript: string): TurnResult {
   let text: string | undefined
   let uuid: string | undefined
   let replied = false
-  // fix-loop #7: tool_use_ids of reply results that came back isError. We walk
-  // BACKWARD, so a tool_result echo (later in the transcript) is seen BEFORE
-  // its tool_use (earlier) — this set is populated by the time we reach the
-  // reply tool_use, so a BLOCKED reply never sets `replied`.
-  const erroredReplyIds = new Set<string>()
+  // fix-loop #7 / fix-loop-2: tool_use_ids of reply results that came back as an
+  // ASK-GUARD BLOCK (isError + marker). We walk BACKWARD, so a tool_result echo
+  // (later in the transcript) is seen BEFORE its tool_use (earlier) — this set
+  // is populated by the time we reach the reply tool_use, so a BLOCKED reply
+  // never sets `replied`. A generic reply error is NOT collected here, so it
+  // still sets `replied` (suppressed → no duplicate delivery).
+  const blockedReplyIds = new Set<string>()
   for (let i = lines.length - 1; i >= 0; i--) {
     let obj: unknown
     try {
@@ -309,17 +345,18 @@ export function analyzeCurrentTurn(transcript: string): TurnResult {
           promptText !== undefined ? extractLeadingTelegramChatId(promptText) : undefined
         return { text, uuid, replied, chatId, promptText }
       }
-      // tool_result echo — record any isError reply results before continuing.
-      for (const id of errorToolResultIds(content)) erroredReplyIds.add(id)
+      // tool_result echo — record any ask-guard-BLOCKED reply results before
+      // continuing (generic errors are deliberately NOT recorded: ambiguous).
+      for (const id of askGuardBlockedReplyIds(content)) blockedReplyIds.add(id)
       continue
     }
 
     if (role !== 'assistant') continue
-    // A reply counts as delivered ONLY if its result was NOT isError. A blocked
-    // reply (ask-guard isError) leaves the owner unanswered → the turn's final
-    // text must still be eligible for the fallback (which re-guards it).
+    // A reply counts as delivered UNLESS it was an ASK-GUARD BLOCK (proven
+    // undelivered). A generic reply error is ambiguous and still counts as
+    // delivered so the fallback does not double-send.
     for (const id of replyToolUseIds(content)) {
-      if (!erroredReplyIds.has(id)) replied = true
+      if (!blockedReplyIds.has(id)) replied = true
     }
     if (text === undefined) {
       const t = assistantText(content)

--- a/plugin/src/channel/tools.ts
+++ b/plugin/src/channel/tools.ts
@@ -18,6 +18,7 @@ import type { ReactionTypeEmoji } from 'grammy/types'
 import { z } from 'zod'
 
 import type { AppConfig, StatePaths } from '../config.js'
+import { resolveAskGuardMode } from '../config.js'
 import type { Logger } from '../log.js'
 import type { MultichatPolicy } from '../chats/policy-loader.js'
 import type { StatusManager, StatusState } from '../status/status-manager.js'
@@ -30,6 +31,7 @@ import {
   StatusArgsSchema,
 } from '../schemas.js'
 import {
+  activeLeases,
   consumeLease,
   loadAutonomyState,
   renderAutonomyStatus,
@@ -38,6 +40,7 @@ import {
   updateAutonomyState,
   type UpdateResult,
 } from '../autonomy/store.js'
+import { analyzeAsk, askGuardAdvisoryHint, askGuardBlockMessage } from '../safety/ask-guard.js'
 import { assertAllowedChat } from '../telegram/gate.js'
 import type { GuestQueryRegistry } from '../telegram/guest-queries.js'
 import {
@@ -631,6 +634,65 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
         } catch (err) {
           return toolError(name, err instanceof Error ? err.message : String(err))
         }
+
+        // ── Ask-guard (autonomy M3) ──────────────────────────────────────
+        // The single choke point that enforces owner-granted autonomy
+        // mandates on the OWNER-egress reply path. When an ACTIVE lease
+        // exists for this chat AND the outgoing body is a self-gating
+        // permission-ask («жду го / дай добро»), intercept:
+        //   * block mode  → refuse the send (isError, nothing shipped). NO
+        //                   resend-valve — an identical re-send is analyzed
+        //                   the same way and blocked again (analyzeAsk is
+        //                   pure/stateless).
+        //   * advisory    → the reply still ships; a hint is appended to the
+        //                   tool result (computed here, attached near the
+        //                   result below) nudging act-with-veto.
+        // Never touches the guest path (handled above, returns before here),
+        // edit_message (a separate case) or the AskUserQuestion relay (a
+        // different tool). Fail-open on ANY error — a guard fault must never
+        // gate a real reply.
+        let askGuardHint = ''
+        try {
+          const askGuardMode = resolveAskGuardMode(config)
+          if (askGuardMode !== 'off') {
+            const autonomyState = loadAutonomyState(statePaths, args.chat_id, log)
+            const leases = activeLeases(autonomyState, Date.now())
+            if (leases.length > 0) {
+              const finding = analyzeAsk(args.text, { hasActiveLease: true })[0]
+              if (finding !== undefined) {
+                const lease = leases[0]! // soonest-expiry first
+                if (askGuardMode === 'block') {
+                  log.info('ask_guard blocked a self-gating permission-ask (mandate active)', {
+                    code: 'ask_guard_block',
+                    chat_id: args.chat_id,
+                    lease_id: lease.id,
+                    pattern: finding.code,
+                  })
+                  return {
+                    content: [{ type: 'text', text: askGuardBlockMessage(lease.id, lease.scope) }],
+                    isError: true,
+                  }
+                }
+                // advisory — message still ships; attach the hint below.
+                log.info('ask_guard advisory on a self-gating permission-ask (mandate active)', {
+                  code: 'ask_guard_advisory',
+                  chat_id: args.chat_id,
+                  lease_id: lease.id,
+                  pattern: finding.code,
+                })
+                askGuardHint = askGuardAdvisoryHint(lease.id)
+              }
+            }
+          }
+        } catch (err) {
+          // Fail-open: a guard fault must never block a real reply.
+          log.warn('ask_guard evaluation failed — failing open (reply sent unguarded)', {
+            code: 'ask_guard_error',
+            chat_id: args.chat_id,
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
+
         const files = args.files ?? []
 
         // Resolve every attachment through the workspace gate up front, so a
@@ -807,7 +869,13 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
             error: err instanceof Error ? err.message : String(err),
           })
         }
-        const resultText = hint ? `${result}\n${hint}` : result
+        // Assemble the tool result: base «sent …» line, plus the ask-guard
+        // advisory hint (M3) when a mandate is active and the body self-gated,
+        // plus the observe-only format hint. Each is optional and independent.
+        const resultParts = [result]
+        if (askGuardHint) resultParts.push(askGuardHint)
+        if (hint) resultParts.push(hint)
+        const resultText = resultParts.join('\n')
         return { content: [{ type: 'text', text: resultText }] }
       }
 

--- a/plugin/src/channel/tools.ts
+++ b/plugin/src/channel/tools.ts
@@ -40,7 +40,7 @@ import {
   updateAutonomyState,
   type UpdateResult,
 } from '../autonomy/store.js'
-import { analyzeAsk, askGuardAdvisoryHint, askGuardBlockMessage } from '../safety/ask-guard.js'
+import { analyzeAskDetailed, askGuardAdvisoryHint, askGuardBlockMessage } from '../safety/ask-guard.js'
 import { assertAllowedChat } from '../telegram/gate.js'
 import type { GuestQueryRegistry } from '../telegram/guest-queries.js'
 import {
@@ -636,10 +636,10 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
         }
 
         // ── Ask-guard (autonomy M3) ──────────────────────────────────────
-        // The single choke point that enforces owner-granted autonomy
-        // mandates on the OWNER-egress reply path. When an ACTIVE lease
-        // exists for this chat AND the outgoing body is a self-gating
-        // permission-ask («жду го / дай добро»), intercept:
+        // Enforces owner-granted autonomy mandates on the OWNER-egress
+        // `reply`-tool path. When an ACTIVE lease exists for this chat AND the
+        // outgoing body is a self-gating permission-ask («жду го / дай добро»),
+        // intercept:
         //   * block mode  → refuse the send (isError, nothing shipped). NO
         //                   resend-valve — an identical re-send is analyzed
         //                   the same way and blocked again (analyzeAsk is
@@ -647,18 +647,33 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
         //   * advisory    → the reply still ships; a hint is appended to the
         //                   tool result (computed here, attached near the
         //                   result below) nudging act-with-veto.
-        // Never touches the guest path (handled above, returns before here),
-        // edit_message (a separate case) or the AskUserQuestion relay (a
-        // different tool). Fail-open on ANY error — a guard fault must never
-        // gate a real reply.
+        // SCOPE (fix-loop #9 — honest coverage): this guards ONLY the `reply`
+        // tool. The guest path returns above; `edit_message` is UNGUARDED BY
+        // DESIGN (interim progress edits are not owner-egress go-questions); the
+        // AskUserQuestion relay is a different tool (the legitimate escape). The
+        // DM Stop-hook fallback route (POST /hooks/fallback-reply) runs the SAME
+        // analyzeAsk guard so a turn's final text cannot bypass this via the
+        // fallback. Fail-open on ANY error — a guard fault must never gate a
+        // real reply.
         let askGuardHint = ''
         try {
-          const askGuardMode = resolveAskGuardMode(config)
+          const askGuardMode = resolveAskGuardMode(config, log)
           if (askGuardMode !== 'off') {
             const autonomyState = loadAutonomyState(statePaths, args.chat_id, log)
             const leases = activeLeases(autonomyState, Date.now())
             if (leases.length > 0) {
-              const finding = analyzeAsk(args.text, { hasActiveLease: true })[0]
+              const analysis = analyzeAskDetailed(args.text, { hasActiveLease: true })
+              // fix-loop #2: a hard-gate marker that survives ONLY inside a
+              // fenced/quoted zone still exempts (fail-safe) but is a distinct
+              // audit class for calibration week.
+              if (analysis.exemptReason === 'hard_gate_protected_only') {
+                log.info('ask_guard exempt — hard-gate marker only in a protected zone', {
+                  code: 'ask_guard_exempt_protected_only',
+                  chat_id: args.chat_id,
+                  lease_id: leases[0]!.id,
+                })
+              }
+              const finding = analysis.findings[0]
               if (finding !== undefined) {
                 const lease = leases[0]! // soonest-expiry first
                 if (askGuardMode === 'block') {
@@ -668,8 +683,11 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
                     lease_id: lease.id,
                     pattern: finding.code,
                   })
+                  // fix-loop #3: list ALL active lease scopes so the model can
+                  // self-check its intended action; never claim authorization.
+                  const scopes = leases.map((l) => l.scope)
                   return {
-                    content: [{ type: 'text', text: askGuardBlockMessage(lease.id, lease.scope) }],
+                    content: [{ type: 'text', text: askGuardBlockMessage(lease.id, scopes) }],
                     isError: true,
                   }
                 }
@@ -685,12 +703,18 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
             }
           }
         } catch (err) {
-          // Fail-open: a guard fault must never block a real reply.
-          log.warn('ask_guard evaluation failed — failing open (reply sent unguarded)', {
-            code: 'ask_guard_error',
-            chat_id: args.chat_id,
-            error: err instanceof Error ? err.message : String(err),
-          })
+          // Fail-open: a guard fault must never block a real reply. fix-loop #5
+          // (Codex MED-5): the log call itself is wrapped so a THROWING logger
+          // can never abort delivery from the catch path.
+          try {
+            log.warn('ask_guard evaluation failed — failing open (reply sent unguarded)', {
+              code: 'ask_guard_error',
+              chat_id: args.chat_id,
+              error: err instanceof Error ? err.message : String(err),
+            })
+          } catch {
+            /* a logger fault must not gate a real reply */
+          }
         }
 
         const files = args.files ?? []

--- a/plugin/src/channel/tools.ts
+++ b/plugin/src/channel/tools.ts
@@ -668,7 +668,7 @@ export async function callTool(req: CallToolRequest, deps: ToolDeps): Promise<Ca
               // audit class for calibration week.
               if (analysis.exemptReason === 'hard_gate_protected_only') {
                 log.info('ask_guard exempt — hard-gate marker only in a protected zone', {
-                  code: 'ask_guard_exempt_protected_only',
+                  code: 'hard_gate_protected_only',
                   chat_id: args.chat_id,
                   lease_id: leases[0]!.id,
                 })

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -330,6 +330,26 @@ export const AppConfigSchema = z.object({
     enabled: z.boolean().default(false),
     allowed_user_ids: z.array(z.number().int().positive()).optional(),
   }).optional(),
+  // Ask-guard (autonomy M3, 2026-07-10) — the ENFORCEMENT of owner-granted
+  // autonomy mandates on the owner-egress reply path. When the agent holds an
+  // ACTIVE lease for a chat and still writes a «жду го / дай добро»-style
+  // self-gating permission-ask, the guard intercepts (see safety/ask-guard.ts).
+  //
+  //   `mode`:
+  //     'off'      — never engage (equivalent to the kill-switch);
+  //     'advisory' — the reply IS sent, plus an `ask_guard_hint` nudging the
+  //                  agent to act-with-veto (the calibration-week default);
+  //     'block'    — the reply is REFUSED (isError, not sent); the agent must
+  //                  act in-scope and report, or ask via the AskUserQuestion
+  //                  card (that path is never guarded).
+  //
+  // The block is OPTIONAL (no `.default({})`), like `hud`/`guest_mode` below,
+  // so the many pre-M3 test config literals stay valid without adding it.
+  // `resolveAskGuardMode` applies the 'advisory' default and the env overrides
+  // (`ASK_GUARD_MODE`, kill-switch `ASK_GUARD_ENABLED=0`) in one place.
+  ask_guard: z.object({
+    mode: z.enum(['off', 'advisory', 'block']).default('advisory'),
+  }).optional(),
   // Context HUD (wave 3B) — a single pinned Telegram message in the owner's
   // chat that shows context-window usage (bar + percentage) plus the «Сжать»
   // action button, refreshed after each turn (SessionStart / Stop hooks).
@@ -962,6 +982,39 @@ export function resolveContextWindowTokens(config: AppConfig): number {
 
 export function resolveHudEnabled(config: AppConfig): boolean {
   return config.hud?.enabled ?? true
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// resolveAskGuardMode — the effective ask-guard mode (autonomy M3). The
+// `ask_guard` config block is optional, so callers MUST go through this
+// helper rather than reading `config.ask_guard?.mode` directly: the
+// 'advisory' default AND the direct-env overrides live in exactly one place.
+//
+// Precedence (first decisive wins):
+//   1. kill-switch `ASK_GUARD_ENABLED` set to a falsy value (0/false/no/off)
+//      → 'off' (a hard OFF that beats any configured mode);
+//   2. `ASK_GUARD_MODE` env (off|advisory|block, case-insensitive);
+//   3. `config.ask_guard.mode`;
+//   4. 'advisory' (the calibration-week default).
+//
+// These two env vars are read from process.env directly (NOT via the
+// TELEGRAM_-prefixed RuntimeEnvSchema) — the same pattern as
+// resolveContextWindowOverride reading JARVIS_CONTEXT_WINDOW.
+// ─────────────────────────────────────────────────────────────────────
+
+export type AskGuardMode = 'off' | 'advisory' | 'block'
+
+export function resolveAskGuardMode(config: AppConfig): AskGuardMode {
+  const enabled = process.env.ASK_GUARD_ENABLED
+  if (enabled !== undefined && /^(0|false|no|off)$/i.test(enabled.trim())) {
+    return 'off'
+  }
+  const envMode = process.env.ASK_GUARD_MODE
+  if (envMode !== undefined) {
+    const m = envMode.trim().toLowerCase()
+    if (m === 'off' || m === 'advisory' || m === 'block') return m
+  }
+  return config.ask_guard?.mode ?? 'advisory'
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -1004,15 +1004,35 @@ export function resolveHudEnabled(config: AppConfig): boolean {
 
 export type AskGuardMode = 'off' | 'advisory' | 'block'
 
-export function resolveAskGuardMode(config: AppConfig): AskGuardMode {
+// Minimal structural logger (avoids importing the full Logger type here and a
+// config.ts ↔ log.ts cycle). Matches Logger.warn's shape.
+export interface AskGuardModeLogger {
+  warn: (msg: string, ctx?: Record<string, unknown>) => void
+}
+
+export function resolveAskGuardMode(
+  config: AppConfig,
+  log?: AskGuardModeLogger,
+): AskGuardMode {
   const enabled = process.env.ASK_GUARD_ENABLED
   if (enabled !== undefined && /^(0|false|no|off)$/i.test(enabled.trim())) {
     return 'off'
   }
   const envMode = process.env.ASK_GUARD_MODE
-  if (envMode !== undefined) {
+  if (envMode !== undefined && envMode.trim() !== '') {
     const m = envMode.trim().toLowerCase()
     if (m === 'off' || m === 'advisory' || m === 'block') return m
+    // fix-loop #6 (Codex LOW-6): a SET-but-INVALID env value (e.g. «of», a typo
+    // of «off») must NOT silently fall through to a configured `block` — that
+    // would surprise-enable enforcement from a typo. Fail to the calibration
+    // default (advisory) and warn, so the misconfiguration is visible.
+    if (log) {
+      log.warn('ASK_GUARD_MODE set to an invalid value — defaulting to advisory', {
+        code: 'ask_guard_mode_invalid',
+        value: envMode.trim().slice(0, 32),
+      })
+    }
+    return 'advisory'
   }
   return config.ask_guard?.mode ?? 'advisory'
 }

--- a/plugin/src/safety/ask-guard.ts
+++ b/plugin/src/safety/ask-guard.ts
@@ -80,19 +80,36 @@ const TIER1: ReadonlyArray<AskPattern> = [
     ),
   },
   // «жду подтверждени(е|я)» — fires ONLY when owner-directed (fix-loop #4,
-  // Codex MED-4 / Fable MED-4). A bare «жду подтверждения» that ENDS the clause
-  // (nothing meaningful after — end-of-line or punctuation) is an owner-wait;
-  // «жду подтверждения от тебя / твоего / вождь» is explicitly owner-directed.
-  // But «жду подтверждения <noun>» (оплаты / завершения workflow от GitHub /
-  // вебхука / CI / от провайдера) is a STATUS wait on an external system, not a
-  // self-gate — the trailing noun after «подтверждения» is not owner-ref/terminal,
-  // so the lookahead fails and it does NOT fire. Same ASK_WAIT_GO code as the
-  // generic wait so the finding taxonomy (and existing logs/tests) are stable.
+  // Codex MED-4 / Fable MED-4; narrowed again in fix-loop #6). Two shapes fire:
+  //   (A) owner-PREFIXED «жду тво[её]… подтверждения» — «твоего/твоё» before the
+  //       noun makes it unambiguously owner-directed regardless of what trails,
+  //       so it fires on the whole phrase (a money-flavoured trailer like
+  //       «оплаты» is caught by the whole-text hard-gate exemption anyway).
+  //   (B) no owner prefix «жду подтверждения …» + one of:
+  //         • TERMINAL: optional non-comma sentence punctuation then end-of-line
+  //           (a bare owner-wait that ENDS the clause), OR
+  //         • COMMA + owner ref («жду подтверждения, вождь / твоё / от тебя»), OR
+  //         • SPACE + owner ref («жду подтверждения от тебя / твоё / вождь»).
+  // fix-loop #6 (Codex round-2): the OLD terminal branch accepted ANY comma
+  // regardless of the following words, so a STATUS wait «жду подтверждения, что
+  // CI завершился» self-gated by mistake. The comma now only satisfies the
+  // lookahead when an owner ref follows it. «жду подтверждения <noun>» (оплаты /
+  // завершения workflow / вебхука / статуса CI / от провайдера) still does NOT
+  // fire. Same ASK_WAIT_GO code so the finding taxonomy stays stable.
   {
     code: 'ASK_WAIT_GO',
     re: new RegExp(
-      `${B}жду\\s+подтвержден(?:и[еяю]|ья)` +
-        `(?=\\s*(?:[.,!?…)]|$)|\\s+(?:от\\s+тебя|тво[её]${LETTER}*|вожд${LETTER}*)(?!${LETTER}))`,
+      `${B}жду\\s+(?:` +
+        // (A) owner-prefixed — always owner-directed
+        `тво[её]${LETTER}*\\s+подтвержден(?:и[еяю]|ья)${A}` +
+        `|` +
+        // (B) no prefix — needs a terminal-at-EOL / comma-owner / space-owner tail
+        `подтвержден(?:и[еяю]|ья)(?=` +
+          `\\s*[.!?…)]?\\s*$` +
+          `|\\s*,\\s*(?:от\\s+тебя|тво[её]${LETTER}*|вожд${LETTER}*)` +
+          `|\\s+(?:от\\s+тебя|тво[её]${LETTER}*|вожд${LETTER}*)(?!${LETTER})` +
+        `)` +
+      `)`,
       'i',
     ),
   },
@@ -290,6 +307,14 @@ export function analyzeAsk(text: string, opts: { hasActiveLease: boolean }): Ask
 
 const SCOPE_CLIP_CHARS = 80
 
+// Machine-readable marker that leads every block-mode refusal text
+// (`askGuardBlockMessage`). It is the ONLY signal the DM Stop-hook uses to tell
+// an ask-guard block (owner NOT reached → forward the fallback) apart from a
+// generic reply error (ambiguous — may have been delivered → suppress to avoid
+// a duplicate). Keep it stable and in sync with the hook that matches on it
+// (scripts/fallback-reply-hook.ts).
+export const ASK_GUARD_BLOCK_MARKER = 'ASK_GUARD'
+
 /**
  * The advisory tool-result hint appended when the message IS sent (advisory
  * mode). Codes/anchor only — never any message text. Mirrors format-check's
@@ -319,7 +344,7 @@ export function askGuardBlockMessage(leaseId: string, scopes: readonly string[])
       ? scopes.map((s) => `«${clip(s, SCOPE_CLIP_CHARS)}»`).join('; ')
       : '(scope не указан)'
   return (
-    `ASK_GUARD (мандат ${leaseId}): этот вопрос-разрешение НЕ отправлен. ` +
+    `${ASK_GUARD_BLOCK_MARKER} (мандат ${leaseId}): этот вопрос-разрешение НЕ отправлен. ` +
     '1) Если это деньги/prod-БД/деструктив/массовые отправки/конфиг модели или ' +
     'gateway — это hard-gate: отправь вопрос карточкой AskUserQuestion (кнопки), ' +
     'этот путь НЕ гейтится. ' +

--- a/plugin/src/safety/ask-guard.ts
+++ b/plugin/src/safety/ask-guard.ts
@@ -1,0 +1,212 @@
+// Ask-guard (autonomy M3) — the ENFORCEMENT analysis for owner-granted
+// autonomy mandates.
+//
+// Context: M1 built a durable per-chat registry of owner-granted autonomy
+// mandates (leases); M2 added the grant paths. This module is the pure,
+// deterministic analysis behind M3: when the agent holds an ACTIVE lease for a
+// chat and STILL writes a «жду го / дай добро»-style permission-ask to the
+// owner, that ask is self-gating — the owner already handed over authority
+// inside the lease's scope, so the agent must ACT (act-with-veto) instead of
+// asking again. `analyzeAsk` recognises those narrow, high-precision patterns.
+//
+// Design (GPT-5.6 Sol architectural review — binding):
+//   * NO resend-valve: an agent that re-sends the SAME blocked text must NOT
+//     slip through (that would be a self-bypass). This module is stateless —
+//     identical input yields an identical finding every time; the reply path
+//     that consumes it therefore blocks a resend exactly as it blocked the
+//     first send.
+//   * The legal escape for a GENUINE product question is the AskUserQuestion
+//     card path, which is NEVER routed through here — so a real decision the
+//     owner must make still reaches him (as tappable buttons), only the
+//     self-gating "may I proceed?" prose is intercepted.
+//   * HARD-GATE EXEMPTION: a permission-ask that mentions a hard-gate action
+//     (money, prod DB, migrations, destructive ops, model/gateway config, mass
+//     sends…) is ALWAYS legitimate — those genuinely require the owner's word
+//     regardless of any lease — so any such text yields NO finding.
+//
+// Style mirrors format-check.ts: fence-protected line scan, a small findings
+// model, never throws by contract (the caller treats a throw as "no findings"
+// and fails open). Like format-check it NEVER rewrites prose; unlike it, it
+// carries the matched snippet so the reply path can log which pattern fired.
+
+import { fenceProtectedLines } from '../format/rich.js'
+
+export interface AskGuardFinding {
+  // Machine code for the tier-1 pattern that matched (stable — surfaces in
+  // logs). One finding per distinct code, even if a pattern matches twice.
+  code: string
+  // The matched snippet (clipped), for the structured log. NEVER the whole
+  // message body — only the offending fragment.
+  snippet: string
+}
+
+// A single cased letter class covering Cyrillic + Latin. The `i` flag on each
+// pattern makes it match the upper-case forms too (and folds inside classes),
+// so `[а-яёa-z]` behaves as "any Russian/English letter" for boundary checks.
+// NB: JS `\w` does NOT match Cyrillic, which is why the spec's `\w*` becomes
+// an explicit class here.
+const LETTER = '[а-яёa-z]'
+// Word boundaries that respect Cyrillic (`\b` is ASCII-only in JS). A keyword
+// must not be glued to another letter on either side, so «жду городах» never
+// matches «жду го» and «добросовестно» never matches «добро».
+const B = `(?<!${LETTER})`
+const A = `(?!${LETTER})`
+
+// Optional quote wrapper around a bare «да» / «yes» token (plain, guillemet or
+// typographic) — the spec's `"?да"?`.
+const Q = '["«»“”]?'
+
+// Tier-1 self-gating permission-ask patterns (narrow, high-precision, Russian).
+// Case-insensitive; matched only OUTSIDE fenced code and blockquotes by the
+// scanner below. Each is anchored on Cyrillic-aware boundaries so near-misses
+// («жду результатов CI», «дай знать как посмотришь», «подтверждение доставки»,
+// «жду завершения тестов») do NOT fire.
+interface AskPattern {
+  code: string
+  re: RegExp
+}
+
+const TIER1: ReadonlyArray<AskPattern> = [
+  // «жду (го|отмашк…|твоего слова|подтвержден…|команд…|добро)»
+  {
+    code: 'ASK_WAIT_GO',
+    re: new RegExp(
+      `${B}жду\\s+(?:го|отмашк${LETTER}*|твоего\\s+слова|подтвержден${LETTER}*|команд${LETTER}*|добро)${A}`,
+      'i',
+    ),
+  },
+  // «дай (го|добро|отмашку)»
+  {
+    code: 'ASK_GIVE_GO',
+    re: new RegExp(`${B}дай\\s+(?:го|добро|отмашку)${A}`, 'i'),
+  },
+  // «скажи ("да"|го) [—] (и|тогда)? (я)? (запущу|начну|продолжу|сделаю)»
+  {
+    code: 'ASK_SAY_YES',
+    re: new RegExp(
+      `${B}скажи\\s+(?:${Q}да${Q}|го)\\s*[—–,-]?\\s*(?:и|тогда)?\\s*(?:я\\s+)?(?:запущу|начну|продолжу|сделаю)${A}`,
+      'i',
+    ),
+  },
+  // «подтверди(шь)? [,] (и|тогда)»
+  {
+    code: 'ASK_CONFIRM_THEN',
+    re: new RegExp(`${B}подтверди(?:шь)?[,\\s]+(?:и|тогда)${A}`, 'i'),
+  },
+  // «нужно твоё "да"»
+  {
+    code: 'ASK_NEED_YES',
+    re: new RegExp(`${B}нужно\\s+тво[её]\\s+${Q}да${Q}${A}`, 'i'),
+  },
+  // «могу (начинать|продолжать|запускать)?»
+  {
+    code: 'ASK_CAN_I',
+    re: new RegExp(`${B}могу\\s+(?:начинать|продолжать|запускать)\\s*\\?`, 'i'),
+  },
+  // «жду (решения|твоего решения) (по|для)? (мержу|деплою|запуску)»
+  {
+    code: 'ASK_WAIT_DECISION',
+    re: new RegExp(
+      `${B}жду\\s+(?:тво[её]го\\s+)?решени[яе]\\s+(?:по|для)?\\s*(?:мержу|деплою|запуску)${A}`,
+      'i',
+    ),
+  },
+]
+
+// Hard-gate markers — questions about these actions are ALWAYS legitimate
+// (they need the owner's word regardless of any lease), so their presence
+// anywhere in the SAME text suppresses every finding. Case-insensitive covers
+// «БД»/«DB» and any cased Cyrillic.
+// `ден[ье]г` deliberately covers BOTH «деньги/деньгах/деньгами» (stem `деньг`)
+// and the common genitive «денег» (as in «списание денег») — the bare `деньг`
+// stem misses «денег», a false-negative that would let a real money-ask be
+// intercepted as a self-gate.
+const HARD_GATE_RE =
+  /(?:ден[ье]г|платеж|биллинг|prod.?(?:баз[а-яё]*|бд|db)|миграци|rm -rf|force-push|деструктив|массов[а-яё]*\s+(?:отправк|рассылк)|model config|gateway|рестарт\s+(?:канала|gateway))/i
+
+// A blockquote line (`>` prefix) — treated as protected like fenced code, so a
+// quoted permission-ask (e.g. the agent echoing the owner) never fires.
+const BLOCKQUOTE_RE = /^\s*>/
+
+// Truncate on code points (not UTF-16 units) so a surrogate pair is never
+// sliced — mirrors store.ts truncate.
+function clip(s: string, maxChars: number): string {
+  const cps = Array.from(s)
+  if (cps.length <= maxChars) return s
+  return `${cps.slice(0, Math.max(0, maxChars - 1)).join('')}…`
+}
+
+const SNIPPET_MAX_CHARS = 60
+
+/**
+ * Analyze `text` for self-gating permission-asks. Returns one finding per
+ * distinct tier-1 pattern that fired, or an empty array when clean.
+ *
+ * Short-circuits (empty result) when:
+ *   * `opts.hasActiveLease` is false — no lease, no enforcement;
+ *   * the text is empty;
+ *   * the text mentions a HARD-GATE action anywhere — such asks are always
+ *     legitimate.
+ *
+ * PURE + stateless: identical input → identical output, which is what makes
+ * the no-resend-valve guarantee hold in the reply path.
+ */
+export function analyzeAsk(text: string, opts: { hasActiveLease: boolean }): AskGuardFinding[] {
+  if (!opts.hasActiveLease) return []
+  if (text.length === 0) return []
+
+  const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+
+  // Hard-gate exemption is judged on the WHOLE message (the spec: "if the SAME
+  // text contains hard-gate markers"). A permission-ask that touches money /
+  // prod / migrations etc. is legitimate no matter the lease.
+  if (HARD_GATE_RE.test(normalized)) return []
+
+  const lines = normalized.split('\n')
+  const fenceMask = fenceProtectedLines(lines)
+
+  const findings: AskGuardFinding[] = []
+  const seen = new Set<string>()
+  for (let i = 0; i < lines.length; i++) {
+    if (fenceMask[i]) continue
+    const line = lines[i] as string
+    if (BLOCKQUOTE_RE.test(line)) continue
+    for (const p of TIER1) {
+      if (seen.has(p.code)) continue
+      const m = line.match(p.re)
+      if (m !== null) {
+        findings.push({ code: p.code, snippet: clip(m[0], SNIPPET_MAX_CHARS) })
+        seen.add(p.code)
+      }
+    }
+  }
+  return findings
+}
+
+const SCOPE_CLIP_CHARS = 80
+
+/**
+ * The advisory tool-result hint appended when the message IS sent (advisory
+ * mode). Codes/anchor only — never any message text. Mirrors format-check's
+ * `format_hint:` shape.
+ */
+export function askGuardAdvisoryHint(leaseId: string): string {
+  return (
+    `ask_guard_hint: ASK_GATE — активен мандат ${leaseId}; ` +
+    'действуй act-with-veto («делаю X, скажи стоп»), не жди разрешения'
+  )
+}
+
+/**
+ * The block-mode refusal text (returned as an isError tool result WITHOUT
+ * sending). Tells the agent to act in-scope and report, and points at the
+ * un-guarded AskUserQuestion card path for a genuine product question.
+ */
+export function askGuardBlockMessage(leaseId: string, scope: string): string {
+  return (
+    `ASK_GUARD: активен мандат ${leaseId} («${clip(scope, SCOPE_CLIP_CHARS)}»). ` +
+    'Это in-scope вопрос-разрешение — действуй сам и доложи результат ' +
+    '(«делаю X, скажи стоп если против»). Если это НАСТОЯЩИЙ продуктовый ' +
+    'вопрос — отправь его карточкой AskUserQuestion (кнопки), этот путь не гардится.'
+  )
+}

--- a/plugin/src/safety/ask-guard.ts
+++ b/plugin/src/safety/ask-guard.ts
@@ -67,11 +67,32 @@ interface AskPattern {
 }
 
 const TIER1: ReadonlyArray<AskPattern> = [
-  // «жду (го|отмашк…|твоего слова|подтвержден…|команд…|добро)»
+  // «жду (го|отмашк…|твоего слова|команд…|добро)». NB: «подтвержден…» is
+  // NOT here — it moved to ASK_WAIT_CONFIRM below (fix-loop #4), which only
+  // fires when the confirmation-wait is OWNER-directed, so a status-wait like
+  // «жду подтверждения оплаты от провайдера» / «жду подтверждения вебхука»
+  // no longer self-gates.
   {
     code: 'ASK_WAIT_GO',
     re: new RegExp(
-      `${B}жду\\s+(?:го|отмашк${LETTER}*|твоего\\s+слова|подтвержден${LETTER}*|команд${LETTER}*|добро)${A}`,
+      `${B}жду\\s+(?:го|отмашк${LETTER}*|твоего\\s+слова|команд${LETTER}*|добро)${A}`,
+      'i',
+    ),
+  },
+  // «жду подтверждени(е|я)» — fires ONLY when owner-directed (fix-loop #4,
+  // Codex MED-4 / Fable MED-4). A bare «жду подтверждения» that ENDS the clause
+  // (nothing meaningful after — end-of-line or punctuation) is an owner-wait;
+  // «жду подтверждения от тебя / твоего / вождь» is explicitly owner-directed.
+  // But «жду подтверждения <noun>» (оплаты / завершения workflow от GitHub /
+  // вебхука / CI / от провайдера) is a STATUS wait on an external system, not a
+  // self-gate — the trailing noun after «подтверждения» is not owner-ref/terminal,
+  // so the lookahead fails and it does NOT fire. Same ASK_WAIT_GO code as the
+  // generic wait so the finding taxonomy (and existing logs/tests) are stable.
+  {
+    code: 'ASK_WAIT_GO',
+    re: new RegExp(
+      `${B}жду\\s+подтвержден(?:и[еяю]|ья)` +
+        `(?=\\s*(?:[.,!?…)]|$)|\\s+(?:от\\s+тебя|тво[её]${LETTER}*|вожд${LETTER}*)(?!${LETTER}))`,
       'i',
     ),
   },
@@ -117,12 +138,60 @@ const TIER1: ReadonlyArray<AskPattern> = [
 // (they need the owner's word regardless of any lease), so their presence
 // anywhere in the SAME text suppresses every finding. Case-insensitive covers
 // «БД»/«DB» and any cased Cyrillic.
-// `ден[ье]г` deliberately covers BOTH «деньги/деньгах/деньгами» (stem `деньг`)
-// and the common genitive «денег» (as in «списание денег») — the bare `деньг`
-// stem misses «денег», a false-negative that would let a real money-ask be
-// intercepted as a self-gate.
-const HARD_GATE_RE =
-  /(?:ден[ье]г|платеж|биллинг|prod.?(?:баз[а-яё]*|бд|db)|миграци|rm -rf|force-push|деструктив|массов[а-яё]*\s+(?:отправк|рассылк)|model config|gateway|рестарт\s+(?:канала|gateway))/i
+//
+// The vocabulary is deliberately BROAD (fix-loop #1, Codex BLOCK-1 / Fable
+// HIGH-1 — safety-critical): a hard-gate ask that leaks through the guard is a
+// far worse failure than an over-exemption (which merely delivers a benign
+// reply). Conservative principle: WHEN UNCERTAIN, EXEMPT. The regex is tested
+// against a ё→е-folded copy of the message (see `foldYo`), so «платёж» folds to
+// «платеж» and matches the `платеж` stem without a separate ё-branch.
+//
+// `ден[ье]г` covers «деньги/деньгах» (stem `деньг`) AND the genitive «денег».
+const HARD_GATE_RE = new RegExp(
+  [
+    // ── money / payments ──
+    'ден[ье]г', // деньги / денег
+    'оплат[а-яё]*', // оплата / оплаты / оплат / оплатить
+    'платеж[а-яё]*', // платёж→платеж (folded) / платежный / платежи
+    'биллинг',
+    'billing',
+    'payment',
+    // ── prod DB / migrations (Latin `prod` AND Cyrillic «прод») ──
+    '(?:prod|прод)[\\s.\\-]?(?:баз[а-яё]*|бд|db)', // prod бд / прод-базу
+    'production\\s+database',
+    'миграци[а-яё]*',
+    'migrat', // migration / migrate
+    'drop\\s+table',
+    'truncate',
+    'delete\\s+from',
+    // ── destructive ──
+    'rm\\s+-rf',
+    'force-?push',
+    'git\\s+reset\\s+--hard',
+    'git\\s+clean',
+    'удал[а-яё]*', // удалю / удаление / удалить (data deletion)
+    'деструктив[а-яё]*',
+    // ── mass sends ──
+    'массов[а-яё]*', // массовая (рассылка/отправка/…)
+    'рассылк[а-яё]*', // рассылка (inherently a mass send)
+    'отправк[а-яё]*\\s+(?:по\\s+)?(?:баз|юзер|всем|пользовател)', // отправка по базе/юзерам/всем
+    'mass\\s+send',
+    'broadcast',
+    // ── model / gateway / bot config + own-channel restarts ──
+    'model\\s+config',
+    'gateway',
+    'конфиг\\s+(?:модел[а-яё]*|gateway)', // конфиг модели / конфиг gateway
+    'рестарт\\s+(?:канала|gateway|бота)',
+  ].join('|'),
+  'i',
+)
+
+// Fold «ё»→«е» (both cases) on a COPY used only for the hard-gate test, so
+// «платёж» matches the `платеж` stem. Never mutates the text scanned for
+// tier-1 findings (that scan keeps ё so Cyrillic boundaries stay exact).
+function foldYo(s: string): string {
+  return s.replace(/ё/g, 'е').replace(/Ё/g, 'Е')
+}
 
 // A blockquote line (`>` prefix) — treated as protected like fenced code, so a
 // quoted permission-ask (e.g. the agent echoing the owner) never fires.
@@ -138,32 +207,60 @@ function clip(s: string, maxChars: number): string {
 
 const SNIPPET_MAX_CHARS = 60
 
+// Why a message was hard-gate exempted (fix-loop #2, Codex HIGH-3 / Fable
+// LOW-5). `hard_gate` = the marker is in real prose. `hard_gate_protected_only`
+// = the marker survives ONLY inside a fenced/quoted zone (the fence/quote-masked
+// prose does NOT match) — STILL exempt (whole-text OR fails safe against
+// over-blocking), but flagged so calibration week can see this class and decide
+// whether a quoted hard-gate word is masking a genuine self-gate.
+export type AskExemptReason = 'hard_gate' | 'hard_gate_protected_only'
+
+export interface AskGuardAnalysis {
+  // One finding per distinct tier-1 pattern that fired, or empty when clean or
+  // exempt.
+  findings: AskGuardFinding[]
+  // Set ONLY when a hard-gate exemption suppressed the scan. Undefined for a
+  // clean pass (findings may be non-empty) and for the no-lease/empty
+  // short-circuits.
+  exemptReason?: AskExemptReason
+}
+
 /**
- * Analyze `text` for self-gating permission-asks. Returns one finding per
- * distinct tier-1 pattern that fired, or an empty array when clean.
+ * Full analysis of `text` for self-gating permission-asks. PURE + stateless:
+ * identical input → identical output, which is what makes the no-resend-valve
+ * guarantee hold in the reply path.
  *
- * Short-circuits (empty result) when:
- *   * `opts.hasActiveLease` is false — no lease, no enforcement;
- *   * the text is empty;
- *   * the text mentions a HARD-GATE action anywhere — such asks are always
- *     legitimate.
+ * Short-circuits (empty findings, no exemptReason) when there is no active
+ * lease or the text is empty.
  *
- * PURE + stateless: identical input → identical output, which is what makes
- * the no-resend-valve guarantee hold in the reply path.
+ * Hard-gate exemption is judged on the WHOLE message (the spec: "if the SAME
+ * text contains hard-gate markers") so an over-exemption always fails safe —
+ * but we ALSO recompute the marker on the fence/quote-masked prose to classify
+ * whether the exemption came only from a protected zone (`exemptReason`).
  */
-export function analyzeAsk(text: string, opts: { hasActiveLease: boolean }): AskGuardFinding[] {
-  if (!opts.hasActiveLease) return []
-  if (text.length === 0) return []
+export function analyzeAskDetailed(
+  text: string,
+  opts: { hasActiveLease: boolean },
+): AskGuardAnalysis {
+  if (!opts.hasActiveLease) return { findings: [] }
+  if (text.length === 0) return { findings: [] }
 
   const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
-
-  // Hard-gate exemption is judged on the WHOLE message (the spec: "if the SAME
-  // text contains hard-gate markers"). A permission-ask that touches money /
-  // prod / migrations etc. is legitimate no matter the lease.
-  if (HARD_GATE_RE.test(normalized)) return []
-
   const lines = normalized.split('\n')
   const fenceMask = fenceProtectedLines(lines)
+
+  // Whole-text hard-gate test (the authoritative, fail-safe check).
+  if (HARD_GATE_RE.test(foldYo(normalized))) {
+    // Recompute on prose with fenced/blockquoted lines stripped. If the marker
+    // is gone, the exemption rested ONLY on a protected zone → distinct code.
+    const prose = lines
+      .filter((l, i) => !fenceMask[i] && !BLOCKQUOTE_RE.test(l as string))
+      .join('\n')
+    const reason: AskExemptReason = HARD_GATE_RE.test(foldYo(prose))
+      ? 'hard_gate'
+      : 'hard_gate_protected_only'
+    return { findings: [], exemptReason: reason }
+  }
 
   const findings: AskGuardFinding[] = []
   const seen = new Set<string>()
@@ -180,7 +277,15 @@ export function analyzeAsk(text: string, opts: { hasActiveLease: boolean }): Ask
       }
     }
   }
-  return findings
+  return { findings }
+}
+
+/**
+ * Thin wrapper returning ONLY the findings array — the stable surface used by
+ * unit tests and any caller that does not need the exemption classification.
+ */
+export function analyzeAsk(text: string, opts: { hasActiveLease: boolean }): AskGuardFinding[] {
+  return analyzeAskDetailed(text, opts).findings
 }
 
 const SCOPE_CLIP_CHARS = 80
@@ -199,14 +304,27 @@ export function askGuardAdvisoryHint(leaseId: string): string {
 
 /**
  * The block-mode refusal text (returned as an isError tool result WITHOUT
- * sending). Tells the agent to act in-scope and report, and points at the
- * un-guarded AskUserQuestion card path for a genuine product question.
+ * sending). fix-loop #3 (Codex HIGH-2 / Fable MED-2): the guard must NOT assert
+ * that the ask is in-scope/authorized — it cannot know that. Instead it lays
+ * out BOTH branches and lets the model self-check against the actual lease
+ * scope(s):
+ *   1) hard-gate → the AskUserQuestion card path (never guarded);
+ *   2) covered by an active mandate's scope → act-with-veto and report.
+ * All active lease scopes are listed (not just the soonest-expiry one) so the
+ * model can match its intended action against the real granted text.
  */
-export function askGuardBlockMessage(leaseId: string, scope: string): string {
+export function askGuardBlockMessage(leaseId: string, scopes: readonly string[]): string {
+  const scopeList =
+    scopes.length > 0
+      ? scopes.map((s) => `«${clip(s, SCOPE_CLIP_CHARS)}»`).join('; ')
+      : '(scope не указан)'
   return (
-    `ASK_GUARD: активен мандат ${leaseId} («${clip(scope, SCOPE_CLIP_CHARS)}»). ` +
-    'Это in-scope вопрос-разрешение — действуй сам и доложи результат ' +
-    '(«делаю X, скажи стоп если против»). Если это НАСТОЯЩИЙ продуктовый ' +
-    'вопрос — отправь его карточкой AskUserQuestion (кнопки), этот путь не гардится.'
+    `ASK_GUARD (мандат ${leaseId}): этот вопрос-разрешение НЕ отправлен. ` +
+    '1) Если это деньги/prod-БД/деструктив/массовые отправки/конфиг модели или ' +
+    'gateway — это hard-gate: отправь вопрос карточкой AskUserQuestion (кнопки), ' +
+    'этот путь НЕ гейтится. ' +
+    '2) Если действие покрыто scope активного мандата — действуй act-with-veto ' +
+    '(«делаю X, скажи стоп если против») и доложи результат. ' +
+    `Активные мандаты: ${scopeList}.`
   )
 }

--- a/plugin/src/webhook/routes/fallback-reply.ts
+++ b/plugin/src/webhook/routes/fallback-reply.ts
@@ -3,7 +3,9 @@
 
 import type { IncomingMessage, ServerResponse } from 'http'
 
-import { redactToken } from '../../config.js'
+import { redactToken, resolveAskGuardMode } from '../../config.js'
+import { activeLeases, loadAutonomyState } from '../../autonomy/store.js'
+import { analyzeAskDetailed } from '../../safety/ask-guard.js'
 import { FallbackReplyRouteRequestSchema } from '../../schemas.js'
 import type { WebhookDeps } from '../server.js'
 import { authGate, chatIdAllowed, readJsonBody, reply } from './shared.js'
@@ -27,7 +29,7 @@ export async function handleFallbackReply(
   deps: WebhookDeps,
   webhookToken: string | undefined,
 ): Promise<void> {
-  const { config, log, sendMessage } = deps
+  const { config, log, sendMessage, statePaths } = deps
 
   if (!authGate(req, res, webhookToken)) return
 
@@ -54,6 +56,68 @@ export async function handleFallbackReply(
     log.warn('fallback-reply chatId not in allowlist', { chat_id: payload.chat_id })
     reply(res, 403, { error: 'chatId not in allowlist' })
     return
+  }
+
+  // ── Ask-guard (autonomy M3, fix-loop #7) ────────────────────────────────
+  // The DM Stop-hook forwards a turn's FINAL assistant text here when the turn
+  // ended without an MCP reply — including when the `reply` tool was BLOCKED by
+  // the choke point (the hook no longer counts an isError reply as delivered).
+  // Without a guard here, a self-gating go-question would slip out through the
+  // fallback, bypassing the reply-tool guard. So we run the SAME analysis:
+  //   * block   → do NOT forward; log + answer 200 {status:'ask_guard_blocked'}
+  //               (the hook does not dedup a non-'sent' status → no owner send).
+  //   * advisory → forward unchanged + log (calibration-week observe-only).
+  // Fail-open on ANY error — a guard fault must never drop a real fallback.
+  try {
+    const mode = resolveAskGuardMode(config, log)
+    if (mode !== 'off') {
+      const state = loadAutonomyState(statePaths, payload.chat_id, log)
+      const leases = activeLeases(state, Date.now())
+      if (leases.length > 0) {
+        const analysis = analyzeAskDetailed(payload.text, { hasActiveLease: true })
+        if (analysis.exemptReason === 'hard_gate_protected_only') {
+          log.info('ask_guard exempt — hard-gate marker only in a protected zone', {
+            code: 'ask_guard_exempt_protected_only',
+            variant: 'fallback',
+            chat_id: payload.chat_id,
+            lease_id: leases[0]!.id,
+          })
+        }
+        const finding = analysis.findings[0]
+        if (finding !== undefined && mode === 'block') {
+          log.info('ask_guard blocked a self-gating fallback reply (mandate active)', {
+            code: 'ask_guard_block',
+            variant: 'fallback',
+            chat_id: payload.chat_id,
+            lease_id: leases[0]!.id,
+            pattern: finding.code,
+          })
+          reply(res, 200, { status: 'ask_guard_blocked' })
+          return
+        }
+        if (finding !== undefined) {
+          // advisory — the fallback still forwards; observe-only log.
+          log.info('ask_guard advisory on a self-gating fallback reply (mandate active)', {
+            code: 'ask_guard_advisory',
+            variant: 'fallback',
+            chat_id: payload.chat_id,
+            lease_id: leases[0]!.id,
+            pattern: finding.code,
+          })
+        }
+      }
+    }
+  } catch (err) {
+    try {
+      log.warn('ask_guard (fallback) evaluation failed — failing open (forwarded unguarded)', {
+        code: 'ask_guard_error',
+        variant: 'fallback',
+        chat_id: payload.chat_id,
+        error: err instanceof Error ? redactToken(err.message) : String(err),
+      })
+    } catch {
+      /* a logger fault must not drop a real fallback */
+    }
   }
 
   try {

--- a/plugin/src/webhook/routes/fallback-reply.ts
+++ b/plugin/src/webhook/routes/fallback-reply.ts
@@ -77,7 +77,7 @@ export async function handleFallbackReply(
         const analysis = analyzeAskDetailed(payload.text, { hasActiveLease: true })
         if (analysis.exemptReason === 'hard_gate_protected_only') {
           log.info('ask_guard exempt — hard-gate marker only in a protected zone', {
-            code: 'ask_guard_exempt_protected_only',
+            code: 'hard_gate_protected_only',
             variant: 'fallback',
             chat_id: payload.chat_id,
             lease_id: leases[0]!.id,

--- a/plugin/tests/channel/tools.ask-guard.test.ts
+++ b/plugin/tests/channel/tools.ask-guard.test.ts
@@ -1,0 +1,282 @@
+// Integration tests for the ask-guard choke point on the reply tool
+// (autonomy M3). These exercise the REAL wiring in src/channel/tools.ts: the
+// guard reads the per-chat autonomy registry, and only when an ACTIVE lease
+// exists AND the outgoing body is a self-gating permission-ask does it
+// intercept (block) or annotate (advisory). Everything else — no lease, a
+// hard-gate ask, benign prose, the kill-switch — ships the reply unchanged.
+//
+// The harness mirrors tools.test.ts (a stub TelegramApi that records sends, a
+// tmp state dir, a default AppConfig). The ASK_GUARD_* env vars are cleared in
+// beforeEach and restored in afterEach so a stray global value can never leak
+// between tests (resolveAskGuardMode reads process.env directly).
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import {
+  callTool,
+  type AnswerGuestQueryOpts,
+  type CallToolRequest,
+  type DownloadResult,
+  type EditOpts,
+  type SendDocumentOpts,
+  type SendMessageOpts,
+  type TelegramApi,
+  type ToolDeps,
+} from '../../src/channel/tools.js'
+import type { AppConfig, StatePaths } from '../../src/config.js'
+import { createLogger } from '../../src/log.js'
+import {
+  addLease,
+  emptyAutonomyState,
+  saveAutonomyState,
+} from '../../src/autonomy/store.js'
+
+const silentLog = createLogger('test', { stream: { write: () => true } as unknown as NodeJS.WritableStream })
+
+const CHAT = '164795011'
+const HOUR = 3_600_000
+
+interface SentRecord {
+  chatId: string
+  text: string
+}
+
+function makeRecordingApi(sent: SentRecord[]): TelegramApi {
+  return {
+    sendMessage: async (chatId: string, text: string, _opts: SendMessageOpts) => {
+      sent.push({ chatId, text })
+      return { message_id: 1 }
+    },
+    sendRichMessage: async () => ({ fallback: true as const }),
+    editMessageText: async (_c: string, _m: number, _t: string, _o: EditOpts) => {},
+    setMessageReaction: async (_c: string, _m: number, _e: string) => {},
+    sendChatAction: async () => {},
+    sendDocument: async (_c: string, _f: string, _o: SendDocumentOpts) => ({ message_id: 2 }),
+    sendPhoto: async (_c: string, _f: string, _o: SendDocumentOpts) => ({ message_id: 3 }),
+    downloadFile: async (_id: string, destDir: string): Promise<DownloadResult> => ({
+      path: join(destDir, 'fake.bin'),
+      size: 0,
+    }),
+    deleteMessage: async (_c: string, _m: number) => {},
+    answerGuestQuery: async (_id: string, _t: string, _o: AnswerGuestQueryOpts) => {},
+  }
+}
+
+function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    bot_id: 8507713167,
+    dm_only: true,
+    allowed_user_ids: [164795011],
+    allowed_chat_ids: [164795011],
+    status: { enabled: false, interval_ms: 700, ttl_ms: 300_000, delete_on_complete: true, suppress_typing_bubble: false },
+    album: { flush_ms: 2000 },
+    voice: { provider: 'groq', language: 'ru', model: 'whisper-large-v3-turbo' },
+    webhook: { enabled: false, host: '127.0.0.1', port: 0 },
+    permission_relay: { enabled: true, allowed_user_ids: [164795011], bash_only_proof: true },
+    commands: { help: true, status: true, stop: true, reset: true, new: true },
+    memory: {
+      enabled: false,
+      source_tag: 'tg',
+      max_hot_bytes: 20480,
+      trim_keep_lines: 600,
+      buffer_ttl_ms: 5 * 60 * 1000,
+      buffer_max_entries: 100,
+    },
+    progress: { enabled: false, edit_throttle_ms: 3000, recent_buffer: 10, session_ttl_ms: 600000 },
+    task_mirror: { enabled: false, edit_throttle_ms: 3000, session_ttl_ms: 600000, collapse_completed_after: 5 },
+    watcher: { enabled: false, debounce_ms: 10_000, busy_threshold_ms: 30_000 },
+    tmux_mirror: { enabled: false, pane_target: '', socket_name: '', poll_interval_ms: 5000, line_count: 50, hide_segments: [], mode: 'latest_inbound_only', max_lines: 14 },
+    multichat: { enabled: false },
+    ask_user_question: { enabled: false, timeout_ms: 300_000, max_preview_chars: 1000 },
+    permission_gate: { enabled: false, timeout_ms: 120_000 },
+    richMessages: { enabled: false, perChatOptOut: [] },
+    ...overrides,
+  }
+}
+
+function makeStatePaths(): StatePaths {
+  const root = mkdtempSync(join(tmpdir(), 'dashi-ask-guard-tools-'))
+  return {
+    root,
+    env: join(root, '.env'),
+    config: join(root, 'config.json'),
+    allowlist: join(root, 'allowlist.json'),
+    pid: join(root, 'bot.pid'),
+    lock: join(root, 'bot.lock'),
+    updateOffset: join(root, 'update-offset'),
+    inbox: join(root, 'inbox'),
+    sessionIds: join(root, 'session-ids'),
+    deadLetterUpdates: join(root, 'dead-letter', 'updates'),
+    deadLetterWebhook: join(root, 'dead-letter', 'webhook'),
+    deadLetterOutbound: join(root, 'dead-letter', 'outbound'),
+    logs: {
+      server: join(root, 'logs', 'server.log'),
+      telegram: join(root, 'logs', 'telegram.log'),
+      permissions: join(root, 'logs', 'permissions.jsonl'),
+      webhook: join(root, 'logs', 'webhook.log'),
+      ask_user_question: join(root, 'logs', 'ask-user-question.jsonl'),
+      permission_gate: join(root, 'logs', 'permission-gate.jsonl'),
+    },
+  }
+}
+
+function makeStubStatusManager(): ToolDeps['statusManager'] {
+  return {
+    isActive: () => false,
+    activeChatIds: () => [],
+    start: async () => ({ chatId: '0', messageId: 0, startedAt: 0 }),
+    update: async () => {},
+    updateByChatId: async () => {},
+    complete: async () => {},
+    cancel: async () => {},
+  } as unknown as ToolDeps['statusManager']
+}
+
+// Seed an ACTIVE lease into the per-chat autonomy registry under `paths`.
+function seedActiveLease(paths: StatePaths, chatId: string, nowMs: number): void {
+  const { state } = addLease(
+    emptyAutonomyState(),
+    { scope: 'реализуй M3 ask-guard по порядку', expiresAtMs: nowMs + 4 * HOUR, source: 'owner_cmd', chatId },
+    nowMs,
+  )
+  saveAutonomyState(paths, chatId, state)
+}
+
+function replyReq(text: string): CallToolRequest {
+  return { params: { name: 'reply', arguments: { chat_id: CHAT, text } } }
+}
+
+let statePaths: StatePaths
+let sent: SentRecord[]
+let deps: ToolDeps
+let savedEnabled: string | undefined
+let savedMode: string | undefined
+
+beforeEach(() => {
+  statePaths = makeStatePaths()
+  sent = []
+  deps = {
+    config: makeConfig(),
+    statePaths,
+    telegramApi: makeRecordingApi(sent),
+    log: silentLog,
+    statusManager: makeStubStatusManager(),
+  }
+  savedEnabled = process.env.ASK_GUARD_ENABLED
+  savedMode = process.env.ASK_GUARD_MODE
+  delete process.env.ASK_GUARD_ENABLED
+  delete process.env.ASK_GUARD_MODE
+})
+
+afterEach(() => {
+  rmSync(statePaths.root, { recursive: true, force: true })
+  if (savedEnabled === undefined) delete process.env.ASK_GUARD_ENABLED
+  else process.env.ASK_GUARD_ENABLED = savedEnabled
+  if (savedMode === undefined) delete process.env.ASK_GUARD_MODE
+  else process.env.ASK_GUARD_MODE = savedMode
+})
+
+function resultText(res: Awaited<ReturnType<typeof callTool>>): string {
+  const first = res.content[0]
+  return first !== undefined && first.type === 'text' ? first.text : ''
+}
+
+describe('ask-guard reply choke point — block mode', () => {
+  test('blocks a self-gating ask when a lease is active: nothing sent, isError', async () => {
+    process.env.ASK_GUARD_MODE = 'block'
+    seedActiveLease(statePaths, CHAT, Date.now())
+    const res = await callTool(replyReq('Всё собрано. Жду го, мой вождь.'), deps)
+    expect(res.isError).toBe(true)
+    expect(sent.length).toBe(0)
+    expect(resultText(res)).toContain('ASK_GUARD')
+    expect(resultText(res)).toContain('AskUserQuestion')
+  })
+
+  test('NO resend-valve: an identical re-send is blocked again', async () => {
+    process.env.ASK_GUARD_MODE = 'block'
+    seedActiveLease(statePaths, CHAT, Date.now())
+    const first = await callTool(replyReq('жду го'), deps)
+    const second = await callTool(replyReq('жду го'), deps)
+    expect(first.isError).toBe(true)
+    expect(second.isError).toBe(true)
+    expect(sent.length).toBe(0)
+  })
+
+  test('block does NOT fire for a hard-gate ask (money) — reply ships', async () => {
+    process.env.ASK_GUARD_MODE = 'block'
+    seedActiveLease(statePaths, CHAT, Date.now())
+    const res = await callTool(replyReq('жду го на списание денег'), deps)
+    expect(res.isError).toBeUndefined()
+    expect(sent.length).toBe(1)
+  })
+
+  test('block does NOT fire for benign prose — reply ships unchanged', async () => {
+    process.env.ASK_GUARD_MODE = 'block'
+    seedActiveLease(statePaths, CHAT, Date.now())
+    const res = await callTool(replyReq('Готово, мой вождь. Код чист.'), deps)
+    expect(res.isError).toBeUndefined()
+    expect(sent.length).toBe(1)
+    expect(resultText(res)).not.toContain('ask_guard_hint')
+  })
+
+  test('block does NOT fire without an active lease — reply ships', async () => {
+    process.env.ASK_GUARD_MODE = 'block'
+    // no lease seeded
+    const res = await callTool(replyReq('жду го'), deps)
+    expect(res.isError).toBeUndefined()
+    expect(sent.length).toBe(1)
+  })
+})
+
+describe('ask-guard reply choke point — advisory mode (default)', () => {
+  test('ships the reply AND appends ask_guard_hint when lease active + self-gate', async () => {
+    // default mode is advisory (no env, no config.ask_guard)
+    seedActiveLease(statePaths, CHAT, Date.now())
+    const res = await callTool(replyReq('жду го'), deps)
+    expect(res.isError).toBeUndefined()
+    expect(sent.length).toBe(1)
+    expect(resultText(res)).toContain('ask_guard_hint')
+  })
+
+  test('no hint when there is no active lease', async () => {
+    const res = await callTool(replyReq('жду го'), deps)
+    expect(sent.length).toBe(1)
+    expect(resultText(res)).not.toContain('ask_guard_hint')
+  })
+
+  test('no hint for a benign reply under an active lease', async () => {
+    seedActiveLease(statePaths, CHAT, Date.now())
+    const res = await callTool(replyReq('Готово. Порядок восстановлен.'), deps)
+    expect(sent.length).toBe(1)
+    expect(resultText(res)).not.toContain('ask_guard_hint')
+  })
+})
+
+describe('ask-guard reply choke point — kill-switch', () => {
+  test('ASK_GUARD_ENABLED=0 forces off: self-gate ships with no hint, even in block config', async () => {
+    process.env.ASK_GUARD_ENABLED = '0'
+    process.env.ASK_GUARD_MODE = 'block'
+    seedActiveLease(statePaths, CHAT, Date.now())
+    const res = await callTool(replyReq('жду го'), deps)
+    expect(res.isError).toBeUndefined()
+    expect(sent.length).toBe(1)
+    expect(resultText(res)).not.toContain('ask_guard_hint')
+  })
+})
+
+describe('ask-guard reply choke point — edit_message is NOT guarded', () => {
+  test('edit_message with a self-gating body under an active lease is untouched', async () => {
+    process.env.ASK_GUARD_MODE = 'block'
+    seedActiveLease(statePaths, CHAT, Date.now())
+    const res = await callTool(
+      { params: { name: 'edit_message', arguments: { chat_id: CHAT, message_id: '42', text: 'жду го' } } },
+      deps,
+    )
+    // edit_message path returns a plain "edited" ack, never the guard refusal.
+    expect(res.isError).toBeUndefined()
+    expect(resultText(res)).toContain('edited')
+  })
+})

--- a/plugin/tests/channel/tools.ask-guard.test.ts
+++ b/plugin/tests/channel/tools.ask-guard.test.ts
@@ -31,8 +31,10 @@ import { createLogger } from '../../src/log.js'
 import {
   addLease,
   emptyAutonomyState,
+  revokeLease,
   saveAutonomyState,
 } from '../../src/autonomy/store.js'
+import type { Logger } from '../../src/log.js'
 
 const silentLog = createLogger('test', { stream: { write: () => true } as unknown as NodeJS.WritableStream })
 
@@ -145,8 +147,47 @@ function seedActiveLease(paths: StatePaths, chatId: string, nowMs: number): void
   saveAutonomyState(paths, chatId, state)
 }
 
+// Seed an EXPIRED lease (expiresAtMs already in the past).
+function seedExpiredLease(paths: StatePaths, chatId: string, nowMs: number): void {
+  const { state } = addLease(
+    emptyAutonomyState(),
+    { scope: 'истёкший мандат', expiresAtMs: nowMs - HOUR, source: 'owner_cmd', chatId },
+    nowMs - 2 * HOUR,
+  )
+  saveAutonomyState(paths, chatId, state)
+}
+
+// Seed a REVOKED (but not-yet-expired) lease.
+function seedRevokedLease(paths: StatePaths, chatId: string, nowMs: number): void {
+  const added = addLease(
+    emptyAutonomyState(),
+    { scope: 'отозванный мандат', expiresAtMs: nowMs + 4 * HOUR, source: 'owner_cmd', chatId },
+    nowMs,
+  )
+  const leaseId = added.state.leases[0]!.id
+  const { state } = revokeLease(added.state, leaseId, nowMs, 'вождь', 'test')
+  saveAutonomyState(paths, chatId, state)
+}
+
 function replyReq(text: string): CallToolRequest {
   return { params: { name: 'reply', arguments: { chat_id: CHAT, text } } }
+}
+
+function replyReqChat(chatId: string, text: string): CallToolRequest {
+  return { params: { name: 'reply', arguments: { chat_id: chatId, text } } }
+}
+
+// A logger whose `info` ALWAYS throws — used to prove the fail-open path
+// (fix-loop #5): a throwing logger must never abort a real reply.
+function makeThrowingInfoLogger(): Logger {
+  return {
+    debug: () => {},
+    info: () => {
+      throw new Error('logger boom')
+    },
+    warn: () => {},
+    error: () => {},
+  } as unknown as Logger
 }
 
 let statePaths: StatePaths
@@ -264,6 +305,62 @@ describe('ask-guard reply choke point — kill-switch', () => {
     expect(res.isError).toBeUndefined()
     expect(sent.length).toBe(1)
     expect(resultText(res)).not.toContain('ask_guard_hint')
+  })
+})
+
+// fix-loop #8 (Fable LOW-6) — integration coverage at the chokepoint for the
+// lease-inactive cases and a fail-open throw after loadAutonomyState.
+describe('ask-guard reply choke point — inactive-lease cases (fix-loop #8)', () => {
+  test('(a) EXPIRED lease → guard does not fire, reply ships', async () => {
+    process.env.ASK_GUARD_MODE = 'block'
+    seedExpiredLease(statePaths, CHAT, Date.now())
+    const res = await callTool(replyReq('жду го'), deps)
+    expect(res.isError).toBeUndefined()
+    expect(sent.length).toBe(1)
+  })
+
+  test('(b) REVOKED lease → guard does not fire, reply ships', async () => {
+    process.env.ASK_GUARD_MODE = 'block'
+    seedRevokedLease(statePaths, CHAT, Date.now())
+    const res = await callTool(replyReq('жду го'), deps)
+    expect(res.isError).toBeUndefined()
+    expect(sent.length).toBe(1)
+  })
+
+  test('(c) lease active ONLY in a different chat → no fire for THIS chat', async () => {
+    process.env.ASK_GUARD_MODE = 'block'
+    // Lease seeded in a different chat's per-chat registry; THIS chat has none.
+    const OTHER = '999999999'
+    seedActiveLease(statePaths, OTHER, Date.now())
+    const res = await callTool(replyReqChat(CHAT, 'жду го'), deps)
+    expect(res.isError).toBeUndefined()
+    expect(sent.length).toBe(1)
+  })
+})
+
+describe('ask-guard reply choke point — fail-open (fix-loop #5 / #8d)', () => {
+  test('(d) a throwing logger after loadAutonomyState never aborts delivery', async () => {
+    // advisory (default) + active lease + self-gate → the guard reaches the
+    // advisory log.info, which THROWS. The nested-guarded catch must swallow it
+    // and the reply must still ship (without the hint, since the throw preempts
+    // it). Proves the guard can never gate a real reply on a logger fault.
+    seedActiveLease(statePaths, CHAT, Date.now())
+    const throwingDeps: ToolDeps = { ...deps, log: makeThrowingInfoLogger() }
+    const res = await callTool(replyReq('жду го'), throwingDeps)
+    expect(res.isError).toBeUndefined()
+    expect(sent.length).toBe(1)
+    expect(resultText(res)).not.toContain('ask_guard_hint')
+  })
+
+  test('a throwing logger in BLOCK mode also fails open (reply ships)', async () => {
+    process.env.ASK_GUARD_MODE = 'block'
+    seedActiveLease(statePaths, CHAT, Date.now())
+    const throwingDeps: ToolDeps = { ...deps, log: makeThrowingInfoLogger() }
+    const res = await callTool(replyReq('жду го'), throwingDeps)
+    // The block-path log.info throws before the isError return → caught →
+    // fail-open → the reply ships rather than the delivery being aborted.
+    expect(res.isError).toBeUndefined()
+    expect(sent.length).toBe(1)
   })
 })
 

--- a/plugin/tests/config.test.ts
+++ b/plugin/tests/config.test.ts
@@ -6,6 +6,7 @@ import {
   getStatePaths,
   loadConfig,
   redactToken,
+  resolveAskGuardMode,
   resolveAskUserQuestionAllowedUserIds,
   RuntimeEnvSchema,
 } from '../src/config.js'
@@ -539,5 +540,96 @@ describe('single progress surface defaults (2026-06-09 duplicate-windows fix)', 
     const cfg = loadConfig(env())
     expect(cfg.status.enabled).toBe(true)
     expect(cfg.progress.enabled).toBe(true)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// resolveAskGuardMode (autonomy M3). The `ask_guard` config block is
+// optional; the helper applies the 'advisory' default and the two direct-env
+// overrides (kill-switch ASK_GUARD_ENABLED, ASK_GUARD_MODE) in one place. The
+// two env vars are read from process.env DIRECTLY, so these tests set/restore
+// process.env rather than passing an env object.
+// ─────────────────────────────────────────────────────────────────────
+
+describe('resolveAskGuardMode', () => {
+  let savedEnabled: string | undefined
+  let savedMode: string | undefined
+
+  beforeEach(() => {
+    savedEnabled = process.env.ASK_GUARD_ENABLED
+    savedMode = process.env.ASK_GUARD_MODE
+    delete process.env.ASK_GUARD_ENABLED
+    delete process.env.ASK_GUARD_MODE
+  })
+
+  afterEach(() => {
+    if (savedEnabled === undefined) delete process.env.ASK_GUARD_ENABLED
+    else process.env.ASK_GUARD_ENABLED = savedEnabled
+    if (savedMode === undefined) delete process.env.ASK_GUARD_MODE
+    else process.env.ASK_GUARD_MODE = savedMode
+  })
+
+  test('defaults to advisory when nothing is configured', () => {
+    const cfg = loadConfig(env())
+    expect(resolveAskGuardMode(cfg)).toBe('advisory')
+  })
+
+  test('config.json ask_guard.mode = block is honored', () => {
+    writeFileSync(join(stateDir, 'config.json'), JSON.stringify({ ask_guard: { mode: 'block' } }))
+    const cfg = loadConfig(env())
+    expect(resolveAskGuardMode(cfg)).toBe('block')
+  })
+
+  test('config.json ask_guard.mode = off is honored', () => {
+    writeFileSync(join(stateDir, 'config.json'), JSON.stringify({ ask_guard: { mode: 'off' } }))
+    const cfg = loadConfig(env())
+    expect(resolveAskGuardMode(cfg)).toBe('off')
+  })
+
+  test('ASK_GUARD_MODE env overrides config.json', () => {
+    writeFileSync(join(stateDir, 'config.json'), JSON.stringify({ ask_guard: { mode: 'advisory' } }))
+    const cfg = loadConfig(env())
+    process.env.ASK_GUARD_MODE = 'block'
+    expect(resolveAskGuardMode(cfg)).toBe('block')
+  })
+
+  test('ASK_GUARD_MODE env is case-insensitive and trimmed', () => {
+    const cfg = loadConfig(env())
+    process.env.ASK_GUARD_MODE = '  BLOCK '
+    expect(resolveAskGuardMode(cfg)).toBe('block')
+  })
+
+  test('an invalid ASK_GUARD_MODE falls through to the config/default', () => {
+    const cfg = loadConfig(env())
+    process.env.ASK_GUARD_MODE = 'nonsense'
+    expect(resolveAskGuardMode(cfg)).toBe('advisory')
+  })
+
+  test('kill-switch ASK_GUARD_ENABLED=0 forces off, beating a configured block', () => {
+    writeFileSync(join(stateDir, 'config.json'), JSON.stringify({ ask_guard: { mode: 'block' } }))
+    const cfg = loadConfig(env())
+    process.env.ASK_GUARD_ENABLED = '0'
+    expect(resolveAskGuardMode(cfg)).toBe('off')
+  })
+
+  test('kill-switch ASK_GUARD_ENABLED=false beats ASK_GUARD_MODE=block', () => {
+    const cfg = loadConfig(env())
+    process.env.ASK_GUARD_ENABLED = 'false'
+    process.env.ASK_GUARD_MODE = 'block'
+    expect(resolveAskGuardMode(cfg)).toBe('off')
+  })
+
+  test('kill-switch accepts no/off variants (case-insensitive)', () => {
+    const cfg = loadConfig(env())
+    for (const v of ['no', 'OFF', 'No']) {
+      process.env.ASK_GUARD_ENABLED = v
+      expect(resolveAskGuardMode(cfg)).toBe('off')
+    }
+  })
+
+  test('ASK_GUARD_ENABLED with a truthy value does NOT force off (default applies)', () => {
+    const cfg = loadConfig(env())
+    process.env.ASK_GUARD_ENABLED = '1'
+    expect(resolveAskGuardMode(cfg)).toBe('advisory')
   })
 })

--- a/plugin/tests/config.test.ts
+++ b/plugin/tests/config.test.ts
@@ -599,10 +599,30 @@ describe('resolveAskGuardMode', () => {
     expect(resolveAskGuardMode(cfg)).toBe('block')
   })
 
-  test('an invalid ASK_GUARD_MODE falls through to the config/default', () => {
+  test('an invalid ASK_GUARD_MODE resolves to advisory (no config set)', () => {
     const cfg = loadConfig(env())
     process.env.ASK_GUARD_MODE = 'nonsense'
     expect(resolveAskGuardMode(cfg)).toBe('advisory')
+  })
+
+  // fix-loop #6 (Codex LOW-6): a SET-but-INVALID env value must NOT silently
+  // retain a configured `block` — it resolves to advisory and logs a warning.
+  test('an invalid ASK_GUARD_MODE does NOT retain a configured block → advisory + warn', () => {
+    writeFileSync(join(stateDir, 'config.json'), JSON.stringify({ ask_guard: { mode: 'block' } }))
+    const cfg = loadConfig(env())
+    process.env.ASK_GUARD_MODE = 'of' // typo of «off»
+    const warns: string[] = []
+    const log = { warn: (msg: string) => warns.push(msg) }
+    expect(resolveAskGuardMode(cfg, log)).toBe('advisory')
+    expect(warns.length).toBe(1)
+    expect(warns[0]).toContain('ASK_GUARD_MODE')
+  })
+
+  test('an empty ASK_GUARD_MODE is treated as unset (falls through to config)', () => {
+    writeFileSync(join(stateDir, 'config.json'), JSON.stringify({ ask_guard: { mode: 'block' } }))
+    const cfg = loadConfig(env())
+    process.env.ASK_GUARD_MODE = '   '
+    expect(resolveAskGuardMode(cfg)).toBe('block')
   })
 
   test('kill-switch ASK_GUARD_ENABLED=0 forces off, beating a configured block', () => {

--- a/plugin/tests/hooks/fallback-reply-hook.test.ts
+++ b/plugin/tests/hooks/fallback-reply-hook.test.ts
@@ -104,6 +104,61 @@ describe('analyzeCurrentTurn', () => {
     expect(analyzeCurrentTurn(transcript).replied).toBe(true)
   })
 
+  // fix-loop #7: a reply whose tool_result came back isError did NOT reach the
+  // owner (e.g. blocked by the ask-guard) → it must NOT count as delivered, so
+  // the turn's final text stays eligible for the fallback (re-guarded there).
+  test('(a2) BLOCKED reply (isError result) does NOT set replied — final text forwards', () => {
+    const transcript = [
+      line('user', TG_PROMPT('164795011', 10)),
+      line('assistant', [{ type: 'text', text: 'жду го' }], 'u1'),
+      line(
+        'assistant',
+        [{ type: 'tool_use', id: 'tu1', name: 'mcp__dashi-channel__reply', input: { text: 'жду го' } }],
+        'u2',
+      ),
+      line('user', [{ type: 'tool_result', tool_use_id: 'tu1', is_error: true, content: 'ASK_GUARD ...' }]),
+    ].join('\n')
+    const r = analyzeCurrentTurn(transcript)
+    expect(r.replied).toBe(false)
+    expect(r.text).toBe('жду го')
+    expect(r.chatId).toBe('164795011')
+  })
+
+  test('(a3) SUCCESSFUL reply (non-error result) DOES set replied (suppress)', () => {
+    const transcript = [
+      line('user', TG_PROMPT('1', 10)),
+      line(
+        'assistant',
+        [{ type: 'tool_use', id: 'tu2', name: 'mcp__dashi-channel__reply', input: {} }],
+        'u2',
+      ),
+      line('user', [{ type: 'tool_result', tool_use_id: 'tu2', content: 'sent' }]),
+    ].join('\n')
+    expect(analyzeCurrentTurn(transcript).replied).toBe(true)
+  })
+
+  test('(a4) reply tool_use without an id still counts as replied (legacy transcript)', () => {
+    // No id on the tool_use → can never match an is_error tool_use_id → replied.
+    const transcript = [
+      line('user', TG_PROMPT('1', 10)),
+      line('assistant', [{ type: 'tool_use', name: 'mcp__dashi-channel__reply', input: {} }], 'u2'),
+    ].join('\n')
+    expect(analyzeCurrentTurn(transcript).replied).toBe(true)
+  })
+
+  test('(a5) a BLOCKED reply followed by a later SUCCESSFUL reply → replied (delivered)', () => {
+    // Same turn: first reply blocked (tu1 isError), agent rephrases and the
+    // second reply (tu2) succeeds → the owner got an answer → suppress.
+    const transcript = [
+      line('user', TG_PROMPT('1', 10)),
+      line('assistant', [{ type: 'tool_use', id: 'tu1', name: 'mcp__dashi-channel__reply', input: {} }], 'u1'),
+      line('user', [{ type: 'tool_result', tool_use_id: 'tu1', is_error: true, content: 'blocked' }]),
+      line('assistant', [{ type: 'tool_use', id: 'tu2', name: 'mcp__dashi-channel__reply', input: {} }], 'u2'),
+      line('user', [{ type: 'tool_result', tool_use_id: 'tu2', content: 'sent' }]),
+    ].join('\n')
+    expect(analyzeCurrentTurn(transcript).replied).toBe(true)
+  })
+
   test('(b) no reply tool + final text + telegram chat_id → would forward', () => {
     const transcript = [
       line('user', TG_PROMPT('164795011', 10)),

--- a/plugin/tests/hooks/fallback-reply-hook.test.ts
+++ b/plugin/tests/hooks/fallback-reply-hook.test.ts
@@ -147,16 +147,60 @@ describe('analyzeCurrentTurn', () => {
   })
 
   test('(a5) a BLOCKED reply followed by a later SUCCESSFUL reply → replied (delivered)', () => {
-    // Same turn: first reply blocked (tu1 isError), agent rephrases and the
-    // second reply (tu2) succeeds → the owner got an answer → suppress.
+    // Same turn: first reply ask-guard-blocked (tu1 isError + ASK_GUARD marker),
+    // agent rephrases and the second reply (tu2) succeeds → owner got an answer.
     const transcript = [
       line('user', TG_PROMPT('1', 10)),
       line('assistant', [{ type: 'tool_use', id: 'tu1', name: 'mcp__dashi-channel__reply', input: {} }], 'u1'),
-      line('user', [{ type: 'tool_result', tool_use_id: 'tu1', is_error: true, content: 'blocked' }]),
+      line('user', [{ type: 'tool_result', tool_use_id: 'tu1', is_error: true, content: 'ASK_GUARD (мандат…): не отправлен' }]),
       line('assistant', [{ type: 'tool_use', id: 'tu2', name: 'mcp__dashi-channel__reply', input: {} }], 'u2'),
       line('user', [{ type: 'tool_result', tool_use_id: 'tu2', content: 'sent' }]),
     ].join('\n')
     expect(analyzeCurrentTurn(transcript).replied).toBe(true)
+  })
+
+  // fix-loop-2 (Codex round-2 HIGH): a GENERIC reply error (network/HTTP
+  // timeout, no ASK_GUARD marker) is AMBIGUOUS — the send may have reached
+  // Telegram before the client saw the error — so it must KEEP the suppression
+  // (replied=true), otherwise the Stop-hook forwards the final text and the
+  // owner gets a DUPLICATE. Only an explicit ask-guard block unsuppresses.
+  test('(a6) generic reply error (no ASK_GUARD marker) → replied=true (suppress, no duplicate)', () => {
+    const transcript = [
+      line('user', TG_PROMPT('164795011', 10)),
+      line('assistant', [{ type: 'text', text: 'вот ответ' }], 'u1'),
+      line(
+        'assistant',
+        [{ type: 'tool_use', id: 'tu1', name: 'mcp__dashi-channel__reply', input: { text: 'вот ответ' } }],
+        'u2',
+      ),
+      line('user', [{ type: 'tool_result', tool_use_id: 'tu1', is_error: true, content: 'fetch failed: ETIMEDOUT' }]),
+    ].join('\n')
+    expect(analyzeCurrentTurn(transcript).replied).toBe(true)
+  })
+
+  // Counterpart to (a6): an explicit ASK-GUARD block (isError + marker, content
+  // as an array of text blocks) DOES unsuppress → the final text forwards.
+  test('(a7) ask-guard-blocked reply (marker in array content) → replied=false (forward)', () => {
+    const transcript = [
+      line('user', TG_PROMPT('164795011', 10)),
+      line('assistant', [{ type: 'text', text: 'жду го' }], 'u1'),
+      line(
+        'assistant',
+        [{ type: 'tool_use', id: 'tu1', name: 'mcp__dashi-channel__reply', input: { text: 'жду го' } }],
+        'u2',
+      ),
+      line('user', [
+        {
+          type: 'tool_result',
+          tool_use_id: 'tu1',
+          is_error: true,
+          content: [{ type: 'text', text: 'ASK_GUARD (мандат L-1): НЕ отправлен' }],
+        },
+      ]),
+    ].join('\n')
+    const r = analyzeCurrentTurn(transcript)
+    expect(r.replied).toBe(false)
+    expect(r.text).toBe('жду го')
   })
 
   test('(b) no reply tool + final text + telegram chat_id → would forward', () => {

--- a/plugin/tests/safety/ask-guard.test.ts
+++ b/plugin/tests/safety/ask-guard.test.ts
@@ -354,6 +354,38 @@ describe('analyzeAsk — «жду подтверждения» false-positive na
   })
 })
 
+// fix-loop-2 (Codex round-2) — two residual regex defects in the «жду
+// подтверждения» pattern.
+describe('analyzeAsk — «жду подтверждения» fix-loop-2 defects', () => {
+  // (a) The OLD terminal branch accepted ANY comma regardless of what followed,
+  // so a comma-continued STATUS wait self-gated. It must now require an owner
+  // ref after the comma; a plain «, что …» is a status wait → does NOT fire.
+  test('«жду подтверждения, что CI завершился» does NOT fire (comma+non-owner)', () => {
+    expect(
+      analyzeAsk('жду подтверждения, что CI завершился', { hasActiveLease: LEASE }),
+    ).toEqual([])
+  })
+
+  // (b) «жду твоего подтверждения» (owner-PREFIXED) is unambiguously
+  // owner-directed but the old pattern only looked AFTER the noun, so it missed
+  // the prefix and did NOT fire. It must now fire.
+  test('«жду твоего подтверждения» fires (owner-prefixed)', () => {
+    const f = analyzeAsk('жду твоего подтверждения', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_WAIT_GO')
+  })
+
+  test('«жду твоё подтверждение» fires (owner-prefixed, other case ending)', () => {
+    const f = analyzeAsk('жду твоё подтверждение', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_WAIT_GO')
+  })
+
+  // «жду подтверждения, вождь» — comma+owner ref DOES still fire.
+  test('«жду подтверждения, вождь» fires (comma+owner)', () => {
+    const f = analyzeAsk('жду подтверждения, вождь', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_WAIT_GO')
+  })
+})
+
 describe('analyzeAsk — fenced-code exclusion', () => {
   test('an ask INSIDE a ``` fence never fires', () => {
     const body = '```\nжду го\n```'

--- a/plugin/tests/safety/ask-guard.test.ts
+++ b/plugin/tests/safety/ask-guard.test.ts
@@ -1,0 +1,288 @@
+// Tests for the ask-guard (autonomy M3) — the pure, stateless analysis that
+// intercepts self-gating «жду го / дай добро»-style permission-asks when the
+// agent holds an ACTIVE owner-granted autonomy mandate (lease) for a chat.
+//
+// The analysis (analyzeAsk) is pure: identical input → identical findings, which
+// is what makes the no-resend-valve guarantee hold on the reply path. These
+// tests cover the tier-1 pattern hits, the hard-gate suppression, the
+// fence/blockquote/quote exclusions, the no-lease short-circuit, boundary
+// near-misses that must NOT fire, and the two message builders.
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  analyzeAsk,
+  askGuardAdvisoryHint,
+  askGuardBlockMessage,
+} from '../../src/safety/ask-guard.js'
+
+const LEASE = true as const
+
+describe('analyzeAsk — no-lease short-circuit', () => {
+  test('returns empty when no active lease, even for a blatant ask', () => {
+    expect(analyzeAsk('жду го, мой вождь', { hasActiveLease: false })).toEqual([])
+  })
+
+  test('returns empty for empty text (with lease)', () => {
+    expect(analyzeAsk('', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('returns empty for benign prose (with lease)', () => {
+    expect(analyzeAsk('Готово, мой вождь. Код чист.', { hasActiveLease: LEASE })).toEqual([])
+  })
+})
+
+describe('analyzeAsk — tier-1 pattern hits', () => {
+  test('«жду го» fires ASK_WAIT_GO', () => {
+    const f = analyzeAsk('жду го', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_WAIT_GO')
+  })
+
+  test('«жду твоего слова» fires ASK_WAIT_GO', () => {
+    const f = analyzeAsk('Готов начать, жду твоего слова.', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_WAIT_GO')
+  })
+
+  test('«жду отмашки» fires ASK_WAIT_GO', () => {
+    const f = analyzeAsk('Всё собрано, жду отмашки на мерж.', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_WAIT_GO')
+  })
+
+  test('«жду подтверждения» fires ASK_WAIT_GO', () => {
+    const f = analyzeAsk('жду подтверждения от тебя', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_WAIT_GO')
+  })
+
+  test('«жду команды» fires ASK_WAIT_GO', () => {
+    const f = analyzeAsk('жду команды, вождь', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_WAIT_GO')
+  })
+
+  test('«дай добро» fires ASK_GIVE_GO', () => {
+    const f = analyzeAsk('Дай добро — и я задеплою.', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_GIVE_GO')
+  })
+
+  test('«дай го» fires ASK_GIVE_GO', () => {
+    const f = analyzeAsk('дай го', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_GIVE_GO')
+  })
+
+  test('«дай отмашку» fires ASK_GIVE_GO', () => {
+    const f = analyzeAsk('дай отмашку', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_GIVE_GO')
+  })
+
+  test('«скажи да — и я запущу» fires ASK_SAY_YES', () => {
+    const f = analyzeAsk('скажи да — и я запущу пайплайн', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_SAY_YES')
+  })
+
+  test('«скажи го, тогда продолжу» fires ASK_SAY_YES', () => {
+    const f = analyzeAsk('скажи го, тогда продолжу', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_SAY_YES')
+  })
+
+  test('«подтверди, и начну» fires ASK_CONFIRM_THEN', () => {
+    const f = analyzeAsk('подтверди, и начну сборку', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_CONFIRM_THEN')
+  })
+
+  test('«подтвердишь тогда» fires ASK_CONFIRM_THEN', () => {
+    const f = analyzeAsk('подтвердишь тогда стартую', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_CONFIRM_THEN')
+  })
+
+  test('«нужно твоё да» fires ASK_NEED_YES', () => {
+    const f = analyzeAsk('Для мержа нужно твоё да.', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_NEED_YES')
+  })
+
+  test('«нужно твоё «да»» (guillemets) fires ASK_NEED_YES', () => {
+    const f = analyzeAsk('нужно твоё «да»', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_NEED_YES')
+  })
+
+  test('«могу продолжать?» fires ASK_CAN_I', () => {
+    const f = analyzeAsk('могу продолжать?', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_CAN_I')
+  })
+
+  test('«могу начинать?» fires ASK_CAN_I', () => {
+    const f = analyzeAsk('Всё готово. могу начинать?', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_CAN_I')
+  })
+
+  test('«жду решения по мержу» fires ASK_WAIT_DECISION', () => {
+    const f = analyzeAsk('жду решения по мержу', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_WAIT_DECISION')
+  })
+
+  test('«жду твоего решения по деплою» fires ASK_WAIT_DECISION', () => {
+    const f = analyzeAsk('жду твоего решения по деплою', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_WAIT_DECISION')
+  })
+
+  test('case-insensitive: «ЖДУ ГО» still fires', () => {
+    const f = analyzeAsk('ЖДУ ГО', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_WAIT_GO')
+  })
+})
+
+describe('analyzeAsk — findings shape', () => {
+  test('carries a clipped snippet of the offending fragment, not the whole body', () => {
+    const body = 'Огромный контекст перед этим. '.repeat(5) + 'жду го'
+    const f = analyzeAsk(body, { hasActiveLease: LEASE })
+    expect(f.length).toBeGreaterThan(0)
+    const snip = f[0]!.snippet
+    expect(snip.length).toBeLessThanOrEqual(60)
+    expect(snip.toLowerCase()).toContain('жду го')
+    // Never the whole message.
+    expect(snip.length).toBeLessThan(body.length)
+  })
+
+  test('dedupes by code — one finding per distinct pattern even on repeats', () => {
+    const f = analyzeAsk('жду го\nи ещё раз жду го', { hasActiveLease: LEASE })
+    const waitGo = f.filter((x) => x.code === 'ASK_WAIT_GO')
+    expect(waitGo.length).toBe(1)
+  })
+
+  test('multiple distinct patterns yield multiple findings', () => {
+    const f = analyzeAsk('дай добро.\nмогу продолжать?', { hasActiveLease: LEASE })
+    const codes = new Set(f.map((x) => x.code))
+    expect(codes.has('ASK_GIVE_GO')).toBe(true)
+    expect(codes.has('ASK_CAN_I')).toBe(true)
+  })
+})
+
+describe('analyzeAsk — hard-gate suppression', () => {
+  test('«деньги» in the same text suppresses all findings', () => {
+    expect(analyzeAsk('жду го на списание денег', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('«миграци» suppresses', () => {
+    expect(analyzeAsk('дай добро, применяю миграцию на прод', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('«платеж» suppresses', () => {
+    expect(analyzeAsk('могу продолжать? это платежный конфиг', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('«prod бд» suppresses', () => {
+    expect(analyzeAsk('жду отмашки на запись в prod бд', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('«rm -rf» suppresses', () => {
+    expect(analyzeAsk('дай го на rm -rf каталога', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('«force-push» suppresses', () => {
+    expect(analyzeAsk('подтверди, и сделаю force-push', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('«массовая рассылка» suppresses', () => {
+    expect(analyzeAsk('жду го на массовую рассылку юзерам', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('«деструктив» suppresses', () => {
+    expect(analyzeAsk('дай добро — операция деструктивная', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('«gateway» suppresses', () => {
+    expect(analyzeAsk('могу продолжать? нужен рестарт gateway', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('«биллинг» suppresses', () => {
+    expect(analyzeAsk('жду твоего слова по биллингу', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('hard-gate marker is judged over the WHOLE message, across lines', () => {
+    const body = 'жду го\n\nконтекст: это меняет платежный конфиг'
+    expect(analyzeAsk(body, { hasActiveLease: LEASE })).toEqual([])
+  })
+})
+
+describe('analyzeAsk — fenced-code exclusion', () => {
+  test('an ask INSIDE a ``` fence never fires', () => {
+    const body = '```\nжду го\n```'
+    expect(analyzeAsk(body, { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('prose ask outside the fence still fires while fenced copy is ignored', () => {
+    const body = '```\nдай добро\n```\nмогу продолжать?'
+    const f = analyzeAsk(body, { hasActiveLease: LEASE })
+    const codes = new Set(f.map((x) => x.code))
+    expect(codes.has('ASK_CAN_I')).toBe(true)
+    // The fenced «дай добро» must NOT contribute.
+    expect(codes.has('ASK_GIVE_GO')).toBe(false)
+  })
+})
+
+describe('analyzeAsk — blockquote / quoted-line exclusion', () => {
+  test('a «>»-quoted ask never fires', () => {
+    expect(analyzeAsk('> жду го', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('quoting the owner then acting: only the non-quoted line is scanned', () => {
+    const body = '> ты просил: жду го\nделаю сам, доложу.'
+    expect(analyzeAsk(body, { hasActiveLease: LEASE })).toEqual([])
+  })
+})
+
+describe('analyzeAsk — boundary near-misses do NOT fire', () => {
+  test('«жду городах» does not match «жду го»', () => {
+    expect(analyzeAsk('жду городах новых фич', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('«добросовестно» does not match «добро»', () => {
+    expect(analyzeAsk('делаю добросовестно и в срок', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('«жду результатов CI» does not fire', () => {
+    expect(analyzeAsk('жду результатов CI перед мержем', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('«жду завершения тестов» does not fire', () => {
+    expect(analyzeAsk('жду завершения тестов, доложу', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('«подтверждение доставки» (noun) does not fire ASK_CONFIRM_THEN', () => {
+    expect(analyzeAsk('пришло подтверждение доставки платежа', { hasActiveLease: LEASE })).toEqual([])
+  })
+})
+
+describe('analyzeAsk — never throws (fails open by contract)', () => {
+  test('handles CRLF and lone CR without throwing', () => {
+    expect(() => analyzeAsk('жду го\r\nещё\rтекст', { hasActiveLease: LEASE })).not.toThrow()
+  })
+
+  test('handles a very long single line', () => {
+    const body = 'слово '.repeat(5000) + 'жду го'
+    expect(() => analyzeAsk(body, { hasActiveLease: LEASE })).not.toThrow()
+  })
+})
+
+describe('askGuardAdvisoryHint / askGuardBlockMessage', () => {
+  test('advisory hint carries the lease id and the act-with-veto nudge, no message text', () => {
+    const hint = askGuardAdvisoryHint('L-20260710-abcd1234')
+    expect(hint).toContain('ask_guard_hint')
+    expect(hint).toContain('L-20260710-abcd1234')
+    expect(hint.toLowerCase()).toContain('act-with-veto')
+  })
+
+  test('block message names the lease, the scope, and the AskUserQuestion escape', () => {
+    const msg = askGuardBlockMessage('L-20260710-abcd1234', 'реализуй M3 ask-guard по порядку')
+    expect(msg).toContain('ASK_GUARD')
+    expect(msg).toContain('L-20260710-abcd1234')
+    expect(msg).toContain('реализуй M3 ask-guard')
+    expect(msg).toContain('AskUserQuestion')
+  })
+
+  test('block message clips an over-long scope', () => {
+    const longScope = 'очень длинный скоуп '.repeat(20)
+    const msg = askGuardBlockMessage('L-1', longScope)
+    // The full scope must not be echoed verbatim (it is clipped to ~80 cps).
+    expect(msg).toContain('…')
+    expect(msg.length).toBeLessThan(longScope.length + 200)
+  })
+})

--- a/plugin/tests/safety/ask-guard.test.ts
+++ b/plugin/tests/safety/ask-guard.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, test } from 'bun:test'
 
 import {
   analyzeAsk,
+  analyzeAskDetailed,
   askGuardAdvisoryHint,
   askGuardBlockMessage,
 } from '../../src/safety/ask-guard.js'
@@ -202,6 +203,157 @@ describe('analyzeAsk — hard-gate suppression', () => {
   })
 })
 
+// fix-loop #1 (Codex BLOCK-1 / Fable HIGH-1) — the hard-gate vocabulary must
+// exempt EVERY phrase both reviews raised. Each row is a self-gating ask that
+// ALSO names a hard-gate action → it must NOT self-gate (findings === []). The
+// Fable probe phrases and the Codex examples are enumerated verbatim.
+describe('analyzeAsk — hard-gate vocabulary (fix-loop #1, table-driven)', () => {
+  const EXEMPT: ReadonlyArray<[string, string]> = [
+    // — Fable probe phrases —
+    ['прод БД', 'жду го на запись в прод БД'],
+    ['прод-базу', 'дай добро — трону прод-базу'],
+    ['платёж (ё-fold)', 'могу продолжать? это платёж'],
+    ['оплата', 'жду отмашки на оплату подписки'],
+    ['оплаты', 'дай го — проведу оплаты'],
+    ['рассылка по базе', 'жду го на рассылку по базе'],
+    ['удаление данных', 'дай добро на удаление данных'],
+    // — Codex examples / hard-gate canon —
+    ['удалю данные', 'жду го — удалю данные пользователя'],
+    ['DROP TABLE', 'подтверди, и запущу DROP TABLE users'],
+    ['TRUNCATE', 'могу продолжать? это TRUNCATE logs'],
+    ['DELETE FROM', 'жду твоего слова на DELETE FROM orders'],
+    ['git reset --hard', 'дай го на git reset --hard origin/main'],
+    ['git clean', 'жду отмашки — сделаю git clean -fdx'],
+    ['production database', 'дай добро: migrate the production database'],
+    ['migration', 'жду го на migration to prod'],
+    ['migrate', 'могу начинать? нужно migrate now'],
+    ['billing', 'жду твоего слова по billing change'],
+    ['payment', 'дай добро на payment config edit'],
+    ['mass send', 'жду го на mass send to all users'],
+    ['broadcast', 'дай добро — broadcast to everyone'],
+    ['рестарт бота', 'могу продолжать? нужен рестарт бота'],
+    ['конфиг модели', 'жду го — правлю конфиг модели'],
+    ['конфиг gateway', 'дай добро на конфиг gateway'],
+    // — already-covered canon, kept as a regression floor —
+    ['rm -rf', 'дай го на rm -rf каталога'],
+    ['force-push', 'подтверди, и сделаю force-push'],
+    ['деньги', 'жду го на списание денег'],
+  ]
+
+  for (const [label, body] of EXEMPT) {
+    test(`«${label}» exempts (delivers): ${body}`, () => {
+      expect(analyzeAsk(body, { hasActiveLease: LEASE })).toEqual([])
+    })
+  }
+})
+
+// The self-gate phrases must STILL fire when NO hard-gate marker is present —
+// the broadened vocabulary must not swallow the guard entirely.
+describe('analyzeAsk — self-gates still fire without a hard-gate marker (fix-loop #1)', () => {
+  const FIRES: ReadonlyArray<[string, string, string]> = [
+    ['ASK_WAIT_GO', 'жду го', 'жду го, мой вождь'],
+    ['ASK_GIVE_GO', 'дай добро', 'дай добро — и я задеплою лендинг'],
+    ['ASK_SAY_YES', 'скажи да', 'скажи да — и я запущу сборку'],
+    ['ASK_CONFIRM_THEN', 'подтверди, и', 'подтверди, и начну'],
+    ['ASK_NEED_YES', 'нужно твоё да', 'для мержа нужно твоё да'],
+    ['ASK_CAN_I', 'могу продолжать?', 'могу продолжать?'],
+    ['ASK_WAIT_DECISION', 'жду решения по мержу', 'жду решения по мержу'],
+  ]
+  for (const [code, label, body] of FIRES) {
+    test(`«${label}» still fires ${code}`, () => {
+      const f = analyzeAsk(body, { hasActiveLease: LEASE })
+      expect(f.map((x) => x.code)).toContain(code)
+    })
+  }
+})
+
+// fix-loop #2 (Codex HIGH-3 / Fable LOW-5) — hard-gate vs protected zones.
+describe('analyzeAskDetailed — protected-only hard-gate classification (fix-loop #2)', () => {
+  test('marker in real prose → exemptReason "hard_gate"', () => {
+    const r = analyzeAskDetailed('жду го на списание денег', { hasActiveLease: LEASE })
+    expect(r.findings).toEqual([])
+    expect(r.exemptReason).toBe('hard_gate')
+  })
+
+  test('marker ONLY inside a fence → exemptReason "hard_gate_protected_only", still exempt', () => {
+    const body = 'жду го\n```\nплатеж по счёту\n```'
+    const r = analyzeAskDetailed(body, { hasActiveLease: LEASE })
+    // Still exempt (whole-text OR fails safe)...
+    expect(r.findings).toEqual([])
+    // ...but flagged as protected-only for calibration.
+    expect(r.exemptReason).toBe('hard_gate_protected_only')
+  })
+
+  test('marker ONLY inside a blockquote → protected-only', () => {
+    const body = 'жду го\n> контекст: платёж пройдёт завтра'
+    const r = analyzeAskDetailed(body, { hasActiveLease: LEASE })
+    expect(r.findings).toEqual([])
+    expect(r.exemptReason).toBe('hard_gate_protected_only')
+  })
+
+  test('a clean self-gate carries no exemptReason', () => {
+    const r = analyzeAskDetailed('жду го', { hasActiveLease: LEASE })
+    expect(r.findings.map((x) => x.code)).toContain('ASK_WAIT_GO')
+    expect(r.exemptReason).toBeUndefined()
+  })
+
+  test('no lease → no findings, no exemptReason (short-circuit)', () => {
+    const r = analyzeAskDetailed('жду го на списание денег', { hasActiveLease: false })
+    expect(r.findings).toEqual([])
+    expect(r.exemptReason).toBeUndefined()
+  })
+})
+
+// fix-loop #4 (Codex MED-4 / Fable MED-4) — «жду подтверждения X» must fire
+// only when owner-directed; a wait on an external system's confirmation is a
+// legitimate status, not a self-gate.
+describe('analyzeAsk — «жду подтверждения» false-positive narrowing (fix-loop #4)', () => {
+  test('bare «жду подтверждения» (clause end) fires ASK_WAIT_GO', () => {
+    const f = analyzeAsk('всё собрано, жду подтверждения.', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_WAIT_GO')
+  })
+
+  test('«жду подтверждения от тебя» fires (owner-directed)', () => {
+    const f = analyzeAsk('жду подтверждения от тебя', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_WAIT_GO')
+  })
+
+  test('«жду подтверждение, вождь» fires (owner-directed)', () => {
+    const f = analyzeAsk('жду подтверждение, вождь', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_WAIT_GO')
+  })
+
+  test('«жду подтверждения твоего решения» fires (owner-directed)', () => {
+    const f = analyzeAsk('жду подтверждения твоего решения', { hasActiveLease: LEASE })
+    expect(f.map((x) => x.code)).toContain('ASK_WAIT_GO')
+  })
+
+  // Status waits on external systems — must NOT fire.
+  test('«жду подтверждения завершения workflow от GitHub» does NOT fire', () => {
+    expect(
+      analyzeAsk('жду подтверждения завершения workflow от GitHub', { hasActiveLease: LEASE }),
+    ).toEqual([])
+  })
+
+  test('«жду подтверждения вебхука» does NOT fire', () => {
+    expect(analyzeAsk('жду подтверждения вебхука', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('«жду подтверждения от провайдера» (bank/provider) does NOT fire', () => {
+    // Note: no «оплаты» here, so the narrowing (not the hard-gate) is what
+    // suppresses it — «от провайдера» is not an owner reference.
+    expect(analyzeAsk('жду подтверждения от провайдера', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('«жду подтверждения статуса CI» (CI) does NOT fire', () => {
+    expect(analyzeAsk('жду подтверждения статуса CI', { hasActiveLease: LEASE })).toEqual([])
+  })
+
+  test('«жду подтверждения от внешней системы» does NOT fire', () => {
+    expect(analyzeAsk('жду подтверждения от внешней системы', { hasActiveLease: LEASE })).toEqual([])
+  })
+})
+
 describe('analyzeAsk — fenced-code exclusion', () => {
   test('an ask INSIDE a ``` fence never fires', () => {
     const body = '```\nжду го\n```'
@@ -271,7 +423,7 @@ describe('askGuardAdvisoryHint / askGuardBlockMessage', () => {
   })
 
   test('block message names the lease, the scope, and the AskUserQuestion escape', () => {
-    const msg = askGuardBlockMessage('L-20260710-abcd1234', 'реализуй M3 ask-guard по порядку')
+    const msg = askGuardBlockMessage('L-20260710-abcd1234', ['реализуй M3 ask-guard по порядку'])
     expect(msg).toContain('ASK_GUARD')
     expect(msg).toContain('L-20260710-abcd1234')
     expect(msg).toContain('реализуй M3 ask-guard')
@@ -280,9 +432,35 @@ describe('askGuardAdvisoryHint / askGuardBlockMessage', () => {
 
   test('block message clips an over-long scope', () => {
     const longScope = 'очень длинный скоуп '.repeat(20)
-    const msg = askGuardBlockMessage('L-1', longScope)
+    const msg = askGuardBlockMessage('L-1', [longScope])
     // The full scope must not be echoed verbatim (it is clipped to ~80 cps).
     expect(msg).toContain('…')
     expect(msg.length).toBeLessThan(longScope.length + 200)
+  })
+
+  // fix-loop #3: the block message must NOT assert the ask is in-scope /
+  // authorized (that is exactly the false claim the reviewers flagged). It
+  // presents both branches (hard-gate → card; in-scope → act-with-veto) and
+  // lets the model self-check.
+  test('block message does NOT claim the ask is authorized/in-scope', () => {
+    const msg = askGuardBlockMessage('L-1', ['deploy the frontend'])
+    // Presents the hard-gate escape and the act-with-veto branch...
+    expect(msg).toContain('AskUserQuestion')
+    expect(msg.toLowerCase()).toContain('act-with-veto')
+    expect(msg).toContain('hard-gate')
+    // ...but never asserts «это in-scope вопрос» (the removed false claim).
+    expect(msg).not.toContain('Это in-scope')
+  })
+
+  test('block message lists ALL active lease scopes, not just the first', () => {
+    const msg = askGuardBlockMessage('L-1', ['scope alpha', 'scope beta'])
+    expect(msg).toContain('scope alpha')
+    expect(msg).toContain('scope beta')
+  })
+
+  test('block message tolerates an empty scope list', () => {
+    const msg = askGuardBlockMessage('L-1', [])
+    expect(msg).toContain('ASK_GUARD')
+    expect(msg).toContain('L-1')
   })
 })

--- a/plugin/tests/webhook/fallback-reply-route.test.ts
+++ b/plugin/tests/webhook/fallback-reply-route.test.ts
@@ -254,6 +254,24 @@ describe('POST /hooks/fallback-reply — ask-guard', () => {
     expect(calls.length).toBe(1)
   })
 
+  // fix-loop-2 (Codex round-2): a comma-continued STATUS wait must NOT be
+  // discarded by the guard — «жду подтверждения, что CI завершился» is a status
+  // report, not a self-gate, so the fallback forwards it (regression guard for
+  // the narrowed «жду подтверждения» comma branch).
+  test('block mode + active lease + CI-status wait → forwarded (not discarded)', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    process.env.ASK_GUARD_MODE = 'block'
+    seedActiveLease(WARCHIEF_ID)
+    const { h, calls } = await start()
+    const resp = await post(h, {
+      chat_id: WARCHIEF_ID,
+      text: 'жду подтверждения, что CI завершился',
+    })
+    expect(resp.status).toBe(200)
+    expect(await resp.json()).toEqual({ status: 'sent' })
+    expect(calls).toEqual([{ chatId: WARCHIEF_ID, text: 'жду подтверждения, что CI завершился' }])
+  })
+
   test('advisory mode + active lease + self-gate → forwarded unchanged', async () => {
     process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
     process.env.ASK_GUARD_MODE = 'advisory'

--- a/plugin/tests/webhook/fallback-reply-route.test.ts
+++ b/plugin/tests/webhook/fallback-reply-route.test.ts
@@ -14,6 +14,7 @@ import { join } from 'path'
 import { getStatePaths, loadConfig, type AppConfig, type StatePaths } from '../../src/config.js'
 import { createLogger } from '../../src/log.js'
 import { ensureStateDirs } from '../../src/state/store.js'
+import { addLease, emptyAutonomyState, saveAutonomyState } from '../../src/autonomy/store.js'
 import { startWebhookServer, type WebhookDeps, type WebhookServerHandle } from '../../src/webhook/server.js'
 
 const FAKE_TOKEN = '123456789:AAH-fake_test_token_with_at_least_thirty_chars'
@@ -25,6 +26,20 @@ let stateDir: string
 let paths: StatePaths
 let baseConfig: AppConfig
 let handle: WebhookServerHandle | null
+let savedAskMode: string | undefined
+
+const HOUR = 3_600_000
+
+// Seed an ACTIVE lease into the per-chat autonomy registry used by the route
+// (deps.statePaths = paths). chatId is the fallback body's chat_id.
+function seedActiveLease(chatId: string): void {
+  const { state } = addLease(
+    emptyAutonomyState(),
+    { scope: 'реализуй фичу по порядку', expiresAtMs: Date.now() + 4 * HOUR, source: 'owner_cmd', chatId },
+    Date.now(),
+  )
+  saveAutonomyState(paths, chatId, state)
+}
 
 interface StubMcp {
   server: { notification: () => Promise<void> }
@@ -45,6 +60,8 @@ beforeEach(() => {
   paths = getStatePaths(baseConfig, { TELEGRAM_BOT_TOKEN: FAKE_TOKEN, TELEGRAM_STATE_DIR: stateDir })
   ensureStateDirs(paths)
   handle = null
+  savedAskMode = process.env.ASK_GUARD_MODE
+  delete process.env.ASK_GUARD_MODE
 })
 
 afterEach(async () => {
@@ -53,6 +70,8 @@ afterEach(async () => {
     handle = null
   }
   delete process.env.TELEGRAM_WEBHOOK_TOKEN
+  if (savedAskMode === undefined) delete process.env.ASK_GUARD_MODE
+  else process.env.ASK_GUARD_MODE = savedAskMode
   rmSync(stateDir, { recursive: true, force: true })
 })
 
@@ -195,5 +214,76 @@ describe('POST /hooks/fallback-reply', () => {
     expect(resp.status).toBe(200)
     expect(await resp.json()).toEqual({ status: 'sent' })
     expect(calls).toEqual([{ chatId: WARCHIEF_ID, text: cjk }])
+  })
+})
+
+// fix-loop #7 (Fable MED-3) — the fallback route runs the SAME ask-guard so a
+// blocked reply's final text cannot bypass the choke point through the DM
+// fallback path.
+describe('POST /hooks/fallback-reply — ask-guard', () => {
+  test('block mode + active lease + self-gate → NOT forwarded, status ask_guard_blocked', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    process.env.ASK_GUARD_MODE = 'block'
+    seedActiveLease(WARCHIEF_ID)
+    const { h, calls } = await start()
+    const resp = await post(h, { chat_id: WARCHIEF_ID, text: 'жду го, мой вождь' })
+    expect(resp.status).toBe(200)
+    expect(await resp.json()).toEqual({ status: 'ask_guard_blocked' })
+    expect(calls).toEqual([]) // nothing sent to the owner
+  })
+
+  test('block mode + active lease + BENIGN status text → forwarded (rephrased status goes out)', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    process.env.ASK_GUARD_MODE = 'block'
+    seedActiveLease(WARCHIEF_ID)
+    const { h, calls } = await start()
+    const resp = await post(h, { chat_id: WARCHIEF_ID, text: 'Готово, мой вождь. Задеплоил.' })
+    expect(resp.status).toBe(200)
+    expect(await resp.json()).toEqual({ status: 'sent' })
+    expect(calls).toEqual([{ chatId: WARCHIEF_ID, text: 'Готово, мой вождь. Задеплоил.' }])
+  })
+
+  test('block mode + active lease + hard-gate self-gate → forwarded (hard-gate exempt)', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    process.env.ASK_GUARD_MODE = 'block'
+    seedActiveLease(WARCHIEF_ID)
+    const { h, calls } = await start()
+    const resp = await post(h, { chat_id: WARCHIEF_ID, text: 'жду го на списание денег' })
+    expect(resp.status).toBe(200)
+    expect(await resp.json()).toEqual({ status: 'sent' })
+    expect(calls.length).toBe(1)
+  })
+
+  test('advisory mode + active lease + self-gate → forwarded unchanged', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    process.env.ASK_GUARD_MODE = 'advisory'
+    seedActiveLease(WARCHIEF_ID)
+    const { h, calls } = await start()
+    const resp = await post(h, { chat_id: WARCHIEF_ID, text: 'жду го' })
+    expect(resp.status).toBe(200)
+    expect(await resp.json()).toEqual({ status: 'sent' })
+    expect(calls).toEqual([{ chatId: WARCHIEF_ID, text: 'жду го' }])
+  })
+
+  test('block mode but NO active lease → forwarded (guard inert)', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    process.env.ASK_GUARD_MODE = 'block'
+    // no lease seeded
+    const { h, calls } = await start()
+    const resp = await post(h, { chat_id: WARCHIEF_ID, text: 'жду го' })
+    expect(resp.status).toBe(200)
+    expect(await resp.json()).toEqual({ status: 'sent' })
+    expect(calls.length).toBe(1)
+  })
+
+  test('kill-switch off + active lease + self-gate → forwarded (guard disabled)', async () => {
+    process.env.TELEGRAM_WEBHOOK_TOKEN = WEBHOOK_TOKEN
+    process.env.ASK_GUARD_MODE = 'off'
+    seedActiveLease(WARCHIEF_ID)
+    const { h, calls } = await start()
+    const resp = await post(h, { chat_id: WARCHIEF_ID, text: 'жду го' })
+    expect(resp.status).toBe(200)
+    expect(await resp.json()).toEqual({ status: 'sent' })
+    expect(calls.length).toBe(1)
   })
 })


### PR DESCRIPTION
## Автономия M3 — ask-guard на reply-пути

Третья веха автономии (после M1 lease-store #110, M2 [LEASE:]-карточек #112, M4 delivery/heartbeat #111). Перехватывает self-gating «жду го / дай добро» на owner-egress reply-пути, когда у чата уже есть активный мандат — вождь передал полномочия внутри scope, агент должен ДЕЙСТВОВАТЬ (act-with-veto), а не переспрашивать.

### Дизайн
- **`src/safety/ask-guard.ts`** — чистый stateless-анализ `analyzeAsk(text, { hasActiveLease })`. Стиль зеркалит `format-check`: fence-protected построчный скан, модель находок, по контракту не бросает (caller трактует throw как «нет находок» и fail-open).
- **Срабатывает ТОЛЬКО** когда: активный лиз для чата (через M1 `activeLeases`) И self-gating паттерн И НЕТ hard-gate маркеров.
- **Tier-1 паттерны** (narrow, Russian, Cyrillic-aware границы `\b` не работает для кириллицы): «жду (го/отмашки/твоего слова/подтверждения/команды/добро)», «дай (го/добро/отмашку)», «скажи да — и запущу», «подтверди, и…», «нужно твоё да», «могу продолжать?», «жду решения по мержу/деплою». Near-miss («жду городах», «добросовестно», «жду результатов CI», «жду завершения тестов») не срабатывают.
- **Hard-gate подавление**: деньги/платёж/биллинг/prod БД/миграции/rm -rf/force-push/деструктив/массовая рассылка/gateway/model config — такие вопросы легитимны при любом лизе, находки подавляются на всём тексте. (Стем `деньг` расширен до `ден[ье]г` — покрывает genitive «денег», иначе реальный money-ask ошибочно перехватывался бы как self-gate.)

### Режимы (`resolveAskGuardMode`)
- **`off`** — kill-switch. **`advisory`** (дефолт калибровочной недели) — ответ уходит + `ask_guard_hint` в tool-result. **`block`** — ответ НЕ отправляется (isError), агенту возвращается инструкция: активен мандат — действуй act-with-veto, ЛИБО для настоящего решения — карточка AskUserQuestion (этот путь НИКОГДА не гардится), ЛИБО вождь оверрайдит.
- Приоритет: kill-switch `ASK_GUARD_ENABLED` (0/false/no/off) > `ASK_GUARD_MODE` env > `config.ask_guard.mode` > `advisory`. Env читается из `process.env` напрямую (паттерн `resolveContextWindowOverride`).

### Точка перехвата
Единственная — `case 'reply'` в `src/channel/tools.ts` (после guest-возврата и `assertAllowedChat`, до отправки). Guest-путь возвращается раньше, `edit_message`/`react`/`status` — отдельные case, AskUserQuestion — отдельный tool. Fail-open на любой ошибке гарда.

### Без resend-valve (Sol architecture decision)
`analyzeAsk` чистая/stateless: идентичный вход → идентичная находка. Повторная отправка того же заблокированного текста блокируется так же — нет логики «второй раз проходит».

### Исключения от false-positive
Fenced-код (```), «>»-blockquote и цитаты не матчатся — скан идёт по plain-prose остатку через `fenceProtectedLines`.

### Логирование
Структурные решения (`ask_guard_block` / `ask_guard_advisory` / `ask_guard_error`) с guardVersion-аналогом (code), leaseId, matched pattern, mode — через существующий `log` (тот же механизм, что forensics M1).

### Тесты (+70, всего 2625 pass / 0 fail)
- `tests/safety/ask-guard.test.ts` (50): tier-1 хиты, дедуп по code, сниппет-клиппинг, hard-gate подавление (вкл. «денег»), fenced/blockquote/near-miss исключения, не бросает, message-builders.
- `tests/config.test.ts` (+10): дефолт advisory, config-режим, env-override, регистронезависимость, kill-switch варианты.
- `tests/channel/tools.ask-guard.test.ts` (10): block не отправляет + isError, no-resend-valve, advisory+hint, no-lease/hard-gate/benign проходят, kill-switch, edit_message не гардится.
- `tsc --noEmit` чистый, `bun test` — 2625 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Fix-loop 1 (двойное ревью: Codex GPT-5.6 Sol = BLOCK, Fable = SHIP-WITH-CHANGES)

Дизайн сохранён (no resend-valve, fail-open, advisory-дефолт). Устранены все консолидированные находки; suite 2625 → **2692 pass / 0 fail** (+67 тестов), `tsc --noEmit` чист.

| # | Находка (ревьюер) | Статус | Как закрыто |
|---|---|---|---|
| 1 | Узкий словарь hard-gate (Codex BLOCK-1 / Fable HIGH-1, safety) | fixed | `HARD_GATE_RE` расширен: прод-БД/прод-базу, оплата, платёж (ё→е-fold на копии), рассылка/broadcast/mass send, удал+, DROP TABLE/TRUNCATE/DELETE FROM, git reset --hard/clean, migration, billing/payment, рестарт бота, конфиг модели/gateway. Принцип «при неоднозначности — EXEMPT». Табличный регресс-тест на все фразы обоих ревью + тесты, что self-gates всё ещё срабатывают без hard-gate-маркера. |
| 2 | Hard-gate vs protected zones (Codex HIGH-3 / Fable LOW-5) | fixed | `analyzeAskDetailed`: whole-text OR (fail-safe) + повторная проверка на fence/quote-masked прозе; `exemptReason='hard_gate_protected_only'` логируется отдельным кодом `ask_guard_exempt_protected_only` на reply-пути и в fallback-роуте. |
| 3 | Block-message утверждает in-scope/authorized (Codex HIGH-2 / Fable MED-2) | fixed | Переписан: сперва hard-gate→AskUserQuestion (не гейтится), затем act-with-veto; печатает ВСЕ активные scope. Никаких заявлений об авторизации. |
| 4 | FP «жду подтверждения X» (Codex MED-4 / Fable MED-4) | fixed | Срабатывает только owner-directed (голое + терминал, или «от тебя/твоего/вождь»). Статус-кейсы CI/провайдер/вебхук/workflow не гейтятся — добавлены тесты. |
| 5 | Fail-open catch (Codex MED-5) | fixed | log-вызов в catch обёрнут вложенным try/catch; тест с throwing-логгером (advisory и block) доказывает доставку. |
| 6 | Config resolver (Codex LOW-6) | fixed | invalid `ASK_GUARD_MODE` (напр. «of») → advisory + warn, не удерживает сконфигурированный block; empty = unset. |
| 7 | Fallback-route обход (Fable MED-3) | fixed | (a) `POST /hooks/fallback-reply` прогоняет тот же гард: block→не форвардит (`ask_guard_blocked`), advisory→форвардит+лог, fail-open. (b) Stop-хук: reply tool_use с isError-результатом больше не считается «доставленным» — блокированный reply не гасит fallback, финальный текст доходит до роута и пере-гардится. Тесты на обе ветки. |
| 8 | Недостающие интеграционные тесты (Fable LOW-6) | fixed | Чекпоинт: expired lease, revoked lease, lease в другом чате, fail-open throw после loadAutonomyState. |
| 9 | «single choke point» комментарий overclaim (Fable) | fixed | Переформулирован: покрытие = reply-tool; edit_message unguarded by design; fallback-route теперь под гардом. |

**Коммиты:** `948cf12` (ядро 1-4), `47cbbb1` (resolver 6), `a1cad1e` (choke point 2/3/5/8/9), `9975030` (fallback 7).

**Споров/отклонений нет** — все находки приняты как обоснованные.



---

## Fix-loop 2 (контрольное round-2 Codex GPT-5.6 Sol: 3 остаточных дефекта)

Fix-loop 1 подтверждён; Codex round-2 нашёл 3 остаточных дефекта. Устранены точечно; suite 2692 → **2699 pass / 0 fail** (+7 тестов), `tsc --noEmit` чист.

| # | Находка (Codex round-2) | Статус | Как закрыто |
|---|---|---|---|
| 1 | HIGH — Stop-хук снимал подавление на ЛЮБОЙ `isError` reply. При неоднозначном сбое Telegram/сети (сервер мог принять до таймаута клиента) это давало ДУБЛЬ доставки. | fixed | Подавление снимается ТОЛЬКО при явном машиночитаемом маркере ask-guard блока. `askGuardBlockMessage` теперь начинается с экспортируемой константы `ASK_GUARD_BLOCK_MARKER` (ask-guard.ts); хук импортирует её и матчит текст tool_result (строка ИЛИ массив `{type:'text'}`-блоков). `errorToolResultIds`→`askGuardBlockedReplyIds` (только isError + маркер). Generic-ошибки сохраняют старое подавление (reply считается доставленным). Тесты: (a6) generic network-error → replied=true (нет дубля); (a7) ask-guard блок с маркером в array-content → replied=false (форвард). |
| 2 | HIGH — регекс «жду подтверждения»: (a) ветка пунктуации принимала ЛЮБУЮ запятую, «жду подтверждения, что CI завершился» ложно срабатывал; (b) «жду твоего подтверждения» (owner-directed) НЕ матчился. | fixed | Регекс разбит на две ветки: (A) owner-PREFIXED «жду тво[её]… подтверждения» — срабатывает всегда (money-хвост ловит whole-text hard-gate); (B) без префикса «жду подтверждения» + один из: терминальная не-запятая пунктуация → конец строки, ЛИБО запятая+owner-реф, ЛИБО пробел+owner-реф. Запятая больше не терминальна сама по себе. Тесты: «…, что CI завершился» не срабатывает; «жду твоего подтверждения» / «жду твоё подтверждение» / «жду подтверждения, вождь» срабатывают; route-регресс — CI-status wait форвардится (`status:'sent'`), не отбрасывается. |
| 3 | LOW — код телеметрии `ask_guard_exempt_protected_only` расходился с контрактом PR (`hard_gate_protected_only`). | fixed | Канонический код = `hard_gate_protected_only` (совпадает с `AskExemptReason`). Выровнены оба emit-сайта: `src/channel/tools.ts` и `src/webhook/routes/fallback-reply.ts`. Констант/тестов на старую строку не было. |

**Коммит:** `738dd29`.

**Споров/отклонений нет** — все три находки приняты.
