### PR TITLE
v1.2.1: .mcp.json без приватных gbrain-серверов (фикс для учеников)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dashi-channel",
   "displayName": "Dashi Channel — Telegram bridge for Claude Code",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Telegram channel plugin for Claude Code: personal DM bridge + public multichat, permission relay, confirm-panel keys, context HUD with a single pinned status card, rich messages (Bot API 10.1), Guest Mode, voice transcription, terminal mirror, secret redaction.",
   "author": { "name": "qwwiwi" },
   "repository": "https://github.com/qwwiwi/dashi-plugin-claude-code",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ Versions before 1.0.0 were not tracked — the project shipped ~60 merged PRs
 between 2026-05-14 and 2026-06-14 without a version discipline. 1.0.0
 retroactively marks the state of `main` on 2026-06-14.
 
+## [1.2.1] — 2026-07-21
+
+### Changed
+- **`plugin/.mcp.json` ships only the `dashi-channel` server.** The four
+  `dashi-gbrain-*` HTTP servers pointed at the author's private shared-memory
+  host (`mcp.orgrimmar.xyz`), which issues no public tokens — fresh installs
+  saw a permanent auth warning and agents wasted time probing an unreachable
+  service. Shared-memory MCP entries now live in
+  `examples/mcp.gbrain.example.json` as an opt-in template: self-host your own
+  brain (https://github.com/qwwiwi/public-gbrain-agentos), point the template
+  at YOUR host and merge it in. `.env.example` comment updated to match.
+
 ## [1.2.0] — 2026-07-10
 
 ### Added

--- a/examples/mcp.gbrain.example.json
+++ b/examples/mcp.gbrain.example.json
@@ -1,0 +1,33 @@
+{
+  "//": "OPTIONAL shared-memory MCP servers (gbrain). These are NOT part of the Telegram bridge and the plugin works fine without them. To use a shared brain, self-host your own instance (https://github.com/qwwiwi/public-gbrain-agentos), replace the host below with YOUR server, set GBRAIN_BEARER to a token issued by YOUR instance, and merge these entries into plugin/.mcp.json.",
+  "mcpServers": {
+    "gbrain-memory": {
+      "type": "http",
+      "url": "https://YOUR-GBRAIN-HOST/memory/mcp",
+      "headers": {
+        "Authorization": "Bearer ${GBRAIN_BEARER}"
+      }
+    },
+    "gbrain-recall": {
+      "type": "http",
+      "url": "https://YOUR-GBRAIN-HOST/recall/mcp",
+      "headers": {
+        "Authorization": "Bearer ${GBRAIN_BEARER}"
+      }
+    },
+    "gbrain-swarm": {
+      "type": "http",
+      "url": "https://YOUR-GBRAIN-HOST/swarm/mcp",
+      "headers": {
+        "Authorization": "Bearer ${GBRAIN_BEARER}"
+      }
+    },
+    "gbrain-tasks": {
+      "type": "http",
+      "url": "https://YOUR-GBRAIN-HOST/task/mcp",
+      "headers": {
+        "Authorization": "Bearer ${GBRAIN_BEARER}"
+      }
+    }
+  }
+}

--- a/plugin/.env.example
+++ b/plugin/.env.example
@@ -6,5 +6,6 @@
 # ChatPlace MCP key — sent as `Authorization: Bearer`. Source: ~/.secrets/chatplace.key
 CHATPLACE_API_KEY=cpk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
-# gbrain (mcp.orgrimmar.xyz) Bearer — shared across memory/recall/swarm/tasks servers
+# OPTIONAL: gbrain Bearer for a SELF-HOSTED shared brain (see examples/mcp.gbrain.example.json;
+# distribution: https://github.com/qwwiwi/public-gbrain-agentos). Not needed for the Telegram bridge.
 GBRAIN_BEARER=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -5,34 +5,6 @@
       "args": [
         "./src/server.ts"
       ]
-    },
-    "dashi-gbrain-memory": {
-      "type": "http",
-      "url": "https://mcp.orgrimmar.xyz/memory/mcp",
-      "headers": {
-        "Authorization": "Bearer ${GBRAIN_BEARER}"
-      }
-    },
-    "dashi-gbrain-recall": {
-      "type": "http",
-      "url": "https://mcp.orgrimmar.xyz/recall/mcp",
-      "headers": {
-        "Authorization": "Bearer ${GBRAIN_BEARER}"
-      }
-    },
-    "dashi-gbrain-swarm": {
-      "type": "http",
-      "url": "https://mcp.orgrimmar.xyz/swarm/mcp",
-      "headers": {
-        "Authorization": "Bearer ${GBRAIN_BEARER}"
-      }
-    },
-    "dashi-gbrain-tasks": {
-      "type": "http",
-      "url": "https://mcp.orgrimmar.xyz/task/mcp",
-      "headers": {
-        "Authorization": "Bearer ${GBRAIN_BEARER}"
-      }
     }
   }
 }

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashi-channel",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Ученики AgentOS при установке плагина получали предупреждение: четыре `dashi-gbrain-*` сервера в `plugin/.mcp.json` указывают на приватный хост автора `mcp.orgrimmar.xyz`, токены к которому не выдаются. Агент ученика уходил в вопрос «дай токен».

- `plugin/.mcp.json` теперь содержит только `dashi-channel` — мост работает без gbrain.
- gbrain-серверы вынесены в `examples/mcp.gbrain.example.json` с шаблоном `YOUR-GBRAIN-HOST` и ссылкой на self-host дистрибутив qwwiwi/public-gbrain-agentos.
- `.env.example`: комментарий про GBRAIN_BEARER переписан как opt-in.
- Версия 1.2.1 (plugin.json + package.json в lockstep, version-sync тест зелёный), CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)