### PR TITLE
Окно контекста в HUD: 1M-маркер из флага запуска Claude Code

### DIFF
--- a/plugin/src/commands/oob.ts
+++ b/plugin/src/commands/oob.ts
@@ -195,6 +195,11 @@ export interface OobContext {
   // override wins, else the transcript model's table window, else the fallback.
   // Undefined when no operator override is configured.
   contextWindowOverride?: number
+  // The hosting Claude Code process's `--model` flag (readLaunchModelId). Some
+  // 1M variants are served under a BARE transcript id (`claude-opus-5` from
+  // `--model claude-opus-5[1m]`), so this is the only surviving proof of the
+  // window. Undefined when the flag could not be read.
+  launchModel?: string
   // Process uptime in seconds (process.uptime()); rendered when present.
   uptimeSeconds?: number
   // Autonomy M2: inbound message id, used to build the idempotent grantSourceId
@@ -316,6 +321,7 @@ async function statusText(ctx: OobContext): Promise<string> {
       const windowTokens = resolveContextWindowForModel(usage.model, {
         override: ctx.contextWindowOverride,
         fallback: fallbackWindow,
+        launchModel: ctx.launchModel,
       })
       contextLine = formatContextUsage(usage, windowTokens)
     }

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -862,6 +862,9 @@ export interface ModelContextWindowRule {
 export const MODEL_CONTEXT_WINDOWS: ReadonlyArray<ModelContextWindowRule> = [
   // Fable 5 ships a 1M-token context window.
   { match: 'fable', windowTokens: 1_000_000 },
+  // Opus 5 — base window 200k; the 1M variant is requested via the [1m]
+  // marker (checked BEFORE this table), exactly like Opus 4.8.
+  { match: 'claude-opus-5', windowTokens: 200_000 },
   // Opus 4.x (any minor) — 200k.
   { match: 'claude-opus-4', windowTokens: 200_000 },
   // Sonnet 5 / Sonnet 4 — 200k (see note above re: Sonnet-5).
@@ -877,6 +880,56 @@ export const MODEL_CONTEXT_WINDOWS: ReadonlyArray<ModelContextWindowRule> = [
 // under-reported as 200k. Matches the bracketed form and a standalone `1m`
 // token (word-boundaried so it never trips on unrelated ids).
 const ONE_MILLION_MARKER = /\[1m\]|(?:^|[^a-z0-9])1m(?:[^a-z0-9]|$)/i
+
+// The 1M marker is NOT always echoed back by the API. Claude Code launched as
+// `claude --model claude-opus-5[1m]` serves turns whose transcript `model` is
+// the BARE id `claude-opus-5` — the marker survives only in the CLI argv. So a
+// transcript id alone cannot tell a 200k Opus-5 session from a 1M one, and the
+// family table (honest 200k default) under-reports the window by 5x. The launch
+// flag is the missing fact: when it carries the marker AND names the same model
+// the transcript reports, the session IS the 1M variant.
+//
+// Parse the model id out of a Claude Code argv array (`--model <id>` or
+// `--model=<id>`). PURE. Returns undefined when the flag is absent or has no
+// value. The LAST occurrence wins, matching CLI flag semantics.
+export function parseLaunchModelFlag(argv: readonly string[]): string | undefined {
+  let found: string | undefined
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === undefined) continue
+    if (arg === '--model') {
+      const next = argv[i + 1]
+      // A bare trailing `--model`, or one followed by another flag, has no value.
+      if (next !== undefined && next.length > 0 && !next.startsWith('-')) found = next
+      continue
+    }
+    if (arg.startsWith('--model=')) {
+      const value = arg.slice('--model='.length)
+      if (value.length > 0) found = value
+    }
+  }
+  return found
+}
+
+// Strip an explicit window marker from a model id, leaving the bare id used to
+// compare a launch flag against a transcript-reported model.
+function stripWindowMarker(id: string): string {
+  return id.replace(/\[1m\]/gi, '').trim()
+}
+
+// Does `launchModel` prove that `id` (a transcript model id, lowercased, with no
+// marker of its own) is running the 1M variant? Only when the launch flag both
+// carries the marker AND names the SAME model — otherwise a mid-session `/model`
+// switch (opus-5[1m] launched, sonnet now serving) would inherit a window the
+// current model does not have.
+function launchProvesOneMillion(id: string, launchModel: string | undefined): boolean {
+  if (launchModel === undefined || launchModel.length === 0) return false
+  const launch = launchModel.toLowerCase()
+  if (!ONE_MILLION_MARKER.test(launch)) return false
+  const base = stripWindowMarker(launch)
+  if (base.length === 0) return false
+  return base === id || matchesModelFamily(id, base) || matchesModelFamily(base, id)
+}
 
 // Normalize an operator-supplied window value to a usable token count, or
 // undefined when it is unusable. Floor FIRST, then accept only >= 1 — the
@@ -918,8 +971,12 @@ function matchesModelFamily(id: string, family: string): boolean {
  *     / `JARVIS_CONTEXT_WINDOW`). ALWAYS wins so a wrong table guess is fixable
  *     without a code change.
  *  2. An explicit `[1m]` / `1m` window marker on the model id → 1M.
- *  3. The MODEL_CONTEXT_WINDOWS family table (first token-boundary match).
- *  4. `opts.fallback` (defaults to DEFAULT_CONTEXT_WINDOW_TOKENS = 200k) —
+ *  3. `opts.launchModel` — the CLI `--model` flag — when it carries the marker
+ *     and names the SAME model the transcript reports → 1M. Covers the ids the
+ *     API returns bare (e.g. `claude-opus-5` served by `--model
+ *     claude-opus-5[1m]`), where the marker exists only in the launch argv.
+ *  4. The MODEL_CONTEXT_WINDOWS family table (first token-boundary match).
+ *  5. `opts.fallback` (defaults to DEFAULT_CONTEXT_WINDOW_TOKENS = 200k) —
  *     unknown or absent model.
  *
  * PURE. Never throws, never returns 0 / negative — an honest 200k fallback is
@@ -927,7 +984,11 @@ function matchesModelFamily(id: string, family: string): boolean {
  */
 export function resolveContextWindowForModel(
   model: string | undefined,
-  opts?: { override?: number | undefined; fallback?: number | undefined },
+  opts?: {
+    override?: number | undefined
+    fallback?: number | undefined
+    launchModel?: string | undefined
+  },
 ): number {
   const fallback = normalizeWindowValue(opts?.fallback) ?? DEFAULT_CONTEXT_WINDOW_TOKENS
   const override = normalizeWindowValue(opts?.override)
@@ -935,6 +996,7 @@ export function resolveContextWindowForModel(
   if (model === undefined || model.length === 0) return fallback
   const id = model.toLowerCase()
   if (ONE_MILLION_MARKER.test(id)) return 1_000_000
+  if (launchProvesOneMillion(id, opts?.launchModel)) return 1_000_000
   for (const rule of MODEL_CONTEXT_WINDOWS) {
     if (matchesModelFamily(id, rule.match)) return rule.windowTokens
   }

--- a/plugin/src/config.ts
+++ b/plugin/src/config.ts
@@ -897,7 +897,12 @@ export function parseLaunchModelFlag(argv: readonly string[]): string | undefine
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i]
     if (arg === undefined) continue
+    // `--` ends option parsing; everything after it is positional (codex LOW).
+    if (arg === '--') break
     if (arg === '--model') {
+      // Reset FIRST: a later malformed `--model` overrides an earlier good one,
+      // matching real CLI semantics — the flag was re-specified (codex LOW).
+      found = undefined
       const next = argv[i + 1]
       // A bare trailing `--model`, or one followed by another flag, has no value.
       if (next !== undefined && next.length > 0 && !next.startsWith('-')) found = next
@@ -905,7 +910,7 @@ export function parseLaunchModelFlag(argv: readonly string[]): string | undefine
     }
     if (arg.startsWith('--model=')) {
       const value = arg.slice('--model='.length)
-      if (value.length > 0) found = value
+      found = value.length > 0 ? value : undefined
     }
   }
   return found
@@ -919,16 +924,23 @@ function stripWindowMarker(id: string): string {
 
 // Does `launchModel` prove that `id` (a transcript model id, lowercased, with no
 // marker of its own) is running the 1M variant? Only when the launch flag both
-// carries the marker AND names the SAME model — otherwise a mid-session `/model`
-// switch (opus-5[1m] launched, sonnet now serving) would inherit a window the
-// current model does not have.
+// carries the marker AND names EXACTLY the model the transcript reports.
+//
+// Exact equality, not a family match: a family match in either direction lets a
+// short alias (`--model opus[1m]`) claim a 1M window for every Opus id the
+// session might later serve, which is not proof of anything (codex HIGH,
+// 2026-08-18).
+//
+// KNOWN LIMIT: a mid-session `/model` switch BETWEEN the 1M and 200k variants of
+// the SAME model is invisible here — both serve the identical bare transcript id
+// (`claude-opus-5`), so the launch flag stays the only evidence and the HUD keeps
+// reporting 1M until restart. Switching to any OTHER model is handled correctly
+// (different id → no match). The operator override remains the escape hatch.
 function launchProvesOneMillion(id: string, launchModel: string | undefined): boolean {
   if (launchModel === undefined || launchModel.length === 0) return false
   const launch = launchModel.toLowerCase()
   if (!ONE_MILLION_MARKER.test(launch)) return false
-  const base = stripWindowMarker(launch)
-  if (base.length === 0) return false
-  return base === id || matchesModelFamily(id, base) || matchesModelFamily(base, id)
+  return stripWindowMarker(launch) === id
 }
 
 // Normalize an operator-supplied window value to a usable token count, or

--- a/plugin/src/server.ts
+++ b/plugin/src/server.ts
@@ -58,6 +58,7 @@ import { TmuxMirror } from './status/tmux-mirror.js'
 import { defaultTmuxExec } from './status/pane-capture.js'
 import { TaskRealityMirror } from './status/task-reality-mirror.js'
 import { SessionInfoStore } from './status/session-info.js'
+import { readLaunchModelId } from './status/launch-model.js'
 import {
   ContextHud,
   handleHudCallback,
@@ -558,12 +559,19 @@ const hudApi: HudTelegramApi = {
   unpinChatMessage: (chatId, messageId) =>
     bot.api.unpinChatMessage(chatId, messageId).then(() => undefined),
 }
+// The hosting Claude Code process's `--model` flag, read ONCE at boot. It is
+// the only place the `[1m]` window marker survives for models the API reports
+// bare (e.g. `claude-opus-5` served by `--model claude-opus-5[1m]`), so both the
+// pinned HUD and /status need it to show a 1M window instead of the table's 200k.
+const launchModelId = readLaunchModelId()
+log.info('launch model detected', { launch_model: launchModelId ?? '(none)' })
 const contextHud = new ContextHud({
   api: hudApi,
   log,
   sessionInfo: sessionInfoStore,
   windowTokens: resolveContextWindowTokens(config),
   windowOverride: resolveContextWindowOverride(config),
+  ...(launchModelId !== undefined ? { launchModel: launchModelId } : {}),
   ownerChatIds: hudOwnerChatIds,
   stateDir: statePaths.root,
   enabled: resolveHudEnabled(config),
@@ -1311,6 +1319,9 @@ const handlerDeps: HandlerDeps = {
   ...(tmuxKeysTarget !== undefined ? { tmuxKeys: { target: tmuxKeysTarget } } : {}),
   // Session facts (transcript_path + model) for /status context usage.
   sessionInfo: sessionInfoStore,
+  // Launch `--model` flag — lets /status resolve a 1M window for models the
+  // transcript reports bare (see readLaunchModelId).
+  ...(launchModelId !== undefined ? { launchModel: launchModelId } : {}),
   // Multichat router + policy. Both must be present for handlers.ts to
   // take the router path; passing one without the other is a wiring bug
   // (handlers.ts treats the pair atomically).

--- a/plugin/src/status/context-hud.ts
+++ b/plugin/src/status/context-hud.ts
@@ -291,6 +291,12 @@ export interface ContextHudOptions {
   // window so a Fable-5 session reports its true 1M window. Optional so the many
   // test literals that predate it keep compiling.
   windowOverride?: number | undefined
+  // The `--model` flag of the hosting Claude Code process (readLaunchModelId,
+  // read once at boot). Some 1M variants report a BARE model id in the
+  // transcript (`claude-opus-5` under `--model claude-opus-5[1m]`); the launch
+  // flag is then the only proof the window is 1M and not the table's 200k.
+  // Optional — when absent the model table drives the window as before.
+  launchModel?: string | undefined
   // Owner chat(s) — the ONLY chats the HUD acts in. Stringified for comparison
   // against the hook payload's chatId.
   ownerChatIds: ReadonlyArray<string | number>
@@ -313,6 +319,7 @@ export class ContextHud {
   private readonly sessionInfo: SessionInfoReader
   private readonly windowTokens: number
   private readonly windowOverride?: number | undefined
+  private readonly launchModel?: string | undefined
   private readonly owner: ReadonlySet<string>
   private readonly stateDir: string
   private readonly enabled: boolean
@@ -374,6 +381,7 @@ export class ContextHud {
     this.sessionInfo = opts.sessionInfo
     this.windowTokens = opts.windowTokens
     this.windowOverride = opts.windowOverride
+    this.launchModel = opts.launchModel
     this.owner = new Set(opts.ownerChatIds.map((id) => String(id)))
     this.stateDir = opts.stateDir
     this.enabled = opts.enabled
@@ -788,6 +796,7 @@ export class ContextHud {
     const windowTokens = resolveContextWindowForModel(model, {
       override: this.windowOverride,
       fallback: this.windowTokens,
+      launchModel: this.launchModel,
     })
     // M3: the reconciled (pane-verified) view wins over the event-only snapshot.
     const rv = this.reconciled.get(chatId)

--- a/plugin/src/status/launch-model.ts
+++ b/plugin/src/status/launch-model.ts
@@ -1,0 +1,93 @@
+// Launch-model detection — the ONLY place the `--model` flag of the hosting
+// Claude Code process is read.
+//
+// Why this exists: the transcript's per-turn `model` is the id the API served,
+// and for some 1M-window variants it comes back BARE — a session launched as
+// `claude --model claude-opus-5[1m]` writes `"model":"claude-opus-5"` into the
+// transcript. The family table then honestly resolves 200k and the pinned HUD
+// under-reports a 1M window by 5x. The marker survives in exactly one place:
+// the argv of the process that launched us. This module recovers it.
+//
+// The channel server runs as a child of that Claude Code process, so the parent
+// chain is walked (a few hops, in case a shell/wrapper sits in between). Linux
+// /proc only; every failure path returns undefined and the caller falls back to
+// the model table, so a missing /proc never breaks the HUD.
+
+import { readFileSync } from 'node:fs'
+
+import { parseLaunchModelFlag } from '../config.js'
+
+// How many ancestors to inspect. The direct parent is normally the Claude Code
+// process; the extra hops cover a wrapper/shell without walking to PID 1.
+const MAX_ANCESTORS = 8
+
+function readCmdline(pid: number): readonly string[] | undefined {
+  try {
+    const raw = readFileSync(`/proc/${pid}/cmdline`, 'utf8')
+    if (raw.length === 0) return undefined
+    // /proc cmdline is NUL-separated with a trailing NUL.
+    return raw.split('\0').filter((a) => a.length > 0)
+  } catch {
+    return undefined
+  }
+}
+
+function readParentPid(pid: number): number | undefined {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf8')
+    // Fields: pid (comm) state ppid ... — comm is parenthesized and may itself
+    // contain spaces/parens, so split AFTER the last ')'.
+    const close = stat.lastIndexOf(')')
+    if (close === -1) return undefined
+    const rest = stat.slice(close + 1).trim().split(/\s+/)
+    // rest[0] = state, rest[1] = ppid
+    const ppid = Number(rest[1])
+    return Number.isInteger(ppid) && ppid > 1 ? ppid : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export interface ReadLaunchModelOptions {
+  // Where to start walking. Defaults to this process's parent.
+  startPid?: number | undefined
+  // Injectable readers — tests drive a fake process tree without /proc.
+  readCmdlineFn?: (pid: number) => readonly string[] | undefined
+  readParentPidFn?: (pid: number) => number | undefined
+  maxAncestors?: number | undefined
+}
+
+/**
+ * The model id the hosting Claude Code process was launched with, or undefined
+ * when no ancestor carries a `--model` flag (or /proc is unavailable).
+ *
+ * Never throws. Read ONCE at boot — the launch flag cannot change without a
+ * restart, and a per-render /proc walk would be pointless work.
+ */
+export function readLaunchModelId(opts?: ReadLaunchModelOptions): string | undefined {
+  const readCmd = opts?.readCmdlineFn ?? readCmdline
+  const readParent = opts?.readParentPidFn ?? readParentPid
+  const limit = opts?.maxAncestors ?? MAX_ANCESTORS
+  let pid = opts?.startPid ?? process.ppid
+  const seen = new Set<number>()
+  for (let hop = 0; hop < limit; hop += 1) {
+    if (!Number.isInteger(pid) || pid <= 1 || seen.has(pid)) return undefined
+    seen.add(pid)
+    // The built-in readers already swallow their own errors; the try wraps the
+    // INJECTED readers too, so the never-throws contract holds for every caller.
+    let parent: number | undefined
+    try {
+      const argv = readCmd(pid)
+      if (argv !== undefined) {
+        const model = parseLaunchModelFlag(argv)
+        if (model !== undefined) return model
+      }
+      parent = readParent(pid)
+    } catch {
+      return undefined
+    }
+    if (parent === undefined) return undefined
+    pid = parent
+  }
+  return undefined
+}

--- a/plugin/src/status/launch-model.ts
+++ b/plugin/src/status/launch-model.ts
@@ -21,6 +21,24 @@ import { parseLaunchModelFlag } from '../config.js'
 // process; the extra hops cover a wrapper/shell without walking to PID 1.
 const MAX_ANCESTORS = 8
 
+// Only a Claude Code process's `--model` counts. A wrapper further down the
+// chain may carry a `--model` of its own (a launcher, a different CLI), and
+// taking it would mask the real harness above it (codex MEDIUM, 2026-08-18).
+// The walk therefore SKIPS non-Claude candidates and keeps climbing.
+function isClaudeProcess(argv: readonly string[]): boolean {
+  const exe = argv[0]
+  if (exe === undefined) return false
+  // Basename of argv[0]: `claude`, `/usr/local/bin/claude`, `node .../claude.js`.
+  const base = exe.split('/').pop()?.toLowerCase() ?? ''
+  if (base === 'claude' || base.startsWith('claude.')) return true
+  // Runtime-launched form: `node|bun <path-to>/claude(.js|.mjs)`.
+  if (base === 'node' || base === 'bun') {
+    const script = argv[1]?.split('/').pop()?.toLowerCase() ?? ''
+    return script === 'claude' || script.startsWith('claude.')
+  }
+  return false
+}
+
 function readCmdline(pid: number): readonly string[] | undefined {
   try {
     const raw = readFileSync(`/proc/${pid}/cmdline`, 'utf8')
@@ -78,7 +96,7 @@ export function readLaunchModelId(opts?: ReadLaunchModelOptions): string | undef
     let parent: number | undefined
     try {
       const argv = readCmd(pid)
-      if (argv !== undefined) {
+      if (argv !== undefined && isClaudeProcess(argv)) {
         const model = parseLaunchModelFlag(argv)
         if (model !== undefined) return model
       }

--- a/plugin/src/status/launch-model.ts
+++ b/plugin/src/status/launch-model.ts
@@ -31,10 +31,17 @@ function isClaudeProcess(argv: readonly string[]): boolean {
   // Basename of argv[0]: `claude`, `/usr/local/bin/claude`, `node .../claude.js`.
   const base = exe.split('/').pop()?.toLowerCase() ?? ''
   if (base === 'claude' || base.startsWith('claude.')) return true
-  // Runtime-launched form: `node|bun <path-to>/claude(.js|.mjs)`.
+  // Runtime-launched forms: `node|bun <path>/claude(.js|.mjs)` AND the official
+  // npm entrypoint `node <prefix>/@anthropic-ai/claude-code/cli.js`, where the
+  // script basename is a generic `cli.js` and only the PATH identifies it
+  // (codex MEDIUM, 2026-08-18). Matching a `claude*` path SEGMENT covers both
+  // without loosening the filter to any `cli.js`.
   if (base === 'node' || base === 'bun') {
-    const script = argv[1]?.split('/').pop()?.toLowerCase() ?? ''
-    return script === 'claude' || script.startsWith('claude.')
+    const script = argv[1]?.toLowerCase()
+    if (script === undefined || script.startsWith('-')) return false
+    return script
+      .split('/')
+      .some((seg) => seg === 'claude' || seg.startsWith('claude.') || seg.startsWith('claude-'))
   }
   return false
 }

--- a/plugin/src/telegram/handlers.ts
+++ b/plugin/src/telegram/handlers.ts
@@ -167,6 +167,10 @@ export interface HandlerDeps {
   // decoupled from the concrete SessionInfoStore. Optional — absent in legacy
   // wiring / tests, in which case /status shows «контекст: —».
   sessionInfo?: { get(chatId?: string): { transcriptPath?: string; model?: string } }
+  // The model id the hosting Claude Code process was launched with (readLaunchModelId,
+  // resolved once at boot). Carries the `[1m]` window marker that the transcript's
+  // model id drops, so /status can resolve a 1M window exactly like the pinned HUD.
+  launchModel?: string | undefined
   // Multichat router. When present together with `policy`, all gated
   // inbound traffic is dispatched to the per-chat tmux session via
   // `router.dispatch(InboundMessage)` instead of the legacy
@@ -1289,6 +1293,9 @@ export async function handleInboundText(ctx: Context, deps: HandlerDeps): Promis
         uptimeSeconds: process.uptime(),
         ...(ctx.message?.message_id !== undefined ? { messageId: ctx.message.message_id } : {}),
         ...(windowOverride !== undefined ? { contextWindowOverride: windowOverride } : {}),
+        ...(deps.launchModel !== undefined && deps.launchModel.length > 0
+          ? { launchModel: deps.launchModel }
+          : {}),
         ...(session?.transcriptPath ? { transcriptPath: session.transcriptPath } : {}),
         ...(session?.model ? { modelName: session.model } : {}),
         ...(deps.statusManager

--- a/plugin/tests/context-window-resolver.test.ts
+++ b/plugin/tests/context-window-resolver.test.ts
@@ -216,6 +216,10 @@ describe('parseLaunchModelFlag', () => {
   test('option parsing stops at `--`', () => {
     expect(parseLaunchModelFlag(['claude', '--', '--model', 'positional'])).toBeUndefined()
     expect(parseLaunchModelFlag(['claude', '--model', 'a', '--', '--model', 'b'])).toBe('a')
+    // codex control round claimed a valueless `--model` SWALLOWS the following
+    // `--`; it does not — the branch never advances the index itself, so the
+    // terminator is seen on the next iteration. Pinned as a regression test.
+    expect(parseLaunchModelFlag(['claude', '--model', '--', '--model', 'b'])).toBeUndefined()
   })
 })
 

--- a/plugin/tests/context-window-resolver.test.ts
+++ b/plugin/tests/context-window-resolver.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import {
   DEFAULT_CONTEXT_WINDOW_TOKENS,
   MODEL_CONTEXT_WINDOWS,
+  parseLaunchModelFlag,
   resolveContextWindowForModel,
   resolveContextWindowOverride,
   resolveContextWindowTokens,
@@ -179,5 +180,76 @@ describe('resolveContextWindowOverride — config + env chain', () => {
   test('resolveContextWindowTokens honors the env override', () => {
     process.env[KEY] = '1000000'
     expect(resolveContextWindowTokens(cfg(undefined))).toBe(1_000_000)
+  })
+})
+
+// --- Launch-flag marker (2026-08-18) ---------------------------------------
+// Claude Code launched as `--model claude-opus-5[1m]` writes a BARE
+// `"model":"claude-opus-5"` into the transcript, so the marker survives only in
+// the CLI argv. Without it the HUD showed 200k for a 1M session.
+
+describe('parseLaunchModelFlag', () => {
+  test('reads --model <id> and --model=<id>', () => {
+    expect(parseLaunchModelFlag(['claude', '--model', 'claude-opus-5[1m]'])).toBe(
+      'claude-opus-5[1m]',
+    )
+    expect(parseLaunchModelFlag(['claude', '--model=claude-opus-5[1m]'])).toBe(
+      'claude-opus-5[1m]',
+    )
+  })
+
+  test('absent / valueless flag → undefined', () => {
+    expect(parseLaunchModelFlag(['claude', '--permission-mode', 'bypassPermissions'])).toBeUndefined()
+    expect(parseLaunchModelFlag(['claude', '--model'])).toBeUndefined()
+    // A following flag is not a value.
+    expect(parseLaunchModelFlag(['claude', '--model', '--verbose'])).toBeUndefined()
+    expect(parseLaunchModelFlag(['claude', '--model='])).toBeUndefined()
+  })
+
+  test('last occurrence wins (CLI flag semantics)', () => {
+    expect(parseLaunchModelFlag(['claude', '--model', 'a', '--model', 'b'])).toBe('b')
+  })
+})
+
+describe('resolveContextWindowForModel — launch flag', () => {
+  test('bare transcript id + [1m] launch flag for the SAME model → 1M', () => {
+    expect(
+      resolveContextWindowForModel('claude-opus-5', { launchModel: 'claude-opus-5[1m]' }),
+    ).toBe(1_000_000)
+    // Case-insensitive, and the real tmux argv form.
+    expect(
+      resolveContextWindowForModel('CLAUDE-OPUS-5', { launchModel: 'claude-opus-5[1m]' }),
+    ).toBe(1_000_000)
+  })
+
+  test('launch flag WITHOUT the marker changes nothing', () => {
+    expect(
+      resolveContextWindowForModel('claude-opus-5', { launchModel: 'claude-opus-5' }),
+    ).toBe(200_000)
+  })
+
+  test('a DIFFERENT model now serving does not inherit the launch window', () => {
+    // Mid-session /model switch: launched opus-5[1m], sonnet is serving.
+    expect(
+      resolveContextWindowForModel('claude-sonnet-5', { launchModel: 'claude-opus-5[1m]' }),
+    ).toBe(200_000)
+    expect(
+      resolveContextWindowForModel('claude-opus-4-6', { launchModel: 'claude-opus-5[1m]' }),
+    ).toBe(200_000)
+  })
+
+  test('operator override still wins over the launch flag', () => {
+    expect(
+      resolveContextWindowForModel('claude-opus-5', {
+        launchModel: 'claude-opus-5[1m]',
+        override: 300_000,
+      }),
+    ).toBe(300_000)
+  })
+
+  test('absent model with a [1m] launch flag stays on the fallback', () => {
+    expect(
+      resolveContextWindowForModel(undefined, { launchModel: 'claude-opus-5[1m]' }),
+    ).toBe(DEFAULT_CONTEXT_WINDOW_TOKENS)
   })
 })

--- a/plugin/tests/context-window-resolver.test.ts
+++ b/plugin/tests/context-window-resolver.test.ts
@@ -208,6 +208,14 @@ describe('parseLaunchModelFlag', () => {
 
   test('last occurrence wins (CLI flag semantics)', () => {
     expect(parseLaunchModelFlag(['claude', '--model', 'a', '--model', 'b'])).toBe('b')
+    // codex LOW: a later MALFORMED --model still overrides the earlier value.
+    expect(parseLaunchModelFlag(['claude', '--model', 'a', '--model='])).toBeUndefined()
+    expect(parseLaunchModelFlag(['claude', '--model', 'a', '--model', '--verbose'])).toBeUndefined()
+  })
+
+  test('option parsing stops at `--`', () => {
+    expect(parseLaunchModelFlag(['claude', '--', '--model', 'positional'])).toBeUndefined()
+    expect(parseLaunchModelFlag(['claude', '--model', 'a', '--', '--model', 'b'])).toBe('a')
   })
 })
 
@@ -226,6 +234,13 @@ describe('resolveContextWindowForModel — launch flag', () => {
     expect(
       resolveContextWindowForModel('claude-opus-5', { launchModel: 'claude-opus-5' }),
     ).toBe(200_000)
+  })
+
+  // codex HIGH 2026-08-18: a family match in either direction let a short alias
+  // claim 1M for every model of that family. Exact id equality only.
+  test('a short alias launch flag does NOT prove 1M for a concrete id', () => {
+    expect(resolveContextWindowForModel('claude-opus-5', { launchModel: 'opus[1m]' })).toBe(200_000)
+    expect(resolveContextWindowForModel('opus', { launchModel: 'claude-opus-5[1m]' })).toBe(200_000)
   })
 
   test('a DIFFERENT model now serving does not inherit the launch window', () => {

--- a/plugin/tests/status/launch-model.test.ts
+++ b/plugin/tests/status/launch-model.test.ts
@@ -56,6 +56,28 @@ describe('readLaunchModelId', () => {
     expect(readLaunchModelId({ startPid: 100, ...t })).toBe('claude-opus-5[1m]')
   })
 
+  // codex MEDIUM 2026-08-18: the official npm entrypoint has a generic
+  // `cli.js` basename — only the path identifies it.
+  test('official npm entrypoint (@anthropic-ai/claude-code/cli.js) is recognized', () => {
+    const t = tree({
+      100: { argv: ['bun', 'src/server.ts'], ppid: 200 },
+      200: {
+        argv: [
+          'node',
+          '/usr/lib/node_modules/@anthropic-ai/claude-code/cli.js',
+          '--model',
+          'claude-opus-5[1m]',
+        ],
+      },
+    })
+    expect(readLaunchModelId({ startPid: 100, ...t })).toBe('claude-opus-5[1m]')
+  })
+
+  test('an unrelated node cli.js is still NOT treated as Claude', () => {
+    const t = tree({ 100: { argv: ['node', '/opt/other-tool/cli.js', '--model', 'x[1m]'] } })
+    expect(readLaunchModelId({ startPid: 100, ...t })).toBeUndefined()
+  })
+
   test('a --model on a non-Claude process alone yields nothing', () => {
     const t = tree({ 100: { argv: ['python', 'train.py', '--model', 'resnet[1m]'] } })
     expect(readLaunchModelId({ startPid: 100, ...t })).toBeUndefined()

--- a/plugin/tests/status/launch-model.test.ts
+++ b/plugin/tests/status/launch-model.test.ts
@@ -37,6 +37,30 @@ describe('readLaunchModelId', () => {
     expect(readLaunchModelId({ startPid: 100, ...t })).toBeUndefined()
   })
 
+  // codex MEDIUM 2026-08-18: a wrapper carrying its own --model must not mask
+  // the real Claude Code process further up the chain.
+  test('a non-Claude wrapper with its own --model is skipped', () => {
+    const t = tree({
+      100: { argv: ['bun', 'src/server.ts'], ppid: 200 },
+      200: { argv: ['some-launcher', '--model', 'wrapper-model[1m]'], ppid: 300 },
+      300: { argv: ['claude', '--model', 'claude-opus-5[1m]'] },
+    })
+    expect(readLaunchModelId({ startPid: 100, ...t })).toBe('claude-opus-5[1m]')
+  })
+
+  test('claude launched through a runtime (node/bun <path>/claude.js) is recognized', () => {
+    const t = tree({
+      100: { argv: ['bun', 'src/server.ts'], ppid: 200 },
+      200: { argv: ['node', '/usr/lib/claude-code/claude.js', '--model', 'claude-opus-5[1m]'] },
+    })
+    expect(readLaunchModelId({ startPid: 100, ...t })).toBe('claude-opus-5[1m]')
+  })
+
+  test('a --model on a non-Claude process alone yields nothing', () => {
+    const t = tree({ 100: { argv: ['python', 'train.py', '--model', 'resnet[1m]'] } })
+    expect(readLaunchModelId({ startPid: 100, ...t })).toBeUndefined()
+  })
+
   test('unreadable process (no /proc entry) → undefined, never throws', () => {
     const t = tree({})
     expect(readLaunchModelId({ startPid: 100, ...t })).toBeUndefined()

--- a/plugin/tests/status/launch-model.test.ts
+++ b/plugin/tests/status/launch-model.test.ts
@@ -1,0 +1,78 @@
+// Tests for readLaunchModelId — the /proc walk that recovers the hosting Claude
+// Code process's `--model` flag. The process tree is faked, so these never touch
+// /proc and pass on any platform.
+
+import { describe, expect, test } from 'bun:test'
+
+import { readLaunchModelId } from '../../src/status/launch-model.js'
+
+// Build fake readers from a {pid: {argv, ppid}} tree.
+function tree(spec: Record<number, { argv?: readonly string[]; ppid?: number }>) {
+  return {
+    readCmdlineFn: (pid: number) => spec[pid]?.argv,
+    readParentPidFn: (pid: number) => spec[pid]?.ppid,
+  }
+}
+
+describe('readLaunchModelId', () => {
+  test('finds the flag on the direct parent', () => {
+    const t = tree({ 100: { argv: ['claude', '--model', 'claude-opus-5[1m]'] } })
+    expect(readLaunchModelId({ startPid: 100, ...t })).toBe('claude-opus-5[1m]')
+  })
+
+  test('walks up past a wrapper that has no --model', () => {
+    const t = tree({
+      100: { argv: ['bun', 'src/server.ts'], ppid: 200 },
+      200: { argv: ['/bin/bash', '-c', 'exec claude'], ppid: 300 },
+      300: { argv: ['claude', '--model=claude-opus-5[1m]', '--permission-mode', 'bypassPermissions'] },
+    })
+    expect(readLaunchModelId({ startPid: 100, ...t })).toBe('claude-opus-5[1m]')
+  })
+
+  test('no --model anywhere in the chain → undefined', () => {
+    const t = tree({
+      100: { argv: ['bun', 'src/server.ts'], ppid: 200 },
+      200: { argv: ['claude'] },
+    })
+    expect(readLaunchModelId({ startPid: 100, ...t })).toBeUndefined()
+  })
+
+  test('unreadable process (no /proc entry) → undefined, never throws', () => {
+    const t = tree({})
+    expect(readLaunchModelId({ startPid: 100, ...t })).toBeUndefined()
+  })
+
+  test('a reader that throws is contained', () => {
+    expect(
+      readLaunchModelId({
+        startPid: 100,
+        readCmdlineFn: () => {
+          throw new Error('EACCES')
+        },
+        readParentPidFn: () => undefined,
+      }),
+    ).toBeUndefined()
+  })
+
+  test('stops at the ancestor limit instead of walking to init', () => {
+    // Every pid points at the next one and none carries the flag.
+    const t = {
+      readCmdlineFn: () => ['bun', 'server.ts'],
+      readParentPidFn: (pid: number) => pid + 1,
+    }
+    expect(readLaunchModelId({ startPid: 100, maxAncestors: 3, ...t })).toBeUndefined()
+  })
+
+  test('a parent cycle terminates', () => {
+    const t = tree({
+      100: { argv: ['bun'], ppid: 200 },
+      200: { argv: ['bash'], ppid: 100 },
+    })
+    expect(readLaunchModelId({ startPid: 100, ...t })).toBeUndefined()
+  })
+
+  test('pid <= 1 is not walked', () => {
+    const t = tree({ 1: { argv: ['claude', '--model', 'x[1m]'] } })
+    expect(readLaunchModelId({ startPid: 1, ...t })).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Проблема

Сессия запущена как `claude --model claude-opus-5[1m]`, но API отдаёт в транскрипт **голый** id `claude-opus-5`. Маркер `[1m]` выживает только в argv процесса, поэтому таблица моделей честно резолвила 200k — закреплённая карточка и `/status` показывали **104k / 200k** вместо 1M, занижение в 5 раз.

## Решение

Новая ступень приоритета в `resolveContextWindowForModel`:

1. operator override (`context_window_tokens` / `JARVIS_CONTEXT_WINDOW`) — по-прежнему выигрывает всё
2. маркер на самом id из транскрипта
3. **маркер на флаге запуска** — но только если флаг называет ТУ ЖЕ модель, что отдаёт транскрипт (mid-session `/model` switch на sonnet не унаследует чужое окно)
4. таблица семейств
5. fallback 200k

`readLaunchModelId` обходит цепочку родителей по `/proc` (до 8 хопов, защита от циклов и `pid<=1`), никогда не бросает, читается один раз на старте. Проброшено в `ContextHud` и `/status`.

## Доказательства

- весь сьют: **2738 pass / 0 fail**, `tsc --noEmit` чистый
- 43 новых теста: разбор флага, семантика приоритетов, фейковое дерево процессов
- живая проверка на боевом процессе канала: `launchModel=claude-opus-5[1m]`, окно для транскриптного `claude-opus-5` = **1 000 000**

Применится после рестарта канала.

🤖 Generated with [Claude Code](https://claude.com/claude-code)