### PR TITLE
Fix classifyPane: background-agent busy marker lost at 5+ agents

### DIFF
--- a/plugin/src/commands/keys.ts
+++ b/plugin/src/commands/keys.ts
@@ -386,14 +386,28 @@ const BOTTOM_CHROME_LINES = 12
 // live pane state (a false 'unknown'/'idle'). Trimming the blank tail keeps the
 // markers inside the window. classifyPane, the queued-check and firedMarkerCount
 // all read through this trimmed region.
-function bottomChrome(text: string): string {
+function trailingChrome(text: string, maxLines: number): string {
   const lines = text.split('\n')
   let end = lines.length
   while (end > 0 && lines[end - 1]!.trim().length === 0) end--
   const trimmed = lines.slice(0, end)
-  if (trimmed.length <= BOTTOM_CHROME_LINES) return trimmed.join('\n')
-  return trimmed.slice(trimmed.length - BOTTOM_CHROME_LINES).join('\n')
+  if (trimmed.length <= maxLines) return trimmed.join('\n')
+  return trimmed.slice(trimmed.length - maxLines).join('\n')
 }
+
+function bottomChrome(text: string): string {
+  return trailingChrome(text, BOTTOM_CHROME_LINES)
+}
+
+// The `● main` / `◯ <agent> …` background-agent list adds ONE LINE PER RUNNING
+// AGENT above the composer footer, so the transient `Waiting for N background
+// agents to finish` busy marker (checked below) gets pushed out of the narrow
+// BOTTOM_CHROME_LINES(12) window once 5+ agents are listed — a genuinely busy
+// pane then reads as idle (verified: N=1..4 correctly 'busy', N=5+ falsely
+// 'idle' against the 12-line window). Give JUST that one marker a much wider
+// trailing window. This stays within the fail-safe bias above: matching it too
+// far up only yields a FALSE busy (refuse to send, safe) — never a false idle.
+const BACKGROUND_WAIT_LINES = 60
 
 // Classify a pane snapshot by string-matching Claude Code TUI v2.1.200 markers,
 // anchored to the bottom UI chrome (FIX-5). PURE (no I/O) so it is trivially
@@ -455,7 +469,7 @@ export function classifyPane(text: string): PaneState {
   if (
     chrome.includes('esc to interrupt') ||
     /·\s*[↓↑][\s\d.,]*k?\s*tokens?\)/i.test(chrome) ||
-    /Waiting for \d+ background agents? to finish/i.test(chrome)
+    /Waiting for \d+ background agents? to finish/i.test(trailingChrome(text, BACKGROUND_WAIT_LINES))
   ) {
     return 'busy'
   }

--- a/plugin/tests/commands/keys-control.test.ts
+++ b/plugin/tests/commands/keys-control.test.ts
@@ -219,6 +219,34 @@ describe('classifyPane', () => {
     expect(classifyPane('✻ Waiting for 3 background agents to finish')).toBe('busy')
   })
 
+  // Fix-loop (2026-07-20): the `● main` / `◯ <agent> …` list adds ONE LINE PER
+  // RUNNING AGENT above the footer, so with 5+ concurrent background agents the
+  // `Waiting for N…` marker (line 1 of the block) fell OUT of the 12-line
+  // BOTTOM_CHROME_LINES window while the idle footer tail stayed inside it — a
+  // busy pane misclassified as idle (RED against the #114 HEAD: N=1..4 'busy',
+  // N=5+ 'idle'). The marker is now matched against a much wider trailing
+  // window (BACKGROUND_WAIT_LINES=60) than the other chrome markers.
+  test('background-wait pane stays busy however many agents are listed', () => {
+    for (const n of [4, 5, 6, 8, 10]) {
+      const lines = [
+        `✻ Waiting for ${n} background agents to finish`,
+        '',
+        '──────────────────────────────────────────────────────────────────────',
+        '❯ some prompt',
+        '──────────────────────────────────────────────────────────────────────',
+        '  ⏵⏵ bypass permissions on · 2 shells · ← for agents · ↓ to manage',
+        '',
+        '  ● main',
+      ]
+      for (let i = 0; i < n; i++) {
+        lines.push(
+          `  ◯ agent-${i}  some task label                                                     4m 48s · ↓ 134.0k tokens`,
+        )
+      }
+      expect(classifyPane(lines.join('\n'))).toBe('busy')
+    }
+  })
+
   // The OPPOSITE state must stay idle: once the main turn ends the wait line is
   // gone, but the `◯ <agent> … Nk tokens` list line PERSISTS while a background
   // agent keeps running and the composer is genuinely idle. This is the exact


### PR DESCRIPTION
## Summary
- `Waiting for N background agents to finish` (the busy discriminator added in #114 for a main turn blocked on background subagents) was matched only inside the same 12-line `BOTTOM_CHROME_LINES` window as the other pane-state markers.
- The `● main` / `◯ <agent> …` list grows one line per running background agent, so at 5+ concurrent agents the marker line scrolled out of that window while the idle footer tail stayed inside it — a genuinely busy pane read as `idle`.
- `sendControlCommand` treats `idle` as license to blind-type a command and press Enter, so this could inject a command into a live, busy turn.
- Fix: give this one marker its own wider trailing window (`BACKGROUND_WAIT_LINES = 60`). Per the file's documented fail-safe bias, matching it too far up only produces a false `busy` (refuse to send — safe), never a false `idle`.

## Test plan
- [x] `bun test tests/commands/keys-control.test.ts` — 34/34 pass, including a new test scaling to 4/5/6/8/10 concurrent background agents (reproduces the bug pre-fix: N=1..4 'busy', N=5+ 'idle').
- [x] `bun test` (full suite) — 2706/2706 pass.
- [x] `bun run typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)