### PR TITLE
Безопасность: поиск больше не обходит запрет на чтение секретов

### DIFF
--- a/plugin/src/security/permission-policy.ts
+++ b/plugin/src/security/permission-policy.ts
@@ -164,7 +164,10 @@ const READ_ONLY_TOOLS = new Set<string>([
 ])
 
 // Tools that take a filesystem path we must policy-check.
-const READ_PATH_TOOLS = new Set<string>(['Read', 'NotebookRead'])
+// Инструменты, чей путь ОБЯЗАН проверяться на секретность. Grep/Glob/LS входят
+// сюда наравне с Read: поиск по файлу выдаёт его содержимое строками, то есть
+// это чтение — и запрет на чтение секретов должен работать одинаково для всех.
+const READ_PATH_TOOLS = new Set<string>(['Read', 'NotebookRead', 'Grep', 'Glob', 'LS'])
 const WRITE_PATH_TOOLS = new Set<string>(['Edit', 'Write', 'NotebookEdit', 'MultiEdit'])
 
 // ── Built-in hard rules (operator cannot relax) ─────────────────────────
@@ -179,6 +182,14 @@ const BUILTIN_DENY_PATHS: readonly string[] = [
   '**/*.key',
   '**/.secrets/**',
   '**/secrets/**',
+  // Сам каталог, без содержимого: шаблон с завершающим `/**` не совпадает с
+  // `~/.ssh` или `~/.secrets`, поэтому перечисление каталога (Glob/LS) проходило
+  // мимо запрета. Список файлов с ключами — это уже разведка, закрываем.
+  '**/.secrets',
+  '**/secrets',
+  '**/.ssh',
+  '**/.aws',
+  '**/.config/gcloud',
   '**/id_rsa*',
   '**/id_ed25519*',
   '**/.ssh/**',
@@ -2000,7 +2011,12 @@ function rulesMatch(
 }
 
 function extractPath(toolInput: Record<string, unknown>): string | undefined {
-  const fp = toolInput.file_path ?? toolInput.notebook_path
+  // `path` — поле Grep/Glob/LS. Без него поисковые инструменты приходили сюда
+  // БЕЗ пути, проверка секретных путей не выполнялась, а сами они помечены
+  // read-only → tier=allow. Итог: `Grep(pattern:"TOKEN", path:"~/.secrets")`
+  // возвращал строки с секретами там, где `Read` того же файла жёстко запрещён
+  // (сообщено внешним исследователем 2026-08-03, воспроизведено по коду).
+  const fp = toolInput.file_path ?? toolInput.notebook_path ?? toolInput.path
   return typeof fp === 'string' && fp.length > 0 ? fp : undefined
 }
 

--- a/plugin/tests/permission-secret-search-bypass.test.ts
+++ b/plugin/tests/permission-secret-search-bypass.test.ts
@@ -1,0 +1,77 @@
+// Обход запрета на чтение секретов через поисковые инструменты.
+//
+// Сообщено внешним исследователем 2026-08-03, воспроизведено по коду 2026-08-08.
+// Механика: `extractPath` брал только `file_path`/`notebook_path`, а у Grep/Glob/LS
+// путь лежит в `path`. Поэтому политика видела вызов БЕЗ пути, проверка секретных
+// путей не выполнялась, а сами инструменты помечены read-only → tier=allow.
+// Итог: `Grep(pattern:"TOKEN", path:"~/.secrets")` возвращал строки с секретами
+// там, где `Read` того же файла жёстко запрещён. Бьёт по всем, кто работает
+// в режиме без подтверждений.
+
+import { describe, expect, it } from 'bun:test'
+import { classifyToolCall } from '../src/security/permission-policy.js'
+
+const policy = { version: 1, default_tier: 'confirm' as const, rules: [] }
+
+const SECRET_TARGETS = [
+  '/home/user/.env',
+  '~/.ssh/id_ed25519',
+  '~/.aws/credentials',
+  '/home/user/.secrets/tokens.json',
+  '/etc/ssl/private/server.key',
+]
+
+describe('чтение секретов через поиск', () => {
+  for (const target of SECRET_TARGETS) {
+    it(`Grep по ${target} запрещён так же, как Read`, () => {
+      const grep = classifyToolCall({
+        toolName: 'Grep',
+        toolInput: { pattern: 'TOKEN|KEY|SECRET', path: target },
+        policy,
+      })
+      const read = classifyToolCall({
+        toolName: 'Read',
+        toolInput: { file_path: target },
+        policy,
+      })
+      expect(read.tier).toBe('deny')
+      expect(grep.tier).toBe('deny')
+    })
+  }
+
+  it('Glob по каталогу секретов запрещён', () => {
+    const verdict = classifyToolCall({
+      toolName: 'Glob',
+      toolInput: { pattern: '**/*', path: '~/.secrets' },
+      policy,
+    })
+    expect(verdict.tier).toBe('deny')
+  })
+
+  it('LS каталога с ключами запрещён', () => {
+    const verdict = classifyToolCall({
+      toolName: 'LS',
+      toolInput: { path: '~/.ssh' },
+      policy,
+    })
+    expect(verdict.tier).toBe('deny')
+  })
+
+  it('обычный Grep по коду по-прежнему разрешён', () => {
+    const verdict = classifyToolCall({
+      toolName: 'Grep',
+      toolInput: { pattern: 'function', path: 'src/security' },
+      policy,
+    })
+    expect(verdict.tier).toBe('allow')
+  })
+
+  it('Grep без пути не ломается', () => {
+    const verdict = classifyToolCall({
+      toolName: 'Grep',
+      toolInput: { pattern: 'TODO' },
+      policy,
+    })
+    expect(verdict.tier).toBe('allow')
+  })
+})


### PR DESCRIPTION
## Что

Запрет на чтение секретов обходился через инструменты поиска. Сообщено внешним исследователем **03.08** в личку владельцу, воспроизведено по коду **08.08**.

Затрагивает всех, кто работает в режиме без подтверждений — то есть большинство пользователей плагина.

## Механика обхода

Два правила срабатывали подряд:

1. `extractPath` брал путь только из `file_path` / `notebook_path`. У `Grep` / `Glob` / `LS` путь лежит в `path` — политика видела вызов **без пути** и встроенную проверку секретных путей не выполняла вовсе.
2. Эти же инструменты помечены read-only → `default_tier` отдавал `allow`.

Итог:

```
Read(file_path: "~/.secrets/tokens.json")          -> deny
Grep(pattern: "TOKEN", path: "~/.secrets")         -> allow   (и возвращал строки с ключами)
```

Поиск по файлу выдаёт его содержимое — это чтение, и запрет обязан работать одинаково.

## Фикс

- `extractPath` читает и `path`
- `READ_PATH_TOOLS` расширен: `Grep`, `Glob`, `LS` проверяются наравне с `Read`
- `BUILTIN_DENY_PATHS`: добавлены **сами каталоги** (`.ssh`, `.aws`, `.secrets`, `secrets`, `.config/gcloud`). Шаблон с `/**` не совпадает с `~/.ssh`, поэтому перечисление каталога с ключами проходило мимо запрета — **вторая щель, найденная собственными тестами уже во время фикса**

## Проверка

9 новых тестов: поиск по пяти видам секретных целей, перечисление каталога через `Glob` и `LS`, плюс контрольные — обычный поиск по коду и поиск без пути продолжают работать.

Полный набор плагина: **2758 тестов, 0 падений**.

## Отдельно

У репозитория не включены приватные сообщения об уязвимостях и нет `SECURITY.md` — исследователю буквально некуда написать тихо, поэтому он писал владельцу в личку и ждал ответа пять дней. Стоит включить: одна настройка.

🤖 Generated with [Claude Code](https://claude.com/claude-code)