### PR TITLE
Фикс: тихая гибель MCP-канала dashi-channel (архивариус)

### DIFF
--- a/plugin/src/process-watchdog.ts
+++ b/plugin/src/process-watchdog.ts
@@ -1,0 +1,31 @@
+// Classifies why server.ts's orphan/stdin watchdog interval might fire.
+// Kept as a pure function so it is unit-testable — server.ts is a binary
+// entry point with side effects at import time and can't be imported in
+// tests (see tests/server.pid.test.ts).
+//
+// BUG (2026-07-23, archivist channel crash — bug-archivist-channel-crash.md):
+// stdin ending/closing used to be treated as equivalent to true orphaning
+// (parent process died) and triggered a full shutdown(), taking the
+// Telegram poller/webhook/memory-writer down with it. Empirically, Claude
+// Code can sever just the MCP stdio pipe to one server while its own
+// process stays alive and every other MCP connection keeps working — a
+// live idle process died ~85-125s after start with ppid unchanged, no
+// signal, no OOM, no uncaught exception anywhere. Only real reparenting to
+// init means the parent is actually gone and shutdown() is warranted;
+// losing stdin alone should just disable the tool-call interface.
+export type WatchdogState = 'alive' | 'stdio-lost' | 'orphaned'
+
+export interface WatchdogInput {
+  ppid: number
+  bootPpid: number
+  platform: NodeJS.Platform
+  stdinDestroyed: boolean
+  stdinReadableEnded: boolean
+}
+
+export function classifyWatchdogState(input: WatchdogInput): WatchdogState {
+  const trueOrphan = input.platform !== 'win32' && input.ppid !== input.bootPpid
+  if (trueOrphan) return 'orphaned'
+  if (input.stdinDestroyed || input.stdinReadableEnded) return 'stdio-lost'
+  return 'alive'
+}

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -37,6 +37,7 @@ import {
   type StatePaths,
 } from './config.js'
 import { createLogger } from './log.js'
+import { classifyWatchdogState } from './process-watchdog.js'
 import { ensureStateDirs, migrateLegacyAllowlist, writeDeadLetter } from './state/store.js'
 import {
   callTool,
@@ -1429,22 +1430,64 @@ function shutdown(): void {
     .then(() => Promise.resolve(bot.stop()))
     .finally(() => process.exit(0))
 }
-process.stdin.on('end', shutdown)
-process.stdin.on('close', shutdown)
+// The MCP tool-call interface and the Telegram bridge (poller/webhook/
+// memory writer) have independent lifecycles — the bridge doesn't need a
+// live stdio transport to keep receiving and archiving messages. See
+// process-watchdog.ts for why stdin loss alone must NOT shut everything
+// down (bug-archivist-channel-crash.md).
+let stdioLossWarned = false
+const warnStdioLost = (): void => {
+  if (stdioLossWarned) return
+  stdioLossWarned = true
+  log.warn(
+    'mcp stdio transport ended while parent process is still alive — ' +
+      'tool-call interface unavailable, telegram bridge keeps running',
+    { ppid: process.ppid },
+  )
+}
+process.stdin.on('end', warnStdioLost)
+process.stdin.on('close', warnStdioLost)
 process.on('SIGTERM', shutdown)
 process.on('SIGINT', shutdown)
 process.on('SIGHUP', shutdown)
 
-// Orphan watchdog: stdin events above don't reliably fire when the parent
-// chain is severed by a crash. Poll for reparenting (POSIX) or dead stdin.
 const bootPpid = process.ppid
 setInterval(() => {
-  const orphaned =
-    (process.platform !== 'win32' && process.ppid !== bootPpid) ||
-    process.stdin.destroyed ||
-    process.stdin.readableEnded
-  if (orphaned) shutdown()
+  const state = classifyWatchdogState({
+    ppid: process.ppid,
+    bootPpid,
+    platform: process.platform,
+    stdinDestroyed: process.stdin.destroyed,
+    stdinReadableEnded: process.stdin.readableEnded,
+  })
+  if (state === 'orphaned') {
+    shutdown()
+    return
+  }
+  if (state === 'stdio-lost') warnStdioLost()
 }, 5000).unref()
+
+// Keep-alive: the webhook HTTP server and the poller's in-flight
+// long-poll request SHOULD already keep Bun's event loop alive on their
+// own — but relying on that implicitly has proven unreliable in practice
+// (bug-archivist-channel-crash.md): a freshly-restarted, otherwise-idle
+// process (no real Telegram traffic — no incoming messages, no MCP tool
+// calls) died silently ~65-125s after start on every observed run, with
+// no signal, no OOM, no crash, no orphaning, and no error logged
+// anywhere. Adding a `beforeExit`/`exit` listener during investigation
+// made the same idle process survive well past that window on every
+// subsequent run — strong evidence the loop was going empty for a brief
+// instant (a natural, voluntary exit(0)) rather than being killed. This
+// almost never surfaces on sibling agents (marketer/coder) because their
+// stdio is kept busy by frequent real MCP tool-call traffic; archivist
+// currently has none, so the rare empty-loop instant is far more likely
+// to be hit. Rather than depend on incidental listener side effects, we
+// pin a persistent, deliberately-NOT-unref'd no-op interval: the loop can
+// never go empty, regardless of any other handle's ref-counting.
+setInterval(() => {}, 60_000)
+process.on('exit', (code) => {
+  log.info('process exiting', { code })
+})
 
 // ─────────────────────────────────────────────────────────────────────
 // Connect MCP transport. After this, Claude Code can list tools.

--- a/plugin/tests/process-watchdog.test.ts
+++ b/plugin/tests/process-watchdog.test.ts
@@ -1,0 +1,92 @@
+// Pins the contract behind the 2026-07-23 archivist channel crash fix
+// (bug-archivist-channel-crash.md): stdin loss alone must NOT be treated
+// as fatal orphaning. Only a real ppid change (reparented to init) is.
+import { describe, expect, test } from 'bun:test'
+
+import { classifyWatchdogState } from '../src/process-watchdog.js'
+
+describe('classifyWatchdogState', () => {
+  test('alive: ppid unchanged, stdin intact', () => {
+    expect(
+      classifyWatchdogState({
+        ppid: 100,
+        bootPpid: 100,
+        platform: 'linux',
+        stdinDestroyed: false,
+        stdinReadableEnded: false,
+      }),
+    ).toBe('alive')
+  })
+
+  test('stdio-lost: stdin ended, ppid unchanged — the archivist crash scenario', () => {
+    expect(
+      classifyWatchdogState({
+        ppid: 100,
+        bootPpid: 100,
+        platform: 'linux',
+        stdinDestroyed: false,
+        stdinReadableEnded: true,
+      }),
+    ).toBe('stdio-lost')
+  })
+
+  test('stdio-lost: stdin destroyed, ppid unchanged', () => {
+    expect(
+      classifyWatchdogState({
+        ppid: 100,
+        bootPpid: 100,
+        platform: 'linux',
+        stdinDestroyed: true,
+        stdinReadableEnded: false,
+      }),
+    ).toBe('stdio-lost')
+  })
+
+  test('orphaned: ppid changed (reparented to init), stdin intact', () => {
+    expect(
+      classifyWatchdogState({
+        ppid: 1,
+        bootPpid: 100,
+        platform: 'linux',
+        stdinDestroyed: false,
+        stdinReadableEnded: false,
+      }),
+    ).toBe('orphaned')
+  })
+
+  test('orphaned takes precedence over stdio-lost when both conditions hold', () => {
+    expect(
+      classifyWatchdogState({
+        ppid: 1,
+        bootPpid: 100,
+        platform: 'linux',
+        stdinDestroyed: true,
+        stdinReadableEnded: true,
+      }),
+    ).toBe('orphaned')
+  })
+
+  test('win32: ppid changes are never treated as orphaning', () => {
+    expect(
+      classifyWatchdogState({
+        ppid: 1,
+        bootPpid: 100,
+        platform: 'win32',
+        stdinDestroyed: false,
+        stdinReadableEnded: false,
+      }),
+    ).toBe('alive')
+  })
+
+  test('win32: stdin loss is still detected', () => {
+    expect(
+      classifyWatchdogState({
+        ppid: 1,
+        bootPpid: 100,
+        platform: 'win32',
+        stdinDestroyed: true,
+        stdinReadableEnded: false,
+      }),
+    ).toBe('stdio-lost')
+  })
+})


### PR DESCRIPTION
## Проблема

Архивариус (`claude-memory.service`) периодически терял входящие Telegram-сообщения: дочерний `bun ./src/server.ts` MCP-процесс тихо умирал через ~65-125с после старта при живом внешнем `claude`-процессе, без единой ошибки в логах, без OOM, без смены ppid. Полная диагностика: см. задачу id=1 в gbrain-tasks и `bug-archivist-channel-crash.md`.

## Корневые причины и фикс

1. **Watchdog путал потерю stdio с настоящим осиротением.** `process.stdin.on('end'/'close', shutdown)` валил весь процесс (телеграм-поллер, вебхук, запись в память) при потере MCP stdio-транспорта, хотя это независимые от tool-call интерфейса подсистемы. Вынес классификацию в `src/process-watchdog.ts` (`classifyWatchdogState`: `alive` / `stdio-lost` / `orphaned`) — теперь shutdown только при реальном `orphaned` (смена ppid), `stdio-lost` — просто warn в лог.
2. **Вероятный настоящий убийца простаивающего процесса:** событийный цикл Bun мог на мгновение опустеть (никакой активный handle/timer) и естественно завершиться через `exit(0)` — соседи (marketer/coder) не ловят это, потому что их stdio постоянно заняты реальным MCP tool-call трафиком. Добавлен постоянный, намеренно НЕ `unref()`-нутый no-op `setInterval`, который не даёт циклу опустеть ни при каких обстоятельствах.

## Тесты

`tests/process-watchdog.test.ts` — юнит-тесты на классификацию состояний watchdog. `bun test`: 2712 pass, 0 fail.

## Деплой и проверка (после мержа)

Задеплою на `claude-memory` и проверю оба критерия готовности задачи: часы непрерывной работы дочернего процесса + доставка живого тестового сообщения.

🤖 Generated with [Claude Code](https://claude.com/claude-code)