### PR TITLE
Редактор секретов: публичные IPv4 показываются целиком, маскируются только приватные

### DIFF
--- a/plugin/src/safety/redact.ts
+++ b/plugin/src/safety/redact.ts
@@ -118,14 +118,53 @@ const DISCORD_WEBHOOK_RE =
   /(discord(?:app)?\.com\/api\/webhooks\/\d+\/)[A-Za-z0-9_-]+/gi
 const SLACK_WEBHOOK_RE = /(hooks\.slack\.com\/services\/)[A-Za-z0-9/]+/gi
 
-// IPv4 — keep first and last octet (helps debugging) and mask the middle
-// two. Loopback (127.*) and 0.* placeholders are pure debug noise; the
-// callback returns the raw match unchanged for those so operators can read
-// "127.0.0.1" verbatim. Port of activity-renderer.ts:62-73.
-const IPV4_RE = /\b(\d{1,3})\.\d{1,3}\.\d{1,3}\.(\d{1,3})\b/g
-function ipv4Replacer(full: string, first: string, last: string): string {
-  if (first === '127' || first === '0') return full
-  return `${first}.***.***.${last}`
+// IPv4 — mask ONLY private/internal ranges plus any operator-configured host
+// IP(s); PUBLIC addresses pass through in full. Rationale: public IPs that show
+// up in operator messages are values people NEED to read whole — a static-host
+// or CDN A-record, a client's current DNS host, etc. Blanket middle-octet
+// masking broke DNS-guidance workflows. What actually warrants hiding is a
+// deployment's own server address and internal (RFC1918/CGNAT/link-local)
+// topology. Loopback (127.*) and 0.* stay verbatim as debug noise.
+const IPV4_RE = /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g
+// Extra host IP(s) to mask alongside the private ranges — typically the
+// deployment's own public server address, which an operator may not want
+// echoed into chat or logs. Supplied via the DASHI_OWN_HOST_IPS env var as a
+// comma-separated list; empty by default, so with nothing configured every
+// public IP is shown in full. Deliberately NOT hardcoded: a specific
+// deployment's server address is not a value that belongs in shared source.
+// Read per call so the list can change without restarting the process.
+function ownHostIps(): ReadonlySet<string> {
+  return new Set(
+    (process.env.DASHI_OWN_HOST_IPS ?? '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  )
+}
+function isPrivateIpv4(a: number, b: number): boolean {
+  if (a === 10) return true // 10.0.0.0/8
+  if (a === 172 && b >= 16 && b <= 31) return true // 172.16.0.0/12
+  if (a === 192 && b === 168) return true // 192.168.0.0/16
+  if (a === 169 && b === 254) return true // 169.254.0.0/16 link-local
+  if (a === 100 && b >= 64 && b <= 127) return true // 100.64.0.0/10 CGNAT
+  return false
+}
+function ipv4Replacer(full: string): string {
+  const parts = full.split('.')
+  if (parts.length !== 4) return full
+  const nums = parts.map((p) => Number.parseInt(p, 10))
+  const a = nums[0]
+  const b = nums[1]
+  const d = nums[3]
+  // Guards double as noUncheckedIndexedAccess narrowing. A malformed octet
+  // (> 255 — e.g. a version string "999.1.2.3") is not an IP; leave it be.
+  if (a === undefined || b === undefined || d === undefined) return full
+  if (nums.some((n) => Number.isNaN(n) || n < 0 || n > 255)) return full
+  if (a === 127 || a === 0) return full // loopback / placeholder — show
+  if (ownHostIps().has(full) || isPrivateIpv4(a, b)) {
+    return `${a}.***.***.${d}`
+  }
+  return full // public IP — shown in full (DNS records people must read)
 }
 
 // Secret paths.
@@ -241,7 +280,7 @@ const RULES: ReadonlyArray<RedactionRule> = [
   { pattern: JWT_RE, replacement: '[REDACTED]' },
   { pattern: DISCORD_WEBHOOK_RE, replacement: '$1[REDACTED]' },
   { pattern: SLACK_WEBHOOK_RE, replacement: '$1[REDACTED]' },
-  // 4. IPv4 — middle-octet mask.
+  // 4. IPv4 — mask private/internal + own-host only; public IPs shown.
   { pattern: IPV4_RE, replacement: ipv4Replacer },
   // 5. Secret paths.
   { pattern: SECRET_PATH_TILDE_RE, replacement: '$1secrets/***' },

--- a/plugin/tests/safety/redact.test.ts
+++ b/plugin/tests/safety/redact.test.ts
@@ -81,14 +81,55 @@ describe('redactSecrets — Bearer + query-string', () => {
 })
 
 describe('redactSecrets — IPv4 masking', () => {
-  test('masks middle octets of public IPv4, keeps first+last', () => {
+  test('masks private ranges, shows public IPs in full', () => {
+    // Private ranges — masked (keep first + last octet).
     expect(redactSecrets('connect 10.2.3.44 done')).toBe('connect 10.***.***.44 done')
-    expect(redactSecrets('host 8.8.8.8')).toBe('host 8.***.***.8')
+    expect(redactSecrets('lan 192.168.1.1')).toBe('lan 192.***.***.1')
+    expect(redactSecrets('cgn 100.64.5.9')).toBe('cgn 100.***.***.9')
+    expect(redactSecrets('vpc 172.20.5.9')).toBe('vpc 172.***.***.9')
+    // Public IPs — shown in full (DNS records people must read).
+    // Examples use RFC 5737 documentation ranges; a real CDN / static-host
+    // A-record (the motivating case) is public and must stay readable.
+    expect(redactSecrets('host 192.0.2.1')).toBe('host 192.0.2.1')
+    expect(redactSecrets('A 192.0.2.153')).toBe('A 192.0.2.153')
+    // 172.x outside 16-31 is public — shown.
+    expect(redactSecrets('pub 172.15.0.1')).toBe('pub 172.15.0.1')
+    expect(redactSecrets('pub 172.32.0.1')).toBe('pub 172.32.0.1')
+  })
+
+  test('masks IPs configured via DASHI_OWN_HOST_IPS, shows others', () => {
+    const saved = process.env.DASHI_OWN_HOST_IPS
+    try {
+      // TEST-NET-3 / TEST-NET-2 documentation addresses (RFC 5737).
+      process.env.DASHI_OWN_HOST_IPS = '203.0.113.7, 198.51.100.4'
+      expect(redactSecrets('srv 203.0.113.7')).toBe('srv 203.***.***.7')
+      expect(redactSecrets('alt 198.51.100.4')).toBe('alt 198.***.***.4')
+      // A public IP not in the list is still shown.
+      expect(redactSecrets('cdn 192.0.2.1')).toBe('cdn 192.0.2.1')
+    } finally {
+      if (saved === undefined) delete process.env.DASHI_OWN_HOST_IPS
+      else process.env.DASHI_OWN_HOST_IPS = saved
+    }
+  })
+
+  test('with no DASHI_OWN_HOST_IPS set, all public IPs pass through', () => {
+    const saved = process.env.DASHI_OWN_HOST_IPS
+    try {
+      delete process.env.DASHI_OWN_HOST_IPS
+      expect(redactSecrets('srv 203.0.113.7')).toBe('srv 203.0.113.7')
+    } finally {
+      if (saved !== undefined) process.env.DASHI_OWN_HOST_IPS = saved
+    }
   })
 
   test('leaves loopback 127.* and 0.* untouched', () => {
     expect(redactSecrets('curl 127.0.0.1:8080')).toBe('curl 127.0.0.1:8080')
     expect(redactSecrets('bind 0.0.0.0:80')).toBe('bind 0.0.0.0:80')
+  })
+
+  test('idempotent on masked IPv4', () => {
+    const once = redactSecrets('lan 192.168.1.1 wan 10.0.0.5')
+    expect(redactSecrets(once)).toBe(once)
   })
 })
 
@@ -345,7 +386,7 @@ describe('redactSecrets — idempotency', () => {
       'token=8507713167:AABBCCDDEEFFGGHHIIJJKKLLMMNNOOPPQQRR',
       'GROQ=gsk_' + 'X'.repeat(45),
       'Authorization: Bearer abcdefghijklmnopqrstuvwxyz1234',
-      'ip 8.8.8.8',
+      'ip 192.0.2.1',
       'host abcdefghij1234567890.supabase.co',
       '"private_key":"deadbeef"',
     ].join(' ')

--- a/plugin/tests/status/activity-renderer.test.ts
+++ b/plugin/tests/status/activity-renderer.test.ts
@@ -425,8 +425,8 @@ describe('IPv4 mask exemptions (M3)', () => {
     expect(maskSecrets('bind 0.0.0.0:80')).toBe('bind 0.0.0.0:80')
   })
 
-  test('public IPv4 ranges still masked', () => {
-    expect(maskSecrets('curl 8.8.8.8')).toBe('curl 8.***.***.8')
+  test('public IPv4 is shown in full; private ranges stay masked', () => {
+    expect(maskSecrets('curl 8.8.8.8')).toBe('curl 8.8.8.8')
     expect(maskSecrets('connect 10.2.3.44 done')).toBe('connect 10.***.***.44 done')
   })
 


### PR DESCRIPTION
## Проблема

`redactSecrets` маскировал средние октеты **любого** IPv4, включая публичные адреса. Из-за этого ломались рабочие сценарии, где оператору нужно прочитать адрес целиком: A-запись статик-хостинга, текущий DNS-хост клиента, адрес CDN. В отчёте вместо `185.199.108.153` оператор видел `185.***.***.153` и не мог понять, куда реально смотрит домен.

Публичный IP в сообщении оператора — это, как правило, значение, которое нужно прочитать. Скрывать имеет смысл другое: собственный адрес развёртывания и внутреннюю топологию (RFC1918 / CGNAT / link-local).

## Что меняется

`redact.ts`, правило IPv4:

- **Маскируются** приватные диапазоны: `10/8`, `172.16-31/12`, `192.168/16`, `169.254/16` (link-local), `100.64/10` (CGNAT).
- **Маскируются** адреса из `DASHI_OWN_HOST_IPS` — список через запятую, пусто по умолчанию. Сюда оператор кладёт собственный адрес сервера, если не хочет видеть его в чате и логах. Намеренно не захардкожено: адрес конкретного развёртывания не место в общем исходнике. Читается на каждый вызов, так что список меняется без рестарта процесса.
- **Показываются целиком** публичные адреса.
- Без изменений: `127.*` и `0.*` остаются как есть.
- Малформед-октет (`>255`, например строка версии `999.1.2.3`) не считается адресом и не трогается.

Формат маски прежний: `10.***.***.44`.

## Тесты

- `tests/safety/redact.test.ts`: приватные диапазоны, публичные насквозь, `DASHI_OWN_HOST_IPS` (задан / не задан), идемпотентность. Примеры на документационных диапазонах RFC 5737.
- `tests/status/activity-renderer.test.ts`: тест «public IPv4 ranges still masked» закреплял старую политику и падал. `maskSecrets` там — тонкая обёртка над `redactSecrets`, то есть фикс меняет её поведение по определению. Переписан под новую политику: `8.8.8.8` виден целиком, `10.2.3.44` остаётся замаскирован.

Полный прогон: **2708 pass / 0 fail** (102 файла), `tsc --noEmit` чисто.
